### PR TITLE
Enable Workload Profiles for Container Apps Environment with VNET Integration

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/Azure/azure-sdk-for-go v45.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v56.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.3/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
@@ -115,6 +121,8 @@ github.com/hashicorp/go-azure-helpers v0.63.0 h1:7bYnYZsqzPjxVevi0z8Irwp5DwS8okL
 github.com/hashicorp/go-azure-helpers v0.63.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
 github.com/hashicorp/go-azure-sdk v0.20231106.1151347 h1:K/9sLZafuu+xHSSUx+T3ZObUFwaJo+tl6p4ZxuU6q9k=
 github.com/hashicorp/go-azure-sdk v0.20231106.1151347/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
+github.com/hashicorp/go-azure-sdk v0.20231114.1115341 h1:ZOHAr+Hr7dIZFK2SEM1Tz2UIVM9D5t7klKj92URDVaI=
+github.com/hashicorp/go-azure-sdk v0.20231114.1115341/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -33,6 +33,7 @@ type ContainerAppEnvironmentModel struct {
 	InfrastructureSubnetId                  string                 `tfschema:"infrastructure_subnet_id"`
 	InternalLoadBalancerEnabled             bool                   `tfschema:"internal_load_balancer_enabled"`
 	ZoneRedundant                           bool                   `tfschema:"zone_redundancy_enabled"`
+	WorkloadProfileEnabled 					bool				   `tfschema:"workload_profile_enabled"`
 	Tags                                    map[string]interface{} `tfschema:"tags"`
 
 	DefaultDomain         string `tfschema:"default_domain"`
@@ -112,6 +113,15 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 			RequiredWith: []string{"infrastructure_subnet_id"},
 		},
 
+		"workload_profiles_enabled": {
+			Type: 		  pluginsdk.TypeBool,
+			Optional: 	  true,
+			ForceNew: 	  true,
+			Default: 	  false,
+			Description:  "Should the environment be Workload Profile enabled? Defaults to `false`. "
+			RequiredWith: []string{"infrastructure_subnet_id"},
+		}
+
 		"tags": commonschema.Tags(),
 	}
 }
@@ -183,6 +193,7 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				Properties: &managedenvironments.ManagedEnvironmentProperties{
 					VnetConfiguration: &managedenvironments.VnetConfiguration{},
 					ZoneRedundant:     pointer.To(containerAppEnvironment.ZoneRedundant),
+					WorkloadProfileEnabled:	pointer.To(containerAppEnvironment.WorkloadProfileEnabled),
 				},
 				Tags: tags.Expand(containerAppEnvironment.Tags),
 			}
@@ -277,6 +288,7 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					}
 
 					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
+					state.WorkloadProfileEnabled = pointer.From(props.WorkloadProfileEnabled)
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
 				}

--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -244,12 +244,7 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				managedEnvironment.Properties.VnetConfiguration.InfrastructureSubnetId = pointer.To(containerAppEnvironment.InfrastructureSubnetId)
 				managedEnvironment.Properties.VnetConfiguration.Internal = pointer.To(containerAppEnvironment.InternalLoadBalancerEnabled)
 
-				if containerAppEnvironment.WorkloadProfileEnabled == true {
-					consumption := helpers.WorkloadProfile{
-						Name:                "Consumption",
-						WorkloadProfileType: "consumption",
-					}
-					containerAppEnvironment.WorkloadProfiles = append(containerAppEnvironment.WorkloadProfiles, consumption)
+				if containerAppEnvironment.WorkloadProfileEnabled {
 					managedEnvironment.Properties.WorkloadProfiles = helpers.ExpandWorkloadProfiles(containerAppEnvironment.WorkloadProfiles)
 				}
 			}
@@ -373,7 +368,7 @@ func (r ContainerAppEnvironmentResource) Update() sdk.ResourceFunc {
 				existing.Model.Tags = tags.Expand(state.Tags)
 			}
 
-			if metadata.ResourceData.HasChange("workload_profile") {
+			if metadata.ResourceData.HasChange("workload_profiles") {
 				existing.Model.Properties.WorkloadProfiles = helpers.ExpandWorkloadProfiles(state.WorkloadProfiles)
 			}
 

--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -33,7 +33,7 @@ type ContainerAppEnvironmentModel struct {
 	InfrastructureSubnetId                  string                 `tfschema:"infrastructure_subnet_id"`
 	InternalLoadBalancerEnabled             bool                   `tfschema:"internal_load_balancer_enabled"`
 	ZoneRedundant                           bool                   `tfschema:"zone_redundancy_enabled"`
-	WorkloadProfileEnabled 					bool				   `tfschema:"workload_profile_enabled"`
+	WorkloadProfileEnabled                  bool                   `tfschema:"workload_profile_enabled"`
 	Tags                                    map[string]interface{} `tfschema:"tags"`
 
 	DefaultDomain         string `tfschema:"default_domain"`
@@ -114,13 +114,13 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 		},
 
 		"workload_profiles_enabled": {
-			Type: 		  pluginsdk.TypeBool,
-			Optional: 	  true,
-			ForceNew: 	  true,
-			Default: 	  false,
-			Description:  "Should the environment be Workload Profile enabled? Defaults to `false`. "
+			Type:         pluginsdk.TypeBool,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      false,
+			Description:  "Should the environment be Workload Profile enabled? Defaults to `false`.",
 			RequiredWith: []string{"infrastructure_subnet_id"},
-		}
+		},
 
 		"tags": commonschema.Tags(),
 	}
@@ -193,7 +193,6 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				Properties: &managedenvironments.ManagedEnvironmentProperties{
 					VnetConfiguration: &managedenvironments.VnetConfiguration{},
 					ZoneRedundant:     pointer.To(containerAppEnvironment.ZoneRedundant),
-					WorkloadProfileEnabled:	pointer.To(containerAppEnvironment.WorkloadProfileEnabled),
 				},
 				Tags: tags.Expand(containerAppEnvironment.Tags),
 			}
@@ -240,6 +239,15 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 			if containerAppEnvironment.InfrastructureSubnetId != "" {
 				managedEnvironment.Properties.VnetConfiguration.InfrastructureSubnetId = pointer.To(containerAppEnvironment.InfrastructureSubnetId)
 				managedEnvironment.Properties.VnetConfiguration.Internal = pointer.To(containerAppEnvironment.InternalLoadBalancerEnabled)
+
+				if containerAppEnvironment.WorkloadProfileEnabled == true {
+					managedEnvironment.Properties.WorkloadProfiles = &[]managedenvironments.WorkloadProfile{
+						{
+							Name:                "Consumption",
+							WorkloadProfileType: "Consumption",
+						},
+					}
+				}
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, managedEnvironment); err != nil {
@@ -288,7 +296,7 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					}
 
 					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
-					state.WorkloadProfileEnabled = pointer.From(props.WorkloadProfileEnabled)
+					state.WorkloadProfileEnabled = len(*props.WorkloadProfiles) > 0
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
 				}

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -285,12 +285,11 @@ resource "azurerm_container_app_environment" "test" {
   infrastructure_subnet_id       = azurerm_subnet.control.id
   zone_redundancy_enabled        = true
   internal_load_balancer_enabled = true
-  workload_profile_enabled      = true
+  workload_profile_enabled       = true
+
   workload_profiles {
-	minimum_count         = 0
-	maximum_count         = 0
 	name                  = "Consumption"
-	workload_profile_type = "consumption"
+	workload_profile_type = "Consumption"
   }
 
   tags = {
@@ -320,17 +319,10 @@ resource "azurerm_container_app_environment" "test" {
   workload_profile_enabled       = true
 
   workload_profiles {
-	minimum_count         = 0	
-	maximum_count         = 1
+	minimum_count         = 1
+	maximum_count         = 4
 	name                  = "TestProfile"
 	workload_profile_type = "D4"
-  }
-
-  workload_profiles {
-	minimum_count         = null
-	maximum_count         = null
-	name                  = "Consumption"
-	workload_profile_type = "consumption"
   }
 
   tags = {

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -101,6 +101,21 @@ func TestAccContainerAppEnvironment_daprApplicationInsightsConnectionString(t *t
 	})
 }
 
+func TestAccContainerAppEnvironment_workloadProfilesEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeWorkloadProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id"),
+	})
+}
+
 func TestAccContainerAppEnvironment_zoneRedundant(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentResource{}
@@ -230,6 +245,32 @@ resource "azurerm_container_app_environment" "test" {
   infrastructure_subnet_id       = azurerm_subnet.control.id
   zone_redundancy_enabled        = true
   internal_load_balancer_enabled = true
+
+  tags = {
+    Foo    = "Bar"
+    secret = "sauce"
+  }
+}
+`, r.templateVNet(data), data.RandomInteger)
+}
+
+func (r ContainerAppEnvironmentResource) completeWorkloadProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                           = "acctest-CAEnv%[2]d"
+  resource_group_name            = azurerm_resource_group.test.name
+  location                       = azurerm_resource_group.test.location
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.test.id
+  infrastructure_subnet_id       = azurerm_subnet.control.id
+  zone_redundancy_enabled        = true
+  internal_load_balancer_enabled = true
+  workload_profile_enabled       = true
 
   tags = {
     Foo    = "Bar"

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -100,7 +100,7 @@ func (r ContainerAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"workload_profile_name": {
 			Type:         pluginsdk.TypeString,
-			Required:     false,
+			Optional:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 			ForceNew:     true,
 			Description:  "Workload profile name to pin for container app execution.",

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -104,6 +104,7 @@ func (r ContainerAppResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.StringIsNotEmpty,
 			ForceNew:     true,
 			Description:  "Workload profile name to pin for container app execution.",
+			Default:      "Consumption",
 		},
 
 		"ingress": helpers.ContainerAppIngressSchema(),

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -206,6 +206,21 @@ func TestAccContainerAppResource_completeWithVNet(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_completeWithWorkloadProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeWithProfile(data, "rev1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeWithSidecar(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -889,6 +904,96 @@ resource "azurerm_container_app" "test" {
   resource_group_name          = azurerm_resource_group.test.name
   container_app_environment_id = azurerm_container_app_environment.test.id
   revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    volume {
+      name         = azurerm_container_app_environment_storage.test.name
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.test.name
+    }
+
+    min_replicas = 2
+    max_replicas = 3
+
+    revision_suffix = "%[3]s"
+  }
+
+  ingress {
+    allow_insecure_connections = true
+    target_port                = 5000
+    transport                  = "http"
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server               = azurerm_container_registry.test.login_server
+    username             = azurerm_container_registry.test.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+
+  tags = {
+    foo     = "Bar"
+    accTest = "1"
+  }
+}
+`, r.templateWithVnet(data), data.RandomInteger, revisionSuffix)
+}
+
+func (r ContainerAppResource) completeWithProfile(data acceptance.TestData, revisionSuffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
 
   template {
     container {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3060,7 +3060,6 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					ValidateFunc: validation.IntAtLeast(1),
 					Optional:     true,
-					RequiredWith: []string{"minimum_count"},
 				},
 				"minimum_count": {
 					Type:         pluginsdk.TypeInt,
@@ -3136,3 +3135,38 @@ func UnpackWorkloadProfiles(input []managedenvironments.WorkloadProfile) *[]Work
 
 	return &result
 }
+
+// func EnableWorkloadProfileOnSubnet(subnetID string) error {
+
+// 	resourceSlices := strings.Split(subnetID, "/")
+// 	fmt.Printf("[DEBUG] Enabling Subnet Delegation for subnet %s to Microsoft.App/environments", resourceSlices[9])
+
+// 	env := environments.Api{}
+// 	err, subnetClient := subnets.NewSubnetsClientWithBaseURI()
+// 	// subnetClient.Authorizer = authorizer
+
+// 	subnet, err := subnetClient.Get(context.Background(), resourceSlices[3], resourceSlices[7], resourceSlices[9], "")
+// 	if err != nil {
+// 		fmt.Println(err)
+// 		return err
+// 	}
+
+// 	if subnet.Properties.Delegations == nil {
+// 		subnet.Properties.Delegations = &[]subnet.Delegation{}
+// 	}
+
+// 	subnet.Delegations = &append(*subnet.Delegations, subnet.Delegation{
+// 		Name: to.StringPtr("WorkloadProfileDelegation"),
+// 		Properties: &subnets.ServiceDelegationPropertiesFormat{
+// 			ServiceName: to.StringPtr("Microsoft.App/environments"),
+// 		},
+// 	})
+
+// 	_, err = subnetClient.CreateOrUpdateThenPoll(context.Background(), resourceSlices[3], resourceSlices[7], resourceSlices[9], subnet, "")
+// 	if err != nil {
+// 		fmt.Println(err)
+// 		return err
+// 	}
+
+// 	return nil
+// }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3048,23 +3048,27 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the Workload to run",
 				},
 				"workload_profile_type": {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						"consumption", "D4", "D8", "D16", "D32", "E4", "E8", "E16", "E32",
+						"Consumption", "D4", "D8", "D16", "D32", "E4", "E8", "E16", "E32",
 					}, false),
+					Description: "The type of compute to assign to the workload.  `D` types are General Purpose, while `E` types are Memory-Optimized",
 				},
 				"maximum_count": {
 					Type:         pluginsdk.TypeInt,
 					ValidateFunc: validation.IntAtLeast(1),
 					Optional:     true,
+					Description:  "The maximum number of instances to run in this profile.",
 				},
 				"minimum_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
-					ValidateFunc: validation.IntAtLeast(0),
+					ValidateFunc: validation.IntAtLeast(1),
+					Description:  "The minimum number of instances to run in this profile.",
 				},
 			},
 		},
@@ -3078,20 +3082,24 @@ func WorkloadProfileSchemaComputed() *pluginsdk.Schema {
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the Workload to run",
 				},
 				"workload_profile_type": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The type of compute to assign to the workload.  `D` types are General Purpose, while `E` types are Memory-Optimized",
 				},
 				"maximum_count": {
-					Type:     pluginsdk.TypeInt,
-					Computed: true,
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The maximum number of instances to run in this profile.",
 				},
 				"minimum_count": {
-					Type:     pluginsdk.TypeInt,
-					Computed: true,
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The minimum number of instances to run in this profile.",
 				},
 			},
 		},
@@ -3135,38 +3143,3 @@ func UnpackWorkloadProfiles(input []managedenvironments.WorkloadProfile) *[]Work
 
 	return &result
 }
-
-// func EnableWorkloadProfileOnSubnet(subnetID string) error {
-
-// 	resourceSlices := strings.Split(subnetID, "/")
-// 	fmt.Printf("[DEBUG] Enabling Subnet Delegation for subnet %s to Microsoft.App/environments", resourceSlices[9])
-
-// 	env := environments.Api{}
-// 	err, subnetClient := subnets.NewSubnetsClientWithBaseURI()
-// 	// subnetClient.Authorizer = authorizer
-
-// 	subnet, err := subnetClient.Get(context.Background(), resourceSlices[3], resourceSlices[7], resourceSlices[9], "")
-// 	if err != nil {
-// 		fmt.Println(err)
-// 		return err
-// 	}
-
-// 	if subnet.Properties.Delegations == nil {
-// 		subnet.Properties.Delegations = &[]subnet.Delegation{}
-// 	}
-
-// 	subnet.Delegations = &append(*subnet.Delegations, subnet.Delegation{
-// 		Name: to.StringPtr("WorkloadProfileDelegation"),
-// 		Properties: &subnets.ServiceDelegationPropertiesFormat{
-// 			ServiceName: to.StringPtr("Microsoft.App/environments"),
-// 		},
-// 	})
-
-// 	_, err = subnetClient.CreateOrUpdateThenPoll(context.Background(), resourceSlices[3], resourceSlices[7], resourceSlices[9], subnet, "")
-// 	if err != nil {
-// 		fmt.Println(err)
-// 		return err
-// 	}
-
-// 	return nil
-// }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3030,3 +3030,109 @@ func (c *ContainerTemplate) flattenContainerAppScaleRules(input *[]containerapps
 		c.TCPScaleRules = tcpScaleRules
 	}
 }
+
+type WorkloadProfile struct {
+	Name                string `tfschema:"name"`
+	WorkloadProfileType string `tfschema:"workload_profile_type"`
+	MaximumCount        *int64 `tfschema:"maximum_count"`
+	MinimumCount        *int64 `tfschema:"minimum_count"`
+}
+
+func WorkloadProfileSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"workload_profile_type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"consumption", "D4", "D8", "D16", "D32", "E4", "E8", "E16", "E32",
+					}, false),
+				},
+				"maximum_count": {
+					Type:         pluginsdk.TypeInt,
+					ValidateFunc: validation.IntAtLeast(1),
+					Optional:     true,
+					RequiredWith: []string{"minimum_count"},
+				},
+				"minimum_count": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+			},
+		},
+	}
+}
+
+func WorkloadProfileSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"workload_profile_type": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"maximum_count": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+				"minimum_count": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func ExpandWorkloadProfiles(input []WorkloadProfile) *[]managedenvironments.WorkloadProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]managedenvironments.WorkloadProfile, 0)
+
+	for _, v := range input {
+		result = append(result, managedenvironments.WorkloadProfile{
+			Name:                v.Name,
+			WorkloadProfileType: v.WorkloadProfileType,
+			MaximumCount:        v.MaximumCount,
+			MinimumCount:        v.MinimumCount,
+		})
+	}
+
+	return &result
+}
+
+func UnpackWorkloadProfiles(input []managedenvironments.WorkloadProfile) *[]WorkloadProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]WorkloadProfile, 0)
+
+	for _, v := range input {
+		result = append(result, WorkloadProfile{
+			Name:                v.Name,
+			WorkloadProfileType: v.WorkloadProfileType,
+			MaximumCount:        v.MaximumCount,
+			MinimumCount:        v.MinimumCount,
+		})
+	}
+
+	return &result
+}

--- a/website/docs/d/container_app_environment.html.markdown
+++ b/website/docs/d/container_app_environment.html.markdown
@@ -64,6 +64,22 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `tags` - A mapping of tags assigned to the resource.
 
+* `workload_profile_enabled` - Whether Workload Profiles are enabled for this resource
+
+* `workload_profiles` - Zero or more Workload Profiles blocks if `workload_profile_enabled` is `true`.
+
+---
+
+`workload_profiles` consists of the following:
+
+* `name` - The name of the Workload Profile for identification
+
+* `workload_profile_type` - 
+
+* `maximum_count` - The maximum number of instances running on the profile
+
+* `minimum_count` - The minimum number of instances running on the profile
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -37,6 +37,7 @@ resource "azurerm_container_app" "example" {
   container_app_environment_id = azurerm_container_app_environment.example.id
   resource_group_name          = azurerm_resource_group.example.name
   revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
 
   template {
     container {
@@ -76,6 +77,8 @@ The following arguments are supported:
 * `secret` - (Optional) One or more `secret` block as detailed below.
 
 * `tags` - (Optional) A mapping of tags to assign to the Container App.
+
+* `workload_profile_name` - (Optional) The name of the Workload Profile to bind the Container App. Defaults to `Consumption`.
 
 ---
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -48,9 +48,13 @@ The following arguments are supported:
 
 * `dapr_application_insights_connection_string` - (Optional) Application Insights connection string used by Dapr to export Service to Service communication telemetry. Changing this forces a new resource to be created.
 
+~> **Note:** can only be set if `workload_profiles_enabled` is set to `true`. 
+
+* `workload_profiles` - (Optional) A list of `workload_profile` objects to create with the container app.
+
 * `infrastructure_subnet_id` - (Optional) The existing Subnet to use for the Container Apps Control Plane. Changing this forces a new resource to be created. 
 
-~> **NOTE:** The Subnet must have a `/21` or larger address space. 
+~> **NOTE:** The Subnet must have a `/23` or larger address space for a `Consumption` (Default) workload. If `workload_profiles_enabled` is `true`, you can use a `/27` or larger subnet. 
 
 * `internal_load_balancer_enabled` - (Optional) Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. Changing this forces a new resource to be created.
 
@@ -68,6 +72,18 @@ The following arguments are supported:
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `workload_profile` object consists of the following:
+
+* `name` - (Required) The name of the profile to deploy
+
+* `workload_profile_type` - (Required) The type of profile to deploy. The default `Consumption` profile is created automatically.  The `D` profile types are `General Purpose`, while `E` profile types are `Memory Optimized`. Allowed values: `consumption`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16`, `E32`.
+
+* `maximum_count` - (Optional) The maximum number of instances to deploy.  Must be at least `1`.
+
+* `minimum_count` - (Optional) The minimum number of instances to deploy. Must be `0` or greater.
 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -58,6 +58,11 @@ The following arguments are supported:
 
 * `zone_redundancy_enabled` - (Optional) Should the Container App Environment be created with Zone Redundancy enabled? Defaults to `false`. Changing this forces a new resource to be created.
 
+
+~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
+
+* `workload_profiles_enabled` - (Optional) Should the Container App Environment be created with Workload Profles enabled? Defaults to `false`. Changing this forces a new resource to be created.
+
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
 
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -65,9 +65,13 @@ The following arguments are supported:
 
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
 
-* `workload_profiles_enabled` - (Optional) Should the Container App Environment be created with Workload Profles enabled? Defaults to `false`. Changing this forces a new resource to be created.
+* `workload_profile_enabled` - (Optional) Should the Container App Environment be created with Workload Profles enabled? Defaults to `false`. Changing this forces a new resource to be created.
 
-~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
+~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified.
+
+* `workload_profiles` - (Optional) Zero or more Workload Profiles blocks defining the workloads you wish to run as defined below.
+
+~> **Note:** can only be specified if `workload_profile_enabled` is specified.
 
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
@@ -75,15 +79,15 @@ The following arguments are supported:
 
 ---
 
-A `workload_profile` object consists of the following:
+A `workload_profiles` block consists of the following:
 
 * `name` - (Required) The name of the profile to deploy
 
-* `workload_profile_type` - (Required) The type of profile to deploy. The default `Consumption` profile is created automatically.  The `D` profile types are `General Purpose`, while `E` profile types are `Memory Optimized`. Allowed values: `consumption`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16`, `E32`.
+* `workload_profile_type` - (Required) The type of profile to deploy. The default `Consumption` profile is created automatically.  The `D` profile types are `General Purpose`, while `E` profile types are `Memory Optimized`. Allowed values: `Consumption`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16`, `E32`.
 
-* `maximum_count` - (Optional) The maximum number of instances to deploy.  Must be at least `1`.
+* `maximum_count` - (Optional) The maximum number of instances to deploy.  Must be at least `1`, *DO NOT* Specify for `Consumption` profiles.
 
-* `minimum_count` - (Optional) The minimum number of instances to deploy. Must be `0` or greater.
+* `minimum_count` - (Optional) The minimum number of instances to deploy. Must be `0` or greater, *DO NOT* Specify for `Consumption` profiles.
 
 ## Attributes Reference
 


### PR DESCRIPTION
There's presently no way to create a workload-profile enabled Container App Environment.  This issue costs me a few days as it wasn't evident what the issue was due to Azure not responding with an error and just timing out after failing to provision.  Once I passed the value from CLI, it succeeded.  This replicates that behavior.