### PR TITLE
`azurerm_log_analytics_workspace` - support for the `identity` property

### DIFF
--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -77,9 +77,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the identity type of the Function App. Possible values are `SystemAssigned` (where Azure will generate a Service Principal for you), `UserAssigned` where you can specify the Service Principal IDs in the `identity_ids` field, and `SystemAssigned, UserAssigned` which assigns both a system managed identity as well as the specified user assigned identities.
+* `type` - (Required) Specifies the identity type of the Log Analytics Workspace. Possible values are `SystemAssigned` (where Azure will generate a Service Principal for you) and `UserAssigned` where you can specify the Service Principal IDs in the `identity_ids` field.
 
-~> **NOTE:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Function App has been created. More details are available below.
+~> **NOTE:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Log Analytics Workspace has been created.
 
 * `identity_ids` - (Optional) Specifies a list of user managed identity ids to be assigned. Required if `type` is `UserAssigned`.
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 * `cmk_for_query_forced` - (Optional) Is Customer Managed Storage mandatory for query management?
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `internet_ingestion_enabled` - (Optional) Should the Log Analytics Workspace support ingestion over the Public Internet? Defaults to `true`.
 
 * `internet_query_enabled` - (Optional) Should the Log Analytics Workspace support querying over the Public Internet? Defaults to `true`.
@@ -70,6 +72,16 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> **NOTE:** If a `azurerm_log_analytics_workspace` is connected to a `azurerm_log_analytics_cluster` via a `azurerm_log_analytics_linked_service` you will not be able to modify the workspaces `sku` field until the link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource. All other fields are modifiable while the workspace is linked to a cluster.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the identity type of the Function App. Possible values are `SystemAssigned` (where Azure will generate a Service Principal for you), `UserAssigned` where you can specify the Service Principal IDs in the `identity_ids` field, and `SystemAssigned, UserAssigned` which assigns both a system managed identity as well as the specified user assigned identities.
+
+~> **NOTE:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Function App has been created. More details are available below.
+
+* `identity_ids` - (Optional) Specifies a list of user managed identity ids to be assigned. Required if `type` is `UserAssigned`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
test
---
```
 tftest loganalytics TestAccLogAnalyticsWorkspace           
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:96: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== RUN   TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== RUN   TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== RUN   TestAccLogAnalyticsWorkspace_updateSku
=== PAUSE TestAccLogAnalyticsWorkspace_updateSku
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== RUN   TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
=== RUN   TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== RUN   TestAccLogAnalyticsWorkspace_toggleIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_toggleIdentity
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== CONT  TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== CONT  TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
=== CONT  TestAccLogAnalyticsWorkspace_toggleIdentity
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_basic (192.66s)
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (195.24s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
--- PASS: TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity (196.22s)
=== CONT  TestAccLogAnalyticsWorkspace_updateSku
--- PASS: TestAccLogAnalyticsWorkspace_withUserAssignedIdentity (216.38s)
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (265.71s)
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (265.78s)
=== CONT  TestAccLogAnalyticsWorkspace_complete
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule (297.61s)
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
--- PASS: TestAccLogAnalyticsWorkspace_toggleIdentity (363.54s)
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (182.84s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
--- PASS: TestAccLogAnalyticsWorkspace_complete (182.81s)
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
--- PASS: TestAccLogAnalyticsWorkspace_updateSku (253.42s)
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (186.39s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (261.29s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth (288.48s)
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (199.71s)
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (250.26s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission (288.89s)
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (252.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	701.567s
```