### PR TITLE
provider: adding a test ensuring that Data Sources do not support import 

### DIFF
--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -100,6 +100,24 @@ func schemaContainsSensitiveFieldsNotMarkedAsSensitive(input map[string]*plugins
 	return nil
 }
 
+func TestDataSourcesShouldNotSupportImport(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	dataSourceNames := make([]string, 0)
+	for dataSourceName := range provider.DataSourcesMap {
+		dataSourceNames = append(dataSourceNames, dataSourceName)
+	}
+	sort.Strings(dataSourceNames)
+
+	for _, dataSourceName := range dataSourceNames {
+		dataSource := provider.DataSourcesMap[dataSourceName]
+		if dataSource.Importer != nil {
+			t.Fatalf("the Data Source %q supports Import but Terraform does not support this - please remove the `Importer` from this Data Source", dataSourceName)
+		}
+	}
+}
+
 func TestDataSourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
 	// This test validates that Data Sources do not contain a field suffixed with `_enabled` that isn't a Boolean.
 	//

--- a/internal/services/dataprotection/data_protection_backup_vault_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_data_source.go
@@ -29,11 +29,6 @@ func dataSourceDataProtectionBackupVault() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := backupvaults.ParseBackupVaultID(id)
-			return err
-		}),
-
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/kusto/kusto_database_data_source.go
+++ b/internal/services/kusto/kusto_database_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/parse"
 	kustoValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -21,11 +20,6 @@ import (
 func dataSourceKustoDatabase() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Read: dataSourceKustoDatabaseRead,
-
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.DatabaseID(id)
-			return err
-		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/network/virtual_hub_route_table_data_source.go
+++ b/internal/services/network/virtual_hub_route_table_data_source.go
@@ -24,11 +24,6 @@ func dataSourceVirtualHubRouteTable() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.HubRouteTableID(id)
-			return err
-		}),
-
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:         pluginsdk.TypeString,


### PR DESCRIPTION
This PR fixes an issue spotted where 3 data sources incorrectly define `import` functions, which aren't valid - so these aren't usable by first adding a test to detect the issue and then removing the `importer` functions as needed.