### PR TITLE
`azurerm_gallery_application_version` - Support `config_file_name`, `package_file_name` and `target_region.exclude_from_latest`

### DIFF
--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -568,7 +568,7 @@ func flattenGalleryApplicationVersionTargetRegion(input *[]galleryapplicationver
 		}
 
 		if item.ExcludeFromLatest != nil {
-			obj.ExcludeFromLatest = bool(*item.ExcludeFromLatest)
+			obj.ExcludeFromLatest = *item.ExcludeFromLatest
 		}
 
 		if item.RegionalReplicaCount != nil {

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -33,12 +33,12 @@ type GalleryApplicationVersionModel struct {
 	Name                 string            `tfschema:"name"`
 	GalleryApplicationId string            `tfschema:"gallery_application_id"`
 	Location             string            `tfschema:"location"`
-	ConfigFileName       string            `tfschema:"config_file_name"`
+	ConfigFile           string            `tfschema:"config_file"`
 	EnableHealthCheck    bool              `tfschema:"enable_health_check"`
 	EndOfLifeDate        string            `tfschema:"end_of_life_date"`
 	ExcludeFromLatest    bool              `tfschema:"exclude_from_latest"`
 	ManageAction         []ManageAction    `tfschema:"manage_action"`
-	PackageFileName      string            `tfschema:"package_file_name"`
+	PackageFile          string            `tfschema:"package_file"`
 	Source               []Source          `tfschema:"source"`
 	TargetRegion         []TargetRegion    `tfschema:"target_region"`
 	Tags                 map[string]string `tfschema:"tags"`
@@ -80,7 +80,7 @@ func (r GalleryApplicationVersionResource) Arguments() map[string]*pluginsdk.Sch
 
 		"location": commonschema.Location(),
 
-		"config_file_name": {
+		"config_file": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
@@ -136,7 +136,7 @@ func (r GalleryApplicationVersionResource) Arguments() map[string]*pluginsdk.Sch
 			},
 		},
 
-		"package_file_name": {
+		"package_file": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
@@ -259,12 +259,12 @@ func (r GalleryApplicationVersionResource) Create() sdk.ResourceFunc {
 				Tags: pointer.To(state.Tags),
 			}
 
-			if state.ConfigFileName != "" {
+			if state.ConfigFile != "" {
 				if payload.Properties.PublishingProfile.Settings == nil {
 					payload.Properties.PublishingProfile.Settings = &galleryapplicationversions.UserArtifactSettings{}
 				}
 
-				payload.Properties.PublishingProfile.Settings.ConfigFileName = &state.ConfigFileName
+				payload.Properties.PublishingProfile.Settings.ConfigFileName = &state.ConfigFile
 			}
 
 			if state.EndOfLifeDate != "" {
@@ -272,12 +272,12 @@ func (r GalleryApplicationVersionResource) Create() sdk.ResourceFunc {
 				payload.Properties.PublishingProfile.SetEndOfLifeDateAsTime(endOfLifeDate)
 			}
 
-			if state.PackageFileName != "" {
+			if state.PackageFile != "" {
 				if payload.Properties.PublishingProfile.Settings == nil {
 					payload.Properties.PublishingProfile.Settings = &galleryapplicationversions.UserArtifactSettings{}
 				}
 
-				payload.Properties.PublishingProfile.Settings.PackageFileName = &state.PackageFileName
+				payload.Properties.PublishingProfile.Settings.PackageFileName = &state.PackageFile
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
@@ -340,11 +340,11 @@ func (r GalleryApplicationVersionResource) Read() sdk.ResourceFunc {
 					}
 					state.ExcludeFromLatest = excludeFromLatest
 
-					state.ConfigFileName = ""
-					state.PackageFileName = ""
+					state.ConfigFile = ""
+					state.PackageFile = ""
 					if props.PublishingProfile.Settings != nil {
-						state.ConfigFileName = pointer.From(props.PublishingProfile.Settings.ConfigFileName)
-						state.PackageFileName = pointer.From(props.PublishingProfile.Settings.PackageFileName)
+						state.ConfigFile = pointer.From(props.PublishingProfile.Settings.ConfigFileName)
+						state.PackageFile = pointer.From(props.PublishingProfile.Settings.PackageFileName)
 					}
 
 					state.ManageAction = flattenGalleryApplicationVersionManageAction(props.PublishingProfile.ManageActions)

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -33,10 +33,12 @@ type GalleryApplicationVersionModel struct {
 	Name                 string            `tfschema:"name"`
 	GalleryApplicationId string            `tfschema:"gallery_application_id"`
 	Location             string            `tfschema:"location"`
+	ConfigFileName       string            `tfschema:"config_file_name"`
 	EnableHealthCheck    bool              `tfschema:"enable_health_check"`
 	EndOfLifeDate        string            `tfschema:"end_of_life_date"`
 	ExcludeFromLatest    bool              `tfschema:"exclude_from_latest"`
 	ManageAction         []ManageAction    `tfschema:"manage_action"`
+	PackageFileName      string            `tfschema:"package_file_name"`
 	Source               []Source          `tfschema:"source"`
 	TargetRegion         []TargetRegion    `tfschema:"target_region"`
 	Tags                 map[string]string `tfschema:"tags"`
@@ -56,6 +58,7 @@ type ManageAction struct {
 type TargetRegion struct {
 	Name                 string `tfschema:"name"`
 	RegionalReplicaCount int    `tfschema:"regional_replica_count"`
+	ExcludeFromLatest    bool   `tfschema:"exclude_from_latest"`
 	StorageAccountType   string `tfschema:"storage_account_type"`
 }
 
@@ -76,6 +79,13 @@ func (r GalleryApplicationVersionResource) Arguments() map[string]*pluginsdk.Sch
 		},
 
 		"location": commonschema.Location(),
+
+		"config_file_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
 
 		"enable_health_check": {
 			Type:     pluginsdk.TypeBool,
@@ -126,6 +136,13 @@ func (r GalleryApplicationVersionResource) Arguments() map[string]*pluginsdk.Sch
 			},
 		},
 
+		"package_file_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
 		"source": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
@@ -162,6 +179,12 @@ func (r GalleryApplicationVersionResource) Arguments() map[string]*pluginsdk.Sch
 						Type:         pluginsdk.TypeInt,
 						Required:     true,
 						ValidateFunc: validation.IntBetween(1, 10),
+					},
+
+					"exclude_from_latest": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
 					},
 
 					"storage_account_type": {
@@ -236,9 +259,25 @@ func (r GalleryApplicationVersionResource) Create() sdk.ResourceFunc {
 				Tags: pointer.To(state.Tags),
 			}
 
+			if state.ConfigFileName != "" {
+				if payload.Properties.PublishingProfile.Settings == nil {
+					payload.Properties.PublishingProfile.Settings = &galleryapplicationversions.UserArtifactSettings{}
+				}
+
+				payload.Properties.PublishingProfile.Settings.ConfigFileName = &state.ConfigFileName
+			}
+
 			if state.EndOfLifeDate != "" {
 				endOfLifeDate, _ := time.Parse(time.RFC3339, state.EndOfLifeDate)
 				payload.Properties.PublishingProfile.SetEndOfLifeDateAsTime(endOfLifeDate)
+			}
+
+			if state.PackageFileName != "" {
+				if payload.Properties.PublishingProfile.Settings == nil {
+					payload.Properties.PublishingProfile.Settings = &galleryapplicationversions.UserArtifactSettings{}
+				}
+
+				payload.Properties.PublishingProfile.Settings.PackageFileName = &state.PackageFileName
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
@@ -300,6 +339,13 @@ func (r GalleryApplicationVersionResource) Read() sdk.ResourceFunc {
 						excludeFromLatest = *props.PublishingProfile.ExcludeFromLatest
 					}
 					state.ExcludeFromLatest = excludeFromLatest
+
+					state.ConfigFileName = ""
+					state.PackageFileName = ""
+					if props.PublishingProfile.Settings != nil {
+						state.ConfigFileName = pointer.From(props.PublishingProfile.Settings.ConfigFileName)
+						state.PackageFileName = pointer.From(props.PublishingProfile.Settings.PackageFileName)
+					}
 
 					state.ManageAction = flattenGalleryApplicationVersionManageAction(props.PublishingProfile.ManageActions)
 					state.Source = flattenGalleryApplicationVersionSource(props.PublishingProfile.Source)
@@ -496,12 +542,19 @@ func flattenGalleryApplicationVersionSource(input galleryapplicationversions.Use
 func expandGalleryApplicationVersionTargetRegion(input []TargetRegion) *[]galleryapplicationversions.TargetRegion {
 	results := make([]galleryapplicationversions.TargetRegion, 0)
 	for _, item := range input {
-		results = append(results, galleryapplicationversions.TargetRegion{
+		targetRegion := galleryapplicationversions.TargetRegion{
 			Name:                 location.Normalize(item.Name),
 			RegionalReplicaCount: pointer.To(int64(item.RegionalReplicaCount)),
 			StorageAccountType:   pointer.To(galleryapplicationversions.StorageAccountType(item.StorageAccountType)),
-		})
+		}
+
+		if item.ExcludeFromLatest {
+			targetRegion.ExcludeFromLatest = &item.ExcludeFromLatest
+		}
+
+		results = append(results, targetRegion)
 	}
+
 	return &results
 }
 
@@ -510,14 +563,22 @@ func flattenGalleryApplicationVersionTargetRegion(input *[]galleryapplicationver
 
 	for _, item := range *input {
 		obj := TargetRegion{
-			Name: location.Normalize(item.Name),
+			Name:              location.Normalize(item.Name),
+			ExcludeFromLatest: false,
 		}
+
+		if item.ExcludeFromLatest != nil {
+			obj.ExcludeFromLatest = bool(*item.ExcludeFromLatest)
+		}
+
 		if item.RegionalReplicaCount != nil {
 			obj.RegionalReplicaCount = int(*item.RegionalReplicaCount)
 		}
+
 		if item.StorageAccountType != nil {
 			obj.StorageAccountType = string(*item.StorageAccountType)
 		}
+
 		results = append(results, obj)
 	}
 

--- a/internal/services/compute/gallery_application_version_resource_test.go
+++ b/internal/services/compute/gallery_application_version_resource_test.go
@@ -386,11 +386,11 @@ resource "azurerm_gallery_application_version" "test" {
   gallery_application_id = azurerm_gallery_application.test.id
   location               = azurerm_gallery_application.test.location
 
-  config_file_name    = "config"
+  config_file         = "config"
   enable_health_check = true
   end_of_life_date    = "%s"
   exclude_from_latest = true
-  package_file_name   = "package"
+  package_file        = "package"
 
   manage_action {
     install = "[install command]"

--- a/internal/services/compute/gallery_application_version_resource_test.go
+++ b/internal/services/compute/gallery_application_version_resource_test.go
@@ -77,7 +77,14 @@ func TestAccGalleryApplicationVersion_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data),
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -379,9 +386,11 @@ resource "azurerm_gallery_application_version" "test" {
   gallery_application_id = azurerm_gallery_application.test.id
   location               = azurerm_gallery_application.test.location
 
+  config_file_name    = "config"
   enable_health_check = true
   end_of_life_date    = "%s"
   exclude_from_latest = true
+  package_file_name   = "package"
 
   manage_action {
     install = "[install command]"
@@ -396,6 +405,7 @@ resource "azurerm_gallery_application_version" "test" {
 
   target_region {
     name                   = azurerm_gallery_application.test.location
+    exclude_from_latest    = true
     regional_replica_count = 1
     storage_account_type   = "Premium_LRS"
   }
@@ -405,6 +415,41 @@ resource "azurerm_gallery_application_version" "test" {
   }
 }
 `, template, time.Now().Add(time.Hour*10).Format(time.RFC3339))
+}
+
+func (r GalleryApplicationVersionResource) update(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_gallery_application_version" "test" {
+  name                   = "0.0.1"
+  gallery_application_id = azurerm_gallery_application.test.id
+  location               = azurerm_gallery_application.test.location
+
+  enable_health_check = true
+  exclude_from_latest = true
+
+  manage_action {
+    install = "[install command]"
+    remove  = "[remove command]"
+  }
+
+  source {
+    media_link = azurerm_storage_blob.test.id
+  }
+
+  target_region {
+    name                   = azurerm_gallery_application.test.location
+    exclude_from_latest    = true
+    regional_replica_count = 1
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+}
+`, template)
 }
 
 func (r GalleryApplicationVersionResource) enableHealthCheck(data acceptance.TestData) string {

--- a/website/docs/r/gallery_application_version.html.markdown
+++ b/website/docs/r/gallery_application_version.html.markdown
@@ -92,11 +92,15 @@ The following arguments are supported:
 
 ---
 
+* `config_file_name` - (Optional) Specifies the name of the config file on the VM. Changing this forces a new resource to be created.
+
 * `enable_health_check` - (Optional) Should the Gallery Application reports health. Defaults to `false`.
 
 * `end_of_life_date` - (Optional) The end of life date in RFC3339 format of the Gallery Application Version.
 
 * `exclude_from_latest` - (Optional) Should the Gallery Application Version be excluded from the `latest` filter? If set to `true` this Gallery Application Version won't be returned for the `latest` version. Defaults to `false`.
+
+* `package_file_name` - (Optional) Specifies the name of the package file on the VM. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Gallery Application Version.
 
@@ -125,6 +129,8 @@ A `target_region` block supports the following:
 * `name` - (Required) The Azure Region in which the Gallery Application Version exists.
 
 * `regional_replica_count` - (Required) The number of replicas of the Gallery Application Version to be created per region. Possible values are between `1` and `10`.
+
+* `exclude_from_latest` - (Optional) Specifies whether this Gallery Application Version should be excluded from the `latest` filter. If set to `true`, this Gallery Application Version won't be returned for the `latest` version. Defaults to `false`.
 
 * `storage_account_type` - (Optional) The storage account type for the Gallery Application Version. Possible values are `Standard_LRS`, `Premium_LRS` and `Standard_ZRS`. Defaults to `Standard_LRS`.
 

--- a/website/docs/r/gallery_application_version.html.markdown
+++ b/website/docs/r/gallery_application_version.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 ---
 
-* `config_file_name` - (Optional) Specifies the name of the config file on the VM. Changing this forces a new resource to be created.
+* `config_file` - (Optional) Specifies the name of the config file on the VM. Changing this forces a new resource to be created.
 
 * `enable_health_check` - (Optional) Should the Gallery Application reports health. Defaults to `false`.
 
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `exclude_from_latest` - (Optional) Should the Gallery Application Version be excluded from the `latest` filter? If set to `true` this Gallery Application Version won't be returned for the `latest` version. Defaults to `false`.
 
-* `package_file_name` - (Optional) Specifies the name of the package file on the VM. Changing this forces a new resource to be created.
+* `package_file` - (Optional) Specifies the name of the package file on the VM. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Gallery Application Version.
 


### PR DESCRIPTION
## Swagger Link:

https://github.com/Azure/azure-rest-api-specs/blob/main/specification/compute/resource-manager/Microsoft.Compute/GalleryRP/stable/2022-03-03/gallery.json

## Test Results:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/cad2a6eb-98c1-4b05-b15c-24513dc2a173)

--- PASS: TestAccGalleryApplicationVersion_basic (868.44s)
--- PASS: TestAccGalleryApplicationVersion_requiresImport (877.59s)
--- PASS: TestAccGalleryApplicationVersion_complete (913.01s)
--- PASS: TestAccGalleryApplicationVersion_endOfLifeDate (1252.19s)
--- PASS: TestAccGalleryApplicationVersion_excludeFromLatest (1537.45s)
--- PASS: TestAccGalleryApplicationVersion_update (1539.47s)
--- PASS: TestAccGalleryApplicationVersion_enableHealthCheck (1576.67s)
--- PASS: TestAccGalleryApplicationVersion_tags (1669.11s)
--- PASS: TestAccGalleryApplicationVersion_targetRegion (1984.23s)