### PR TITLE
provider: support for the postgresql_flexible_server.restart_server_on_configuration_value_change property

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -56,5 +56,8 @@ func Default() UserFeatures {
 		Subscription: SubscriptionFeatures{
 			PreventCancellationOnDestroy: false,
 		},
+		PostgresqlFlexibleServer: PostgresqlFlexibleServerFeatures{
+			RestartServerOnConfigurationValueChange: true,
+		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -4,18 +4,19 @@
 package features
 
 type UserFeatures struct {
-	ApiManagement          ApiManagementFeatures
-	AppConfiguration       AppConfigurationFeatures
-	ApplicationInsights    ApplicationInsightFeatures
-	CognitiveAccount       CognitiveAccountFeatures
-	VirtualMachine         VirtualMachineFeatures
-	VirtualMachineScaleSet VirtualMachineScaleSetFeatures
-	KeyVault               KeyVaultFeatures
-	TemplateDeployment     TemplateDeploymentFeatures
-	LogAnalyticsWorkspace  LogAnalyticsWorkspaceFeatures
-	ResourceGroup          ResourceGroupFeatures
-	ManagedDisk            ManagedDiskFeatures
-	Subscription           SubscriptionFeatures
+	ApiManagement            ApiManagementFeatures
+	AppConfiguration         AppConfigurationFeatures
+	ApplicationInsights      ApplicationInsightFeatures
+	CognitiveAccount         CognitiveAccountFeatures
+	VirtualMachine           VirtualMachineFeatures
+	VirtualMachineScaleSet   VirtualMachineScaleSetFeatures
+	KeyVault                 KeyVaultFeatures
+	TemplateDeployment       TemplateDeploymentFeatures
+	LogAnalyticsWorkspace    LogAnalyticsWorkspaceFeatures
+	ResourceGroup            ResourceGroupFeatures
+	ManagedDisk              ManagedDiskFeatures
+	Subscription             SubscriptionFeatures
+	PostgresqlFlexibleServer PostgresqlFlexibleServerFeatures
 }
 
 type CognitiveAccountFeatures struct {
@@ -78,4 +79,8 @@ type AppConfigurationFeatures struct {
 
 type SubscriptionFeatures struct {
 	PreventCancellationOnDestroy bool
+}
+
+type PostgresqlFlexibleServerFeatures struct {
+	RestartServerOnConfigurationValueChange bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -284,6 +284,21 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 				},
 			},
 		},
+
+		"postgresql_flexible_server": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"restart_server_on_configuration_value_change": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+				},
+			},
+		},
 	}
 
 	// this is a temporary hack to enable us to gradually add provider blocks to test configurations
@@ -477,6 +492,16 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			subscriptionRaw := items[0].(map[string]interface{})
 			if v, ok := subscriptionRaw["prevent_cancellation_on_destroy"]; ok {
 				featuresMap.Subscription.PreventCancellationOnDestroy = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["postgresql_flexible_server"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			subscriptionRaw := items[0].(map[string]interface{})
+			if v, ok := subscriptionRaw["restart_server_on_configuration_value_change"]; ok {
+				featuresMap.PostgresqlFlexibleServer.RestartServerOnConfigurationValueChange = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -71,6 +71,9 @@ func TestExpandFeatures(t *testing.T) {
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: false,
 				},
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: true,
+				},
 			},
 		},
 		{
@@ -120,6 +123,11 @@ func TestExpandFeatures(t *testing.T) {
 					"managed_disk": []interface{}{
 						map[string]interface{}{
 							"expand_without_downtime": true,
+						},
+					},
+					"postgresql_flexible_server": []interface{}{
+						map[string]interface{}{
+							"restart_server_on_configuration_value_change": true,
 						},
 					},
 					"resource_group": []interface{}{
@@ -204,6 +212,9 @@ func TestExpandFeatures(t *testing.T) {
 					ForceDelete:               true,
 					ScaleToZeroOnDelete:       true,
 				},
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: true,
+				},
 			},
 		},
 		{
@@ -253,6 +264,11 @@ func TestExpandFeatures(t *testing.T) {
 					"managed_disk": []interface{}{
 						map[string]interface{}{
 							"expand_without_downtime": false,
+						},
+					},
+					"postgresql_flexible_server": []interface{}{
+						map[string]interface{}{
+							"restart_server_on_configuration_value_change": false,
 						},
 					},
 					"resource_group": []interface{}{
@@ -336,6 +352,9 @@ func TestExpandFeatures(t *testing.T) {
 					ForceDelete:               false,
 					RollInstancesWhenRequired: false,
 					ScaleToZeroOnDelete:       false,
+				},
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: false,
 				},
 			},
 		},
@@ -1250,6 +1269,71 @@ func TestExpandFeaturesSubscription(t *testing.T) {
 			Expected: features.UserFeatures{
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: true,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.Subscription, testCase.Expected.Subscription) {
+			t.Fatalf("Expected %+v but got %+v", result.Subscription, testCase.Expected.Subscription)
+		}
+	}
+}
+
+func TestExpandFeaturesPosgresqlFlexibleServer(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: true,
+				},
+			},
+		},
+		{
+			Name: "Postgresql Flexible Server restarts on configuration change is Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server": []interface{}{
+						map[string]interface{}{
+							"restart_server_on_configuration_value_change": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: true,
+				},
+			},
+		},
+		{
+			Name: "Postgresql Flexible Server restarts on configuration change is Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server": []interface{}{
+						map[string]interface{}{
+							"restart_server_on_configuration_value_change": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
+					RestartServerOnConfigurationValueChange: false,
 				},
 			},
 		},

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -1256,7 +1256,7 @@ func TestExpandFeaturesSubscription(t *testing.T) {
 			},
 		},
 		{
-			Name: "No Downtime Resize Enabled",
+			Name: "Subscription cancellation on destroy is Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"subscription": []interface{}{

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -100,11 +100,13 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 
 		if isDynamicConfig := props.IsDynamicConfig; isDynamicConfig != nil && !*isDynamicConfig {
 			if isReadOnly := props.IsReadOnly; isReadOnly != nil && !*isReadOnly {
-				restartClient := meta.(*clients.Client).Postgres.ServerRestartClient
-				restartServerId := serverrestart.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName)
+				if meta.(*clients.Client).Features.PostgresqlFlexibleServer.RestartServerOnConfigurationValueChange {
+					restartClient := meta.(*clients.Client).Postgres.ServerRestartClient
+					restartServerId := serverrestart.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName)
 
-				if err = restartClient.ServersRestartThenPoll(ctx, restartServerId, serverrestart.RestartParameter{}); err != nil {
-					return fmt.Errorf("restarting server %s: %+v", id, err)
+					if err = restartClient.ServersRestartThenPoll(ctx, restartServerId, serverrestart.RestartParameter{}); err != nil {
+						return fmt.Errorf("restarting server %s: %+v", id, err)
+					}
 				}
 			}
 		}
@@ -186,11 +188,13 @@ func resourceFlexibleServerConfigurationDelete(d *pluginsdk.ResourceData, meta i
 
 		if isDynamicConfig := props.IsDynamicConfig; isDynamicConfig != nil && !*isDynamicConfig {
 			if isReadOnly := props.IsReadOnly; isReadOnly != nil && !*isReadOnly {
-				restartClient := meta.(*clients.Client).Postgres.ServerRestartClient
-				restartServerId := serverrestart.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName)
+				if meta.(*clients.Client).Features.PostgresqlFlexibleServer.RestartServerOnConfigurationValueChange {
+					restartClient := meta.(*clients.Client).Postgres.ServerRestartClient
+					restartServerId := serverrestart.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName)
 
-				if err = restartClient.ServersRestartThenPoll(ctx, restartServerId, serverrestart.RestartParameter{}); err != nil {
-					return fmt.Errorf("restarting server %s: %+v", id, err)
+					if err = restartClient.ServersRestartThenPoll(ctx, restartServerId, serverrestart.RestartParameter{}); err != nil {
+						return fmt.Errorf("restarting server %s: %+v", id, err)
+					}
 				}
 			}
 		}

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -314,18 +314,18 @@ resource "azurerm_postgresql_flexible_server_configuration" "test5" {
 
 func (r PostgresqlFlexibleServerConfigurationResource) withDisabledServerRestarts(data acceptance.TestData, name, value string) string {
 	return fmt.Sprintf(`
-	provider "azurerm" {
-		features {
-			postgresql_flexible_server {
-				restart_server_on_configuration_value_change = false
-			}
+provider "azurerm" {
+	features {
+		postgresql_flexible_server {
+			restart_server_on_configuration_value_change = false
 		}
 	}
-	
-	resource "azurerm_resource_group" "test" {
-		name     = "acctestRG-postgresql-%d"
-		location = "%s"
-	}
+}
+
+resource "azurerm_resource_group" "test" {
+	name     = "acctestRG-postgresql-%d"
+	location = "%s"
+}
 
 resource "azurerm_postgresql_flexible_server" "test" {
   name                   = "acctest-fs-%d"

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -315,16 +315,16 @@ resource "azurerm_postgresql_flexible_server_configuration" "test5" {
 func (r PostgresqlFlexibleServerConfigurationResource) withDisabledServerRestarts(data acceptance.TestData, name, value string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-	features {
-		postgresql_flexible_server {
-			restart_server_on_configuration_value_change = false
-		}
-	}
+  features {
+    postgresql_flexible_server {
+      restart_server_on_configuration_value_change = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {
-	name     = "acctestRG-postgresql-%d"
-	location = "%s"
+  name     = "acctestRG-postgresql-%d"
+  location = "%s"
 }
 
 resource "azurerm_postgresql_flexible_server" "test" {

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -58,6 +58,10 @@ provider "azurerm" {
       expand_without_downtime = true
     }
 
+    postgresql_flexible_server {
+      restart_server_on_configuration_value_change = true
+    }
+
     resource_group {
       prevent_deletion_if_contains_resources = true
     }
@@ -180,6 +184,12 @@ The `managed_disk` block supports the following:
 * `expand_without_downtime` - (Optional) Specifies whether Managed Disks which can be Expanded without Downtime (on either [a Linux VM](https://learn.microsoft.com/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) [or a Windows VM](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime)) should be expanded without restarting the associated Virtual Machine. Defaults to `true`.
 
 ~> **Note:** Expand Without Downtime requires a specific configuration for the Managed Disk and Virtual Machine - Terraform will use Expand Without Downtime when the Managed Disk and Virtual Machine meet these requirements, and shut the Virtual Machine down as needed if this is inapplicable. More information on when Expand Without Downtime is applicable can be found in the [Linux VM](https://learn.microsoft.com/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) [or Windows VM](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime) documentation.
+
+---
+
+The `postgresql_flexible_server` block supports the following:
+
+* `restart_server_on_configuration_value_change` - (Optional) Should the `postgresql_flexible_server` restart after static server parameter change or removal? Defaults to `true`.
 
 ---
 

--- a/website/docs/r/postgresql_flexible_server_configuration.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Sets a PostgreSQL Configuration value on a Azure PostgreSQL Flexible Server.
 
+~> **Note:** Changes to static server parameters will automatically trigger Azure Flex Server restart. This behavior can be disabled in the provider `features` block by setting the `restart_server_on_configuration_value_change` field to `false` within the `postgresql_flexible_server` block.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Adding new azurerm provider feature `postgresql_flexible_server.restart_server_on_configuration_value_change` that allows to opt out from Azure Postgres Flex Server restarts on each static parameter change.

By default, the feature is set to `true`, which is compatible with current azurerm provider behaviour.

The Pull Request also
- includes server-restart check to existing acceptance test, and adds a new acceptance test to cover the scenario when the server-restarts are disabled.
- extends `checkReset` function to support different types of checks, then I reused it for pending-restart property verification.

I executed all Postgres Flex Server Configuration tests in my sandbox subscription via `make acctests SERVICE='postgres' TESTARGS='-run=TestAccFlexibleServerConfiguration_' TESTTIMEOUT='60m'`

Example code to disable postgres flex server restarts:
```
provider "azurerm" {
  features {
    postgresql_flexible_server {
      restart_server_on_configuration_value_change = false
    }
  }
}
```

This PR fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22257