### PR TITLE
Tool: schema snapshot generator not need to expose `ForceNew`

### DIFF
--- a/internal/tools/generator-schema-snapshot/main.go
+++ b/internal/tools/generator-schema-snapshot/main.go
@@ -83,10 +83,6 @@ func SchemaValue(sch *pluginsdk.Schema) Dict {
 		out[Id("Computed")] = True()
 	}
 
-	if sch.ForceNew {
-		out[Id("ForceNew")] = True()
-	}
-
 	switch sch.ConfigMode {
 	case pluginsdk.SchemaConfigModeAttr:
 		out[Id("ConfigMode")] = Qual(SchemaPath, "SchemaConfigModeAttr")


### PR DESCRIPTION
Removing the `ForceNew` settings for the generated schema snapshot by `./internal/tools/generator-schema-snapshot`, based on this comment: https://github.com/hashicorp/terraform-provider-azurerm/pull/23749#discussion_r1378452915