### PR TITLE
dependencies: bump go-azure-sdk to v0.20231113.1151754

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.63.0
-	github.com/hashicorp/go-azure-sdk v0.20231113.1102643
+	github.com/hashicorp/go-azure-sdk v0.20231113.1151754
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.63.0 h1:7bYnYZsqzPjxVevi0z8Irwp5DwS8okLcaA183DQAcmY=
 github.com/hashicorp/go-azure-helpers v0.63.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
-github.com/hashicorp/go-azure-sdk v0.20231113.1102643 h1:heGA1c0LJ3aSWMpvVa4fkuYeN68bUsYV1rI6YcVbcfg=
-github.com/hashicorp/go-azure-sdk v0.20231113.1102643/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
+github.com/hashicorp/go-azure-sdk v0.20231113.1151754 h1:EyN6Hhc0WwQczRC8sO3BCvKKxLIVCjZJzxbYW75bFAM=
+github.com/hashicorp/go-azure-sdk v0.20231113.1151754/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20231113.1102643
+# github.com/hashicorp/go-azure-sdk v0.20231113.1151754
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
Upgrading go-azure-sdk to support new RP SystemCenterVirtualMachineManager.