### PR TITLE
cosmos: consistently using the same constants

### DIFF
--- a/internal/services/cosmos/common/indexing_policy.go
+++ b/internal/services/cosmos/common/indexing_policy.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -257,11 +255,11 @@ func ValidateAzureRmCosmosDbIndexingPolicy(indexingPolicy *cosmosdb.IndexingPoli
 	// Ensure includedPaths or excludedPaths are not set if indexingMode is "None".
 	if *indexingPolicy.IndexingMode == cosmosdb.IndexingModeNone {
 		if indexingPolicy.IncludedPaths != nil {
-			return fmt.Errorf("included_path must not be set if indexing_mode is %q", azure.TitleCase(string(documentdb.IndexingModeNone)))
+			return fmt.Errorf("included_path must not be set if indexing_mode is %q", string(cosmosdb.IndexingModeNone))
 		}
 
 		if indexingPolicy.ExcludedPaths != nil {
-			return fmt.Errorf("excluded_path must not be set if indexing_mode is %q", azure.TitleCase(string(documentdb.IndexingModeNone)))
+			return fmt.Errorf("excluded_path must not be set if indexing_mode is %q", string(cosmosdb.IndexingModeNone))
 		}
 	}
 


### PR DESCRIPTION
We're comparing `cosmosdb.` above and then using `documentdb.` in error messages, so we can consolidate these