### PR TITLE
tooling: outputting the version of `hashicorp/go-azure-sdk` when auto PRs are opened

### DIFF
--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -17,15 +17,15 @@ jobs:
       - name: "open a pull request"
         id: open-pr
         run: |
-          version="$(echo $GH_REF | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")"
-          title="dependencies: updating hashicorp/go-azure-sdk to ${version}"
+          version="$(echo $GH_REF | sed "s/auto-deps-pr\/updating-go-azure-sdk-to-//")"
+          title="dependencies: updating \`hashicorp/go-azure-sdk\` to \`${version}\`"
+          body="This PR updates \`hashicorp/go-azure-sdk\` to \`${version}\` - further details can be found in a comment."
           
           # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
           # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP
-          gh pr create --title "$title" --body "$PR_BODY" -B "$PR_TARGET" > /dev/null
+          gh pr create --title "$title" --body "$body" -B "$PR_TARGET" > /dev/null
 
         env:
-          PR_BODY: "This PR updates `hashicorp/go-azure-sdk` - further details can be found in a comment."
           PR_TARGET: "main"
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_TERRAFORM_TOKEN }}
           GH_REF: ${{ github.ref_name }}


### PR DESCRIPTION
This helps differentiate these from one another