### PR TITLE
`azurerm_hdinsight_hadoop_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_hdinsight_kafka_cluster`, `azurerm_hdinsight_spark_cluster`: unmark `ForceNew` for `script_actions`

### DIFF
--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -349,7 +349,6 @@ func SchemaHDInsightsScriptActions() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
-		ForceNew: true,
 		MinItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -159,7 +159,7 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 ---
 
@@ -257,7 +257,7 @@ A `worker_node` block supports the following:
 
 * `autoscale` - (Optional) A `autoscale` block as defined below.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 ---
 
@@ -291,7 +291,7 @@ A `zookeeper_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 ---
 
@@ -305,7 +305,7 @@ A `edge_node` block supports the following:
 
 * `https_endpoints` - (Optional) The HTTPS Connectivity Endpoint for this HDInsight Hadoop Cluster. One or more `https_endpoints` blocks as defined below.
 
-* `uninstall_script_actions` - (Optional) A `uninstall_script_actions` block as defined below. Changing this forces a new resource to be created.
+* `uninstall_script_actions` - (Optional) A `uninstall_script_actions` block as defined below.
 
 ---
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -159,7 +159,7 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 ---
 
@@ -235,7 +235,7 @@ A `storage_account_gen2` block supports the following:
 
 A `worker_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 
@@ -273,7 +273,7 @@ A `disk_encryption` block supports the following:
 
 A `zookeeper_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -163,7 +163,7 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 ---
 
@@ -239,7 +239,7 @@ A `storage_account_gen2` block supports the following:
 
 A `worker_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 
@@ -279,7 +279,7 @@ A `disk_encryption` block supports the following:
 
 A `zookeeper_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -156,7 +156,7 @@ A `compute_isolation` block supports the following:
 
 A `head_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 * `username` - (Required) The Username of the local administrator for the Head Nodes. Changing this forces a new resource to be created.
 
@@ -234,7 +234,7 @@ A `storage_account_gen2` block supports the following:
 
 A `worker_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 * `number_of_disks_per_node` - (Required) The number of Data Disks which should be assigned to each Worker Node, which can be between 1 and 8. Changing this forces a new resource to be created.
 
@@ -260,7 +260,7 @@ A `worker_node` block supports the following:
 
 A `zookeeper_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.
 
@@ -294,7 +294,7 @@ A `disk_encryption` block supports the following:
 
 A `kafka_management_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 * `username` - (Required) The Username of the local administrator for the Kafka Management Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -161,7 +161,7 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined below.
 
 ---
 
@@ -237,7 +237,7 @@ A `storage_account_gen2` block supports the following:
 
 A `worker_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 
@@ -263,7 +263,7 @@ A `worker_node` block supports the following:
 
 A `zookeeper_node` block supports the following:
 
-* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above. Changing this forces a new resource to be created.
+* `script_actions` - (Optional) The script action which will run on the cluster. One or more `script_actions` blocks as defined above.
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
* `script_actions` should always be able to run after the creation of an HDInsight cluster. It won't trigger a force replacement.