### PR TITLE
`azurerm_recovery_services_vault` - support direct creation with immutability `locked`

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -180,10 +180,7 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 				return old.(bool) && !new.(bool)
 			}),
 			pluginsdk.ForceNewIfChange("immutability", func(ctx context.Context, old, new, meta interface{}) bool {
-				if old.(string) != new.(string) && old.(string) == string(vaults.ImmutabilityStateLocked) {
-					return true
-				}
-				return false
+				return old.(string) == string(vaults.ImmutabilityStateLocked)
 			}),
 		),
 	}
@@ -260,7 +257,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		Properties: &vaults.VaultProperties{},
 	}
 	if immutability, ok := d.GetOk("immutability"); ok {
-		// The API doesn't allow to set the immutability to "Locked" on ceartion.
+		// The API doesn't allow to set the immutability to "Locked" on creation.
 		// Here we firstly make it "Unlocked", and once created, we will update it to "Locked".
 		// Note: The `immutability` could be transitioned only in the limited directions.
 		// Locked <- Unlocked <-> Disabled

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -201,8 +201,23 @@ func TestAccRecoveryServicesVault_immutabilityLocked(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.basicWithImmutability(data, "Disabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithImmutability(data, "Locked"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
+
 func TestAccRecoveryServicesVault_immutability(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
 	r := RecoveryServicesVaultResource{}
@@ -724,7 +739,6 @@ resource "azurerm_recovery_services_vault" "test" {
 }
 
 func (RecoveryServicesVaultResource) basicWithImmutability(data acceptance.TestData, immutability string) string {
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1210,7 +1224,6 @@ resource "azurerm_recovery_services_vault" "test" {
 }
 
 func (RecoveryServicesVaultResource) crossRegionRestoreEnabledWithEncryption(data acceptance.TestData) string {
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -188,13 +188,28 @@ func TestAccRecoveryServicesVault_UserAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccRecoveryServicesVault_immutabilityLocked(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// To test creation with `Locked`, it is irreversible.
+			Config: r.basicWithImmutability(data, "Locked"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
 func TestAccRecoveryServicesVault_immutability(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
 	r := RecoveryServicesVaultResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicWithImmutability(data, true),
+			Config: r.basicWithImmutability(data, "Unlocked"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -208,7 +223,21 @@ func TestAccRecoveryServicesVault_immutability(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basicWithImmutability(data, false),
+			Config: r.basicWithImmutability(data, "Disabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithImmutability(data, "Unlocked"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithImmutability(data, "Locked"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -694,11 +723,7 @@ resource "azurerm_recovery_services_vault" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (RecoveryServicesVaultResource) basicWithImmutability(data acceptance.TestData, enabled bool) string {
-	immutability := `Disabled`
-	if enabled {
-		immutability = `Unlocked`
-	}
+func (RecoveryServicesVaultResource) basicWithImmutability(data acceptance.TestData, immutability string) string {
 
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `immutability` - (Optional) Immutability Settings of vault, possible values include: `Locked`, `Unlocked` and `Disabled`.
 
+-> **Note:** Once `immutability` is set to `Locked`, changing it to other values forces a new Recovery Services Vault to be created.
+
 * `storage_mode_type` - (Optional) The storage type of the Recovery Services Vault. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Defaults to `GeoRedundant`.
 
 * `cross_region_restore_enabled` - (Optional) Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`.


### PR DESCRIPTION
fix #23792

test
---
```
❯ tftest recoveryservices TestAccRecoveryServicesVault   
=== RUN   TestAccRecoveryServicesVault_basic
=== PAUSE TestAccRecoveryServicesVault_basic
=== RUN   TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== RUN   TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== PAUSE TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== RUN   TestAccRecoveryServicesVault_zrs
=== PAUSE TestAccRecoveryServicesVault_zrs
=== RUN   TestAccRecoveryServicesVault_complete
=== PAUSE TestAccRecoveryServicesVault_complete
=== RUN   TestAccRecoveryServicesVault_update
=== PAUSE TestAccRecoveryServicesVault_update
=== RUN   TestAccRecoveryServicesVault_requiresImport
=== PAUSE TestAccRecoveryServicesVault_requiresImport
=== RUN   TestAccRecoveryServicesVault_SystemAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_SystemAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_UserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_UserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_immutabilityLocked
=== PAUSE TestAccRecoveryServicesVault_immutabilityLocked
=== RUN   TestAccRecoveryServicesVault_immutability
=== PAUSE TestAccRecoveryServicesVault_immutability
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== RUN   TestAccRecoveryServicesVault_storageModeType
=== PAUSE TestAccRecoveryServicesVault_storageModeType
=== RUN   TestAccRecoveryServicesVault_crossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_crossRegionRestore
=== RUN   TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== PAUSE TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== RUN   TestAccRecoveryServicesVault_sku
=== PAUSE TestAccRecoveryServicesVault_sku
=== RUN   TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== PAUSE TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== RUN   TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== PAUSE TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== RUN   TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== PAUSE TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== PAUSE TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== CONT  TestAccRecoveryServicesVault_basic
=== CONT  TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== CONT  TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== CONT  TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_SystemAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_softDelete
=== CONT  TestAccRecoveryServicesVault_zrs
=== CONT  TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
--- PASS: TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType (132.82s)
=== CONT  TestAccRecoveryServicesVault_ToggleCrossRegionRestore
--- PASS: TestAccRecoveryServicesVault_basic (255.30s)
=== CONT  TestAccRecoveryServicesVault_requiresImport
--- PASS: TestAccRecoveryServicesVault_zrs (280.71s)
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
--- PASS: TestAccRecoveryServicesVault_SystemAssignedIdentity (286.99s)
=== CONT  TestAccRecoveryServicesVault_basicWithMonitorDisabled
--- PASS: TestAccRecoveryServicesVault_requiresImport (257.37s)
=== CONT  TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
--- PASS: TestAccRecoveryServicesVault_basicWithMonitorDisabled (255.03s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_ToggleCrossRegionRestore (492.08s)
=== CONT  TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption (649.56s)
=== CONT  TestAccRecoveryServicesVault_crossRegionRestore
--- PASS: TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption (656.41s)
=== CONT  TestAccRecoveryServicesVault_storageModeType
--- PASS: TestAccRecoveryServicesVault_softDelete (688.61s)
=== CONT  TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled (203.48s)
=== CONT  TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey (723.78s)
=== CONT  TestAccRecoveryServicesVault_immutabilityLocked
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (551.85s)
=== CONT  TestAccRecoveryServicesVault_immutability
--- PASS: TestAccRecoveryServicesVault_crossRegionRestore (354.93s)
=== CONT  TestAccRecoveryServicesVault_UserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_storageModeType (350.29s)
=== CONT  TestAccRecoveryServicesVault_update
--- PASS: TestAccRecoveryServicesVault_immutabilityLocked (310.72s)
=== CONT  TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
--- PASS: TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity (639.19s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage (632.93s)
=== CONT  TestAccRecoveryServicesVault_sku
--- PASS: TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey (698.02s)
=== CONT  TestAccRecoveryServicesVault_complete
--- PASS: TestAccRecoveryServicesVault_UserAssignedIdentity (332.40s)
--- PASS: TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage (640.67s)
--- PASS: TestAccRecoveryServicesVault_update (468.28s)
--- PASS: TestAccRecoveryServicesVault_complete (249.32s)
--- PASS: TestAccRecoveryServicesVault_immutability (742.50s)
--- PASS: TestAccRecoveryServicesVault_updateSkuWithExistingEncryption (575.72s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithKeyVaultKey (555.78s)
--- PASS: TestAccRecoveryServicesVault_sku (772.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices	2094.502s
```