### PR TITLE
`azurerm_storage_account`: Plan time name validation

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	azautorest "github.com/Azure/go-autorest/autorest"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -1030,6 +1031,25 @@ func resourceStorageAccount() *pluginsdk.Resource {
 		},
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				client := v.(*clients.Client).Storage.AccountsClient
+				// The `name` only changes for the new resource creation scenario, in which case we will further check the name availability.
+				if d.HasChange("name") {
+					_, name := d.GetChange("name")
+					resp, err := client.CheckNameAvailability(ctx, storage.AccountCheckNameAvailabilityParameters{
+						Name: pointer.To(name.(string)),
+						Type: pointer.To("Microsoft.Storage/storageAccounts"),
+					})
+					if err != nil {
+						return err
+					}
+					if ok := resp.NameAvailable; ok != nil && !(*ok) {
+						errmsg := fmt.Sprintf("`name` is not available: [%s]", resp.Reason)
+						if msg := resp.Message; msg != nil {
+							errmsg += " " + *msg
+						}
+						return fmt.Errorf(errmsg)
+					}
+				}
 				if d.HasChange("account_kind") {
 					accountKind, changedKind := d.GetChange("account_kind")
 


### PR DESCRIPTION
This PR extends the customizediff for the `azurerm_storage_account` resource to check the `name` availability for the new resource creation scenario. This makes users to fail fast during the plan stage (actually post-plan customize diff stage) if the `name` is already taken by another storage account.

The example run for the above case is illustrated below:

```shell
storage/account/basic via 💠 default
💤  tf plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /home/magodo/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform planned the following actions, but then encountered a problem:

  # azurerm_resource_group.test will be created
  + resource "azurerm_resource_group" "test" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "acctestRG-storage-mgdtest"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Error: 1 error occurred:
│       * `name` is not available: [AlreadyExists] The storage account named acctestsatsiuipii is already taken.
│
│
│
│   with azurerm_storage_account.test,
│   on main.tf line 14, in resource "azurerm_storage_account" "test":
│   14: resource "azurerm_storage_account" "test" {
│
╵
```

## Test

Ensure this doesn't affect the happy path:

```shell
terraform-provider-azurerm on  storage_account_name_check via 🐹 v1.21.1
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_basic$'
=== RUN   TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== CONT  TestAccStorageAccount_basic
--- PASS: TestAccStorageAccount_basic (263.06s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       263.070s
```