### PR TITLE
automation: updating the branch name when opening an Auto PR for `hashicorp/go-azure-sdk`

### DIFF
--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: "open a pull request"
         id: open-pr
         run: |
-          version="$(echo {{ github.ref_name }} | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")"
+          version="$(echo $GH_REF | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")"
           title="dependencies: updating hashicorp/go-azure-sdk to ${version}"
           
           # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
@@ -28,3 +28,4 @@ jobs:
           PR_BODY: "This PR updates `hashicorp/go-azure-sdk` - further details can be found in a comment."
           PR_TARGET: "main"
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_TERRAFORM_TOKEN }}
+          GH_REF: ${{ github.ref_name }}


### PR DESCRIPTION
This'll output the version of the Go SDK which we're updating to in the title