### PR TITLE
dependencies: updating hashicorp/go-azure-sdk to {{ github.ref_name }}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.63.0
-	github.com/hashicorp/go-azure-sdk v0.20231106.1151347
+	github.com/hashicorp/go-azure-sdk v0.20231108.1164943
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.63.0 h1:7bYnYZsqzPjxVevi0z8Irwp5DwS8okLcaA183DQAcmY=
 github.com/hashicorp/go-azure-helpers v0.63.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
-github.com/hashicorp/go-azure-sdk v0.20231106.1151347 h1:K/9sLZafuu+xHSSUx+T3ZObUFwaJo+tl6p4ZxuU6q9k=
-github.com/hashicorp/go-azure-sdk v0.20231106.1151347/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
+github.com/hashicorp/go-azure-sdk v0.20231108.1164943 h1:Qq+jzx5YJvS0KGHUs1gj5w5Ppo6b1rLBMiN/9/Uqub0=
+github.com/hashicorp/go-azure-sdk v0.20231108.1164943/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
@@ -22,6 +22,7 @@ func AzureChina() *Environment {
 
 	// DataLake, ManagedHSM and OperationalInsights are not available
 	env.ApiManagement = ApiManagementAPI("azure-api.cn")
+	env.AppConfiguration = AppConfigurationAPI("azconfig.azure.cn")
 	env.Batch = BatchAPI("https://batch.chinacloudapi.cn").withResourceIdentifier("https://batch.chinacloudapi.cn")
 	env.ContainerRegistry = ContainerRegistryAPI("azurecr.cn")
 	env.CosmosDB = CosmosDBAPI("documents.azure.cn")

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_gov.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_gov.go
@@ -21,6 +21,7 @@ func AzureUSGovernment() *Environment {
 	env.MicrosoftGraph = MicrosoftGraphAPI("https://graph.microsoft.us").withResourceIdentifier("https://graph.microsoft.us")
 
 	env.ApiManagement = ApiManagementAPI("azure-api.us")
+	env.AppConfiguration = AppConfigurationAPI("azconfig.azure.us")
 	env.Batch = BatchAPI("https://batch.core.usgovcloudapi.net").withResourceIdentifier("https://batch.core.usgovcloudapi.net")
 	env.ContainerRegistry = ContainerRegistryAPI("azurecr.us")
 	env.CosmosDB = CosmosDBAPI("documents.azure.us")

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_public.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_public.go
@@ -21,6 +21,7 @@ func AzurePublic() *Environment {
 	env.MicrosoftGraph = MicrosoftGraphAPI("https://graph.microsoft.com")
 
 	env.ApiManagement = ApiManagementAPI("azure-api.net")
+	env.AppConfiguration = AppConfigurationAPI("azconfig.io")
 	env.Attestation = AttestationAPI("https://attest.azure.net")
 	env.Batch = BatchAPI("https://batch.core.windows.net")
 	env.CDNFrontDoor = CDNFrontDoorAPI("azurefd.net")

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/helpers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/helpers.go
@@ -25,6 +25,16 @@ func ApiManagementAPI(domainSuffix string) Api {
 	}
 }
 
+func AppConfigurationAPI(domainSuffix string) Api {
+	return &ApiEndpoint{
+		domainSuffix:       pointer.To(domainSuffix),
+		endpoint:           nil,
+		appId:              pointer.To(appConfigurationAppId),
+		name:               "AppConfiguration",
+		resourceIdentifier: nil,
+	}
+}
+
 func AttestationAPI(endpoint string) Api {
 	return &ApiEndpoint{
 		domainSuffix:       nil,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20231106.1151347
+# github.com/hashicorp/go-azure-sdk v0.20231108.1164943
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` - further details can be found in a comment.