### PR TITLE
`azurerm_container_app_environment` Document - Update document for `internal_load_balancer_enabled` attribute

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -101,7 +101,7 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 			ForceNew:     true,
 			Default:      false,
 			RequiredWith: []string{"infrastructure_subnet_id"},
-			Description:  "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified.",
+			Description:  "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set if `infrastructure_subnet_id` is specified.",
 		},
 
 		"zone_redundancy_enabled": {

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 ~> **NOTE:** The Subnet must have a `/21` or larger address space. 
 
-* `internal_load_balancer_enabled` - (Optional) Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. Changing this forces a new resource to be created.
+* `internal_load_balancer_enabled` - (Optional) Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. Can only be set if `infrastructure_subnet_id` is specified. Changing this forces a new resource to be created.
 
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
 


### PR DESCRIPTION
The original description `can only be set to true if infrastructure_subnet_id is specified.` is incorrect, once this attribute is set explicitly even to `false` without `infrastructure_subnet_id`, you'll get an error.