### PR TITLE
Add non-public cloud support for app configuration

### DIFF
--- a/internal/services/appconfiguration/client/helpers.go
+++ b/internal/services/appconfiguration/client/helpers.go
@@ -180,10 +180,12 @@ func (c Client) parseNameFromEndpoint(input string) (*string, error) {
 	}
 
 	// https://the-appconfiguration.azconfig.io
+	// https://the-appconfiguration.azconfig.azure.cn
+	// https://the-appconfiguration.azconfig.azure.us
 
 	segments := strings.Split(uri.Host, ".")
-	if len(segments) < 3 || segments[1] != "azconfig" || segments[2] != "io" {
-		return nil, fmt.Errorf("expected a URI in the format `https://the-appconfiguration.azconfig.io` but got %q", uri.Host)
+	if len(segments) < 3 || segments[1] != "azconfig" {
+		return nil, fmt.Errorf("expected a URI in the format `https://the-appconfiguration.azconfig.**` but got %q", uri.Host)
 	}
 	return &segments[0], nil
 }

--- a/internal/services/appconfiguration/migration/key_resource_v1_to_v2.go
+++ b/internal/services/appconfiguration/migration/key_resource_v1_to_v2.go
@@ -9,7 +9,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -51,7 +53,17 @@ func (KeyResourceV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 			return rawState, fmt.Errorf("parseing Configuration Store ID %q: %+v", configurationStoreId, err)
 		}
 
-		configurationStoreEndpoint := fmt.Sprintf("https://%s.azconfig.io", configurationStoreId.ConfigurationStoreName)
+		envName := meta.(*clients.Client).Account.Environment.Name
+		appConfigSuffix := ""
+		switch envName {
+		case environments.AzurePublicCloud:
+			appConfigSuffix = "azconfig.io"
+		case environments.AzureUSGovernmentCloud:
+			appConfigSuffix = "azconfig.azure.us"
+		case environments.AzureChinaCloud:
+			appConfigSuffix = "azconfig.azure.cn"
+		}
+		configurationStoreEndpoint := fmt.Sprintf("https://%s.%s", configurationStoreId.ConfigurationStoreName, appConfigSuffix)
 
 		nestedItemId, err := parse.NewNestedItemID(configurationStoreEndpoint, parsedOldId.Key, parsedOldId.Label)
 		if err != nil {


### PR DESCRIPTION
With version 3.49.0 resources of app configuration for AzureChina and AzureGovernment stopped working as their suffixes weren't supported.
This PR adds support for those clouds.

fixes: [#21550](https://github.com/hashicorp/terraform-provider-azurerm/issues/21550)