### PR TITLE
azurerm_kusto_cluster: changing regex on ClusterName to match the azure naming convention

### DIFF
--- a/internal/services/kusto/validate/name.go
+++ b/internal/services/kusto/validate/name.go
@@ -47,7 +47,7 @@ func EntityName(v interface{}, k string) (warnings []string, errors []error) {
 func ClusterName(v interface{}, k string) (warnings []string, errors []error) {
 	name := v.(string)
 
-	if !regexp.MustCompile(`^[a-z][a-z0-9]+$`).MatchString(name) {
+	if !regexp.MustCompile(`^[a-z][a-z0-9\-]+$`).MatchString(name) {
 		errors = append(errors, fmt.Errorf("%q must begin with a letter and may only contain alphanumeric characters: %q", k, name))
 	}
 


### PR DESCRIPTION
I am pushing this change as it matches the azure provider naming convention better. I am working on a project that exports resources to create them into Terraform. We came across a name on an Azure Cluster that had a hyphen. When we went to do a plan we got the error that it is required to be Alphanumeric. This is incorrect as I am able to create a cluster in the portal with hyphens. I changed the regex to better align with this.