### PR TITLE
Update application_gateway.html.markdown

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -381,7 +381,7 @@ A `path_rule` block supports the following:
 
 ---
 
-A `probe` block support the following:
+A `probe` block supports the following:
 
 * `host` - (Optional) The Hostname used for this Probe. If the Application Gateway is configured for a single site, by default the Host name should be specified as `127.0.0.1`, unless otherwise configured in custom probe. Cannot be set if `pick_host_name_from_backend_http_settings` is set to `true`.
 


### PR DESCRIPTION
Fix typo "A `probe` block support the following" -> "A `probe` block supports the following"