### PR TITLE
`lighthouse` - Fix failed testcase

### DIFF
--- a/internal/services/lighthouse/lighthouse_definition_resource_test.go
+++ b/internal/services/lighthouse/lighthouse_definition_resource_test.go
@@ -198,9 +198,9 @@ func TestAccLighthouseDefinition_plan(t *testing.T) {
 
 func TestAccLighthouseDefinition_eligibleAuthorization(t *testing.T) {
 	secondTenantID := os.Getenv("ARM_TENANT_ID_ALT")
-	principalID := os.Getenv("ARM_PRINCIPAL_ID_ALT_TENANT")
+	principalID := os.Getenv("ARM_USER_GROUP_ID_ALT_TENANT")
 	if secondTenantID == "" || principalID == "" {
-		t.Skip("Skipping as ARM_TENANT_ID_ALT and/or ARM_PRINCIPAL_ID_ALT_TENANT are not specified")
+		t.Skip("Skipping as ARM_TENANT_ID_ALT and/or ARM_USER_GROUP_ID_ALT_TENANT are not specified")
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_lighthouse_definition", "test")


### PR DESCRIPTION
## Description
According to this [doc](https://learn.microsoft.com/en-us/azure/lighthouse/how-to/create-eligible-authorizations#user), `service principals` cannot be used for `eligible authorizations`. Only users and security groups are supported. This PR adds a new evrionment variable `ARM_USER_GROUP_ID_ALT_TENANT` to fix `TestAccLighthouseDefinition_eligibleAuthorization`.

<img width="650" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/6c9ffbe2-bbd0-4dd6-84a3-a68334d4effa">

## Test Result

=== RUN   TestAccLighthouseDefinition_eligibleAuthorization
=== PAUSE TestAccLighthouseDefinition_eligibleAuthorization
=== CONT  TestAccLighthouseDefinition_eligibleAuthorization
--- PASS: TestAccLighthouseDefinition_eligibleAuthorization (68.90s)
PASS