### PR TITLE
`azurerm_batch_pool` - fixes accTest `TestAccBatchPool_certificates`

### DIFF
--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -325,8 +325,8 @@ func TestAccBatchPool_certificates(t *testing.T) {
 	r := BatchPoolResource{}
 
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
-	certificate0ID := fmt.Sprintf("/subscriptions/%s/resourceGroups/testaccbatch%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-312d31a79fa0cef49c00f769afc2b73e9f4edf34", subscriptionID, data.RandomInteger, data.RandomString)
-	certificate1ID := fmt.Sprintf("/subscriptions/%s/resourceGroups/testaccbatch%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-42c107874fd0e4a9583292a2f1098e8fe4b2edda", subscriptionID, data.RandomInteger, data.RandomString)
+	certificate0ID := fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestbatch%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-312d31a79fa0cef49c00f769afc2b73e9f4edf34", subscriptionID, data.RandomInteger, data.RandomString)
+	certificate1ID := fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestbatch%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-42c107874fd0e4a9583292a2f1098e8fe4b2edda", subscriptionID, data.RandomInteger, data.RandomString)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{


### PR DESCRIPTION
Fix accTest `TestAccBatchPool_certificates`
- Update `certificate0ID` and  `certificate1ID` to match the resource group name in the tf template.

Testing evidence:
```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccBatchPool_certificates_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/batch #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccBatchPool_certificates_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccBatchPool_certificates\E$ #gosetup
=== RUN   TestAccBatchPool_certificates
=== PAUSE TestAccBatchPool_certificates
=== CONT  TestAccBatchPool_certificates
--- PASS: TestAccBatchPool_certificates (632.36s)
PASS


Process finished with the exit code 0
```