### PR TITLE
Docs: Fix 'azurerm_api_management_api_operation' example

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -575,7 +575,7 @@ resource "azurerm_api_management_api_operation" "test" {
   api_name            = azurerm_api_management_api.test.name
   api_management_name = azurerm_api_management.test.name
   resource_group_name = azurerm_resource_group.test.name
-	display_name        = "Acceptance Test Operation"
+  display_name        = "Acceptance Test Operation"
   method              = "DELETE"
   url_template        = "/users/{id}/delete"
   description         = "This can only be done by the logged in user."

--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -124,6 +124,21 @@ func TestAccApiManagementApiOperation_representations(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApiOperation_templateParameter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation", "test")
+	r := ApiManagementApiOperationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.templateParameter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApiManagementApiOperation_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation", "test")
 	r := ApiManagementApiOperationResource{}
@@ -546,6 +561,33 @@ SAMPLE
 
       }
     }
+  }
+}
+`, r.template(data))
+}
+
+func (r ApiManagementApiOperationResource) templateParameter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api_operation" "test" {
+  operation_id        = "acctest-operation"
+  api_name            = azurerm_api_management_api.test.name
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+	display_name        = "Acceptance Test Operation"
+  method              = "DELETE"
+  url_template        = "/users/{id}/delete"
+  description         = "This can only be done by the logged in user."
+
+  template_parameter {
+    name     = "id"
+    type     = "number"
+    required = true
+  }
+
+  response {
+    status_code = 200
   }
 }
 `, r.template(data))

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -30,6 +30,12 @@ resource "azurerm_api_management_api_operation" "example" {
   url_template        = "/users/{id}/delete"
   description         = "This can only be done by the logged in user."
 
+  template_parameter {
+    name    = "id"
+    type    = "number"
+    required = true
+  }
+
   response {
     status_code = 200
   }

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `response` - (Optional) One or more `response` blocks as defined below.
 
-* `template_parameter` - (Optional) One or more `template_parameter` blocks as defined below.
+* `template_parameter` - (Optional) One or more `template_parameter` blocks as defined below.  Required if `url_template` contains one or more parameters.
 
 ---
 

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -31,8 +31,8 @@ resource "azurerm_api_management_api_operation" "example" {
   description         = "This can only be done by the logged in user."
 
   template_parameter {
-    name    = "id"
-    type    = "number"
+    name     = "id"
+    type     = "number"
     required = true
   }
 

--- a/website/docs/r/api_management_api_operation_tag.html.markdown
+++ b/website/docs/r/api_management_api_operation_tag.html.markdown
@@ -30,6 +30,12 @@ resource "azurerm_api_management_api_operation" "example" {
   url_template        = "/users/{id}/delete"
   description         = "This can only be done by the logged in user."
 
+  template_parameter {
+    name    = "id"
+    type    = "number"
+    required = true
+  }
+
   response {
     status_code = 200
   }

--- a/website/docs/r/api_management_api_operation_tag.html.markdown
+++ b/website/docs/r/api_management_api_operation_tag.html.markdown
@@ -31,8 +31,8 @@ resource "azurerm_api_management_api_operation" "example" {
   description         = "This can only be done by the logged in user."
 
   template_parameter {
-    name    = "id"
-    type    = "number"
+    name     = "id"
+    type     = "number"
     required = true
   }
 


### PR DESCRIPTION
### Issue

The current `azurerm_api_management_api_operation` example results in the following error:

```
│ Error: creating/updating Operation (Subscription: "000000-000-0000-0000-000000000"
│ Resource Group Name: "example"
│ Service Name: "example-apim"
│ Api: "example-api"
│ Operation: "user-delete"): unexpected status 400 with error: ValidationError: One or more fields contain incorrect values:
│ 
│   with azurerm_api_management_api_operation.example,
│   on main.tf line 12, in resource "azurerm_api_management_api_operation" "example":
```

### Proposed solution

This PR will:

- add the missing `template_parameter` block to the HCL example in the docs
- add a short clarification regarding when `template_parameter` is required, as opposed to optional (default)
- add `TestAccApiManagementApiOperation_templateParameter` to the acceptance test suite