### PR TITLE
`azurerm_logic_app_integration_account_certificate`/`azurerm_logic_app_integration_account_partner` - `name`/`business_identity.value` now accepts underscores.

### DIFF
--- a/internal/services/logic/validate/integration_account_certificate_name.go
+++ b/internal/services/logic/validate/integration_account_certificate_name.go
@@ -23,8 +23,8 @@ func IntegrationAccountCertificateName() pluginsdk.SchemaValidateFunc {
 			return
 		}
 
-		if !regexp.MustCompile(`^[A-Za-z0-9-().]+$`).MatchString(v) {
-			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens.", k))
+		if !regexp.MustCompile(`^[A-Za-z0-9-()._]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses, hyphens and underscores.", k))
 			return
 		}
 

--- a/internal/services/logic/validate/integration_account_partner_business_identity_value.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_value.go
@@ -23,8 +23,8 @@ func IntegrationAccountPartnerBusinessIdentityValue() pluginsdk.SchemaValidateFu
 			return
 		}
 
-		if !regexp.MustCompile(`^[A-Za-z0-9-() .]+$`).MatchString(v) {
-			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens", k))
+		if !regexp.MustCompile(`^[A-Za-z0-9-() ._]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses, hyphens and underscores", k))
 			return
 		}
 


### PR DESCRIPTION
Update regex in `internal/services/logic/validate/integration_account_partner_business_identity_value.go` and `internal/services/logic/validate/integration_account_certificate_name.go` to accept underscores. 