### PR TITLE
DiffSuppressFunc to ignore azurerm_virtual_network.address_space reordering

### DIFF
--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -67,7 +67,7 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"address_space": {
-			Type:     pluginsdk.TypeList,
+			Type:     pluginsdk.TypeSet,
 			Required: true,
 			MinItems: 1,
 			Elem: &pluginsdk.Schema{

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -67,9 +68,10 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"address_space": {
-			Type:     pluginsdk.TypeSet,
+			Type:     pluginsdk.TypeList,
 			Required: true,
 			MinItems: 1,
+			DiffSuppressFunc: suppress.ListOrder,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
 				ValidateFunc: validation.StringIsNotEmpty,

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -68,9 +68,9 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"address_space": {
-			Type:     pluginsdk.TypeList,
-			Required: true,
-			MinItems: 1,
+			Type:             pluginsdk.TypeList,
+			Required:         true,
+			MinItems:         1,
 			DiffSuppressFunc: suppress.ListOrder,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,

--- a/internal/tf/suppress/list.go
+++ b/internal/tf/suppress/list.go
@@ -1,0 +1,45 @@
+package suppress
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ListOrder(key, old, new string, d *schema.ResourceData) bool {
+	// Taken from https://github.com/hashicorp/terraform-plugin-sdk/issues/477#issuecomment-1238807249
+	// For a list, the key is path to the element, rather than the list.
+	// E.g. "node_groups.2.ips.0"
+	lastDotIndex := strings.LastIndex(key, ".")
+	if lastDotIndex != -1 {
+		key = key[:lastDotIndex]
+	}
+
+	oldData, newData := d.GetChange(key)
+	if oldData == nil || newData == nil {
+		return false
+	}
+
+	sOld := make([]string, len(oldData.([]interface{})))
+	sNew := make([]string, len(newData.([]interface{})))
+
+	for i, v := range oldData.([]interface{}) {
+		sOld[i] = fmt.Sprint(v)
+	}
+
+	for i, v := range newData.([]interface{}) {
+		sNew[i] = fmt.Sprint(v)
+	}
+
+	return stringSlicesAreEqual(sOld, sNew)
+}
+
+func stringSlicesAreEqual(a []string, b []string) bool {
+	sort.Strings(a)
+	sort.Strings(b)
+
+	return reflect.DeepEqual(a, b)
+}

--- a/internal/tf/suppress/list_test.go
+++ b/internal/tf/suppress/list_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package suppress
+
+import "testing"
+
+func TestStringSlicesAreEqual(t *testing.T) {
+	cases := []struct {
+		Name     string
+		SliceA   []string
+		SliceB   []string
+		Suppress bool
+	}{
+		{
+			Name:     "empty",
+			SliceA:   []string{""},
+			SliceB:   []string{""},
+			Suppress: true,
+		},
+		{
+			Name:     "same",
+			SliceA:   []string{"value1", "value2"},
+			SliceB:   []string{"value1", "value2"},
+			Suppress: true,
+		},
+		{
+			Name:     "different_order",
+			SliceA:   []string{"value1", "value2"},
+			SliceB:   []string{"value2", "value1"},
+			Suppress: true,
+		},
+		{
+			Name:     "different_values",
+			SliceA:   []string{"value1", "value2"},
+			SliceB:   []string{"value1", "value2", "value3"},
+			Suppress: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if stringSlicesAreEqual(tc.SliceA, tc.SliceB) != tc.Suppress {
+				t.Fatalf("Expected stringSlicesAreEqual to return %t for '%q' == '%q'", tc.Suppress, tc.SliceA, tc.SliceB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This changes `azurerm_virtual_network.address_space` from TypeList to TypeSet, because

* The Azure API is ignoring ordering changes to this property (aka endless plan diffs)
* The ordering as no technical effect on the network itself

Fixes #23328