### PR TITLE
`azurerm_virtual_network_gateway_connection` - add `StateRefreshFunc` for SetSharedKey API

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -21,6 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
+
+var virtualNetworkGatewayConnectionResourceName = "azurerm_virtual_network_gateway_connection"
 
 func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -540,6 +543,9 @@ func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, me
 	if err != nil {
 		return err
 	}
+
+	locks.ByName(id.ConnectionName, virtualNetworkGatewayConnectionResourceName)
+	defer locks.UnlockByName(id.ConnectionName, virtualNetworkGatewayConnectionResourceName)
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ConnectionName)
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -396,6 +396,9 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 		VirtualNetworkGatewayConnectionPropertiesFormat: properties,
 	}
 
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
+
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ConnectionName, connection)
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -23,8 +23,6 @@ import (
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
-var virtualNetworkGatewayConnectionResourceName = "azurerm_virtual_network_gateway_connection"
-
 func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceVirtualNetworkGatewayConnectionCreateUpdate,
@@ -544,8 +542,8 @@ func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	locks.ByName(id.ConnectionName, virtualNetworkGatewayConnectionResourceName)
-	defer locks.UnlockByName(id.ConnectionName, virtualNetworkGatewayConnectionResourceName)
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ConnectionName)
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -353,9 +352,6 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 
 	id := parse.NewNetworkGatewayConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	locks.ByID(id.ID())
-	defer locks.UnlockByID(id.ID())
-
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.ConnectionName)
 		if err != nil {
@@ -544,9 +540,6 @@ func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, me
 	if err != nil {
 		return err
 	}
-
-	locks.ByID(id.ID())
-	defer locks.UnlockByID(id.ID())
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ConnectionName)
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -353,6 +353,9 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 
 	id := parse.NewNetworkGatewayConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
+
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.ConnectionName)
 		if err != nil {
@@ -395,9 +398,6 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 		Tags:     tags.Expand(t),
 		VirtualNetworkGatewayConnectionPropertiesFormat: properties,
 	}
-
-	locks.ByID(id.ID())
-	defer locks.UnlockByID(id.ID())
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ConnectionName, connection)
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -412,11 +412,11 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 		if err != nil {
 			return fmt.Errorf("updating Shared Key for %s: %+v", id, err)
 		}
-
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for deletion of %s: %+v", id, err)
+			return fmt.Errorf("waiting for updating Shared Key for %s: %+v", id, err)
 		}
 
+		// Once this issue https://github.com/Azure/azure-rest-api-specs/issues/26660 is fixed, below this part will be removed
 		stateConf := &pluginsdk.StateChangeConf{
 			Pending:    []string{string(network.ProvisioningStateUpdating)},
 			Target:     []string{string(network.ProvisioningStateSucceeded)},
@@ -555,14 +555,9 @@ func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ConnectionName)
-	if err != nil {
-		return err
-	}
-
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ConnectionName)
 	if err != nil {
-		return fmt.Errorf("deleting %s: %+v,,%+v,,%+v,,%+v,,%+v,,%+v", id, err, resp.ProvisioningState, resp.StatusCode, resp.TunnelConnectionStatus, resp.ConnectionStatus, resp.Status)
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -541,9 +541,14 @@ func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ConnectionName)
+	if err != nil {
+		return err
+	}
+
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ConnectionName)
 	if err != nil {
-		return fmt.Errorf("deleting %s: %+v", id, err)
+		return fmt.Errorf("deleting %s: %+v,,%+v,,%+v,,%+v,,%+v,,%+v", id, err, resp.ProvisioningState, resp.StatusCode, resp.TunnelConnectionStatus, resp.ConnectionStatus, resp.Status)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -74,7 +74,7 @@ func TestAccVirtualNetworkGatewayConnection_vnettonet(t *testing.T) {
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.vnettovnet(data1, data2.RandomInteger, sharedKey),
+			Config: r.vnettovnet(data1, data1.RandomInteger, data2.RandomInteger, sharedKey),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data1.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data1.ResourceName, "shared_key", sharedKey),
@@ -177,7 +177,7 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.vnettovnet(data1, data2.RandomInteger, firstSharedKey),
+			Config: r.vnettovnet(data1, data1.RandomInteger, data2.RandomInteger, firstSharedKey),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data1.ResourceName).ExistsInAzure(r),
 				check.That(data2.ResourceName).ExistsInAzure(r),
@@ -186,7 +186,7 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 			),
 		},
 		{
-			Config: r.vnettovnet(data1, data2.RandomInteger, secondSharedKey),
+			Config: r.vnettovnet(data1, data1.RandomInteger, data2.RandomInteger, secondSharedKey),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data1.ResourceName).ExistsInAzure(r),
 				check.That(data2.ResourceName).ExistsInAzure(r),
@@ -444,7 +444,7 @@ resource "azurerm_virtual_network_gateway_connection" "import" {
 `, r.sitetosite(data))
 }
 
-func (VirtualNetworkGatewayConnectionResource) vnettovnet(data acceptance.TestData, rInt2 int, sharedKey string) string {
+func (VirtualNetworkGatewayConnectionResource) vnettovnet(data acceptance.TestData, rInt1 int, rInt2 int, sharedKey string) string {
 	return fmt.Sprintf(`
 variable "random1" {
   default = "%d"
@@ -566,10 +566,8 @@ resource "azurerm_virtual_network_gateway_connection" "test_2" {
   peer_virtual_network_gateway_id = azurerm_virtual_network_gateway.test_1.id
 
   shared_key = var.shared_key
-
-  depends_on = [azurerm_virtual_network_gateway_connection.test_1]
 }
-`, data.RandomInteger, rInt2, sharedKey, data.Locations.Primary, data.Locations.Secondary)
+`, rInt1, rInt2, sharedKey, data.Locations.Primary, data.Locations.Secondary)
 }
 
 func (VirtualNetworkGatewayConnectionResource) ipsecpolicy(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -566,6 +566,8 @@ resource "azurerm_virtual_network_gateway_connection" "test_2" {
   peer_virtual_network_gateway_id = azurerm_virtual_network_gateway.test_1.id
 
   shared_key = var.shared_key
+
+  depends_on = [azurerm_virtual_network_gateway_connection.test_1]
 }
 `, data.RandomInteger, rInt2, sharedKey, data.Locations.Primary, data.Locations.Secondary)
 }

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -173,6 +173,7 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 	r := VirtualNetworkGatewayConnectionResource{}
 
 	firstSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+	secondSharedKey := "5-v3ry-53cr37-1p53c-5h4r3d-k3y"
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -182,6 +183,15 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 				check.That(data2.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data1.ResourceName, "shared_key", firstSharedKey),
 				acceptance.TestCheckResourceAttr(data2.ResourceName, "shared_key", firstSharedKey),
+			),
+		},
+		{
+			Config: r.vnettovnet(data1, data1.RandomInteger, data2.RandomInteger, secondSharedKey),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data1.ResourceName).ExistsInAzure(r),
+				check.That(data2.ResourceName).ExistsInAzure(r),
+				acceptance.TestCheckResourceAttr(data1.ResourceName, "shared_key", secondSharedKey),
+				acceptance.TestCheckResourceAttr(data2.ResourceName, "shared_key", secondSharedKey),
 			),
 		},
 	})

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -173,7 +173,7 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 	r := VirtualNetworkGatewayConnectionResource{}
 
 	firstSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
-	secondSharedKey := "5-v3ry-53cr37-1p53c-5h4r3d-k3y"
+	secondSharedKey := "4-r33ly-53cr37-1p53c-5h4r3d-k3y"
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -173,7 +173,6 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 	r := VirtualNetworkGatewayConnectionResource{}
 
 	firstSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
-	secondSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -183,15 +182,6 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 				check.That(data2.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data1.ResourceName, "shared_key", firstSharedKey),
 				acceptance.TestCheckResourceAttr(data2.ResourceName, "shared_key", firstSharedKey),
-			),
-		},
-		{
-			Config: r.vnettovnet(data1, data1.RandomInteger, data2.RandomInteger, secondSharedKey),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data1.ResourceName).ExistsInAzure(r),
-				check.That(data2.ResourceName).ExistsInAzure(r),
-				acceptance.TestCheckResourceAttr(data1.ResourceName, "shared_key", secondSharedKey),
-				acceptance.TestCheckResourceAttr(data2.ResourceName, "shared_key", secondSharedKey),
 			),
 		},
 	})

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -173,7 +173,7 @@ func TestAccVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 	r := VirtualNetworkGatewayConnectionResource{}
 
 	firstSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
-	secondSharedKey := "4-r33ly-53cr37-1p53c-5h4r3d-k3y"
+	secondSharedKey := "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
 
 	data1.ResourceTest(t, r, []acceptance.TestStep{
 		{

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -404,9 +403,6 @@ func resourceVirtualNetworkGatewayCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	id := parse.NewVirtualNetworkGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	locks.ByID(id.ID())
-	defer locks.UnlockByID(id.ID())
-
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
@@ -526,9 +522,6 @@ func resourceVirtualNetworkGatewayDelete(d *pluginsdk.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
-
-	locks.ByID(id.ID())
-	defer locks.UnlockByID(id.ID())
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -403,6 +404,9 @@ func resourceVirtualNetworkGatewayCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	id := parse.NewVirtualNetworkGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
+
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
@@ -522,6 +526,9 @@ func resourceVirtualNetworkGatewayDelete(d *pluginsdk.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
+
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {


### PR DESCRIPTION
TestAccVirtualNetworkGatewayConnection_updatingSharedKey is failed in Teamcity for a long time. So I did some investigation for it.

Finding 1:
For the update testing, TestAccVirtualNetworkGatewayConnection_updatingSharedKey triggers unexpected force replacement. So I updated the parameters in test case to not trigger force replacement.

Finding 2:
While calling setSharedKey API, though statusCode is "200" but the provisioningState is "Updating". So I added the StateRefreshFunc.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/f5748814-ce4b-4b7f-9d6e-1070f89d17c2)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/e60ed670-18a9-4ae5-b88a-3eda9c817541)
