### PR TITLE
Added trusted_launch_supported feature to azurerm_shared_image resource

### DIFF
--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -94,13 +94,15 @@ The following arguments are supported:
 
 * `release_note_uri` - (Optional) The URI containing the Release Notes associated with this Shared Image.
 
+* `trusted_launch_supported` - (Optional) Specifies if supports creation of both Trusted Launch virtual machines and Gen2 virtual machines with standard security created from the Shared Image. Changing this forces a new resource to be created.
+
 * `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image. Changing this forces a new resource to be created.
 
 * `confidential_vm_supported` - (Optional) Specifies if supports creation of both Confidential virtual machines and Gen2 virtual machines with standard security from a compatible Gen2 OS disk VHD or Gen2 Managed image. Changing this forces a new resource to be created.
 
 * `confidential_vm_enabled` - (Optional) Specifies if Confidential Virtual Machines enabled. It will enable all the features of trusted, with higher confidentiality features for isolate machines or encrypted data. Available for Gen2 machines. Changing this forces a new resource to be created.
 
--> **Note:**: Only one of `trusted_launch_enabled`, `confidential_vm_supported` and `confidential_vm_enabled` could only be specified.
+-> **Note:**: Only one of `trusted_launch_supported`, `trusted_launch_enabled`, `confidential_vm_supported` and `confidential_vm_enabled` can be specified.
 
 * `accelerated_network_support_enabled` - (Optional) Specifies if the Shared Image supports Accelerated Network. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
The `azurerm_shared_image` resource does not currently support the following feature which can be set using the ARM API.

```
"features": [
    {
        "name": "SecurityType",
        "value": "TrustedLaunchSupported"
    }
]
```

This PR adds the argument `trusted_launch_supported` to the `azurerm_shared_image` resource and updates the existing validation to include this as one of the single values to be set for the `SecurityType` property.

The commit includes documentation and test.

Thanks, Richard