### PR TITLE
Docs: fix typo for resource name 

### DIFF
--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_data_factory_pipeline" "example" {
 
 ```hcl
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
+  name            = "example"
   data_factory_id = azurerm_data_factory.test.id
   variables = {
     "bob" = "item1"


### PR DESCRIPTION
Fix #23827 