### PR TITLE
`azurerm_kubernetes_cluster`, `azurerm_kubernetes_cluster_node_pool` - support for the `gpu_instance_profile` property

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -152,6 +152,19 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 		},
 
+		"gpu_instance_profile": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.GPUInstanceProfileMIGOneg),
+				string(managedclusters.GPUInstanceProfileMIGTwog),
+				string(managedclusters.GPUInstanceProfileMIGThreeg),
+				string(managedclusters.GPUInstanceProfileMIGFourg),
+				string(managedclusters.GPUInstanceProfileMIGSeveng),
+			}, false),
+		},
+
 		"kubelet_disk_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
@@ -466,6 +479,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 		// this must always be sent during creation, but is optional for auto-scaled clusters during update
 		Count: utils.Int64(int64(count)),
+	}
+
+	if gpuInstanceProfile := d.Get("gpu_instance_profile").(string); gpuInstanceProfile != "" {
+		profile.GpuInstanceProfile = utils.ToPtr(agentpools.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
 	if osSku := d.Get("os_sku").(string); osSku != "" {
@@ -839,6 +856,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("enable_host_encryption", props.EnableEncryptionAtHost)
 		d.Set("custom_ca_trust_enabled", props.EnableCustomCATrust)
 		d.Set("fips_enabled", props.EnableFIPS)
+		d.Set("gpu_instance_profile", props.GpuInstanceProfile)
 		d.Set("ultra_ssd_enabled", props.EnableUltraSSD)
 
 		if v := props.KubeletDiskType; v != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -856,11 +856,14 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("enable_host_encryption", props.EnableEncryptionAtHost)
 		d.Set("custom_ca_trust_enabled", props.EnableCustomCATrust)
 		d.Set("fips_enabled", props.EnableFIPS)
-		d.Set("gpu_instance_profile", props.GpuInstanceProfile)
 		d.Set("ultra_ssd_enabled", props.EnableUltraSSD)
 
 		if v := props.KubeletDiskType; v != nil {
 			d.Set("kubelet_disk_type", string(*v))
+		}
+
+		if v := props.GpuInstanceProfile; v != nil {
+			d.Set("gpu_instance_profile", string(*v))
 		}
 
 		if props.CreationData != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -152,7 +152,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 		},
 
-		"gpu_instance_profile": {
+		"gpu_instance": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
@@ -481,7 +481,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		Count: utils.Int64(int64(count)),
 	}
 
-	if gpuInstanceProfile := d.Get("gpu_instance_profile").(string); gpuInstanceProfile != "" {
+	if gpuInstanceProfile := d.Get("gpu_instance").(string); gpuInstanceProfile != "" {
 		profile.GpuInstanceProfile = utils.ToPtr(agentpools.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
@@ -863,7 +863,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		}
 
 		if v := props.GpuInstanceProfile; v != nil {
-			d.Set("gpu_instance_profile", string(*v))
+			d.Set("gpu_instance", string(*v))
 		}
 
 		if props.CreationData != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1034,6 +1034,21 @@ func TestAccKubernetesClusterNodePool_snapshotId(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_gpuInstanceProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.gpuInstanceProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t KubernetesClusterNodePoolResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := agentpools.ParseAgentPoolID(state.ID)
 	if err != nil {
@@ -2705,4 +2720,39 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   ]
 }
  `, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (KubernetesClusterNodePoolResource) gpuInstanceProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_ND96asr_v4"
+  gpu_instance_profile  = "MIG1g"
+}
+ `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2751,7 +2751,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_ND96asr_v4"
+  vm_size               = "Standard_NC24ads_A100_v4"
   gpu_instance          = "MIG1g"
 }
  `, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1034,13 +1034,13 @@ func TestAccKubernetesClusterNodePool_snapshotId(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesClusterNodePool_gpuInstanceProfile(t *testing.T) {
+func TestAccKubernetesClusterNodePool_gpuInstance(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.gpuInstanceProfile(data),
+			Config: r.gpuInstance(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2722,7 +2722,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
  `, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }
 
-func (KubernetesClusterNodePoolResource) gpuInstanceProfile(data acceptance.TestData) string {
+func (KubernetesClusterNodePoolResource) gpuInstance(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -2752,7 +2752,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_ND96asr_v4"
-  gpu_instance_profile  = "MIG1g"
+  gpu_instance          = "MIG1g"
 }
  `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1043,13 +1043,13 @@ func TestAccKubernetesCluster_snapshotId(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_gpuInstanceProfile(t *testing.T) {
+func TestAccKubernetesCluster_gpuInstance(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.gpuInstanceProfile(data),
+			Config: r.gpuInstance(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -3119,7 +3119,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }
 
-func (KubernetesClusterResource) gpuInstanceProfile(data acceptance.TestData) string {
+func (KubernetesClusterResource) gpuInstance(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3137,10 +3137,10 @@ resource "azurerm_kubernetes_cluster" "test" {
   dns_prefix          = "acctestaks%[2]d"
 
   default_node_pool {
-    name                 = "default"
-    node_count           = 1
-    vm_size              = "Standard_ND96asr_v4"
-    gpu_instance_profile = "MIG1g"
+    name         = "default"
+    node_count   = 1
+    vm_size      = "Standard_ND96asr_v4"
+    gpu_instance = "MIG1g"
   }
 
   identity {

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3139,7 +3139,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   default_node_pool {
     name         = "default"
     node_count   = 1
-    vm_size      = "Standard_ND96asr_v4"
+    vm_size      = "Standard_NC24ads_A100_v4"
     gpu_instance = "MIG1g"
   }
 

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1043,6 +1043,21 @@ func TestAccKubernetesCluster_snapshotId(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_gpuInstanceProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.gpuInstanceProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KubernetesClusterResource) basicAvailabilitySetConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -3102,4 +3117,35 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (KubernetesClusterResource) gpuInstanceProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name                 = "default"
+    node_count           = 1
+    vm_size              = "Standard_ND96asr_v4"
+    gpu_instance_profile = "MIG1g"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+  `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -109,7 +109,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ForceNew: true,
 					},
 
-					"gpu_instance_profile": {
+					"gpu_instance": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						ForceNew: true,
@@ -1063,7 +1063,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.CapacityReservationGroupID = utils.String(capacityReservationGroupId)
 	}
 
-	if gpuInstanceProfile := raw["gpu_instance_profile"].(string); gpuInstanceProfile != "" {
+	if gpuInstanceProfile := raw["gpu_instance"].(string); gpuInstanceProfile != "" {
 		profile.GpuInstanceProfile = utils.ToPtr(managedclusters.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
@@ -1497,7 +1497,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"enable_host_encryption":        enableHostEncryption,
 		"custom_ca_trust_enabled":       customCaTrustEnabled,
 		"fips_enabled":                  enableFIPS,
-		"gpu_instance_profile":          gpuInstanceProfile,
+		"gpu_instance":                  gpuInstanceProfile,
 		"host_group_id":                 hostGroupID,
 		"kubelet_disk_type":             kubeletDiskType,
 		"max_count":                     maxCount,

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -109,6 +109,19 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ForceNew: true,
 					},
 
+					"gpu_instance_profile": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(managedclusters.GPUInstanceProfileMIGOneg),
+							string(managedclusters.GPUInstanceProfileMIGTwog),
+							string(managedclusters.GPUInstanceProfileMIGThreeg),
+							string(managedclusters.GPUInstanceProfileMIGFourg),
+							string(managedclusters.GPUInstanceProfileMIGSeveng),
+						}, false),
+					},
+
 					"kubelet_disk_type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
@@ -916,6 +929,10 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 		}
 	}
 
+	if defaultCluster.GpuInstanceProfile != nil {
+		agentpool.Properties.GpuInstanceProfile = utils.ToPtr(agentpools.GPUInstanceProfile(*defaultCluster.GpuInstanceProfile))
+	}
+
 	return agentpool
 }
 
@@ -1044,6 +1061,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 
 	if capacityReservationGroupId := raw["capacity_reservation_group_id"].(string); capacityReservationGroupId != "" {
 		profile.CapacityReservationGroupID = utils.String(capacityReservationGroupId)
+	}
+
+	if gpuInstanceProfile := raw["gpu_instance_profile"].(string); gpuInstanceProfile != "" {
+		profile.GpuInstanceProfile = utils.ToPtr(managedclusters.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
 	count := raw["node_count"].(int)
@@ -1325,6 +1346,11 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		enableHostEncryption = *agentPool.EnableEncryptionAtHost
 	}
 
+	gpuInstanceProfile := ""
+	if agentPool.GpuInstanceProfile != nil {
+		gpuInstanceProfile = string(*agentPool.GpuInstanceProfile)
+	}
+
 	maxCount := 0
 	if agentPool.MaxCount != nil {
 		maxCount = int(*agentPool.MaxCount)
@@ -1471,6 +1497,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"enable_host_encryption":        enableHostEncryption,
 		"custom_ca_trust_enabled":       customCaTrustEnabled,
 		"fips_enabled":                  enableFIPS,
+		"gpu_instance_profile":          gpuInstanceProfile,
 		"host_group_id":                 hostGroupID,
 		"kubelet_disk_type":             kubeletDiskType,
 		"max_count":                     maxCount,

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -398,6 +398,8 @@ A `default_node_pool` block supports the following:
 
 * `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? `temporary_name_for_rotation` must be specified when changing this property.
 
+* `gpu_instance_profile` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
+
 * `host_group_id` - (Optional) Specifies the ID of the Host Group within which this AKS Cluster should be created. Changing this forces a new resource to be created.
 
 * `kubelet_config` - (Optional) A `kubelet_config` block as defined below. `temporary_name_for_rotation` must be specified when changing this block.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -398,7 +398,7 @@ A `default_node_pool` block supports the following:
 
 * `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? `temporary_name_for_rotation` must be specified when changing this property.
 
-* `gpu_instance_profile` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
+* `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
 * `host_group_id` - (Optional) Specifies the ID of the Host Group within which this AKS Cluster should be created. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,6 +98,8 @@ The following arguments are supported:
 
 ~> **Note:** FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
+* `gpu_instance_profile` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
+
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 ~> **Note:** FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
-* `gpu_instance_profile` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
+* `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`.
 


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesClusterNodePool_gpuInstanceProfile
=== PAUSE TestAccKubernetesClusterNodePool_gpuInstanceProfile
=== CONT  TestAccKubernetesClusterNodePool_gpuInstanceProfile
--- PASS: TestAccKubernetesClusterNodePool_gpuInstanceProfile (767.65s)

```