### PR TITLE
`appservice` -  support disabling access for default basic auth

### DIFF
--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -36,27 +36,29 @@ type LinuxFunctionAppDataSourceModel struct {
 	StorageUsesMSI          bool   `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
 	StorageKeyVaultSecretID string `tfschema:"storage_key_vault_secret_id"`
 
-	AppSettings               map[string]string                    `tfschema:"app_settings"`
-	AuthSettings              []helpers.AuthSettings               `tfschema:"auth_settings"`
-	AuthV2Settings            []helpers.AuthV2Settings             `tfschema:"auth_settings_v2"`
-	Availability              string                               `tfschema:"availability"`
-	Backup                    []helpers.Backup                     `tfschema:"backup"` // Not supported on Dynamic or Basic plans
-	BuiltinLogging            bool                                 `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled         bool                                 `tfschema:"client_certificate_enabled"`
-	ClientCertMode            string                               `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths  string                               `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings         []helpers.ConnectionString           `tfschema:"connection_string"`
-	DailyMemoryTimeQuota      int                                  `tfschema:"daily_memory_time_quota"`
-	Enabled                   bool                                 `tfschema:"enabled"`
-	FunctionExtensionsVersion string                               `tfschema:"functions_extension_version"`
-	ForceDisableContentShare  bool                                 `tfschema:"content_share_force_disabled"`
-	HttpsOnly                 bool                                 `tfschema:"https_only"`
-	PublicNetworkAccess       bool                                 `tfschema:"public_network_access_enabled"`
-	SiteConfig                []helpers.SiteConfigLinuxFunctionApp `tfschema:"site_config"`
-	StickySettings            []helpers.StickySettings             `tfschema:"sticky_settings"`
-	Tags                      map[string]string                    `tfschema:"tags"`
-	VirtualNetworkSubnetID    string                               `tfschema:"virtual_network_subnet_id"`
+	AppSettings                      map[string]string                    `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings               `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings             `tfschema:"auth_settings_v2"`
+	Availability                     string                               `tfschema:"availability"`
+	Backup                           []helpers.Backup                     `tfschema:"backup"` // Not supported on Dynamic or Basic plans
+	BuiltinLogging                   bool                                 `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                                 `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                               `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                               `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString           `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                                  `tfschema:"daily_memory_time_quota"`
+	Enabled                          bool                                 `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                               `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                                 `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                                 `tfschema:"https_only"`
+	PublicNetworkAccess              bool                                 `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                                 `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                 `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteConfig                       []helpers.SiteConfigLinuxFunctionApp `tfschema:"site_config"`
+	StickySettings                   []helpers.StickySettings             `tfschema:"sticky_settings"`
+	Tags                             map[string]string                    `tfschema:"tags"`
 
+	VirtualNetworkSubnetID        string   `tfschema:"virtual_network_subnet_id"`
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
 	DefaultHostname               string   `tfschema:"default_hostname"`
 	HostingEnvId                  string   `tfschema:"hosting_environment_id"`
@@ -257,6 +259,16 @@ func (d LinuxFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"site_credential": helpers.SiteCredentialSchema(),
 
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
 		"sticky_settings": helpers.StickySettingsComputedSchema(),
 
 		"virtual_network_subnet_id": {
@@ -361,6 +373,23 @@ func (d LinuxFunctionAppDataSource) Read() sdk.ResourceFunc {
 				Usage:                      string(props.UsageState),
 				PublicNetworkAccess:        !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled),
 			}
+
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				state.HostingEnvId = pointer.From(hostingEnv.ID)

--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -376,14 +376,14 @@ func (d LinuxFunctionAppDataSource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -553,7 +553,7 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -564,7 +564,7 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -728,14 +728,14 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -1066,7 +1066,7 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -1077,7 +1077,7 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -41,28 +41,30 @@ type LinuxFunctionAppModel struct {
 	StorageUsesMSI          bool   `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
 	StorageKeyVaultSecretID string `tfschema:"storage_key_vault_secret_id"`
 
-	AppSettings                 map[string]string                    `tfschema:"app_settings"`
-	StickySettings              []helpers.StickySettings             `tfschema:"sticky_settings"`
-	AuthSettings                []helpers.AuthSettings               `tfschema:"auth_settings"`
-	AuthV2Settings              []helpers.AuthV2Settings             `tfschema:"auth_settings_v2"`
-	Backup                      []helpers.Backup                     `tfschema:"backup"` // Not supported on Dynamic or Basic plans
-	BuiltinLogging              bool                                 `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled           bool                                 `tfschema:"client_certificate_enabled"`
-	ClientCertMode              string                               `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths    string                               `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings           []helpers.ConnectionString           `tfschema:"connection_string"`
-	DailyMemoryTimeQuota        int                                  `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
-	Enabled                     bool                                 `tfschema:"enabled"`
-	FunctionExtensionsVersion   string                               `tfschema:"functions_extension_version"`
-	ForceDisableContentShare    bool                                 `tfschema:"content_share_force_disabled"`
-	HttpsOnly                   bool                                 `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID string                               `tfschema:"key_vault_reference_identity_id"`
-	PublicNetworkAccess         bool                                 `tfschema:"public_network_access_enabled"`
-	SiteConfig                  []helpers.SiteConfigLinuxFunctionApp `tfschema:"site_config"`
-	StorageAccounts             []helpers.StorageAccount             `tfschema:"storage_account"`
-	Tags                        map[string]string                    `tfschema:"tags"`
-	VirtualNetworkSubnetID      string                               `tfschema:"virtual_network_subnet_id"`
-	ZipDeployFile               string                               `tfschema:"zip_deploy_file"`
+	AppSettings                      map[string]string                    `tfschema:"app_settings"`
+	StickySettings                   []helpers.StickySettings             `tfschema:"sticky_settings"`
+	AuthSettings                     []helpers.AuthSettings               `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings             `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup                     `tfschema:"backup"` // Not supported on Dynamic or Basic plans
+	BuiltinLogging                   bool                                 `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                                 `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                               `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                               `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString           `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                                  `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
+	Enabled                          bool                                 `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                               `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                                 `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                                 `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                               `tfschema:"key_vault_reference_identity_id"`
+	PublicNetworkAccess              bool                                 `tfschema:"public_network_access_enabled"`
+	SiteConfig                       []helpers.SiteConfigLinuxFunctionApp `tfschema:"site_config"`
+	StorageAccounts                  []helpers.StorageAccount             `tfschema:"storage_account"`
+	Tags                             map[string]string                    `tfschema:"tags"`
+	VirtualNetworkSubnetID           string                               `tfschema:"virtual_network_subnet_id"`
+	ZipDeployFile                    string                               `tfschema:"zip_deploy_file"`
+	PublishingDeployBasicAuthEnabled bool                                 `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                 `tfschema:"ftp_publish_basic_authentication_enabled"`
 
 	// Computed
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
@@ -257,6 +259,18 @@ func (r LinuxFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
@@ -531,6 +545,29 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for creation of Linux %s: %+v", id, err)
 			}
 
+			// (@jackofallops) - updating the policy for publishing credentials resets the `Use32BitWorkerProcess` property
+			if !functionApp.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !functionApp.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			updateFuture, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
 			if err != nil {
 				return fmt.Errorf("updating properties of Linux %s: %+v", id, err)
@@ -689,6 +726,20 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading logs configuration for Linux %s: %+v", id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := LinuxFunctionAppModel{
 				Name:                        id.SiteName,
 				ResourceGroup:               id.ResourceGroup,
@@ -706,6 +757,9 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 				DefaultHostname:             utils.NormalizeNilableString(props.DefaultHostName),
 				PublicNetworkAccess:         !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled),
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
@@ -1003,6 +1057,28 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 			}
 			if err := updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 				return fmt.Errorf("waiting to update %s: %+v", id, err)
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
 			}
 
 			if _, err := client.UpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, web.SiteConfigResource{SiteConfig: existing.SiteConfig}); err != nil {

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -2903,6 +2903,9 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
+
   tags = {
     terraform = "true"
     Env       = "AccTest"
@@ -3094,6 +3097,9 @@ resource "azurerm_linux_function_app" "test" {
     app_setting_names       = ["foo", "secret"]
     connection_string_names = ["First"]
   }
+
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   tags = {
     terraform = "true"

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -2903,7 +2903,7 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {
@@ -3098,7 +3098,7 @@ resource "azurerm_linux_function_app" "test" {
     connection_string_names = ["First"]
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -31,42 +31,44 @@ import (
 type LinuxFunctionAppSlotResource struct{}
 
 type LinuxFunctionAppSlotModel struct {
-	Name                          string                                   `tfschema:"name"`
-	FunctionAppID                 string                                   `tfschema:"function_app_id"`
-	ServicePlanID                 string                                   `tfschema:"service_plan_id"`
-	StorageAccountName            string                                   `tfschema:"storage_account_name"`
-	StorageAccountKey             string                                   `tfschema:"storage_account_access_key"`
-	StorageUsesMSI                bool                                     `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
-	StorageKeyVaultSecretID       string                                   `tfschema:"storage_key_vault_secret_id"`
-	AppSettings                   map[string]string                        `tfschema:"app_settings"`
-	AuthSettings                  []helpers.AuthSettings                   `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings                 `tfschema:"auth_settings_v2"`
-	Backup                        []helpers.Backup                         `tfschema:"backup"` // Not supported on Dynamic or Basic plans
-	BuiltinLogging                bool                                     `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled             bool                                     `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                                   `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                                   `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings             []helpers.ConnectionString               `tfschema:"connection_string"`
-	DailyMemoryTimeQuota          int                                      `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
-	Enabled                       bool                                     `tfschema:"enabled"`
-	FunctionExtensionsVersion     string                                   `tfschema:"functions_extension_version"`
-	ForceDisableContentShare      bool                                     `tfschema:"content_share_force_disabled"`
-	HttpsOnly                     bool                                     `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID   string                                   `tfschema:"key_vault_reference_identity_id"`
-	SiteConfig                    []helpers.SiteConfigLinuxFunctionAppSlot `tfschema:"site_config"`
-	Tags                          map[string]string                        `tfschema:"tags"`
-	VirtualNetworkSubnetID        string                                   `tfschema:"virtual_network_subnet_id"`
-	CustomDomainVerificationId    string                                   `tfschema:"custom_domain_verification_id"`
-	HostingEnvId                  string                                   `tfschema:"hosting_environment_id"`
-	DefaultHostname               string                                   `tfschema:"default_hostname"`
-	Kind                          string                                   `tfschema:"kind"`
-	OutboundIPAddresses           string                                   `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string                                 `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string                                   `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string                                 `tfschema:"possible_outbound_ip_address_list"`
-	PublicNetworkAccess           bool                                     `tfschema:"public_network_access_enabled"`
-	SiteCredentials               []helpers.SiteCredential                 `tfschema:"site_credential"`
-	StorageAccounts               []helpers.StorageAccount                 `tfschema:"storage_account"`
+	Name                             string                                   `tfschema:"name"`
+	FunctionAppID                    string                                   `tfschema:"function_app_id"`
+	ServicePlanID                    string                                   `tfschema:"service_plan_id"`
+	StorageAccountName               string                                   `tfschema:"storage_account_name"`
+	StorageAccountKey                string                                   `tfschema:"storage_account_access_key"`
+	StorageUsesMSI                   bool                                     `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
+	StorageKeyVaultSecretID          string                                   `tfschema:"storage_key_vault_secret_id"`
+	AppSettings                      map[string]string                        `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings                   `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings                 `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup                         `tfschema:"backup"` // Not supported on Dynamic or Basic plans
+	BuiltinLogging                   bool                                     `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                                     `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                                   `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                                   `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString               `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                                      `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
+	Enabled                          bool                                     `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                                   `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                                     `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                                     `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                                   `tfschema:"key_vault_reference_identity_id"`
+	SiteConfig                       []helpers.SiteConfigLinuxFunctionAppSlot `tfschema:"site_config"`
+	Tags                             map[string]string                        `tfschema:"tags"`
+	VirtualNetworkSubnetID           string                                   `tfschema:"virtual_network_subnet_id"`
+	CustomDomainVerificationId       string                                   `tfschema:"custom_domain_verification_id"`
+	HostingEnvId                     string                                   `tfschema:"hosting_environment_id"`
+	DefaultHostname                  string                                   `tfschema:"default_hostname"`
+	Kind                             string                                   `tfschema:"kind"`
+	OutboundIPAddresses              string                                   `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList            []string                                 `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses      string                                   `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList    []string                                 `tfschema:"possible_outbound_ip_address_list"`
+	PublicNetworkAccess              bool                                     `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                                     `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                     `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteCredentials                  []helpers.SiteCredential                 `tfschema:"site_credential"`
+	StorageAccounts                  []helpers.StorageAccount                 `tfschema:"storage_account"`
 }
 
 var _ sdk.ResourceWithUpdate = LinuxFunctionAppSlotResource{}
@@ -248,6 +250,18 @@ func (r LinuxFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
@@ -528,6 +542,28 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for creation of Linux %s: %+v", id, err)
 			}
 
+			if !functionAppSlot.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !functionAppSlot.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			updateFuture, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)
 			if err != nil {
 				return fmt.Errorf("updating properties of Linux %s: %+v", id, err)
@@ -665,6 +701,20 @@ func (r LinuxFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading logs configuration for Linux %s: %+v", id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := LinuxFunctionAppSlotModel{
 				Name:                        id.SlotName,
 				FunctionAppID:               parse.NewFunctionAppID(id.SubscriptionId, id.ResourceGroup, id.SiteName).ID(),
@@ -679,6 +729,9 @@ func (r LinuxFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				DefaultHostname:             pointer.From(props.DefaultHostName),
 				PublicNetworkAccess:         !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled),
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				state.HostingEnvId = pointer.From(hostingEnv.ID)
@@ -948,6 +1001,28 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 			}
 			if err := updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 				return fmt.Errorf("waiting to update %s: %+v", id, err)
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
 			}
 
 			if _, err := client.UpdateConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, web.SiteConfigResource{SiteConfig: siteConfig}, id.SlotName); err != nil {

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -549,7 +549,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -560,7 +560,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -703,14 +703,14 @@ func (r LinuxFunctionAppSlotResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -1010,7 +1010,7 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -1021,7 +1021,7 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -2066,7 +2066,7 @@ resource "azurerm_linux_function_app_slot" "test" {
     }
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -2066,6 +2066,9 @@ resource "azurerm_linux_function_app_slot" "test" {
     }
   }
 
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
+
   tags = {
     terraform = "true"
     Env       = "AccTest"

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -24,41 +24,43 @@ import (
 type LinuxWebAppDataSource struct{}
 
 type LinuxWebAppDataSourceModel struct {
-	Name                          string                     `tfschema:"name"`
-	ResourceGroup                 string                     `tfschema:"resource_group_name"`
-	Location                      string                     `tfschema:"location"`
-	ServicePlanId                 string                     `tfschema:"service_plan_id"`
-	AppSettings                   map[string]string          `tfschema:"app_settings"`
-	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
-	Availability                  string                     `tfschema:"availability"`
-	Backup                        []helpers.Backup           `tfschema:"backup"`
-	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                     `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                     `tfschema:"client_certificate_exclusion_paths"`
-	Enabled                       bool                       `tfschema:"enabled"`
-	HttpsOnly                     bool                       `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID   string                     `tfschema:"key_vault_reference_identity_id"`
-	LogsConfig                    []helpers.LogsConfig       `tfschema:"logs"`
-	MetaData                      map[string]string          `tfschema:"app_metadata"`
-	SiteConfig                    []helpers.SiteConfigLinux  `tfschema:"site_config"`
-	StickySettings                []helpers.StickySettings   `tfschema:"sticky_settings"`
-	StorageAccounts               []helpers.StorageAccount   `tfschema:"storage_account"`
-	ConnectionStrings             []helpers.ConnectionString `tfschema:"connection_string"`
-	Tags                          map[string]string          `tfschema:"tags"`
-	CustomDomainVerificationId    string                     `tfschema:"custom_domain_verification_id"`
-	HostingEnvId                  string                     `tfschema:"hosting_environment_id"`
-	DefaultHostname               string                     `tfschema:"default_hostname"`
-	Kind                          string                     `tfschema:"kind"`
-	OutboundIPAddresses           string                     `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string                   `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string                     `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string                   `tfschema:"possible_outbound_ip_address_list"`
-	PublicNetworkAccess           bool                       `tfschema:"public_network_access_enabled"`
-	Usage                         string                     `tfschema:"usage"`
-	SiteCredentials               []helpers.SiteCredential   `tfschema:"site_credential"`
-	VirtualNetworkSubnetID        string                     `tfschema:"virtual_network_subnet_id"`
+	Name                             string                     `tfschema:"name"`
+	ResourceGroup                    string                     `tfschema:"resource_group_name"`
+	Location                         string                     `tfschema:"location"`
+	ServicePlanId                    string                     `tfschema:"service_plan_id"`
+	AppSettings                      map[string]string          `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings     `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
+	Availability                     string                     `tfschema:"availability"`
+	Backup                           []helpers.Backup           `tfschema:"backup"`
+	ClientAffinityEnabled            bool                       `tfschema:"client_affinity_enabled"`
+	ClientCertEnabled                bool                       `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                     `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                     `tfschema:"client_certificate_exclusion_paths"`
+	Enabled                          bool                       `tfschema:"enabled"`
+	HttpsOnly                        bool                       `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                     `tfschema:"key_vault_reference_identity_id"`
+	LogsConfig                       []helpers.LogsConfig       `tfschema:"logs"`
+	MetaData                         map[string]string          `tfschema:"app_metadata"`
+	SiteConfig                       []helpers.SiteConfigLinux  `tfschema:"site_config"`
+	StickySettings                   []helpers.StickySettings   `tfschema:"sticky_settings"`
+	StorageAccounts                  []helpers.StorageAccount   `tfschema:"storage_account"`
+	ConnectionStrings                []helpers.ConnectionString `tfschema:"connection_string"`
+	Tags                             map[string]string          `tfschema:"tags"`
+	CustomDomainVerificationId       string                     `tfschema:"custom_domain_verification_id"`
+	HostingEnvId                     string                     `tfschema:"hosting_environment_id"`
+	DefaultHostname                  string                     `tfschema:"default_hostname"`
+	Kind                             string                     `tfschema:"kind"`
+	OutboundIPAddresses              string                     `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList            []string                   `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses      string                     `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList    []string                   `tfschema:"possible_outbound_ip_address_list"`
+	PublicNetworkAccess              bool                       `tfschema:"public_network_access_enabled"`
+	Usage                            string                     `tfschema:"usage"`
+	PublishingDeployBasicAuthEnabled bool                       `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteCredentials                  []helpers.SiteCredential   `tfschema:"site_credential"`
+	VirtualNetworkSubnetID           string                     `tfschema:"virtual_network_subnet_id"`
 }
 
 var _ sdk.DataSource = LinuxWebAppDataSource{}
@@ -215,6 +217,16 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"site_credential": helpers.SiteCredentialSchema(),
 
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
 		"service_plan_id": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
@@ -353,6 +365,23 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 				}
 				webApp.PublicNetworkAccess = !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled)
 			}
+
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
+			webApp.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			webApp.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)
 

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -368,14 +368,14 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -29,39 +29,41 @@ import (
 type LinuxWebAppResource struct{}
 
 type LinuxWebAppModel struct {
-	Name                          string                     `tfschema:"name"`
-	ResourceGroup                 string                     `tfschema:"resource_group_name"`
-	Location                      string                     `tfschema:"location"`
-	ServicePlanId                 string                     `tfschema:"service_plan_id"`
-	AppSettings                   map[string]string          `tfschema:"app_settings"`
-	StickySettings                []helpers.StickySettings   `tfschema:"sticky_settings"`
-	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
-	Backup                        []helpers.Backup           `tfschema:"backup"`
-	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                     `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                     `tfschema:"client_certificate_exclusion_paths"`
-	Enabled                       bool                       `tfschema:"enabled"`
-	HttpsOnly                     bool                       `tfschema:"https_only"`
-	VirtualNetworkSubnetID        string                     `tfschema:"virtual_network_subnet_id"`
-	KeyVaultReferenceIdentityID   string                     `tfschema:"key_vault_reference_identity_id"`
-	LogsConfig                    []helpers.LogsConfig       `tfschema:"logs"`
-	SiteConfig                    []helpers.SiteConfigLinux  `tfschema:"site_config"`
-	StorageAccounts               []helpers.StorageAccount   `tfschema:"storage_account"`
-	ConnectionStrings             []helpers.ConnectionString `tfschema:"connection_string"`
-	ZipDeployFile                 string                     `tfschema:"zip_deploy_file"`
-	Tags                          map[string]string          `tfschema:"tags"`
-	CustomDomainVerificationId    string                     `tfschema:"custom_domain_verification_id"`
-	HostingEnvId                  string                     `tfschema:"hosting_environment_id"`
-	DefaultHostname               string                     `tfschema:"default_hostname"`
-	Kind                          string                     `tfschema:"kind"`
-	OutboundIPAddresses           string                     `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string                   `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string                     `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string                   `tfschema:"possible_outbound_ip_address_list"`
-	PublicNetworkAccess           bool                       `tfschema:"public_network_access_enabled"`
-	SiteCredentials               []helpers.SiteCredential   `tfschema:"site_credential"`
+	Name                             string                     `tfschema:"name"`
+	ResourceGroup                    string                     `tfschema:"resource_group_name"`
+	Location                         string                     `tfschema:"location"`
+	ServicePlanId                    string                     `tfschema:"service_plan_id"`
+	AppSettings                      map[string]string          `tfschema:"app_settings"`
+	StickySettings                   []helpers.StickySettings   `tfschema:"sticky_settings"`
+	AuthSettings                     []helpers.AuthSettings     `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup           `tfschema:"backup"`
+	ClientAffinityEnabled            bool                       `tfschema:"client_affinity_enabled"`
+	ClientCertEnabled                bool                       `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                     `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                     `tfschema:"client_certificate_exclusion_paths"`
+	Enabled                          bool                       `tfschema:"enabled"`
+	HttpsOnly                        bool                       `tfschema:"https_only"`
+	VirtualNetworkSubnetID           string                     `tfschema:"virtual_network_subnet_id"`
+	KeyVaultReferenceIdentityID      string                     `tfschema:"key_vault_reference_identity_id"`
+	LogsConfig                       []helpers.LogsConfig       `tfschema:"logs"`
+	SiteConfig                       []helpers.SiteConfigLinux  `tfschema:"site_config"`
+	StorageAccounts                  []helpers.StorageAccount   `tfschema:"storage_account"`
+	ConnectionStrings                []helpers.ConnectionString `tfschema:"connection_string"`
+	ZipDeployFile                    string                     `tfschema:"zip_deploy_file"`
+	Tags                             map[string]string          `tfschema:"tags"`
+	CustomDomainVerificationId       string                     `tfschema:"custom_domain_verification_id"`
+	HostingEnvId                     string                     `tfschema:"hosting_environment_id"`
+	DefaultHostname                  string                     `tfschema:"default_hostname"`
+	Kind                             string                     `tfschema:"kind"`
+	OutboundIPAddresses              string                     `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList            []string                   `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses      string                     `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList    []string                   `tfschema:"possible_outbound_ip_address_list"`
+	PublicNetworkAccess              bool                       `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                       `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteCredentials                  []helpers.SiteCredential   `tfschema:"site_credential"`
 }
 
 var _ sdk.ResourceWithUpdate = LinuxWebAppResource{}
@@ -162,13 +164,25 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 		},
 
+		"logs": helpers.LogsConfigSchema(),
+
 		"public_network_access_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
 
-		"logs": helpers.LogsConfigSchema(),
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
 		"site_config": helpers.SiteConfigSchemaLinux(),
 
@@ -187,8 +201,6 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"tags": tags.Schema(),
 	}
 }
-
-// TODO - Feature: Deployments (Preview)?
 
 func (r LinuxWebAppResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
@@ -467,6 +479,28 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			if !webApp.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !webApp.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			return nil
 		},
 	}
@@ -553,6 +587,20 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Site Publishing Credential information for Linux %s: %+v", id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := LinuxWebAppModel{}
 			if props := webApp.SiteProperties; props != nil {
 				state = LinuxWebAppModel{
@@ -591,6 +639,9 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 					state.VirtualNetworkSubnetID = subnetId
 				}
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			state.AppSettings = helpers.FlattenWebStringDictionary(appSettings)
 
@@ -915,6 +966,28 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("zip_deploy_file") {
 				if err = helpers.GetCredentialsAndPublish(ctx, client, id.ResourceGroup, id.SiteName, state.ZipDeployFile); err != nil {
 					return err
+				}
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -486,7 +486,7 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -497,7 +497,7 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -589,14 +589,14 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -976,7 +976,7 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -987,7 +987,7 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1372,6 +1372,52 @@ func TestAccLinuxWebApp_zipDeploy(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebApp_disableDeployBasicAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.deployBasicAuthDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_disableDeployBasicAuthUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(), {
+			Config: r.deployBasicAuthDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(), {
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // Network tests
 
 func TestAccLinuxWebApp_vNetIntegration(t *testing.T) {
@@ -1727,6 +1773,9 @@ resource "azurerm_linux_web_app" "test" {
     access_key   = azurerm_storage_account.test.primary_access_key
     mount_path   = "/storage/files"
   }
+
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   tags = {
     Environment = "AccTest"
@@ -3193,7 +3242,27 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger)
 }
 
-// TODO - Test for new acr creds?
+func (r LinuxWebAppResource) deployBasicAuthDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
+
+  site_config {}
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
 
 // Templates
 

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1774,7 +1774,7 @@ resource "azurerm_linux_web_app" "test" {
     mount_path   = "/storage/files"
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {
@@ -3256,7 +3256,7 @@ resource "azurerm_linux_web_app" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -456,7 +456,7 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -467,7 +467,7 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -563,14 +563,14 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -925,7 +925,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -936,7 +936,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2594,7 +2594,7 @@ resource "azurerm_linux_web_app_slot" "test" {
   name           = "acctestWAS-%d"
   app_service_id = azurerm_linux_web_app.test.id
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -1147,6 +1147,50 @@ func TestAccLinuxWebAppSlot_zipDeploy(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebAppSlot_disableDeployBasicAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.deployBasicAuthDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_disableDeployBasicAuthUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.deployBasicAuthDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // Network tests
 
 func TestAccLinuxWebAppSlot_vNetIntegration(t *testing.T) {
@@ -2532,6 +2576,26 @@ resource "azurerm_linux_web_app_slot" "test" {
   app_service_id = azurerm_linux_web_app.test.id
 
   public_network_access_enabled = false
+
+  site_config {}
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r LinuxWebAppSlotResource) deployBasicAuthDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}
 }

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -307,14 +307,14 @@ func (d WindowsFunctionAppDataSource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -36,25 +36,27 @@ type WindowsFunctionAppDataSourceModel struct {
 	StorageUsesMSI          bool   `tfschema:"storage_uses_managed_identity"`
 	StorageKeyVaultSecretID string `tfschema:"storage_key_vault_secret_id"`
 
-	AppSettings               map[string]string                      `tfschema:"app_settings"`
-	AuthSettings              []helpers.AuthSettings                 `tfschema:"auth_settings"`
-	AuthV2Settings            []helpers.AuthV2Settings               `tfschema:"auth_settings_v2"`
-	Backup                    []helpers.Backup                       `tfschema:"backup"`
-	BuiltinLogging            bool                                   `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled         bool                                   `tfschema:"client_certificate_enabled"`
-	ClientCertMode            string                                 `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths  string                                 `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings         []helpers.ConnectionString             `tfschema:"connection_string"`
-	DailyMemoryTimeQuota      int                                    `tfschema:"daily_memory_time_quota"`
-	Enabled                   bool                                   `tfschema:"enabled"`
-	FunctionExtensionsVersion string                                 `tfschema:"functions_extension_version"`
-	ForceDisableContentShare  bool                                   `tfschema:"content_share_force_disabled"`
-	HttpsOnly                 bool                                   `tfschema:"https_only"`
-	PublicNetworkAccess       bool                                   `tfschema:"public_network_access_enabled"`
-	SiteConfig                []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
-	StickySettings            []helpers.StickySettings               `tfschema:"sticky_settings"`
-	Tags                      map[string]string                      `tfschema:"tags"`
-	VirtualNetworkSubnetId    string                                 `tfschema:"virtual_network_subnet_id"`
+	AppSettings                      map[string]string                      `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings                 `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings               `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup                       `tfschema:"backup"`
+	BuiltinLogging                   bool                                   `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                                   `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                                 `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                                 `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString             `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                                    `tfschema:"daily_memory_time_quota"`
+	Enabled                          bool                                   `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                                 `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                                   `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                                   `tfschema:"https_only"`
+	PublicNetworkAccess              bool                                   `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                                   `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                   `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteConfig                       []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
+	StickySettings                   []helpers.StickySettings               `tfschema:"sticky_settings"`
+	Tags                             map[string]string                      `tfschema:"tags"`
+	VirtualNetworkSubnetId           string                                 `tfschema:"virtual_network_subnet_id"`
 
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
 	DefaultHostname               string   `tfschema:"default_hostname"`
@@ -236,6 +238,16 @@ func (d WindowsFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema 
 
 		"site_credential": helpers.SiteCredentialSchema(),
 
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
 		"site_config": helpers.SiteConfigSchemaWindowsFunctionAppComputed(),
 
 		"sticky_settings": helpers.StickySettingsComputedSchema(),
@@ -292,6 +304,23 @@ func (d WindowsFunctionAppDataSource) Read() sdk.ResourceFunc {
 			functionApp.DefaultHostname = utils.NormalizeNilableString(props.DefaultHostName)
 			functionApp.VirtualNetworkSubnetId = utils.NormalizeNilableString(props.VirtualNetworkSubnetID)
 			functionApp.PublicNetworkAccess = !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled)
+
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
+			functionApp.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			functionApp.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				functionApp.HostingEnvId = pointer.From(hostingEnv.ID)

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -41,28 +41,30 @@ type WindowsFunctionAppModel struct {
 	StorageUsesMSI          bool   `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
 	StorageKeyVaultSecretID string `tfschema:"storage_key_vault_secret_id"`
 
-	AppSettings                 map[string]string                      `tfschema:"app_settings"`
-	StickySettings              []helpers.StickySettings               `tfschema:"sticky_settings"`
-	AuthSettings                []helpers.AuthSettings                 `tfschema:"auth_settings"`
-	AuthV2Settings              []helpers.AuthV2Settings               `tfschema:"auth_settings_v2"`
-	Backup                      []helpers.Backup                       `tfschema:"backup"` // Not supported on Dynamic or Basic plans
-	BuiltinLogging              bool                                   `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled           bool                                   `tfschema:"client_certificate_enabled"`
-	ClientCertMode              string                                 `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths    string                                 `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings           []helpers.ConnectionString             `tfschema:"connection_string"`
-	DailyMemoryTimeQuota        int                                    `tfschema:"daily_memory_time_quota"`
-	Enabled                     bool                                   `tfschema:"enabled"`
-	FunctionExtensionsVersion   string                                 `tfschema:"functions_extension_version"`
-	ForceDisableContentShare    bool                                   `tfschema:"content_share_force_disabled"`
-	HttpsOnly                   bool                                   `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID string                                 `tfschema:"key_vault_reference_identity_id"`
-	PublicNetworkAccess         bool                                   `tfschema:"public_network_access_enabled"`
-	SiteConfig                  []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
-	StorageAccounts             []helpers.StorageAccount               `tfschema:"storage_account"`
-	Tags                        map[string]string                      `tfschema:"tags"`
-	VirtualNetworkSubnetID      string                                 `tfschema:"virtual_network_subnet_id"`
-	ZipDeployFile               string                                 `tfschema:"zip_deploy_file"`
+	AppSettings                      map[string]string                      `tfschema:"app_settings"`
+	StickySettings                   []helpers.StickySettings               `tfschema:"sticky_settings"`
+	AuthSettings                     []helpers.AuthSettings                 `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings               `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup                       `tfschema:"backup"` // Not supported on Dynamic or Basic plans
+	BuiltinLogging                   bool                                   `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                                   `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                                 `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                                 `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString             `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                                    `tfschema:"daily_memory_time_quota"`
+	Enabled                          bool                                   `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                                 `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                                   `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                                   `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                                 `tfschema:"key_vault_reference_identity_id"`
+	PublicNetworkAccess              bool                                   `tfschema:"public_network_access_enabled"`
+	SiteConfig                       []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
+	StorageAccounts                  []helpers.StorageAccount               `tfschema:"storage_account"`
+	Tags                             map[string]string                      `tfschema:"tags"`
+	VirtualNetworkSubnetID           string                                 `tfschema:"virtual_network_subnet_id"`
+	ZipDeployFile                    string                                 `tfschema:"zip_deploy_file"`
+	PublishingDeployBasicAuthEnabled bool                                   `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                   `tfschema:"ftp_publish_basic_authentication_enabled"`
 
 	// Computed
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
@@ -257,6 +259,18 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
@@ -528,6 +542,28 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
 			}
 
+			if !functionApp.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !functionApp.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			updateFuture, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
 			if err != nil {
 				return fmt.Errorf("updating properties of Windows %s: %+v", id, err)
@@ -686,6 +722,20 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading logs configuration for Windows %s: %+v", id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := WindowsFunctionAppModel{
 				Name:                        id.SiteName,
 				ResourceGroup:               id.ResourceGroup,
@@ -703,6 +753,9 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 				DefaultHostname:             utils.NormalizeNilableString(props.DefaultHostName),
 				PublicNetworkAccess:         !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled),
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
@@ -1002,6 +1055,28 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 			}
 			if err := updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 				return fmt.Errorf("waiting to update %s: %+v", id, err)
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
 			}
 
 			if _, err := client.UpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, web.SiteConfigResource{SiteConfig: existing.SiteConfig}); err != nil {

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -549,7 +549,7 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -560,7 +560,7 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -724,14 +724,14 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -1064,7 +1064,7 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -1075,7 +1075,7 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -2063,7 +2063,7 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -2063,6 +2063,9 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
+
   tags = {
     terraform = "true"
     Env       = "AccTest"

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -31,29 +31,32 @@ import (
 type WindowsFunctionAppSlotResource struct{}
 
 type WindowsFunctionAppSlotModel struct {
-	Name                          string                                     `tfschema:"name"`
-	FunctionAppID                 string                                     `tfschema:"function_app_id"`
-	ServicePlanID                 string                                     `tfschema:"service_plan_id"`
-	StorageAccountName            string                                     `tfschema:"storage_account_name"`
-	StorageAccountKey             string                                     `tfschema:"storage_account_access_key"`
-	StorageUsesMSI                bool                                       `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
-	StorageKeyVaultSecretID       string                                     `tfschema:"storage_key_vault_secret_id"`
-	AppSettings                   map[string]string                          `tfschema:"app_settings"`
-	AuthSettings                  []helpers.AuthSettings                     `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings                   `tfschema:"auth_settings_v2"`
-	Backup                        []helpers.Backup                           `tfschema:"backup"` // Not supported on Dynamic or Basic plans
-	BuiltinLogging                bool                                       `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled             bool                                       `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                                     `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                                     `tfschema:"client_certificate_exclusion_paths"`
-	ConnectionStrings             []helpers.ConnectionString                 `tfschema:"connection_string"`
-	DailyMemoryTimeQuota          int                                        `tfschema:"daily_memory_time_quota"`
-	Enabled                       bool                                       `tfschema:"enabled"`
-	FunctionExtensionsVersion     string                                     `tfschema:"functions_extension_version"`
-	ForceDisableContentShare      bool                                       `tfschema:"content_share_force_disabled"`
-	HttpsOnly                     bool                                       `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID   string                                     `tfschema:"key_vault_reference_identity_id"`
-	PublicNetworkAccess           bool                                       `tfschema:"public_network_access_enabled"`
+	Name                             string                     `tfschema:"name"`
+	FunctionAppID                    string                     `tfschema:"function_app_id"`
+	ServicePlanID                    string                     `tfschema:"service_plan_id"`
+	StorageAccountName               string                     `tfschema:"storage_account_name"`
+	StorageAccountKey                string                     `tfschema:"storage_account_access_key"`
+	StorageUsesMSI                   bool                       `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
+	StorageKeyVaultSecretID          string                     `tfschema:"storage_key_vault_secret_id"`
+	AppSettings                      map[string]string          `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings     `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup           `tfschema:"backup"` // Not supported on Dynamic or Basic plans
+	BuiltinLogging                   bool                       `tfschema:"builtin_logging_enabled"`
+	ClientCertEnabled                bool                       `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                     `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                     `tfschema:"client_certificate_exclusion_paths"`
+	ConnectionStrings                []helpers.ConnectionString `tfschema:"connection_string"`
+	DailyMemoryTimeQuota             int                        `tfschema:"daily_memory_time_quota"`
+	Enabled                          bool                       `tfschema:"enabled"`
+	FunctionExtensionsVersion        string                     `tfschema:"functions_extension_version"`
+	ForceDisableContentShare         bool                       `tfschema:"content_share_force_disabled"`
+	HttpsOnly                        bool                       `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                     `tfschema:"key_vault_reference_identity_id"`
+	PublicNetworkAccess              bool                       `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                       `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+
 	SiteConfig                    []helpers.SiteConfigWindowsFunctionAppSlot `tfschema:"site_config"`
 	Tags                          map[string]string                          `tfschema:"tags"`
 	CustomDomainVerificationId    string                                     `tfschema:"custom_domain_verification_id"`
@@ -248,6 +251,18 @@ func (r WindowsFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema
 		},
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
@@ -535,6 +550,28 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
 			}
 
+			if !functionAppSlot.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !functionAppSlot.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			updateFuture, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)
 			if err != nil {
 				return fmt.Errorf("updating properties of Windows %s: %+v", id, err)
@@ -673,6 +710,20 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading logs configuration for Windows %s: %+v", id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := WindowsFunctionAppSlotModel{
 				Name:                        id.SlotName,
 				FunctionAppID:               parse.NewFunctionAppID(id.SubscriptionId, id.ResourceGroup, id.SiteName).ID(),
@@ -687,6 +738,9 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				DefaultHostname:             pointer.From(props.DefaultHostName),
 				PublicNetworkAccess:         !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled),
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 				state.HostingEnvId = pointer.From(hostingEnv.ID)
@@ -953,6 +1007,28 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 			}
 			if err := updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 				return fmt.Errorf("waiting to update %s: %+v", id, err)
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
 			}
 
 			if _, err := client.UpdateConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, web.SiteConfigResource{SiteConfig: siteConfig}, id.SlotName); err != nil {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -557,7 +557,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -568,7 +568,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -712,14 +712,14 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -1016,7 +1016,7 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -1027,7 +1027,7 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -1538,7 +1538,7 @@ resource "azurerm_windows_function_app_slot" "test" {
     }
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -1538,6 +1538,9 @@ resource "azurerm_windows_function_app_slot" "test" {
     }
   }
 
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
+
   tags = {
     terraform = "true"
     Env       = "AccTest"

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -24,37 +24,39 @@ import (
 type WindowsWebAppDataSource struct{}
 
 type WindowsWebAppDataSourceModel struct {
-	Name                          string                      `tfschema:"name"`
-	ResourceGroup                 string                      `tfschema:"resource_group_name"`
-	Location                      string                      `tfschema:"location"`
-	ServicePlanId                 string                      `tfschema:"service_plan_id"`
-	AppSettings                   map[string]string           `tfschema:"app_settings"`
-	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_settings_v2"`
-	Backup                        []helpers.Backup            `tfschema:"backup"`
-	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                      `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                      `tfschema:"client_certificate_exclusion_paths"`
-	Enabled                       bool                        `tfschema:"enabled"`
-	HttpsOnly                     bool                        `tfschema:"https_only"`
-	LogsConfig                    []helpers.LogsConfig        `tfschema:"logs"`
-	PublicNetworkAccess           bool                        `tfschema:"public_network_access_enabled"`
-	SiteConfig                    []helpers.SiteConfigWindows `tfschema:"site_config"`
-	StickySettings                []helpers.StickySettings    `tfschema:"sticky_settings"`
-	StorageAccounts               []helpers.StorageAccount    `tfschema:"storage_account"`
-	ConnectionStrings             []helpers.ConnectionString  `tfschema:"connection_string"`
-	CustomDomainVerificationId    string                      `tfschema:"custom_domain_verification_id"`
-	HostingEnvId                  string                      `tfschema:"hosting_environment_id"`
-	DefaultHostname               string                      `tfschema:"default_hostname"`
-	Kind                          string                      `tfschema:"kind"`
-	OutboundIPAddresses           string                      `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string                    `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string                      `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string                    `tfschema:"possible_outbound_ip_address_list"`
-	SiteCredentials               []helpers.SiteCredential    `tfschema:"site_credential"`
-	Tags                          map[string]string           `tfschema:"tags"`
-	VirtualNetworkSubnetID        string                      `tfschema:"virtual_network_subnet_id"`
+	Name                             string                      `tfschema:"name"`
+	ResourceGroup                    string                      `tfschema:"resource_group_name"`
+	Location                         string                      `tfschema:"location"`
+	ServicePlanId                    string                      `tfschema:"service_plan_id"`
+	AppSettings                      map[string]string           `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings      `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings    `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup            `tfschema:"backup"`
+	ClientAffinityEnabled            bool                        `tfschema:"client_affinity_enabled"`
+	ClientCertEnabled                bool                        `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                      `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                      `tfschema:"client_certificate_exclusion_paths"`
+	Enabled                          bool                        `tfschema:"enabled"`
+	HttpsOnly                        bool                        `tfschema:"https_only"`
+	LogsConfig                       []helpers.LogsConfig        `tfschema:"logs"`
+	PublicNetworkAccess              bool                        `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                        `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                        `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteConfig                       []helpers.SiteConfigWindows `tfschema:"site_config"`
+	StickySettings                   []helpers.StickySettings    `tfschema:"sticky_settings"`
+	StorageAccounts                  []helpers.StorageAccount    `tfschema:"storage_account"`
+	ConnectionStrings                []helpers.ConnectionString  `tfschema:"connection_string"`
+	CustomDomainVerificationId       string                      `tfschema:"custom_domain_verification_id"`
+	HostingEnvId                     string                      `tfschema:"hosting_environment_id"`
+	DefaultHostname                  string                      `tfschema:"default_hostname"`
+	Kind                             string                      `tfschema:"kind"`
+	OutboundIPAddresses              string                      `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList            []string                    `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses      string                      `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList    []string                    `tfschema:"possible_outbound_ip_address_list"`
+	SiteCredentials                  []helpers.SiteCredential    `tfschema:"site_credential"`
+	Tags                             map[string]string           `tfschema:"tags"`
+	VirtualNetworkSubnetID           string                      `tfschema:"virtual_network_subnet_id"`
 }
 
 var _ sdk.DataSource = WindowsWebAppDataSource{}
@@ -189,6 +191,16 @@ func (d WindowsWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		"site_credential": helpers.SiteCredentialSchema(),
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		},
@@ -330,6 +342,23 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				}
 				webApp.PublicNetworkAccess = !strings.EqualFold(pointer.From(props.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled)
 			}
+
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
+			webApp.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			webApp.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)
 

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -345,14 +345,14 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -505,7 +505,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -516,7 +516,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -615,14 +615,14 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowed(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -1025,7 +1025,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -1036,7 +1036,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowed(ctx, id.ResourceGroup, id.SiteName, sitePolicy); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -68,6 +68,13 @@ func TestAccWindowsWebApp_completeUpdated(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -76,6 +83,13 @@ func TestAccWindowsWebApp_completeUpdated(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2280,8 +2294,6 @@ resource "azurerm_windows_web_app" "test" {
     minimum_tls_version         = "1.2"
     scm_minimum_tls_version     = "1.2"
     cors {
-      allowed_origins = []
-
       support_credentials = true
     }
 
@@ -2305,6 +2317,9 @@ resource "azurerm_windows_web_app" "test" {
     }
     // auto_swap_slot_name = // TODO - Not supported yet
   }
+
+  ftp_publish_basic_authentication_enabled    = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   tags = {
     foo = "bar"

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2318,7 +2318,7 @@ resource "azurerm_windows_web_app" "test" {
     // auto_swap_slot_name = // TODO - Not supported yet
   }
 
-  ftp_publish_basic_authentication_enabled    = false
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   tags = {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -472,7 +472,7 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -483,7 +483,7 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -586,14 +586,14 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 
 			basicAuthFTP := true
 			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of FTP Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthFTP = pointer.From(csmProps.Allow)
 			}
 
 			basicAuthWebDeploy := true
 			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
-				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+				return fmt.Errorf("retrieving state of WebDeploy Basic Auth for %s: %+v", id, err)
 			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
 				basicAuthWebDeploy = pointer.From(csmProps.Allow)
 			}
@@ -965,7 +965,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for ftp publishing credentials for %s: %+v", id, err)
 				}
 			}
 
@@ -976,7 +976,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 					},
 				}
 				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
-					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+					return fmt.Errorf("setting basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -29,37 +29,39 @@ import (
 type WindowsWebAppSlotResource struct{}
 
 type WindowsWebAppSlotModel struct {
-	Name                          string                                `tfschema:"name"`
-	AppServiceId                  string                                `tfschema:"app_service_id"`
-	ServicePlanID                 string                                `tfschema:"service_plan_id"`
-	AppSettings                   map[string]string                     `tfschema:"app_settings"`
-	AuthSettings                  []helpers.AuthSettings                `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings              `tfschema:"auth_settings_v2"`
-	Backup                        []helpers.Backup                      `tfschema:"backup"`
-	ClientAffinityEnabled         bool                                  `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                                  `tfschema:"client_certificate_enabled"`
-	ClientCertMode                string                                `tfschema:"client_certificate_mode"`
-	ClientCertExclusionPaths      string                                `tfschema:"client_certificate_exclusion_paths"`
-	Enabled                       bool                                  `tfschema:"enabled"`
-	HttpsOnly                     bool                                  `tfschema:"https_only"`
-	KeyVaultReferenceIdentityID   string                                `tfschema:"key_vault_reference_identity_id"`
-	LogsConfig                    []helpers.LogsConfig                  `tfschema:"logs"`
-	PublicNetworkAccess           bool                                  `tfschema:"public_network_access_enabled"`
-	SiteConfig                    []helpers.SiteConfigWindowsWebAppSlot `tfschema:"site_config"`
-	StorageAccounts               []helpers.StorageAccount              `tfschema:"storage_account"`
-	ConnectionStrings             []helpers.ConnectionString            `tfschema:"connection_string"`
-	CustomDomainVerificationId    string                                `tfschema:"custom_domain_verification_id"`
-	HostingEnvId                  string                                `tfschema:"hosting_environment_id"`
-	DefaultHostname               string                                `tfschema:"default_hostname"`
-	Kind                          string                                `tfschema:"kind"`
-	OutboundIPAddresses           string                                `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string                              `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string                                `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string                              `tfschema:"possible_outbound_ip_address_list"`
-	SiteCredentials               []helpers.SiteCredential              `tfschema:"site_credential"`
-	ZipDeployFile                 string                                `tfschema:"zip_deploy_file"`
-	Tags                          map[string]string                     `tfschema:"tags"`
-	VirtualNetworkSubnetID        string                                `tfschema:"virtual_network_subnet_id"`
+	Name                             string                                `tfschema:"name"`
+	AppServiceId                     string                                `tfschema:"app_service_id"`
+	ServicePlanID                    string                                `tfschema:"service_plan_id"`
+	AppSettings                      map[string]string                     `tfschema:"app_settings"`
+	AuthSettings                     []helpers.AuthSettings                `tfschema:"auth_settings"`
+	AuthV2Settings                   []helpers.AuthV2Settings              `tfschema:"auth_settings_v2"`
+	Backup                           []helpers.Backup                      `tfschema:"backup"`
+	ClientAffinityEnabled            bool                                  `tfschema:"client_affinity_enabled"`
+	ClientCertEnabled                bool                                  `tfschema:"client_certificate_enabled"`
+	ClientCertMode                   string                                `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths         string                                `tfschema:"client_certificate_exclusion_paths"`
+	Enabled                          bool                                  `tfschema:"enabled"`
+	HttpsOnly                        bool                                  `tfschema:"https_only"`
+	KeyVaultReferenceIdentityID      string                                `tfschema:"key_vault_reference_identity_id"`
+	LogsConfig                       []helpers.LogsConfig                  `tfschema:"logs"`
+	PublicNetworkAccess              bool                                  `tfschema:"public_network_access_enabled"`
+	PublishingDeployBasicAuthEnabled bool                                  `tfschema:"webdeploy_publish_basic_authentication_enabled"`
+	PublishingFTPBasicAuthEnabled    bool                                  `tfschema:"ftp_publish_basic_authentication_enabled"`
+	SiteConfig                       []helpers.SiteConfigWindowsWebAppSlot `tfschema:"site_config"`
+	StorageAccounts                  []helpers.StorageAccount              `tfschema:"storage_account"`
+	ConnectionStrings                []helpers.ConnectionString            `tfschema:"connection_string"`
+	CustomDomainVerificationId       string                                `tfschema:"custom_domain_verification_id"`
+	HostingEnvId                     string                                `tfschema:"hosting_environment_id"`
+	DefaultHostname                  string                                `tfschema:"default_hostname"`
+	Kind                             string                                `tfschema:"kind"`
+	OutboundIPAddresses              string                                `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList            []string                              `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses      string                                `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList    []string                              `tfschema:"possible_outbound_ip_address_list"`
+	SiteCredentials                  []helpers.SiteCredential              `tfschema:"site_credential"`
+	ZipDeployFile                    string                                `tfschema:"zip_deploy_file"`
+	Tags                             map[string]string                     `tfschema:"tags"`
+	VirtualNetworkSubnetID           string                                `tfschema:"virtual_network_subnet_id"`
 }
 
 var _ sdk.ResourceWithUpdate = WindowsWebAppSlotResource{}
@@ -170,6 +172,18 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		"logs": helpers.LogsConfigSchema(),
 
 		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"webdeploy_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"ftp_publish_basic_authentication_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
@@ -451,6 +465,28 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			if !webAppSlot.PublishingDeployBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if !webAppSlot.PublishingFTPBasicAuthEnabled {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(false),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for ftp publishing credentials for %s: %+v", id, err)
+				}
+			}
+
 			return nil
 		},
 
@@ -548,6 +584,20 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading parent Function App Service Plan information for Linux %s: %+v", *id, err)
 			}
 
+			basicAuthFTP := true
+			if basicAuthFTPResp, err := client.GetFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of FTP Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthFTPResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthFTP = pointer.From(csmProps.Allow)
+			}
+
+			basicAuthWebDeploy := true
+			if basicAuthWebDeployResp, err := client.GetScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName); err != nil {
+				return fmt.Errorf("retreiving state of WebDeploy Basic Auth for %s: %+v", id, err)
+			} else if csmProps := basicAuthWebDeployResp.CsmPublishingCredentialsPoliciesEntityProperties; csmProps != nil {
+				basicAuthWebDeploy = pointer.From(csmProps.Allow)
+			}
+
 			state := WindowsWebAppSlotModel{}
 			if props := webAppSlot.SiteProperties; props != nil {
 				state = WindowsWebAppSlotModel{
@@ -598,6 +648,9 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 					state.VirtualNetworkSubnetID = subnetId
 				}
 			}
+
+			state.PublishingFTPBasicAuthEnabled = basicAuthFTP
+			state.PublishingDeployBasicAuthEnabled = basicAuthWebDeploy
 
 			state.AppSettings = helpers.FlattenWebStringDictionary(appSettings)
 			currentStack := ""
@@ -902,6 +955,28 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("zip_deploy_file") {
 				if err = helpers.GetCredentialsAndPublishSlot(ctx, client, id.ResourceGroup, id.SiteName, state.ZipDeployFile, id.SlotName); err != nil {
 					return err
+				}
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingFTPBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateFtpAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("webdeploy_publish_basic_authentication_enabled") {
+				sitePolicy := web.CsmPublishingCredentialsPoliciesEntity{
+					CsmPublishingCredentialsPoliciesEntityProperties: &web.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: pointer.To(state.PublishingDeployBasicAuthEnabled),
+					},
+				}
+				if _, err := client.UpdateScmAllowedSlot(ctx, id.ResourceGroup, id.SiteName, sitePolicy, id.SlotName); err != nil {
+					return fmt.Errorf("disabling basic auth for deploy publishing credentials for %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1373,6 +1373,9 @@ resource "azurerm_windows_web_app_slot" "test" {
     mount_path   = "/mounts/files"
   }
 
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
+
   tags = {
     Environment = "AccTest"
     foo         = "bar"

--- a/website/docs/d/linux_function_app.html.markdown
+++ b/website/docs/d/linux_function_app.html.markdown
@@ -71,6 +71,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `enabled` - Is the Function App enabled?
 
+* `ftp_publish_basic_authentication_enabled` - Are the default FTP Basic Authentication publishing credentials enabled.
+
 * `functions_extension_version` - The runtime version associated with the Function App.
 
 * `https_only` - Can the Function App only be accessed via HTTPS?
@@ -86,6 +88,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `possible_outbound_ip_address_list` - A list of possible outbound IP addresses, not all of which are necessarily in use. This is a superset of `outbound_ip_address_list`. For example `["52.23.25.3", "52.143.43.12"]`.
 
 * `possible_outbound_ip_addresses` - A comma separated list of possible outbound IP addresses as a string. For example `52.23.25.3,52.143.43.12,52.143.43.17`. This is a superset of `outbound_ip_addresses`.
+
+* `public_network_access_enabled` - Is Public Network Access enabled for this Linux Function App.
 
 * `service_plan_id` - The ID of the App Service Plan within which this Function App has been created.
 
@@ -108,6 +112,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `usage` - The current usage state. Possible values are `Normal` and `Exceeded`.
 
 * `virtual_network_subnet_id` - The subnet id which the Linux Function App is vNet Integrated with.
+
+* `webdeploy_publish_basic_authentication_enabled` - Are the default WebDeploy Basic Authentication publishing credentials enabled.
 
 ---
 

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -46,7 +46,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `auth_settings_v2` - An `auth_settings_v2` block as defined below.
 
 * `availability` - The current availability state. Possible values are `Normal`, `Limited`, and `DisasterRecoveryMode`.
-* 
+
 * `backup` - A `backup` block as defined below.
 
 * `client_affinity_enabled` - Is Client Affinity enabled?
@@ -67,6 +67,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `enabled` - Is the Linux Web App enabled?
 
+* `ftp_publish_basic_authentication_enabled` - Are the default FTP Basic Authentication publishing credentials enabled.
+
 * `https_only` - Should the Linux Web App require HTTPS connections.
 
 * `identity` - A `identity` block as defined below.
@@ -85,6 +87,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.
 
+* `public_network_access_enabled` - Is Public Network Access enabled for this Linux Web App.
+
 * `service_plan_id` - The ID of the Service Plan that this Linux Web App exists in.
 
 * `site_config` - A `site_config` block as defined below.
@@ -98,6 +102,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `virtual_network_subnet_id` - The subnet id which the Linux Web App is vNet Integrated with.
 
 * `usage` - The current usage state. Possible values are `Normal` and `Exceeded`.
+
+* `webdeploy_publish_basic_authentication_enabled` - Are the default WebDeploy Basic Authentication publishing credentials enabled.
 
 * `tags` - A mapping of tags assigned to the Linux Web App.
 

--- a/website/docs/d/windows_function_app.html.markdown
+++ b/website/docs/d/windows_function_app.html.markdown
@@ -67,6 +67,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `enabled` - Is the Function App enabled?
 
+* `ftp_publish_basic_authentication_enabled` - Are the default FTP Basic Authentication publishing credentials enabled.
+
 * `functions_extension_version` - The runtime version associated with the Function App.
 
 * `https_only` - Is the Function App only accessible via HTTPS?
@@ -84,6 +86,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `possible_outbound_ip_address_list` - A list of possible outbound IP addresses, not all of which are necessarily in use. This is a superset of `outbound_ip_address_list`. For example `["52.23.25.3", "52.143.43.12"]`.
 
 * `possible_outbound_ip_addresses` - A comma separated list of possible outbound IP addresses as a string. For example `52.23.25.3,52.143.43.12,52.143.43.17`. This is a superset of `outbound_ip_addresses`.
+
+* `public_network_access_enabled` - Is Public Network Access enabled for the Windows Function App.
 
 * `service_plan_id` - The ID of the App Service Plan.
 
@@ -104,6 +108,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `tags` - A mapping of tags assigned to the Windows Function App.
 
 * `virtual_network_subnet_id` - The subnet id which the Windows Function App is vNet Integrated with.
+
+* `webdeploy_publish_basic_authentication_enabled` - Are the default WebDeploy Basic Authentication publishing credentials enabled.
 
 ---
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -63,6 +63,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `enabled` - Is the Windows Web App enabled?
 
+* `ftp_publish_basic_authentication_enabled` - Are the default FTP Basic Authentication publishing credentials enabled.
+
 * `https_only` - Does the Windows Web App require HTTPS connections.
 
 * `identity` - A `identity` block as defined below.
@@ -81,6 +83,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `possible_outbound_ip_addresses` - The string representation of the list of Possible Outbound IP Addresses that could be used by this Windows Web App.
 
+* `public_network_access_enabled` - Is Public Network Access enabled for the Windows Web App.
+
 * `service_plan_id` - The ID of the Service Plan in which this Windows Web App resides.
 
 * `site_config` - A `site_config` block as defined below.
@@ -94,6 +98,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `tags` - A mapping of tags assigned to the Windows Web App.
 
 * `virtual_network_subnet_id` - The subnet id which the Windows Web App is vNet Integrated with.
+
+* `webdeploy_publish_basic_authentication_enabled` - Are the default WebDeploy Basic Authentication publishing credentials enabled.
 
 ---
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -103,6 +103,8 @@ The following arguments are supported:
 
 * `functions_extension_version` - (Optional) The runtime version associated with the Function App. Defaults to `~4`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`. 
+
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
 * `public_network_access_enabled` - (Optional) Should public network access be enabled for the Function App. Defaults to `true`.
@@ -136,6 +138,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the function app configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Linux Function App.
 			

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -94,6 +94,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Linux Function App Slot enabled. Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Are the default FTP Basic Authentication publishing credentials enabled.
+
 * `functions_extension_version` - (Optional) The runtime version associated with the Function App Slot. Defaults to `~4`.
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
@@ -129,6 +131,8 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the function app slot configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+ 
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
 
 ---
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should the Linux Web App be enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
 * `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
@@ -98,6 +100,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the web app configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Linux Web App.
 			

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should the Linux Web App be enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
 * `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
@@ -101,6 +103,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the web app slot configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Linux Web App.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Function App enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `functions_extension_version` - (Optional) The runtime version associated with the Function App. Defaults to `~4`.
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
@@ -136,6 +138,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the function app configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Windows Function App.
 			

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -93,6 +93,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Windows Function App Slot enabled. Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `functions_extension_version` - (Optional) The runtime version associated with the Function App Slot. Defaults to `~4`.
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
@@ -128,6 +130,8 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the function app slot configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should the Windows Web App be enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `https_only` - (Optional) Should the Windows Web App require HTTPS connections.
 
 * `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
@@ -99,6 +101,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the web app configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Windows Web App.
 			

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should the Windows Web App Slot be enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - Should the default FTP Basic Authentication publishing profile be enabled. Defaults to `true`.
+
 * `https_only` - (Optional) Should the Windows Web App Slot require HTTPS connections.
 
 * `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
@@ -105,6 +107,10 @@ The following arguments are supported:
 ~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously. If the virtual network is set via the resource `app_service_virtual_network_swift_connection` then `ignore_changes` should be used in the web app slot configuration.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
+
+* `webdeploy_publish_basic_authentication_enabled` - Should the default WebDeploy Basic Authentication publishing credentials enabled. Defaults to`true`.
+
+~> **NOTE:** Setting this value to true will disable the ability to use `zip_deploy_file` which currently relies on the default publishing profile.
 
 * `zip_deploy_file` - (Optional) The local path and filename of the Zip packaged application to deploy to this Windows Web App.
 


### PR DESCRIPTION

* `azurerm_linux_function_app` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_linux_function_app_slot` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_linux_web_app` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_linux_web_app_slot` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_windows_function_app` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_windows_function_app_slot` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_windows_web_app` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 
* `azurerm_windows_web_app_slot` - add support for disabling Basic Auth for default Publishing Profile via new properties `ftp_publish_basic_authentication_enabled` and `webdeploy_publish_basic_authentication_enabled` 

closes #9290