### PR TITLE
Docs: update `azurerm_resources.types` field description

### DIFF
--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -56,7 +56,7 @@ resource "azurerm_virtual_network_peering" "spoke_peers" {
 
 * `resource_group_name` - (Optional) The name of the Resource group where the Resources are located.
 
-* `type` - (Optional) The Resource Type of the Resources you want to list (e.g. `Microsoft.Network/virtualNetworks`). A full list of available Resource Types can be found [here](https://docs.microsoft.com/azure/azure-resource-manager/azure-services-resource-providers).
+* `type` - (Optional) The Resource Type of the Resources you want to list (e.g. `Microsoft.Network/virtualNetworks`). A resource type's name follows the format: `{resource-provider}/{resource-type}`. The resource type for a key vault is `Microsoft.KeyVault/vaults`. A full list of available Resource Providers can be found [here](https://docs.microsoft.com/azure/azure-resource-manager/azure-services-resource-providers). A full list of Resources Types can be found [here](https://learn.microsoft.com/en-us/azure/templates/#find-resources).
 
 * `required_tags` - (Optional) A mapping of tags which the resource has to have in order to be included in the result.
 


### PR DESCRIPTION
The old link may not enough for users to find the right resource type. This PR is to add more information/reference link.
fixes: #23885 