### PR TITLE
`tools`: update document linter tool for default value and blocktype detet regex

### DIFF
--- a/internal/tools/document-lint/check/check_default_value.go
+++ b/internal/tools/document-lint/check/check_default_value.go
@@ -32,7 +32,7 @@ func (c defaultDiff) Fix(line string) (result string, err error) {
 			// remove default part from line
 			line = line[:idxs[0]+1] + line[idxs[1]:]
 		} else {
-			line = line[:idxs[4]] + c.Default + line[idxs[5]:]
+			line = line[:idxs[2]] + "`" + c.Default + "`" + line[idxs[3]:]
 		}
 	} else if c.Default != "" {
 		line = strings.TrimSpace(line) + " Defaults to `" + c.Default + "`."

--- a/internal/tools/document-lint/check/check_format_error.go
+++ b/internal/tools/document-lint/check/check_format_error.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/document-lint/md"
@@ -42,13 +43,15 @@ func (f formatErr) String() string {
 	}
 }
 
+var regIncorrectMark = regexp.MustCompile(`(?: blocks?)? as (?:detailed|defined) (below|above)`)
+
 func (f formatErr) Fix(line string) (result string, err error) {
 	// some Note lines with a misleading star mark, try to remove it
 	switch {
 	case strings.HasPrefix(line, "* ~>"):
 		line = strings.TrimPrefix(line, "* ")
 	case strings.Contains(f.msg, md.IncorrectlyBlockMarked):
-		line = strings.ReplaceAll(line, " as defined below", "")
+		line = regIncorrectMark.ReplaceAllLiteralString(line, "")
 	case strings.TrimSpace(line) == "*":
 		line = ""
 	}

--- a/internal/tools/document-lint/check/check_iface.go
+++ b/internal/tools/document-lint/check/check_iface.go
@@ -27,7 +27,7 @@ type checkBase struct {
 }
 
 func (c checkBase) ShouldSkip() bool {
-	if c.MDField() == nil || c.MDField().Skip {
+	if c.line == 0 || c.MDField() == nil || c.MDField().Skip {
 		return true
 	}
 	return false

--- a/internal/tools/document-lint/check/crossproperty.go
+++ b/internal/tools/document-lint/check/crossproperty.go
@@ -192,10 +192,6 @@ func diffCodeMiss(rt, path string, f *model.Field, s *schema2.Schema) (res []Che
 			if defaultStr == f.Default {
 				return true
 			}
-			// `false` not specified in the schema, but in the document, it's fine.
-			if f.Default == "false" && s.Type == pluginsdk.TypeBool && s.Default == nil {
-				return true
-			}
 			if defaultStr == "false" && f.Default == "" {
 				return true
 			}
@@ -215,10 +211,11 @@ func diffCodeMiss(rt, path string, f *model.Field, s *schema2.Schema) (res []Che
 			}
 		}
 	} else if f.Default != "" && !s.Computed {
-		// code no default and not computed/optional property, but document has
-		// if default to is a long sentence, then skip it now.
-		// TODO add more logic to analysis
-		res = append(res, newDefaultDiff(base, f.Default, ""))
+		// schema has no default, but the document has default value, then we need a diff item
+		// but if schema is a boolean type and the document has a false default value, it's fine
+		if !(s.Type == pluginsdk.TypeBool && f.Default == "false") {
+			res = append(res, newDefaultDiff(base, f.Default, ""))
+		}
 	}
 
 	// check forceNew attribute

--- a/internal/tools/document-lint/check/skip_config.go
+++ b/internal/tools/document-lint/check/skip_config.go
@@ -1,43 +1,66 @@
 package check
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 var skipProps = []string{
+	"azurerm_load_test",
+	"azurerm_kubernetes_fleet_manager",
+	"azurerm_dev_center",
+
 	"all.timezone",
 	"all.time_zone",
 	"all.time_zone_id",
 	"azurerm_nginx_deployment.identity.type", // there is a diff between real supported values and common identity schema
+	"/azurerm_container_app.template..+_scale_rule.authentication.trigger_parameter",
+	"/azurerm_container_app.template..+_probe.header",
+	`/azurerm_automanage_configuration.backup.retention_policy.(?:weekly|daily)_schedule.retention_duration.duration_type`,
+	"/azurerm_sentinel_metadata.dependency.*",
+	"/azurerm_orchestrated_virtual_machine_scale_set.os_profile.(windows|linux)_configuration.secret.certificate",
+	"/azurerm_eventgrid_event_subscription.advanced_filter.*",
+	"/azurerm_eventgrid_system_topic_event_subscription.advanced_filter.*",
 }
 
-// skip auto-generated resources document
-var skipResource = []string{
-	"azurerm_load_test",
-	"azurerm_kubernetes_fleet_manager",
+var skipConfig = &struct {
+	skipPaths  map[string]struct{}
+	skipRegexp []*regexp.Regexp
+}{
+	skipPaths: map[string]struct{}{},
 }
-var skipPropMap = map[string]struct{}{}
-var skipResourceMap = map[string]struct{}{}
 
 func init() {
 	for _, k := range skipProps {
-		skipPropMap[k] = struct{}{}
-	}
-	for _, k := range skipResource {
-		skipResourceMap[k] = struct{}{}
+		if strings.HasPrefix(k, "/") {
+			skipConfig.skipRegexp = append(skipConfig.skipRegexp, regexp.MustCompile(k[1:]))
+		} else {
+			skipConfig.skipPaths[k] = struct{}{}
+		}
 	}
 }
 
 func isSkipProp(rt, prop string) bool {
-	if _, ok := skipPropMap[rt]; ok {
+	if _, ok := skipConfig.skipPaths[rt]; ok {
 		return true
 	}
-	if _, ok := skipPropMap[rt+"."+prop]; ok {
+	if _, ok := skipConfig.skipPaths[rt+"."+prop]; ok {
 		return true
 	}
+
+	allKey := prop
 	if idx := strings.LastIndex(prop, "."); idx > 0 {
-		prop = prop[idx+1:]
+		allKey = prop[idx+1:]
 	}
-	if _, ok := skipPropMap["all."+prop]; ok {
+	if _, ok := skipConfig.skipPaths["all."+allKey]; ok {
 		return true
 	}
+
+	for _, reg := range skipConfig.skipRegexp {
+		if reg.MatchString(rt + "." + prop) {
+			return true
+		}
+	}
+
 	return false
 }

--- a/internal/tools/document-lint/md/resource_doc.go
+++ b/internal/tools/document-lint/md/resource_doc.go
@@ -35,11 +35,13 @@ var codeReg = regexp.MustCompile("`([^`]+)`")
 
 var blockHeadReg = regexp.MustCompile("^(an?|An?|The)[^`]+(`[a-zA-Z0-9_]+`[, and]*)+.*blocks?.*$")
 
-var DefaultsReg = regexp.MustCompile("[.?,;] *[Dd]efaults?.* (to|is) ['\"`]([^`\"']+)['\"`][ .,]?")
+var DefaultsReg = regexp.MustCompile("[.,?;](?: *[Tt]he)? *[Dd]efaults?[^.]+(?:to|is) ('[^']+'|`[^`]+`|\"[^\"]+\")[ .,]?")
 
 func getDefaultValue(line string) string {
 	if vals := DefaultsReg.FindStringSubmatch(line); len(vals) > 0 {
-		return vals[2]
+		if val := vals[1]; len(val) > 2 {
+			return val[1 : len(val)-1] // trim leading/tailing character
+		}
 	}
 	return ""
 }
@@ -156,11 +158,7 @@ func extractBlockNames(line string) (res []string) {
 }
 
 var blockPropRegs = []*regexp.Regexp{
-	regexp.MustCompile("blocks?.*(as.*(below|above))"),
-	regexp.MustCompile(`block.*(defined|documented).*(below|above)`),
-	regexp.MustCompile("(one or more) `.*` block"),
-	regexp.MustCompile("as (defined|documented) .* blocks? (below|above)"),
-	regexp.MustCompile("as (defined|documented) (below|above)[. ]?$"),
+	regexp.MustCompile("(?:[Oo]ne|[Ee]ach|more(?: \\(.*\\))?|[Tt]he|as|of|[Aa]n?) ['\"`]([^ ]+)['\"`] (?:block|object)[^.]+(?:below|above)"),
 }
 
 func guessBlockProperty(line string) bool {
@@ -174,7 +172,7 @@ func guessBlockProperty(line string) bool {
 }
 
 var (
-	blockTypeReg = regexp.MustCompile("(a|an|one|one or more) `.*` block")
+	blockTypeReg = blockPropRegs[0]
 )
 
 func newFieldFromLine(line string) *model.Field {
@@ -182,19 +180,8 @@ func newFieldFromLine(line string) *model.Field {
 	if guessBlockProperty(line) {
 		// extract real block type
 		f.BlockTypeName = f.Name
-		// use the first code block value as block type name todo this may not right
-		// process when contains special marks, or it may cause recursive reference, ane make an infinite diff
-		if blockTypeReg.MatchString(strings.ToLower(line)) {
-			start := strings.Index(line, ")")
-			end := strings.Index(line, "block")
-			if end <= 0 {
-				end = strings.Index(line, "defined")
-			}
-			if start > 0 && end > 0 && start < end {
-				if names := util.ExtractCodeValue(line[start:end]); len(names) > 0 && names[0] != f.BlockTypeName {
-					f.BlockTypeName = names[0]
-				}
-			}
+		if match := blockTypeReg.FindAllStringSubmatchIndex(strings.ToLower(line), -1); len(match) > 0 {
+			f.BlockTypeName = line[match[0][2]:match[0][3]]
 		}
 		f.Typ = model.FieldTypeBlock
 	}

--- a/internal/tools/document-lint/md/resource_doc.go
+++ b/internal/tools/document-lint/md/resource_doc.go
@@ -35,7 +35,7 @@ var codeReg = regexp.MustCompile("`([^`]+)`")
 
 var blockHeadReg = regexp.MustCompile("^(an?|An?|The)[^`]+(`[a-zA-Z0-9_]+`[, and]*)+.*blocks?.*$")
 
-var DefaultsReg = regexp.MustCompile("[.,?;](?: *[Tt]he)? *[Dd]efaults?[^.]+(?:to|is) ('[^']+'|`[^`]+`|\"[^\"]+\")[ .,]?")
+var DefaultsReg = regexp.MustCompile("[.,?;](?: *[Tt]he)? *[Dd]efaults?[^`'\".]+(?:to|is) ('[^']+'|`[^`]+`|\"[^\"]+\")[ .,]?")
 
 func getDefaultValue(line string) string {
 	if vals := DefaultsReg.FindStringSubmatch(line); len(vals) > 0 {

--- a/internal/tools/document-lint/md/resource_doc_test.go
+++ b/internal/tools/document-lint/md/resource_doc_test.go
@@ -104,21 +104,27 @@ func TestDefaultValueReg(t *testing.T) {
 	var lines = []string{
 		"* `load_balancing_mode` - (Optional) The Site load balancing. Possible values include: `WeightedRoundRobin`, `LeastRequests`, `LeastResponseTime`, `WeightedTotalTraffic`, `RequestHash`, `PerSiteRoundRobin`. Defaults to `LeastRequests` if omitted.",
 		"* `local_mysql_enabled` - (Optional) Use Local MySQL. Defaults to `false`.",
+		"* `local_mysql_enabled` - (Optional) Use Local MySQL. Defaults to `\"\"`.",
 		"* `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`.",
+		"* `export_policy_enabled` - (Optional) Boolean value that indicates whether export policy is enabled. Defaults to `true`. In order to set it to `false`, make sure the `public_network_access_enabled` is also set to `false`.\n",
+		"* `probe_threshold` - (Optional) The number of consecutive successful or failed probes that allow or deny traffic to this endpoint. Possible values range from `1` to `100`. The default value is `1`.\n",
 	}
 	values := []string{
 		"LeastRequests",
 		"false",
+		`""`,
 		"1.2",
+		"true",
+		"1",
 	}
 	for idx, line := range lines {
-		val := DefaultsReg.FindStringSubmatch(line)
-		if values[idx] != val[2] {
+		val := getDefaultValue(line)
+		if values[idx] != val {
 			t.Fatalf("idx %d want: %s, got: %v", idx, values[idx], val)
 		}
 	}
 	for idx, line := range lines {
-		val := DefaultsReg.FindStringSubmatchIndex(line)
+		val := getDefaultValue(line)
 		t.Logf("%d idxs: %v", idx, val)
 	}
 }


### PR DESCRIPTION
This Pull Request is to make the document linter more flexiable to different kind of format for default vlaues and block field descriptions. It also support to configure regexpressions to skip some fileds.