### PR TITLE
CUD method/timeout consistency across code and doc

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -80,11 +80,11 @@ func TestResourcesSupportCustomTimeouts(t *testing.T) {
 			// every Resource has to have a Create, Read & Destroy timeout
 
 			//lint:ignore SA1019 SDKv2 migration  - staticcheck's own linter directives are currently being ignored under golanci-lint
-			if resource.Timeouts.Create == nil && resource.Create != nil { //nolint:staticcheck
-				t.Fatalf("Resource %q defines a Create method but no Create Timeout", resourceName)
+			if (resource.Timeouts.Create == nil) != (resource.Create == nil && resource.CreateContext == nil) { //nolint:staticcheck
+				t.Fatalf("Resource %q should define/not define the Create(Context) method and the Create Timeout at the same time", resourceName)
 			}
-			if resource.Timeouts.Delete == nil && resource.Delete != nil { //nolint:staticcheck
-				t.Fatalf("Resource %q defines a Delete method but no Delete Timeout", resourceName)
+			if (resource.Timeouts.Delete == nil) != (resource.Delete == nil && resource.DeleteContext == nil) { //nolint:staticcheck
+				t.Fatalf("Resource %q should define/not define the Delete(Context) method and the Delete Timeout at the same time", resourceName)
 			}
 			if resource.Timeouts.Read == nil {
 				t.Fatalf("Resource %q doesn't define a Read timeout", resourceName)
@@ -101,8 +101,8 @@ func TestResourcesSupportCustomTimeouts(t *testing.T) {
 			}
 
 			// Optional
-			if resource.Timeouts.Update == nil && resource.Update != nil { //nolint:staticcheck
-				t.Fatalf("Resource %q defines a Update method but no Update Timeout", resourceName)
+			if (resource.Timeouts.Update == nil) != (resource.Update == nil && resource.UpdateContext == nil) { //nolint:staticcheck
+				t.Fatalf("Resource %q should define/not define the Update(Context) method and the Update Timeout at the same time", resourceName)
 			}
 		})
 	}

--- a/internal/services/apimanagement/api_management_gateway_api_resource.go
+++ b/internal/services/apimanagement/api_management_gateway_api_resource.go
@@ -35,7 +35,6 @@ func resourceApiManagementGatewayApi() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/apimanagement/api_management_group_user_resource.go
+++ b/internal/services/apimanagement/api_management_group_user_resource.go
@@ -31,7 +31,6 @@ func resourceApiManagementGroupUser() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/apimanagement/api_management_product_api_resource.go
+++ b/internal/services/apimanagement/api_management_product_api_resource.go
@@ -31,7 +31,6 @@ func resourceApiManagementProductApi() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/apimanagement/api_management_product_group_resource.go
+++ b/internal/services/apimanagement/api_management_product_group_resource.go
@@ -31,7 +31,6 @@ func resourceApiManagementProductGroup() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/apimanagement/api_management_product_tag_resource.go
+++ b/internal/services/apimanagement/api_management_product_tag_resource.go
@@ -32,7 +32,6 @@ func resourceApiManagementProductTag() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/applicationinsights/application_insights_api_key_resource.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource.go
@@ -40,7 +40,6 @@ func resourceApplicationInsightsAPIKey() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -43,7 +43,6 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/automation/automation_job_schedule_resource.go
+++ b/internal/services/automation/automation_job_schedule_resource.go
@@ -35,7 +35,6 @@ func resourceAutomationJobSchedule() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
@@ -25,7 +25,6 @@ func resourceCdnFrontDoorRuleSet() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/compute/marketplace_agreement_resource.go
+++ b/internal/services/compute/marketplace_agreement_resource.go
@@ -20,7 +20,7 @@ import (
 
 func resourceMarketplaceAgreement() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMarketplaceAgreementCreateUpdate,
+		Create: resourceMarketplaceAgreementCreate,
 		Read:   resourceMarketplaceAgreementRead,
 		Delete: resourceMarketplaceAgreementDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -31,7 +31,6 @@ func resourceMarketplaceAgreement() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -70,7 +69,7 @@ func resourceMarketplaceAgreement() *pluginsdk.Resource {
 	}
 }
 
-func resourceMarketplaceAgreementCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMarketplaceAgreementCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.MarketplaceAgreementsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -30,7 +30,6 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
@@ -31,7 +31,6 @@ func resourceDataProtectionBackupPolicyDisk() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource.go
@@ -31,7 +31,6 @@ func resourceDataProtectionBackupPolicyPostgreSQL() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -30,7 +30,6 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociation() *pluginsdk.Res
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/services/domainservices/active_directory_domain_service_replica_set_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_replica_set_resource.go
@@ -32,7 +32,6 @@ func resourceActiveDirectoryDomainServiceReplicaSet() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(3 * time.Hour),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(2 * time.Hour),
 			Delete: pluginsdk.DefaultTimeout(1 * time.Hour),
 		},
 

--- a/internal/services/iothub/iothub_consumer_group_resource.go
+++ b/internal/services/iothub/iothub_consumer_group_resource.go
@@ -40,7 +40,6 @@ func resourceIotHubConsumerGroup() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
@@ -22,7 +22,7 @@ import (
 
 func resourceKustoClusterPrincipalAssignment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceKustoClusterPrincipalAssignmentCreateUpdate,
+		Create: resourceKustoClusterPrincipalAssignmentCreate,
 		Read:   resourceKustoClusterPrincipalAssignmentRead,
 		Delete: resourceKustoClusterPrincipalAssignmentDelete,
 
@@ -39,7 +39,6 @@ func resourceKustoClusterPrincipalAssignment() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -101,7 +100,7 @@ func resourceKustoClusterPrincipalAssignment() *pluginsdk.Resource {
 	}
 }
 
-func resourceKustoClusterPrincipalAssignmentCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceKustoClusterPrincipalAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Kusto.ClusterPrincipalAssignmentsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/internal/services/loganalytics/log_analytics_saved_search_resource.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource.go
@@ -40,7 +40,6 @@ func resourceLogAnalyticsSavedSearch() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
@@ -39,7 +39,6 @@ func resourceAksInferenceCluster() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/mariadb/mariadb_configuration_resource.go
+++ b/internal/services/mariadb/mariadb_configuration_resource.go
@@ -21,7 +21,7 @@ import (
 
 func resourceMariaDbConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMariaDbConfigurationCreateUpdate,
+		Create: resourceMariaDbConfigurationCreate,
 		Read:   resourceMariaDbConfigurationRead,
 		Delete: resourceMariaDbConfigurationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -32,7 +32,6 @@ func resourceMariaDbConfiguration() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -62,7 +61,7 @@ func resourceMariaDbConfiguration() *pluginsdk.Resource {
 	}
 }
 
-func resourceMariaDbConfigurationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMariaDbConfigurationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MariaDB.ConfigurationsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/internal/services/mariadb/mariadb_database_resource.go
+++ b/internal/services/mariadb/mariadb_database_resource.go
@@ -23,7 +23,7 @@ import (
 
 func resourceMariaDbDatabase() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMariaDbDatabaseCreateUpdate,
+		Create: resourceMariaDbDatabaseCreate,
 		Read:   resourceMariaDbDatabaseRead,
 		Delete: resourceMariaDbDatabaseDelete,
 
@@ -35,7 +35,6 @@ func resourceMariaDbDatabase() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -82,7 +81,7 @@ func resourceMariaDbDatabase() *pluginsdk.Resource {
 	}
 }
 
-func resourceMariaDbDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMariaDbDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MariaDB.DatabasesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/internal/services/media/media_live_output_resource.go
+++ b/internal/services/media/media_live_output_resource.go
@@ -34,7 +34,6 @@ func resourceMediaLiveOutput() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/monitor/monitor_private_link_scoped_service_resource.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource.go
@@ -26,14 +26,13 @@ import (
 
 func resourceMonitorPrivateLinkScopedService() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMonitorPrivateLinkScopedServiceCreateUpdate,
+		Create: resourceMonitorPrivateLinkScopedServiceCreate,
 		Read:   resourceMonitorPrivateLinkScopedServiceRead,
 		Delete: resourceMonitorPrivateLinkScopedServiceDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -74,7 +73,7 @@ func resourceMonitorPrivateLinkScopedService() *pluginsdk.Resource {
 	}
 }
 
-func resourceMonitorPrivateLinkScopedServiceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMonitorPrivateLinkScopedServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Monitor.PrivateLinkScopedResourcesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/internal/services/mssql/mssql_outbound_firewall_rule_resource.go
+++ b/internal/services/mssql/mssql_outbound_firewall_rule_resource.go
@@ -22,7 +22,6 @@ func resourceMsSqlOutboundFirewallRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceMsSqlOutboundFirewallRuleCreate,
 		Read:   resourceMsSqlOutboundFirewallRuleRead,
-		// Update: resourceMsSqlOutboundFirewallRuleCreateUpdate,
 		Delete: resourceMsSqlOutboundFirewallRuleDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -33,7 +32,6 @@ func resourceMsSqlOutboundFirewallRule() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/mysql/mysql_configuration_resource.go
+++ b/internal/services/mysql/mysql_configuration_resource.go
@@ -32,7 +32,6 @@ func resourceMySQLConfiguration() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/mysql/mysql_database_resource.go
+++ b/internal/services/mysql/mysql_database_resource.go
@@ -33,7 +33,6 @@ func resourceMySqlDatabase() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/services/mysql/mysql_flexible_database_resource.go
+++ b/internal/services/mysql/mysql_flexible_database_resource.go
@@ -32,7 +32,6 @@ func resourceMySqlFlexibleDatabase() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -30,7 +30,6 @@ func resourceNetAppSnapshot() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {

--- a/internal/services/network/express_route_circuit_authorization_resource.go
+++ b/internal/services/network/express_route_circuit_authorization_resource.go
@@ -31,7 +31,6 @@ func resourceExpressRouteCircuitAuthorization() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/express_route_port_authorization_resource.go
+++ b/internal/services/network/express_route_port_authorization_resource.go
@@ -31,7 +31,6 @@ func resourceExpressRoutePortAuthorization() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -41,7 +41,6 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation() *
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -47,7 +47,6 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *pluginsdk.Re
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_interface_backend_address_pool_association_resource.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource.go
@@ -42,7 +42,6 @@ func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_interface_nat_rule_association_resource.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource.go
@@ -42,7 +42,6 @@ func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_interface_security_group_association_resource.go
+++ b/internal/services/network/network_interface_security_group_association_resource.go
@@ -43,7 +43,6 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/network_packet_capture_resource.go
+++ b/internal/services/network/network_packet_capture_resource.go
@@ -41,7 +41,6 @@ func resourceNetworkPacketCapture() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/subnet_nat_gateway_association_resource.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource.go
@@ -29,7 +29,6 @@ func resourceSubnetNatGatewayAssociation() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -29,7 +29,6 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/network/subnet_route_table_association_resource.go
+++ b/internal/services/network/subnet_route_table_association_resource.go
@@ -28,7 +28,6 @@ func resourceSubnetRouteTableAssociation() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/postgres/postgresql_configuration_resource.go
+++ b/internal/services/postgres/postgresql_configuration_resource.go
@@ -21,7 +21,7 @@ import (
 
 func resourcePostgreSQLConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourcePostgreSQLConfigurationCreateUpdate,
+		Create: resourcePostgreSQLConfigurationCreate,
 		Read:   resourcePostgreSQLConfigurationRead,
 		Delete: resourcePostgreSQLConfigurationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -32,7 +32,6 @@ func resourcePostgreSQLConfiguration() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -61,7 +60,7 @@ func resourcePostgreSQLConfiguration() *pluginsdk.Resource {
 	}
 }
 
-func resourcePostgreSQLConfigurationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourcePostgreSQLConfigurationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Postgres.ConfigurationsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/internal/services/postgres/postgresql_database_resource.go
+++ b/internal/services/postgres/postgresql_database_resource.go
@@ -34,7 +34,6 @@ func resourcePostgreSQLDatabase() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/services/postgres/postgresql_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_firewall_rule_resource.go
@@ -33,7 +33,6 @@ func resourcePostgreSQLFirewallRule() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/postgres/postgresql_flexible_server_aad_administrator_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_aad_administrator_resource.go
@@ -24,7 +24,6 @@ func resourcePostgresqlFlexibleServerAdministrator() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourcePostgresqlFlexibleServerAdministratorCreate,
 		Read:   resourcePostgresqlFlexibleServerAdministratorRead,
-		Update: nil,
 		Delete: resourcePostgresqlFlexibleServerAdministratorDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := administrators.ParseAdministratorID(id)
@@ -34,7 +33,6 @@ func resourcePostgresqlFlexibleServerAdministrator() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/recoveryservices/backup_container_storage_account_resource.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource.go
@@ -27,7 +27,6 @@ func resourceBackupProtectionContainerStorageAccount() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceBackupProtectionContainerStorageAccountCreate,
 		Read:   resourceBackupProtectionContainerStorageAccountRead,
-		Update: nil,
 		Delete: resourceBackupProtectionContainerStorageAccountDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := protectioncontainers.ParseProtectionContainerID(id)
@@ -37,7 +36,6 @@ func resourceBackupProtectionContainerStorageAccount() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -34,7 +34,6 @@ func resourceSiteRecoveryFabric() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
@@ -35,7 +35,6 @@ func resourceSiteRecoveryNetworkMapping() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource.go
@@ -22,7 +22,6 @@ func resourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceSiteRecoveryProtectionContainerCreate,
 		Read:   resourceSiteRecoveryProtectionContainerRead,
-		Update: nil,
 		Delete: resourceSiteRecoveryProtectionContainerDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := replicationprotectioncontainers.ParseReplicationProtectionContainerID(id)
@@ -32,7 +31,6 @@ func resourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/redis/redis_linked_server_resource.go
+++ b/internal/services/redis/redis_linked_server_resource.go
@@ -34,7 +34,6 @@ func resourceRedisLinkedServer() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/services/sql/sql_managed_database_resource.go
+++ b/internal/services/sql/sql_managed_database_resource.go
@@ -24,7 +24,7 @@ import (
 
 func resourceArmSqlManagedDatabase() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmSqlManagedDatabaseCreateUpdate,
+		Create: resourceArmSqlManagedDatabaseCreate,
 		Read:   resourceArmSqlManagedDatabaseRead,
 		Delete: resourceArmSqlManagedDatabaseDelete,
 
@@ -38,7 +38,6 @@ func resourceArmSqlManagedDatabase() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(24 * time.Hour),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(24 * time.Hour),
 			Delete: schema.DefaultTimeout(24 * time.Hour),
 		},
 
@@ -62,7 +61,7 @@ func resourceArmSqlManagedDatabase() *schema.Resource {
 	}
 }
 
-func resourceArmSqlManagedDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmSqlManagedDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Sql.ManagedDatabasesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -35,7 +35,6 @@ func resourceAppServiceCustomHostnameBinding() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/services/web/app_service_public_certificate_resource.go
+++ b/internal/services/web/app_service_public_certificate_resource.go
@@ -34,7 +34,6 @@ func resourceAppServicePublicCertificate() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/web/static_site_custom_domain_resource.go
+++ b/internal/services/web/static_site_custom_domain_resource.go
@@ -27,7 +27,7 @@ const (
 
 func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceStaticSiteCustomDomainCreateOrUpdate,
+		Create: resourceStaticSiteCustomDomainCreate,
 		Read:   resourceStaticSiteCustomDomainRead,
 		Delete: resourceStaticSiteCustomDomainDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -38,7 +38,6 @@ func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -76,7 +75,7 @@ func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 	}
 }
 
-func resourceStaticSiteCustomDomainCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceStaticSiteCustomDomainCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Web.StaticSitesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/website/docs/r/active_directory_domain_service_replica_set.html.markdown
+++ b/website/docs/r/active_directory_domain_service_replica_set.html.markdown
@@ -303,7 +303,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 3 hours) Used when creating the Domain Service.
-* `update` - (Defaults to 2 hours) Used when updating the Domain Service.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Domain Service.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Domain Service.
 

--- a/website/docs/r/api_management_gateway_api.html.markdown
+++ b/website/docs/r/api_management_gateway_api.html.markdown
@@ -56,7 +56,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Gateway API.
 * `read`   - (Defaults to 5 minutes) Used when retrieving the API Management Gateway API.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Gateway API.
 * `delete` - (Defaults to 30 minutes) Used when deleting the API Management Gateway API.
 
 ## Import

--- a/website/docs/r/api_management_group_user.html.markdown
+++ b/website/docs/r/api_management_group_user.html.markdown
@@ -50,7 +50,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Group User.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Group User.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Group User.
 * `delete` - (Defaults to 30 minutes) Used when deleting the API Management Group User.
 

--- a/website/docs/r/api_management_product_api.html.markdown
+++ b/website/docs/r/api_management_product_api.html.markdown
@@ -62,7 +62,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product API.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Product API.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Product API.
 * `delete` - (Defaults to 30 minutes) Used when deleting the API Management Product API.
 

--- a/website/docs/r/api_management_product_group.html.markdown
+++ b/website/docs/r/api_management_product_group.html.markdown
@@ -61,7 +61,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product Group.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Product Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Product Group.
 * `delete` - (Defaults to 30 minutes) Used when deleting the API Management Product Group.
 

--- a/website/docs/r/api_management_product_tag.html.markdown
+++ b/website/docs/r/api_management_product_tag.html.markdown
@@ -75,7 +75,6 @@ The `timeouts` block allows you to
 specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Product.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Product.
 * `delete` - (Defaults to 30 minutes) Used when deleting the API Management Product.
 

--- a/website/docs/r/app_service_custom_hostname_binding.html.markdown
+++ b/website/docs/r/app_service_custom_hostname_binding.html.markdown
@@ -83,7 +83,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Custom Hostname Binding.
-* `update` - (Defaults to 30 minutes) Used when updating the App Service Custom Hostname Binding.
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Custom Hostname Binding.
 * `delete` - (Defaults to 30 minutes) Used when deleting the App Service Custom Hostname Binding.
 

--- a/website/docs/r/app_service_public_certificate.html.markdown
+++ b/website/docs/r/app_service_public_certificate.html.markdown
@@ -73,7 +73,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Public Certificate.
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Public Certificate.
-* `update` - (Defaults to 30 minutes) Used when updating the App Service Public Certificate.
 * `delete` - (Defaults to 30 minutes) Used when deleting the App Service Public Certificate.
 
 ## Import

--- a/website/docs/r/application_insights_api_key.html.markdown
+++ b/website/docs/r/application_insights_api_key.html.markdown
@@ -94,7 +94,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Insights API Key.
-* `update` - (Defaults to 30 minutes) Used when updating the Application Insights API Key.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Application Insights API Key.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Application Insights API Key.
 

--- a/website/docs/r/automation_job_schedule.html.markdown
+++ b/website/docs/r/automation_job_schedule.html.markdown
@@ -59,7 +59,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Job Schedule.
-* `update` - (Defaults to 30 minutes) Used when updating the Automation Job Schedule.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation Job Schedule.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Automation Job Schedule.
 

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -63,7 +63,6 @@ In addition to the arguments above, the following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Backup Storage Account Container.
-* `update` - (Defaults to 30 minutes) Used when updating the Backup Storage Account Container.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Backup Storage Account Container.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Backup Storage Account Container.
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -51,7 +51,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Front Door Rule Set.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Rule Set.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Rule Set.
-* `update` - (Defaults to 30 minutes) Used when updating the Cdn Frontdoor Rule Set.
 
 ## Import
 

--- a/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
@@ -55,7 +55,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Backup Policy Blob Storage.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy Blob Storage.
-* `update` - (Defaults to 30 minutes) Used when updating the Backup Policy Blob Storage.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Backup Policy Blob Storage.
 
 ## Import

--- a/website/docs/r/data_protection_backup_policy_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_disk.html.markdown
@@ -99,7 +99,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Backup Policy Disk.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy Disk.
-* `update` - (Defaults to 30 minutes) Used when updating the Backup Policy Disk.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Backup Policy Disk.
 
 ## Import

--- a/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
@@ -123,7 +123,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Backup Policy PostgreSQL.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy PostgreSQL.
-* `update` - (Defaults to 30 minutes) Used when updating the Backup Policy PostgreSQL.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Backup Policy PostgreSQL.
 
 ## Import

--- a/website/docs/r/express_route_circuit_authorization.html.markdown
+++ b/website/docs/r/express_route_circuit_authorization.html.markdown
@@ -71,7 +71,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ExpressRoute Circuit Authorization.
-* `update` - (Defaults to 30 minutes) Used when updating the ExpressRoute Circuit Authorization.
 * `read` - (Defaults to 5 minutes) Used when retrieving the ExpressRoute Circuit Authorization.
 * `delete` - (Defaults to 30 minutes) Used when deleting the ExpressRoute Circuit Authorization.
 

--- a/website/docs/r/express_route_port_authorization.html.markdown
+++ b/website/docs/r/express_route_port_authorization.html.markdown
@@ -59,7 +59,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ExpressRoute Port Authorization.
-* `update` - (Defaults to 30 minutes) Used when updating the ExpressRoute Port Authorization.
 * `read` - (Defaults to 5 minutes) Used when retrieving the ExpressRoute Port Authorization.
 * `delete` - (Defaults to 30 minutes) Used when deleting the ExpressRoute Port Authorization.
 

--- a/website/docs/r/iothub_consumer_group.html.markdown
+++ b/website/docs/r/iothub_consumer_group.html.markdown
@@ -64,7 +64,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the IotHub Consumer Group.
-* `update` - (Defaults to 30 minutes) Used when updating the IotHub Consumer Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the IotHub Consumer Group.
 * `delete` - (Defaults to 30 minutes) Used when deleting the IotHub Consumer Group.
 

--- a/website/docs/r/kusto_cluster_principal_assignment.html.markdown
+++ b/website/docs/r/kusto_cluster_principal_assignment.html.markdown
@@ -77,7 +77,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 1 hour) Used when creating the Data Explorer Cluster Principal Assignment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Data Explorer Cluster Principal Assignment.
-* `update` - (Defaults to 1 hour) Used when updating the Data Explorer Cluster Principal Assignment.
 * `delete` - (Defaults to 1 hour) Used when deleting the Data Explorer Cluster Principal Assignment.
 
 ## Import

--- a/website/docs/r/log_analytics_saved_search.html.markdown
+++ b/website/docs/r/log_analytics_saved_search.html.markdown
@@ -67,7 +67,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Saved Search.
-* `update` - (Defaults to 30 minutes) Used when updating the Log Analytics Saved Search.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Log Analytics Saved Search.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Log Analytics Saved Search.
 

--- a/website/docs/r/machine_learning_inference_cluster.html.markdown
+++ b/website/docs/r/machine_learning_inference_cluster.html.markdown
@@ -184,7 +184,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Machine Learning Inference Cluster.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Machine Learning Inference Cluster.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Machine Learning Inference Cluster.
-* `update` - (Defaults to 30 minutes) Used when updating the Machine Learning Inference Cluster.
 
 ## Import
 

--- a/website/docs/r/mariadb_configuration.html.markdown
+++ b/website/docs/r/mariadb_configuration.html.markdown
@@ -60,7 +60,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MariaDB Configuration.
-* `update` - (Defaults to 30 minutes) Used when updating the MariaDB Configuration.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MariaDB Configuration.
 * `delete` - (Defaults to 30 minutes) Used when deleting the MariaDB Configuration.
 

--- a/website/docs/r/mariadb_database.html.markdown
+++ b/website/docs/r/mariadb_database.html.markdown
@@ -69,7 +69,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MariaDB Database.
-* `update` - (Defaults to 60 minutes) Used when updating the MariaDB Database.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MariaDB Database.
 * `delete` - (Defaults to 60 minutes) Used when deleting the MariaDB Database.
 

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -41,7 +41,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Marketplace Agreement.
-* `update` - (Defaults to 30 minutes) Used when updating the Marketplace Agreement.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Marketplace Agreement.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Marketplace Agreement.
 

--- a/website/docs/r/media_live_output.html.markdown
+++ b/website/docs/r/media_live_output.html.markdown
@@ -110,7 +110,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Live Output.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Live Output.
-* `update` - (Defaults to 30 minutes) Used when updating the Live Output.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Live Output.
 
 ## Import

--- a/website/docs/r/monitor_private_link_scoped_service.html.markdown
+++ b/website/docs/r/monitor_private_link_scoped_service.html.markdown
@@ -63,7 +63,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Private Link Scope.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Private Link Scope.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Private Link Scope.
-* `update` - (Defaults to 30 minutes) Used when updating the Monitor Private Link Scoped Service.
 
 ## Import
 

--- a/website/docs/r/mssql_outbound_firewall_rule.html.markdown
+++ b/website/docs/r/mssql_outbound_firewall_rule.html.markdown
@@ -54,7 +54,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Outbound Firewall Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the SQL Outbound Firewall Rule.
 * `read` - (Defaults to 5 minutes) Used when retrieving the SQL Outbound Firewall Rule.
 * `delete` - (Defaults to 30 minutes) Used when deleting the SQL Outbound Firewall Rule.
 

--- a/website/docs/r/mysql_configuration.html.markdown
+++ b/website/docs/r/mysql_configuration.html.markdown
@@ -78,7 +78,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MySQL Configuration.
-* `update` - (Defaults to 30 minutes) Used when updating the MySQL Configuration.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MySQL Configuration.
 * `delete` - (Defaults to 30 minutes) Used when deleting the MySQL Configuration.
 

--- a/website/docs/r/mysql_database.html.markdown
+++ b/website/docs/r/mysql_database.html.markdown
@@ -77,7 +77,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MySQL Database.
-* `update` - (Defaults to 60 minutes) Used when updating the MySQL Database.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MySQL Database.
 * `delete` - (Defaults to 60 minutes) Used when deleting the MySQL Database.
 

--- a/website/docs/r/mysql_flexible_database.html.markdown
+++ b/website/docs/r/mysql_flexible_database.html.markdown
@@ -65,7 +65,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MySQL Database.
-* `update` - (Defaults to 60 minutes) Used when updating the MySQL Database.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MySQL Database.
 * `delete` - (Defaults to 60 minutes) Used when deleting the MySQL Database.
 

--- a/website/docs/r/netapp_snapshot.html.markdown
+++ b/website/docs/r/netapp_snapshot.html.markdown
@@ -107,7 +107,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the NetApp Snapshot.
-* `update` - (Defaults to 30 minutes) Used when updating the NetApp Snapshot.
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Snapshot.
 * `delete` - (Defaults to 30 minutes) Used when deleting the NetApp Snapshot.
 

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -152,7 +152,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Application Gateway Backend Address Pool.
-* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Application Gateway Backend Address Pool.
 * `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Application Gateway Backend Address Pool.
 * `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Application Gateway Backend Address Pool.
 

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -76,7 +76,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Application Security Group.
-* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Application Security Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Application Security Group.
 * `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Application Security Group.
 

--- a/website/docs/r/network_interface_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_backend_address_pool_association.html.markdown
@@ -96,7 +96,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Load Balancers Backend Address Pool.
-* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Load Balancers Backend Address Pool.
 * `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Load Balancers Backend Address Pool.
 * `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Load Balancers Backend Address Pool.
 

--- a/website/docs/r/network_interface_nat_rule_association.html.markdown
+++ b/website/docs/r/network_interface_nat_rule_association.html.markdown
@@ -101,7 +101,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Load Balancers NAT Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Load Balancers NAT Rule.
 * `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Load Balancers NAT Rule.
 * `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Load Balancers NAT Rule.
 

--- a/website/docs/r/network_interface_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_security_group_association.html.markdown
@@ -76,7 +76,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Network Security Group.
-* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Network Security Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Network Security Group.
 * `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Network Security Group.
 

--- a/website/docs/r/network_packet_capture.html.markdown
+++ b/website/docs/r/network_packet_capture.html.markdown
@@ -185,7 +185,6 @@ A `storage_location` block contains:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Packet Capture.
-* `update` - (Defaults to 30 minutes) Used when updating the Packet Capture.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Packet Capture.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Packet Capture.
 

--- a/website/docs/r/postgresql_configuration.html.markdown
+++ b/website/docs/r/postgresql_configuration.html.markdown
@@ -71,7 +71,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Configuration.
-* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Configuration.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Configuration.
 * `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Configuration.
 

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -70,7 +70,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the PostgreSQL Database.
-* `update` - (Defaults to 60 minutes) Used when updating the PostgreSQL Database.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Database.
 * `delete` - (Defaults to 60 minutes) Used when deleting the PostgreSQL Database.
 

--- a/website/docs/r/postgresql_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_firewall_rule.html.markdown
@@ -84,7 +84,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Firewall Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Firewall Rule.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Firewall Rule.
 * `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Firewall Rule.
 

--- a/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
@@ -79,7 +79,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Flexible Server Active Directory Administrator.
-* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Flexible Server Active Directory Administrator.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Flexible Server Active Directory Administrator.
 * `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Flexible Server Active Directory Administrator.
 

--- a/website/docs/r/redis_linked_server.html.markdown
+++ b/website/docs/r/redis_linked_server.html.markdown
@@ -92,7 +92,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 60 minutes) Used when creating the Redis.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis.
-* `update` - (Defaults to 60 minutes) Used when updating the Redis.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Redis.
 
 ## Import

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -170,7 +170,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Role Assignment.
-* `update` - (Defaults to 30 minutes) Used when updating the Role Assignment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Role Assignment.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Role Assignment.
 

--- a/website/docs/r/site_recovery_fabric.html.markdown
+++ b/website/docs/r/site_recovery_fabric.html.markdown
@@ -61,7 +61,6 @@ In addition to the arguments above, the following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Fabric.
-* `update` - (Defaults to 30 minutes) Used when updating the Site Recovery Fabric.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Site Recovery Fabric.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Site Recovery Fabric.
 

--- a/website/docs/r/site_recovery_network_mapping.html.markdown
+++ b/website/docs/r/site_recovery_network_mapping.html.markdown
@@ -99,7 +99,6 @@ In addition to the arguments above, the following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Network Mapping.
-* `update` - (Defaults to 30 minutes) Used when updating the Site Recovery Network Mapping.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Site Recovery Network Mapping.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Site Recovery Network Mapping.
 

--- a/website/docs/r/site_recovery_protection_container.html.markdown
+++ b/website/docs/r/site_recovery_protection_container.html.markdown
@@ -68,7 +68,6 @@ In addition to the arguments above, the following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Protection Container.
-* `update` - (Defaults to 30 minutes) Used when updating the Site Recovery Protection Container.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Site Recovery Protection Container.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Site Recovery Protection Container.
 

--- a/website/docs/r/sql_managed_database.html.markdown
+++ b/website/docs/r/sql_managed_database.html.markdown
@@ -76,7 +76,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Sql Managed Database.
 * `create` - (Defaults to 24 hours) Used when creating the Sql Managed Database.
-* `update` - (Defaults to 24 hours) Used when updating the Sql Managed Database.
 * `delete` - (Defaults to 24 hours) Used when deleting the Sql Managed Database.
 
 ## Import

--- a/website/docs/r/static_site_custom_domain.html.markdown
+++ b/website/docs/r/static_site_custom_domain.html.markdown
@@ -98,7 +98,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Static Site Custom Domain.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Static Site Custom Domain.
-* `update` - (Defaults to 30 minutes) Used when updating the Static Site Custom Domain.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Static Site Custom Domain.
 
 ## Import

--- a/website/docs/r/subnet_nat_gateway_association.html.markdown
+++ b/website/docs/r/subnet_nat_gateway_association.html.markdown
@@ -63,7 +63,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet NAT Gateway Association.
-* `update` - (Defaults to 30 minutes) Used when updating the Subnet NAT Gateway Association.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Subnet NAT Gateway Association.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Subnet NAT Gateway Association.
 

--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -76,7 +76,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet Network Security Group Association.
-* `update` - (Defaults to 30 minutes) Used when updating the Subnet Network Security Group Association.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Subnet Network Security Group Association.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Subnet Network Security Group Association.
 

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -71,7 +71,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet Route Table Association.
-* `update` - (Defaults to 30 minutes) Used when updating the Subnet Route Table Association.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Subnet Route Table Association.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Subnet Route Table Association.
 

--- a/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
@@ -69,7 +69,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Virtual Desktop Workspace.
-* `update` - (Defaults to 60 minutes) Used when updating the Virtual Desktop Workspace.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Desktop Workspace.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Virtual Desktop Workspace.
 


### PR DESCRIPTION
This PR improves `TestResourcesSupportCustomTimeouts` to not only check that when the method of an operation is defined, the timeout of that operation must have been defined, but also check the reverse side that when a method of an operation is not defined, the timeout of that operation must not be defined.

After updating the test, this PR fixes all the violations, together with updating its document.

Related to: #23773