### PR TITLE
Doc: Remove the `update` timeout from the doc of `azurerm_management_lock`

### DIFF
--- a/website/docs/r/management_lock.html.markdown
+++ b/website/docs/r/management_lock.html.markdown
@@ -90,7 +90,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Management Lock.
-* `update` - (Defaults to 30 minutes) Used when updating the Management Lock.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Management Lock.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Management Lock.
 


### PR DESCRIPTION
Fix #23773