### PR TITLE
documentation for the resource group to use for the azurerm_app_service_certificate

### DIFF
--- a/examples/api-management/outputs.tf
+++ b/examples/api-management/outputs.tf
@@ -19,17 +19,17 @@ output "service_public_ip_addresses" {
 output "api_outputs" {
   description = "The IDs, state, and version outputs of the APIs created"
   value = {
-      id             = azurerm_api_management_api.api.id
-      is_current     = azurerm_api_management_api.api.is_current
-      is_online      = azurerm_api_management_api.api.is_online
-      version        = azurerm_api_management_api.api.version
-      version_set_id = azurerm_api_management_api.api.version_set_id
-    }
+    id             = azurerm_api_management_api.api.id
+    is_current     = azurerm_api_management_api.api.is_current
+    is_online      = azurerm_api_management_api.api.is_online
+    version        = azurerm_api_management_api.api.version
+    version_set_id = azurerm_api_management_api.api.version_set_id
+  }
 }
 
 output "product_ids" {
   description = "The ID of the Product created"
-  value = azurerm_api_management_product.product.id
+  value       = azurerm_api_management_product.product.id
 }
 
 output "product_api_ids" {

--- a/examples/api-management/variables.tf
+++ b/examples/api-management/variables.tf
@@ -10,9 +10,9 @@ variable "location" {
 }
 
 variable "open_api_spec_content_format" {
-    description = "The format of the content from which the API Definition should be imported. Possible values are: openapi, openapi+json, openapi+json-link, openapi-link, swagger-json, swagger-link-json, wadl-link-json, wadl-xml, wsdl and wsdl-link."
+  description = "The format of the content from which the API Definition should be imported. Possible values are: openapi, openapi+json, openapi+json-link, openapi-link, swagger-json, swagger-link-json, wadl-link-json, wadl-xml, wsdl and wsdl-link."
 }
 
 variable "open_api_spec_content_value" {
-    description = "The Content from which the API Definition should be imported. When a content_format of *-link-* is specified this must be a URL, otherwise this must be defined inline."
+  description = "The Content from which the API Definition should be imported. When a content_format of *-link-* is specified this must be a URL, otherwise this must be defined inline."
 }

--- a/examples/automation-account/main.tf
+++ b/examples/automation-account/main.tf
@@ -7,13 +7,13 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_automation_account" "example" {
   name                = "${var.prefix}-autoacc"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name = "Basic"
@@ -22,9 +22,9 @@ resource "azurerm_automation_account" "example" {
 
 resource "azurerm_automation_runbook" "example" {
   name                = "Get-AzureVMTutorial"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  account_name        = "${azurerm_automation_account.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_automation_account.example.name
   log_verbose         = "true"
   log_progress        = "true"
   description         = "This is an example runbook"
@@ -37,8 +37,8 @@ resource "azurerm_automation_runbook" "example" {
 
 resource "azurerm_automation_schedule" "one-time" {
   name                    = "${var.prefix}-one-time"
-  resource_group_name     = "${azurerm_resource_group.example.name}"
-  automation_account_name = "${azurerm_automation_account.example.name}"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
   frequency               = "OneTime"
 
   // The start_time defaults to now + 7 min
@@ -46,18 +46,18 @@ resource "azurerm_automation_schedule" "one-time" {
 
 resource "azurerm_automation_schedule" "hour" {
   name                    = "${var.prefix}-hour"
-  resource_group_name     = "${azurerm_resource_group.example.name}"
-  automation_account_name = "${azurerm_automation_account.example.name}"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
   frequency               = "Hour"
   interval                = 2
 
   // Timezone defaults to UTC
 }
 
-  // Schedules the example runbook to run on the hour schedule
+// Schedules the example runbook to run on the hour schedule
 resource "azurerm_automation_job_schedule" "example" {
-  resource_group_name     = "${azurerm_resource_group.example.name}"
-  automation_account_name = "${azurerm_automation_account.example.name}"
-  runbook_name            = "${azurerm_automation_runbook.example.name}"
-  schedule_name           = "${azurerm_automation_schedule.hour.name}"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
+  runbook_name            = azurerm_automation_runbook.example.name
+  schedule_name           = azurerm_automation_schedule.hour.name
 }

--- a/examples/automation-account/outputs.tf
+++ b/examples/automation-account/outputs.tf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "automation_schedule_start_time" {
-  value = "${azurerm_automation_schedule.one-time.start_time}"
+  value = azurerm_automation_schedule.one-time.start_time
 }
 
 output "automation_schedule_week_interval" {
-  value = "${azurerm_automation_schedule.hour.interval}"
+  value = azurerm_automation_schedule.hour.interval
 }

--- a/examples/cdn/frontdoor/frontdoor-managed-ssl-certificate-with-multiple-custom-domains/main.tf
+++ b/examples/cdn/frontdoor/frontdoor-managed-ssl-certificate-with-multiple-custom-domains/main.tf
@@ -214,11 +214,11 @@ resource "azurerm_cdn_frontdoor_rule" "example" {
 }
 
 resource "azurerm_cdn_frontdoor_route" "example" {
-  name                            = "${var.prefix}-route"
-  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.example.id
-  cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.example.id
-  cdn_frontdoor_origin_ids        = [azurerm_cdn_frontdoor_origin.example.id]
-  enabled                         = true
+  name                          = "${var.prefix}-route"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.example.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.example.id]
+  enabled                       = true
 
   forwarding_protocol        = "MatchRequest"
   https_redirect_enabled     = true

--- a/examples/cdn/main.tf
+++ b/examples/cdn/main.tf
@@ -7,29 +7,29 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_storage_account" "stor" {
   name                     = "${var.prefix}stor"
-  location                 = "${azurerm_resource_group.example.location}"
-  resource_group_name      = "${azurerm_resource_group.example.name}"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_cdn_profile" "example" {
   name                = "${var.prefix}-cdn"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard_Akamai"
 }
 
 resource "azurerm_cdn_endpoint" "example" {
   name                = "${var.prefix}-cdn"
-  profile_name        = "${azurerm_cdn_profile.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  profile_name        = azurerm_cdn_profile.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   origin {
     name       = "${var.prefix}origin1"

--- a/examples/confidential-ledger/main.tf
+++ b/examples/confidential-ledger/main.tf
@@ -14,18 +14,18 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_confidential_ledger" "example" {
-	name                = "example-ledger"
-	ledger_type         = "Public"
-	location            = azurerm_resource_group.example.location
-	resource_group_name = azurerm_resource_group.example.name
+  name                = "example-ledger"
+  ledger_type         = "Public"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
-	aad_based_security_principals {
-		principal_id     = data.azurerm_client_config.current.object_id
-		tenant_id        = data.azurerm_client_config.current.tenant_id
-		ledger_role_name = "Administrator"
-	}
-
-	tags = {
-		IsExample = "True"
-	}
+  aad_based_security_principals {
+    principal_id     = data.azurerm_client_config.current.object_id
+    tenant_id        = data.azurerm_client_config.current.tenant_id
+    ledger_role_name = "Administrator"
   }
+
+  tags = {
+    IsExample = "True"
+  }
+}

--- a/examples/container-registry/main.tf
+++ b/examples/container-registry/main.tf
@@ -7,12 +7,12 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_container_registry" "example" {
   name                = "${var.prefix}registry"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sku                 = "Standard"
 }

--- a/examples/container-registry/outputs.tf
+++ b/examples/container-registry/outputs.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "login_server" {
-  value = "${azurerm_container_registry.example.login_server}"
+  value = azurerm_container_registry.example.login_server
 }

--- a/examples/databricks/customer-managed-key/managed-services/main.tf
+++ b/examples/databricks/customer-managed-key/managed-services/main.tf
@@ -80,9 +80,9 @@ resource "azurerm_key_vault_access_policy" "terraform" {
 }
 
 resource "azurerm_key_vault_access_policy" "managed" {
-  key_vault_id   = azurerm_key_vault.example.id
-  tenant_id      = azurerm_key_vault.example.tenant_id
-  object_id      = "See the README.md file for instructions on how to lookup the correct value to enter here"
+  key_vault_id = azurerm_key_vault.example.id
+  tenant_id    = azurerm_key_vault.example.tenant_id
+  object_id    = "See the README.md file for instructions on how to lookup the correct value to enter here"
 
   key_permissions = [
     "get",

--- a/examples/databricks/secure-connectivity-cluster/with-load-balancer/main.tf
+++ b/examples/databricks/secure-connectivity-cluster/with-load-balancer/main.tf
@@ -28,10 +28,10 @@ resource "azurerm_subnet" "public" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -48,10 +48,10 @@ resource "azurerm_subnet" "private" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -123,8 +123,8 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_lb_outbound_rule" "example" {
-  name                     = "Databricks-LB-Outbound-Rules"
-  resource_group_name      = azurerm_resource_group.example.name
+  name                = "Databricks-LB-Outbound-Rules"
+  resource_group_name = azurerm_resource_group.example.name
 
   loadbalancer_id          = azurerm_lb.example.id
   protocol                 = "All"
@@ -140,6 +140,6 @@ resource "azurerm_lb_outbound_rule" "example" {
 }
 
 resource "azurerm_lb_backend_address_pool" "example" {
-  loadbalancer_id     = azurerm_lb.example.id
-  name                = "Databricks-BE"
+  loadbalancer_id = azurerm_lb.example.id
+  name            = "Databricks-BE"
 }

--- a/examples/databricks/secure-connectivity-cluster/without-load-balancer/main.tf
+++ b/examples/databricks/secure-connectivity-cluster/without-load-balancer/main.tf
@@ -28,10 +28,10 @@ resource "azurerm_subnet" "public" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -48,10 +48,10 @@ resource "azurerm_subnet" "private" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }

--- a/examples/datalake/main.tf
+++ b/examples/datalake/main.tf
@@ -7,36 +7,36 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_data_lake_store" "example" {
   name                = "${var.prefix}-dls"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tier                = "Consumption"
 }
 
 resource "azurerm_data_lake_store_firewall_rule" "test" {
   name                = "${var.prefix}-dls-fwrule"
-  account_name        = "${azurerm_data_lake_store.example.name}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  account_name        = azurerm_data_lake_store.example.name
+  resource_group_name = azurerm_resource_group.example.name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
 }
 
 resource "azurerm_data_lake_analytics_account" "example" {
   name                       = "${var.prefix}-dla"
-  resource_group_name        = "${azurerm_resource_group.example.name}"
-  location                   = "${azurerm_resource_group.example.location}"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
   tier                       = "Consumption"
-  default_store_account_name = "${azurerm_data_lake_store.example.name}"
+  default_store_account_name = azurerm_data_lake_store.example.name
 }
 
 resource "azurerm_data_lake_analytics_firewall_rule" "test" {
   name                = "${var.prefix}-dlafwrule"
-  account_name        = "${azurerm_data_lake_analytics_account.example.name}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  account_name        = azurerm_data_lake_analytics_account.example.name
+  resource_group_name = azurerm_resource_group.example.name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
 }

--- a/examples/desktopvirtualization/main.tf
+++ b/examples/desktopvirtualization/main.tf
@@ -2,41 +2,41 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-       features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "example" {
-    name       ="${var.prefix}-resources"
-    location   = "${var.location}"
+  name     = "${var.prefix}-resources"
+  location = var.location
 }
 
 resource "azurerm_virtual_desktop_workspace" "example" {
-    name                     = "${var.prefix}workspace"
-    resource_group_name      = azurerm_resource_group.example.name
-    location                 = azurerm_resource_group.example.location
+  name                = "${var.prefix}workspace"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_virtual_desktop_host_pool" "example" {
-    resource_group_name      = azurerm_resource_group.example.name
-    name                     = "${var.prefix}hostpool"
-    location                 = azurerm_resource_group.example.location
-    
-    validate_environment     = false
-    type                     = "Pooled"
-    maximum_sessions_allowed = 16
-    load_balancer_type       = "BreadthFirst"
+  resource_group_name = azurerm_resource_group.example.name
+  name                = "${var.prefix}hostpool"
+  location            = azurerm_resource_group.example.location
+
+  validate_environment     = false
+  type                     = "Pooled"
+  maximum_sessions_allowed = 16
+  load_balancer_type       = "BreadthFirst"
 }
 
 resource "azurerm_virtual_desktop_application_group" "example" {
-    resource_group_name      = azurerm_resource_group.example.name
-    host_pool_id             = azurerm_virtual_desktop_host_pool.example.id
-    location                 = azurerm_resource_group.example.location
-    type                     = "Desktop"
-    name                     = "${var.prefix}dag"
-    depends_on               = [azurerm_virtual_desktop_host_pool.example]
+  resource_group_name = azurerm_resource_group.example.name
+  host_pool_id        = azurerm_virtual_desktop_host_pool.example.id
+  location            = azurerm_resource_group.example.location
+  type                = "Desktop"
+  name                = "${var.prefix}dag"
+  depends_on          = [azurerm_virtual_desktop_host_pool.example]
 }
 
 resource "azurerm_virtual_desktop_workspace_application_group_association" "example" {
-    application_group_id     = azurerm_virtual_desktop_application_group.example.id
-    workspace_id             = azurerm_virtual_desktop_workspace.example.id
+  application_group_id = azurerm_virtual_desktop_application_group.example.id
+  workspace_id         = azurerm_virtual_desktop_workspace.example.id
 }

--- a/examples/desktopvirtualization/variables.tf
+++ b/examples/desktopvirtualization/variables.tf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "prefix" {
-    description = "The prefix which should be used for all resources in this example"
+  description = "The prefix which should be used for all resources in this example"
 }
 
 variable "location" {
-    description = "The Azure Region in which all resources in this example should be provisioned"
+  description = "The Azure Region in which all resources in this example should be provisioned"
 }

--- a/examples/hdinsight/private-link/hadoop-interactive-spark-hbase-cluster/main.tf
+++ b/examples/hdinsight/private-link/hadoop-interactive-spark-hbase-cluster/main.tf
@@ -127,8 +127,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "example" {
       username = "accexampleusrvm"
       password = "AccTestvdSC4daf986!"
 
-     subnet_id          = azurerm_subnet.example.id
-     virtual_network_id = azurerm_virtual_network.example.id
+      subnet_id          = azurerm_subnet.example.id
+      virtual_network_id = azurerm_virtual_network.example.id
     }
 
     worker_node {
@@ -137,8 +137,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "example" {
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
 
-     subnet_id          = azurerm_subnet.example.id
-     virtual_network_id = azurerm_virtual_network.example.id
+      subnet_id          = azurerm_subnet.example.id
+      virtual_network_id = azurerm_virtual_network.example.id
     }
 
     zookeeper_node {
@@ -146,8 +146,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "example" {
       username = "accexampleusrvm"
       password = "AccTestvdSC4daf986!"
 
-     subnet_id          = azurerm_subnet.example.id
-     virtual_network_id = azurerm_virtual_network.example.id
+      subnet_id          = azurerm_subnet.example.id
+      virtual_network_id = azurerm_virtual_network.example.id
     }
   }
 }

--- a/examples/kubernetes/old/advanced-networking-calico-policy/main.tf
+++ b/examples/kubernetes/old/advanced-networking-calico-policy/main.tf
@@ -7,13 +7,13 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "test" {
   name     = "${var.prefix}-anw-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_route_table" "test" {
   name                = "${var.prefix}-routetable"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   route {
     name                   = "default"
@@ -25,34 +25,34 @@ resource "azurerm_route_table" "test" {
 
 resource "azurerm_virtual_network" "test" {
   name                = "${var.prefix}-network"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.1.0.0/16"]
 }
 
 resource "azurerm_subnet" "test" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
+  resource_group_name  = azurerm_resource_group.test.name
   address_prefixes     = ["10.1.0.0/24"]
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  virtual_network_name = azurerm_virtual_network.test.name
 }
 
 resource "azurerm_subnet_route_table_association" "test" {
-  subnet_id      = "${azurerm_subnet.test.id}"
-  route_table_id = "${azurerm_route_table.test.id}"
+  subnet_id      = azurerm_subnet.test.id
+  route_table_id = azurerm_route_table.test.id
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
   name                = "${var.prefix}-anw"
-  location            = "${azurerm_resource_group.test.location}"
+  location            = azurerm_resource_group.test.location
   dns_prefix          = "${var.prefix}-anw"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  resource_group_name = azurerm_resource_group.test.name
 
   linux_profile {
     admin_username = "acctestuser1"
 
     ssh_key {
-      key_data = "${file(var.public_ssh_key_path)}"
+      key_data = file(var.public_ssh_key_path)
     }
   }
 
@@ -64,12 +64,12 @@ resource "azurerm_kubernetes_cluster" "test" {
     os_disk_size_gb = 30
 
     # Required for advanced networking
-    vnet_subnet_id = "${azurerm_subnet.test.id}"
+    vnet_subnet_id = azurerm_subnet.test.id
   }
 
   service_principal {
-    client_id     = "${var.kubernetes_client_id}"
-    client_secret = "${var.kubernetes_client_secret}"
+    client_id     = var.kubernetes_client_id
+    client_secret = var.kubernetes_client_secret
   }
 
   network_profile {

--- a/examples/kubernetes/old/advanced-networking-calico-policy/outputs.tf
+++ b/examples/kubernetes/old/advanced-networking-calico-policy/outputs.tf
@@ -2,29 +2,29 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "subnet_id" {
-  value = "${azurerm_kubernetes_cluster.test.agent_pool_profile.0.vnet_subnet_id}"
+  value = azurerm_kubernetes_cluster.test.agent_pool_profile.0.vnet_subnet_id
 }
 
 output "network_plugin" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.network_plugin}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.network_plugin
 }
 
 output "network_policy" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.network_policy}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.network_policy
 }
 
 output "service_cidr" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.service_cidr}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.service_cidr
 }
 
 output "dns_service_ip" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.dns_service_ip}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.dns_service_ip
 }
 
 output "docker_bridge_cidr" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.docker_bridge_cidr}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.docker_bridge_cidr
 }
 
 output "pod_cidr" {
-  value = "${azurerm_kubernetes_cluster.test.network_profile.0.pod_cidr}"
+  value = azurerm_kubernetes_cluster.test.network_profile.0.pod_cidr
 }

--- a/examples/kubernetes/old/advanced-networking/main.tf
+++ b/examples/kubernetes/old/advanced-networking/main.tf
@@ -7,7 +7,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-anw-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_route_table" "example" {
@@ -44,15 +44,15 @@ resource "azurerm_subnet_route_table_association" "example" {
 
 resource "azurerm_kubernetes_cluster" "example" {
   name                = "${var.prefix}-anw"
-  location            = "${azurerm_resource_group.example.location}"
+  location            = azurerm_resource_group.example.location
   dns_prefix          = "${var.prefix}-anw"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
 
   linux_profile {
     admin_username = "acctestuser1"
 
     ssh_key {
-      key_data = "${file(var.public_ssh_key_path)}"
+      key_data = file(var.public_ssh_key_path)
     }
   }
 
@@ -64,12 +64,12 @@ resource "azurerm_kubernetes_cluster" "example" {
     os_disk_size_gb = 30
 
     # Required for advanced networking
-    vnet_subnet_id = "${azurerm_subnet.example.id}"
+    vnet_subnet_id = azurerm_subnet.example.id
   }
 
   service_principal {
-    client_id     = "${var.kubernetes_client_id}"
-    client_secret = "${var.kubernetes_client_secret}"
+    client_id     = var.kubernetes_client_id
+    client_secret = var.kubernetes_client_secret
   }
 
   network_profile {

--- a/examples/kubernetes/old/advanced-networking/outputs.tf
+++ b/examples/kubernetes/old/advanced-networking/outputs.tf
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "subnet_id" {
-  value = "${azurerm_kubernetes_cluster.example.agent_pool_profile.0.vnet_subnet_id}"
+  value = azurerm_kubernetes_cluster.example.agent_pool_profile.0.vnet_subnet_id
 }
 
 output "network_plugin" {
-  value = "${azurerm_kubernetes_cluster.example.network_profile.0.network_plugin}"
+  value = azurerm_kubernetes_cluster.example.network_profile.0.network_plugin
 }
 
 output "service_cidr" {
-  value = "${azurerm_kubernetes_cluster.example.network_profile.0.service_cidr}"
+  value = azurerm_kubernetes_cluster.example.network_profile.0.service_cidr
 }
 
 output "dns_service_ip" {
-  value = "${azurerm_kubernetes_cluster.example.network_profile.0.dns_service_ip}"
+  value = azurerm_kubernetes_cluster.example.network_profile.0.dns_service_ip
 }
 
 output "docker_bridge_cidr" {
-  value = "${azurerm_kubernetes_cluster.example.network_profile.0.docker_bridge_cidr}"
+  value = azurerm_kubernetes_cluster.example.network_profile.0.docker_bridge_cidr
 }
 
 output "pod_cidr" {
-  value = "${azurerm_kubernetes_cluster.example.network_profile.0.pod_cidr}"
+  value = azurerm_kubernetes_cluster.example.network_profile.0.pod_cidr
 }

--- a/examples/kubernetes/old/role-based-access-control-azuread/main.tf
+++ b/examples/kubernetes/old/role-based-access-control-azuread/main.tf
@@ -7,13 +7,13 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-rbac-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_kubernetes_cluster" "example" {
   name                = "${var.prefix}-rbac"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   dns_prefix          = "${var.prefix}-rbac"
 
   agent_pool_profile {
@@ -25,8 +25,8 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 
   service_principal {
-    client_id     = "${var.kubernetes_client_id}"
-    client_secret = "${var.kubernetes_client_secret}"
+    client_id     = var.kubernetes_client_id
+    client_secret = var.kubernetes_client_secret
   }
 
   role_based_access_control {
@@ -35,10 +35,10 @@ resource "azurerm_kubernetes_cluster" "example" {
     azure_active_directory {
       # NOTE: in a Production environment these should be different values
       # but for the purposes of this example, this should be sufficient
-      client_app_id = "${var.kubernetes_client_id}"
+      client_app_id = var.kubernetes_client_id
 
-      server_app_id     = "${var.kubernetes_client_id}"
-      server_app_secret = "${var.kubernetes_client_secret}"
+      server_app_id     = var.kubernetes_client_id
+      server_app_secret = var.kubernetes_client_secret
     }
   }
 

--- a/examples/kubernetes/old/role-based-access-control-azuread/outputs.tf
+++ b/examples/kubernetes/old/role-based-access-control-azuread/outputs.tf
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "id" {
-  value = "${azurerm_kubernetes_cluster.example.id}"
+  value = azurerm_kubernetes_cluster.example.id
 }
 
 output "kube_config" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config_raw}"
+  value = azurerm_kubernetes_cluster.example.kube_config_raw
 }
 
 output "client_key" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.client_key}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.client_key
 }
 
 output "client_certificate" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.client_certificate}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.cluster_ca_certificate}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.cluster_ca_certificate
 }
 
 output "host" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.host}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.host
 }

--- a/examples/kubernetes/old/role-based-access-control/main.tf
+++ b/examples/kubernetes/old/role-based-access-control/main.tf
@@ -7,13 +7,13 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-rbac-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_kubernetes_cluster" "example" {
   name                = "${var.prefix}-rbac"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   dns_prefix          = "${var.prefix}-rbac"
 
   agent_pool_profile {
@@ -25,8 +25,8 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 
   service_principal {
-    client_id     = "${var.kubernetes_client_id}"
-    client_secret = "${var.kubernetes_client_secret}"
+    client_id     = var.kubernetes_client_id
+    client_secret = var.kubernetes_client_secret
   }
 
   role_based_access_control {

--- a/examples/kubernetes/old/role-based-access-control/outputs.tf
+++ b/examples/kubernetes/old/role-based-access-control/outputs.tf
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "id" {
-  value = "${azurerm_kubernetes_cluster.example.id}"
+  value = azurerm_kubernetes_cluster.example.id
 }
 
 output "kube_config" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config_raw}"
+  value = azurerm_kubernetes_cluster.example.kube_config_raw
 }
 
 output "client_key" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.client_key}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.client_key
 }
 
 output "client_certificate" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.client_certificate}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.cluster_ca_certificate}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.cluster_ca_certificate
 }
 
 output "host" {
-  value = "${azurerm_kubernetes_cluster.example.kube_config.0.host}"
+  value = azurerm_kubernetes_cluster.example.kube_config.0.host
 }

--- a/examples/logic-app/main.tf
+++ b/examples/logic-app/main.tf
@@ -7,25 +7,25 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_logic_app_workflow" "example" {
   name                = "${var.prefix}-logicapp"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_logic_app_trigger_recurrence" "hourly" {
   name         = "run-every-hour"
-  logic_app_id = "${azurerm_logic_app_workflow.example.id}"
+  logic_app_id = azurerm_logic_app_workflow.example.id
   frequency    = "Hour"
   interval     = 1
 }
 
 resource "azurerm_logic_app_action_http" "main" {
   name         = "clear-stable-objects"
-  logic_app_id = "${azurerm_logic_app_workflow.example.id}"
+  logic_app_id = azurerm_logic_app_workflow.example.id
   method       = "DELETE"
   uri          = "http://example.com/clear-stable-objects"
 }

--- a/examples/private-endpoint/databricks/managed-services/main.tf
+++ b/examples/private-endpoint/databricks/managed-services/main.tf
@@ -35,10 +35,10 @@ resource "azurerm_subnet" "public" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -55,10 +55,10 @@ resource "azurerm_subnet" "private" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -96,10 +96,10 @@ resource "azurerm_databricks_workspace" "example" {
   sku                         = "premium"
   managed_resource_group_name = "${var.prefix}-DBW-managed-private-endpoint-ms-dbfscmk"
 
-  customer_managed_key_enabled              = true
-  managed_services_cmk_key_vault_key_id     = azurerm_key_vault_key.example.id
-  public_network_access_enabled             = false
-  network_security_group_rules_required     = "NoAzureDatabricksRules"
+  customer_managed_key_enabled          = true
+  managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.example.id
+  public_network_access_enabled         = false
+  network_security_group_rules_required = "NoAzureDatabricksRules"
 
   custom_parameters {
     no_public_ip        = true
@@ -221,9 +221,9 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 }
 
 resource "azurerm_key_vault_access_policy" "managed" {
-  key_vault_id   = azurerm_key_vault.example.id
-  tenant_id      = azurerm_key_vault.example.tenant_id
-  object_id      = "See the README.md file for instructions on how to lookup the correct value to enter here"
+  key_vault_id = azurerm_key_vault.example.id
+  tenant_id    = azurerm_key_vault.example.tenant_id
+  object_id    = "See the README.md file for instructions on how to lookup the correct value to enter here"
 
   key_permissions = [
     "get",

--- a/examples/private-endpoint/databricks/private-endpoint/main.tf
+++ b/examples/private-endpoint/databricks/private-endpoint/main.tf
@@ -33,10 +33,10 @@ resource "azurerm_subnet" "public" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }
@@ -53,10 +53,10 @@ resource "azurerm_subnet" "private" {
 
     service_delegation {
       actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
-          "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-          "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-        ]
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
       name = "Microsoft.Databricks/workspaces"
     }
   }

--- a/examples/recovery-services/virtual-machine/modules/virtual-machine/main.tf
+++ b/examples/recovery-services/virtual-machine/modules/virtual-machine/main.tf
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
 data "azurerm_resource_group" "example" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${data.azurerm_resource_group.example.location}"
-  resource_group_name = "${data.azurerm_resource_group.example.name}"
+  location            = data.azurerm_resource_group.example.location
+  resource_group_name = data.azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "example"
-    subnet_id                     = "${var.subnet_id}"
+    subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Dynamic"
   }
 }
 
 resource "azurerm_virtual_machine" "example" {
   name                          = "${var.prefix}-vm"
-  location                      = "${data.azurerm_resource_group.example.location}"
-  resource_group_name           = "${data.azurerm_resource_group.example.name}"
+  location                      = data.azurerm_resource_group.example.location
+  resource_group_name           = data.azurerm_resource_group.example.name
   network_interface_ids         = ["${azurerm_network_interface.example.id}"]
   vm_size                       = "Standard_DS1_v2"
   delete_os_disk_on_termination = true

--- a/examples/recovery-services/virtual-machine/modules/virtual-machine/outputs.tf
+++ b/examples/recovery-services/virtual-machine/modules/virtual-machine/outputs.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "id" {
-  value = "${azurerm_virtual_machine.example.id}"
+  value = azurerm_virtual_machine.example.id
 }

--- a/examples/recovery-services/virtual-machine/modules/virtual-network/main.tf
+++ b/examples/recovery-services/virtual-machine/modules/virtual-network/main.tf
@@ -2,19 +2,19 @@
 # SPDX-License-Identifier: MPL-2.0
 
 data "azurerm_resource_group" "example" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${data.azurerm_resource_group.example.name}"
-  location            = "${data.azurerm_resource_group.example.location}"
+  resource_group_name = data.azurerm_resource_group.example.name
+  location            = data.azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${data.azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = data.azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }

--- a/examples/recovery-services/virtual-machine/modules/virtual-network/outputs.tf
+++ b/examples/recovery-services/virtual-machine/modules/virtual-network/outputs.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "subnet_id" {
-  value = "${azurerm_subnet.example.id}"
+  value = azurerm_subnet.example.id
 }

--- a/examples/search/main.tf
+++ b/examples/search/main.tf
@@ -7,13 +7,13 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_search_service" "example" {
   name                = "${var.prefix}-search"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sku                 = "standard"
   replica_count       = "1"
   partition_count     = "1"

--- a/examples/tfc-checks/app-service-certificate-expiry/main.tf
+++ b/examples/tfc-checks/app-service-certificate-expiry/main.tf
@@ -92,7 +92,7 @@ resource "azurerm_app_service_certificate" "example" {
 
 
 locals {
-  month_in_hour_duration = "${24 * 30}h"
+  month_in_hour_duration            = "${24 * 30}h"
   month_and_2min_in_second_duration = "${(60 * 60 * 24 * 30) + (60 * 2)}s"
 }
 
@@ -104,8 +104,8 @@ data "azurerm_app_service_certificate" "example" {
 check "check_certificate_state" {
   assert {
     condition = timecmp(plantimestamp(), timeadd(
-        data.azurerm_app_service_certificate.example.expiration_date,
-      "-${local.month_in_hour_duration}")) < 0
+      data.azurerm_app_service_certificate.example.expiration_date,
+    "-${local.month_in_hour_duration}")) < 0
     error_message = format("App Service Certificate (%s) is valid for at least 30 days, but is due to expire on `%s`.",
       data.azurerm_app_service_certificate.example.id,
       data.azurerm_app_service_certificate.example.expiration_date

--- a/examples/tfc-checks/vm-power-state/main.tf
+++ b/examples/tfc-checks/vm-power-state/main.tf
@@ -37,17 +37,17 @@ resource "azurerm_network_interface" "example" {
 }
 
 resource "azurerm_linux_virtual_machine" "example" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,
   ]
 
   admin_ssh_key {
-    username = "adminuser"
+    username   = "adminuser"
     public_key = file("~/.ssh/id_rsa.pub")
   }
 

--- a/examples/traffic-manager/virtual-machine/modules/virtual-machine/main.tf
+++ b/examples/traffic-manager/virtual-machine/modules/virtual-machine/main.tf
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
 data "azurerm_resource_group" "example" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${data.azurerm_resource_group.example.location}"
-  resource_group_name = "${data.azurerm_resource_group.example.name}"
+  location            = data.azurerm_resource_group.example.location
+  resource_group_name = data.azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "example"
-    subnet_id                     = "${var.subnet_id}"
+    subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Dynamic"
   }
 }
 
 resource "azurerm_virtual_machine" "example" {
   name                          = "${var.prefix}-vm"
-  location                      = "${data.azurerm_resource_group.example.location}"
-  resource_group_name           = "${data.azurerm_resource_group.example.name}"
+  location                      = data.azurerm_resource_group.example.location
+  resource_group_name           = data.azurerm_resource_group.example.name
   network_interface_ids         = ["${azurerm_network_interface.example.id}"]
   vm_size                       = "Standard_DS1_v2"
   delete_os_disk_on_termination = true
@@ -52,7 +52,7 @@ resource "azurerm_virtual_machine" "example" {
 
 resource "azurerm_virtual_machine_extension" "example" {
   name                       = "CustomScript"
-  virtual_machine_id       = azurerm_virtual_machine.example.id
+  virtual_machine_id         = azurerm_virtual_machine.example.id
   publisher                  = "Microsoft.Azure.Extensions"
   type                       = "CustomScript"
   type_handler_version       = "2.0"

--- a/examples/traffic-manager/virtual-machine/modules/virtual-machine/outputs.tf
+++ b/examples/traffic-manager/virtual-machine/modules/virtual-machine/outputs.tf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "id" {
-  value = "${azurerm_virtual_machine.example.id}"
+  value = azurerm_virtual_machine.example.id
 }
 
 output "network_interface_id" {
-  value = "${azurerm_network_interface.example.id}"
+  value = azurerm_network_interface.example.id
 }

--- a/examples/traffic-manager/virtual-machine/modules/virtual-network/main.tf
+++ b/examples/traffic-manager/virtual-machine/modules/virtual-network/main.tf
@@ -2,19 +2,19 @@
 # SPDX-License-Identifier: MPL-2.0
 
 data "azurerm_resource_group" "example" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${data.azurerm_resource_group.example.name}"
-  location            = "${data.azurerm_resource_group.example.location}"
+  resource_group_name = data.azurerm_resource_group.example.name
+  location            = data.azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${data.azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = data.azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }

--- a/examples/traffic-manager/virtual-machine/modules/virtual-network/outputs.tf
+++ b/examples/traffic-manager/virtual-machine/modules/virtual-network/outputs.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "subnet_id" {
-  value = "${azurerm_subnet.example.id}"
+  value = azurerm_subnet.example.id
 }

--- a/examples/traffic-manager/vm-scale-set/modules/region/1-network.tf
+++ b/examples/traffic-manager/vm-scale-set/modules/region/1-network.tf
@@ -3,19 +3,19 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }

--- a/examples/traffic-manager/vm-scale-set/modules/region/2-load-balancer.tf
+++ b/examples/traffic-manager/vm-scale-set/modules/region/2-load-balancer.tf
@@ -24,22 +24,22 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_lb_backend_address_pool" "example" {
-  name                = "backend"
-  loadbalancer_id     = azurerm_lb.example.id
+  name            = "backend"
+  loadbalancer_id = azurerm_lb.example.id
 }
 
 resource "azurerm_lb_probe" "example" {
-  name                = "probe"
-  loadbalancer_id     = azurerm_lb.example.id
-  protocol            = "Tcp"
-  port                = 80
+  name            = "probe"
+  loadbalancer_id = azurerm_lb.example.id
+  protocol        = "Tcp"
+  port            = 80
 }
 
 resource "azurerm_lb_rule" "example" {
   name                           = "http-lb-rule"
   loadbalancer_id                = azurerm_lb.example.id
   probe_id                       = azurerm_lb_probe.example.id
-  backend_address_pool_ids = [azurerm_lb_backend_address_pool.example.id]
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.example.id]
   frontend_ip_configuration_name = local.frontend_ip_configuration_name
   protocol                       = "Tcp"
   frontend_port                  = "80"

--- a/examples/traffic-manager/vm-scale-set/modules/region/3-vm-scale-set.tf
+++ b/examples/traffic-manager/vm-scale-set/modules/region/3-vm-scale-set.tf
@@ -3,8 +3,8 @@
 
 resource "azurerm_virtual_machine_scale_set" "example" {
   name                = "${var.prefix}-vmss"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   upgrade_policy_mode = "Manual"
 
   sku {
@@ -29,7 +29,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
     ip_configuration {
       name                                   = "internal"
-      subnet_id                              = "${azurerm_subnet.example.id}"
+      subnet_id                              = azurerm_subnet.example.id
       load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.example.id}"]
       primary                                = true
     }

--- a/examples/virtual-machines/linux/azure-disk-encryption/main.tf
+++ b/examples/virtual-machines/linux/azure-disk-encryption/main.tf
@@ -93,17 +93,17 @@ resource "azurerm_network_interface" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_D2s_v3"
-  admin_username                  = "adminuser"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
 
   admin_ssh_key {
-    username = "adminuser"
+    username   = "adminuser"
     public_key = file("~/.ssh/id_rsa.pub")
   }
 

--- a/examples/virtual-machines/linux/basic-password/main.tf
+++ b/examples/virtual-machines/linux/basic-password/main.tf
@@ -41,8 +41,8 @@ resource "azurerm_linux_virtual_machine" "main" {
   resource_group_name             = azurerm_resource_group.main.name
   location                        = azurerm_resource_group.main.location
   size                            = "Standard_D2s_v3"
-  admin_username                  = "${var.username}"
-  admin_password                  = "${var.password}"
+  admin_username                  = var.username
+  admin_password                  = var.password
   disable_password_authentication = false
   network_interface_ids = [
     azurerm_network_interface.main.id,

--- a/examples/virtual-machines/linux/basic-ssh/main.tf
+++ b/examples/virtual-machines/linux/basic-ssh/main.tf
@@ -37,17 +37,17 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_linux_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]
 
   admin_ssh_key {
-    username = "adminuser"
+    username   = "adminuser"
     public_key = file("~/.ssh/id_rsa.pub")
   }
 

--- a/examples/virtual-machines/linux/public-ip/main.tf
+++ b/examples/virtual-machines/linux/public-ip/main.tf
@@ -45,9 +45,9 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_network_interface" "internal" {
-  name                      = "${var.prefix}-nic2"
-  resource_group_name       = azurerm_resource_group.main.name
-  location                  = azurerm_resource_group.main.location
+  name                = "${var.prefix}-nic2"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
   ip_configuration {
     name                          = "internal"

--- a/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/main.tf
+++ b/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/main.tf
@@ -6,22 +6,22 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.resource_group}"
-  location = "${var.location}"
+  name     = var.resource_group
+  location = var.location
 }
 
 resource "azurerm_storage_account" "stor" {
   name                     = "${var.dns_name}stor"
-  location                 = "${var.location}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_replication_type}"
+  location                 = var.location
+  resource_group_name      = azurerm_resource_group.rg.name
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_replication_type
 }
 
 resource "azurerm_availability_set" "avset" {
   name                         = "${var.dns_name}avset"
-  location                     = "${var.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
+  location                     = var.location
+  resource_group_name          = azurerm_resource_group.rg.name
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
   managed                      = true
@@ -29,46 +29,46 @@ resource "azurerm_availability_set" "avset" {
 
 resource "azurerm_public_ip" "lbpip" {
   name                = "${var.rg_prefix}-ip"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Dynamic"
-  domain_name_label   = "${var.lb_ip_dns_name}"
+  domain_name_label   = var.lb_ip_dns_name
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.virtual_network_name}"
-  location            = "${var.location}"
+  name                = var.virtual_network_name
+  location            = var.location
   address_space       = ["${var.address_space}"]
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.rg_prefix}subnet"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["${var.subnet_prefix}"]
 }
 
 resource "azurerm_lb" "lb" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
   name                = "${var.rg_prefix}lb"
-  location            = "${var.location}"
+  location            = var.location
 
   frontend_ip_configuration {
     name                 = "LoadBalancerFrontEnd"
-    public_ip_address_id = "${azurerm_public_ip.lbpip.id}"
+    public_ip_address_id = azurerm_public_ip.lbpip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "backend_pool" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id     = "${azurerm_lb.lb.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.lb.id
   name                = "BackendPool1"
 }
 
 resource "azurerm_lb_nat_rule" "tcp" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.lb.id
   name                           = "RDP-VM-${count.index}"
   protocol                       = "tcp"
   frontend_port                  = "5000${count.index + 1}"
@@ -78,23 +78,23 @@ resource "azurerm_lb_nat_rule" "tcp" {
 }
 
 resource "azurerm_lb_rule" "lb_rule" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.lb.id
   name                           = "LBRule"
   protocol                       = "tcp"
   frontend_port                  = 80
   backend_port                   = 80
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
   enable_floating_ip             = false
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.backend_pool.id}"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.backend_pool.id
   idle_timeout_in_minutes        = 5
-  probe_id                       = "${azurerm_lb_probe.lb_probe.id}"
+  probe_id                       = azurerm_lb_probe.lb_probe.id
   depends_on                     = ["azurerm_lb_probe.lb_probe"]
 }
 
 resource "azurerm_lb_probe" "lb_probe" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id     = "${azurerm_lb.lb.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.lb.id
   name                = "tcpProbe"
   protocol            = "tcp"
   port                = 80
@@ -104,14 +104,14 @@ resource "azurerm_lb_probe" "lb_probe" {
 
 resource "azurerm_network_interface" "nic" {
   name                = "nic${count.index}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
   count               = 2
 
   ip_configuration {
-    name                                    = "ipconfig${count.index}"
-    subnet_id                               = "${azurerm_subnet.subnet.id}"
-    private_ip_address_allocation           = "Dynamic"
+    name                          = "ipconfig${count.index}"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
 
@@ -126,18 +126,18 @@ resource "azurerm_network_interface_nat_rule_association" "natrule" {
 
 resource "azurerm_virtual_machine" "vm" {
   name                  = "vm${count.index}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  availability_set_id   = "${azurerm_availability_set.avset.id}"
-  vm_size               = "${var.vm_size}"
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  availability_set_id   = azurerm_availability_set.avset.id
+  vm_size               = var.vm_size
   network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
   count                 = 2
 
   storage_image_reference {
-    publisher = "${var.image_publisher}"
-    offer     = "${var.image_offer}"
-    sku       = "${var.image_sku}"
-    version   = "${var.image_version}"
+    publisher = var.image_publisher
+    offer     = var.image_offer
+    sku       = var.image_sku
+    version   = var.image_version
   }
 
   storage_os_disk {
@@ -146,9 +146,9 @@ resource "azurerm_virtual_machine" "vm" {
   }
 
   os_profile {
-    computer_name  = "${var.hostname}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    computer_name  = var.hostname
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 
   os_profile_windows_config {}

--- a/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/outputs.tf
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "hostname" {
-  value = "${var.hostname}"
+  value = var.hostname
 }
 
 output "vm_fqdn" {
-  value = "${azurerm_public_ip.lbpip.fqdn}"
+  value = azurerm_public_ip.lbpip.fqdn
 }
 
 output "vms_rdp_access" {
-  value = "${formatlist("RDP_URL=%v:%v", azurerm_public_ip.lbpip.fqdn, azurerm_lb_nat_rule.tcp.*.frontend_port)}"
+  value = formatlist("RDP_URL=%v:%v", azurerm_public_ip.lbpip.fqdn, azurerm_lb_nat_rule.tcp.*.frontend_port)
 }

--- a/examples/virtual-machines/virtual_machine/bastion-box/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/1-dependencies.tf
@@ -3,20 +3,20 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_network_security_group" "bastion" {
   name                = "${azurerm_resource_group.example.name}-mgmt-nsg"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   security_rule {
     name                       = "allow-ssh"
@@ -33,10 +33,10 @@ resource "azurerm_network_security_group" "bastion" {
 }
 
 resource "azurerm_subnet" "bastion" {
-  name                      = "${azurerm_resource_group.example.name}-bastion"
-  virtual_network_name      = "${azurerm_virtual_network.example.name}"
-  resource_group_name       = "${azurerm_resource_group.example.name}"
-  address_prefixes          = ["10.0.0.128/25"]
+  name                 = "${azurerm_resource_group.example.name}-bastion"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
+  address_prefixes     = ["10.0.0.128/25"]
 }
 
 resource "azurerm_subnet_network_security_group_association" "bastion" {
@@ -46,8 +46,8 @@ resource "azurerm_subnet_network_security_group_association" "bastion" {
 
 resource "azurerm_network_security_group" "web" {
   name                = "${azurerm_resource_group.example.name}-web"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   security_rule {
     name                       = "allow-www"
@@ -77,10 +77,10 @@ resource "azurerm_network_security_group" "web" {
 }
 
 resource "azurerm_subnet" "web" {
-  name                      = "${azurerm_resource_group.example.name}-web"
-  virtual_network_name      = "${azurerm_virtual_network.example.name}"
-  resource_group_name       = "${azurerm_resource_group.example.name}"
-  address_prefixes          = ["10.0.1.0/24"]
+  name                 = "${azurerm_resource_group.example.name}-web"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_subnet_network_security_group_association" "web" {

--- a/examples/virtual-machines/virtual_machine/bastion-box/2-generate-ssh.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/2-generate-ssh.tf
@@ -7,5 +7,5 @@ resource "tls_private_key" "example" {
 }
 
 locals {
-  public_ssh_key = "${tls_private_key.example.public_key_openssh}"
+  public_ssh_key = tls_private_key.example.public_key_openssh
 }

--- a/examples/virtual-machines/virtual_machine/bastion-box/main.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/main.tf
@@ -11,15 +11,15 @@ locals {
 }
 
 resource "azurerm_network_interface" "example" {
-  name                      = "${azurerm_resource_group.example.name}-nic"
-  location                  = "${azurerm_resource_group.example.location}"
-  resource_group_name       = "${azurerm_resource_group.example.name}"
+  name                = "${azurerm_resource_group.example.name}-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = "${azurerm_subnet.bastion.id}"
+    subnet_id                     = azurerm_subnet.bastion.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }
 
@@ -30,15 +30,15 @@ resource "azurerm_network_interface_security_group_association" "example" {
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-bastionpip"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Dynamic"
 }
 
 resource "azurerm_virtual_machine" "example" {
-  name                  = "${local.virtual_machine_name}"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  name                  = local.virtual_machine_name
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 
@@ -57,8 +57,8 @@ resource "azurerm_virtual_machine" "example" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
-    admin_username = "${local.admin_username}"
+    computer_name  = local.virtual_machine_name
+    admin_username = local.admin_username
   }
 
   os_profile_linux_config {
@@ -66,7 +66,7 @@ resource "azurerm_virtual_machine" "example" {
 
     ssh_keys {
       path     = "/home/${local.admin_username}/.ssh/authorized_keys"
-      key_data = "${local.public_ssh_key}"
+      key_data = local.public_ssh_key
     }
   }
 }

--- a/examples/virtual-machines/virtual_machine/bastion-box/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/outputs.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "vm_fqdn" {
-  value = "${azurerm_public_ip.example.fqdn}"
+  value = azurerm_public_ip.example.fqdn
 }
 
 output "ssh_command" {

--- a/examples/virtual-machines/virtual_machine/encrypt-running-linux-vm/main.tf
+++ b/examples/virtual-machines/virtual_machine/encrypt-running-linux-vm/main.tf
@@ -6,56 +6,56 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.resource_group}"
-  location = "${var.location}"
+  name     = var.resource_group
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "vnet" {
   name                = "${var.hostname}vnet"
-  location            = "${var.location}"
+  location            = var.location
   address_space       = ["${var.address_space}"]
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.hostname}subnet"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["${var.subnet_prefix}"]
 }
 
 resource "azurerm_network_interface" "nic" {
   name                = "nic"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   ip_configuration {
     name                          = "ipconfig"
-    subnet_id                     = "${azurerm_subnet.subnet.id}"
+    subnet_id                     = azurerm_subnet.subnet.id
     private_ip_address_allocation = "Dynamic"
   }
 }
 
 resource "azurerm_storage_account" "stor" {
   name                     = "${var.hostname}stor"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_replication_type
 }
 
 resource "azurerm_virtual_machine" "vm" {
-  name                  = "${var.hostname}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  vm_size               = "${var.vm_size}"
+  name                  = var.hostname
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  vm_size               = var.vm_size
   network_interface_ids = ["${azurerm_network_interface.nic.id}"]
 
   storage_image_reference {
-    publisher = "${var.image_publisher}"
-    offer     = "${var.image_offer}"
-    sku       = "${var.image_sku}"
-    version   = "${var.image_version}"
+    publisher = var.image_publisher
+    offer     = var.image_offer
+    sku       = var.image_sku
+    version   = var.image_version
   }
 
   storage_os_disk {
@@ -65,9 +65,9 @@ resource "azurerm_virtual_machine" "vm" {
   }
 
   os_profile {
-    computer_name  = "${var.hostname}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    computer_name  = var.hostname
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 
   os_profile_linux_config {
@@ -77,7 +77,7 @@ resource "azurerm_virtual_machine" "vm" {
 
 resource "azurerm_template_deployment" "linux_vm" {
   name                = "encrypt"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
   deployment_mode     = "Incremental"
   depends_on          = ["azurerm_virtual_machine.vm"]
 

--- a/examples/virtual-machines/virtual_machine/encrypt-running-linux-vm/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/encrypt-running-linux-vm/outputs.tf
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "hostname" {
-  value = "${var.hostname}"
+  value = var.hostname
 }
 
 output "BitLockerKey" {
-  value     = "${azurerm_template_deployment.linux_vm.outputs["BitLockerKey"]}"
+  value     = azurerm_template_deployment.linux_vm.outputs["BitLockerKey"]
   sensitive = true
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/attaching-external-disks/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/attaching-external-disks/1-dependencies.tf
@@ -7,31 +7,31 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/attaching-external-disks/main.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/attaching-external-disks/main.tf
@@ -7,8 +7,8 @@ locals {
 
 resource "azurerm_virtual_machine" "example" {
   name                  = "${var.prefix}-vm"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 
@@ -42,19 +42,19 @@ resource "azurerm_virtual_machine" "example" {
 }
 
 resource "azurerm_managed_disk" "external" {
-  count                = "${local.number_of_disks}"
-  name                 = "${var.prefix}-disk${count.index+1}"
-  location             = "${azurerm_resource_group.example.location}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  count                = local.number_of_disks
+  name                 = "${var.prefix}-disk${count.index + 1}"
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = "10"
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "external" {
-  count              = "${local.number_of_disks}"
-  managed_disk_id    = "${azurerm_managed_disk.external.*.id[count.index]}"
-  virtual_machine_id = "${azurerm_virtual_machine.example.id}"
-  lun                = "${10+count.index}"
+  count              = local.number_of_disks
+  managed_disk_id    = azurerm_managed_disk.external.*.id[count.index]
+  virtual_machine_id = azurerm_virtual_machine.example.id
+  lun                = 10 + count.index
   caching            = "ReadWrite"
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/basic/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/basic/1-dependencies.tf
@@ -3,31 +3,31 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/basic/main.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/basic/main.tf
@@ -7,8 +7,8 @@ provider "azurerm" {
 
 resource "azurerm_virtual_machine" "example" {
   name                  = "${var.prefix}-vm"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 

--- a/examples/virtual-machines/virtual_machine/managed-disks/from-custom-image/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/from-custom-image/1-dependencies.tf
@@ -3,31 +3,31 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/from-custom-image/main.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/from-custom-image/main.tf
@@ -7,14 +7,14 @@ provider "azurerm" {
 
 # we assume that this Custom Image already exists
 data "azurerm_image" "custom" {
-  name                = "${var.custom_image_name}"
-  resource_group_name = "${var.custom_image_resource_group_name}"
+  name                = var.custom_image_name
+  resource_group_name = var.custom_image_resource_group_name
 }
 
 resource "azurerm_virtual_machine" "example" {
   name                  = "${var.prefix}-vm"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 
@@ -23,7 +23,7 @@ resource "azurerm_virtual_machine" "example" {
   delete_os_disk_on_termination = true
 
   storage_image_reference {
-    id = "${data.azurerm_image.custom.id}"
+    id = data.azurerm_image.custom.id
   }
 
   storage_os_disk {

--- a/examples/virtual-machines/virtual_machine/managed-disks/from-marketplace-image/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/from-marketplace-image/1-dependencies.tf
@@ -3,39 +3,39 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
   name                         = "${var.prefix}-pip"
-  location                     = "${azurerm_resource_group.example.location}"
-  resource_group_name          = "${azurerm_resource_group.example.name}"
+  location                     = azurerm_resource_group.example.location
+  resource_group_name          = azurerm_resource_group.example.name
   public_ip_address_allocation = "Dynamic"
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/from-marketplace-image/main.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/from-marketplace-image/main.tf
@@ -10,9 +10,9 @@ locals {
 }
 
 resource "azurerm_virtual_machine" "example" {
-  name                  = "${local.virtual_machine_name}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
-  location              = "${azurerm_resource_group.example.location}"
+  name                  = local.virtual_machine_name
+  resource_group_name   = azurerm_resource_group.example.name
+  location              = azurerm_resource_group.example.location
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 

--- a/examples/virtual-machines/virtual_machine/managed-disks/public-ip/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/public-ip/1-dependencies.tf
@@ -3,19 +3,19 @@
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }

--- a/examples/virtual-machines/virtual_machine/managed-disks/public-ip/main.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/public-ip/main.tf
@@ -7,28 +7,28 @@ provider "azurerm" {
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-pip"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }
 
 resource "azurerm_virtual_machine" "example" {
   name                  = "${var.prefix}-vm"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 

--- a/examples/virtual-machines/virtual_machine/managed-disks/public-ip/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/managed-disks/public-ip/outputs.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "public_ip_address" {
-  value = "${azurerm_public_ip.example.ip_address}"
+  value = azurerm_public_ip.example.ip_address
 }
 
 output "ssh_command" {

--- a/examples/virtual-machines/virtual_machine/multiple-network-interfaces/main.tf
+++ b/examples/virtual-machines/virtual_machine/multiple-network-interfaces/main.tf
@@ -11,41 +11,41 @@ locals {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["172.16.0.0/16"]
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_subnet" "external" {
   name                 = "external"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["172.16.1.0/24"]
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["172.16.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-pip"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Dynamic"
 }
 
 resource "azurerm_network_security_group" "example" {
   name                = "${var.prefix}-nsg"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   security_rule {
     name                       = "allow_SSH"
@@ -76,35 +76,35 @@ resource "azurerm_network_security_group" "example" {
 
 resource "azurerm_network_interface" "external" {
   name                      = "${var.prefix}-ext-nic"
-  location                  = "${azurerm_resource_group.example.location}"
-  resource_group_name       = "${azurerm_resource_group.example.name}"
-  network_security_group_id = "${azurerm_network_security_group.example.id}"
+  location                  = azurerm_resource_group.example.location
+  resource_group_name       = azurerm_resource_group.example.name
+  network_security_group_id = azurerm_network_security_group.example.id
 
   ip_configuration {
     name                          = "primary"
-    subnet_id                     = "${azurerm_subnet.external.id}"
+    subnet_id                     = azurerm_subnet.external.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }
 
 resource "azurerm_network_interface" "internal" {
   name                = "${var.prefix}-int-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "primary"
-    subnet_id                     = "${azurerm_subnet.internal.id}"
+    subnet_id                     = azurerm_subnet.internal.id
     private_ip_address_allocation = "Dynamic"
   }
 }
 
 resource "azurerm_virtual_machine" "main" {
   name                          = "${var.prefix}-vm"
-  location                      = "${azurerm_resource_group.example.location}"
-  resource_group_name           = "${azurerm_resource_group.example.name}"
-  primary_network_interface_id  = "${azurerm_network_interface.external.id}"
+  location                      = azurerm_resource_group.example.location
+  resource_group_name           = azurerm_resource_group.example.name
+  primary_network_interface_id  = azurerm_network_interface.external.id
   network_interface_ids         = ["${azurerm_network_interface.external.id}", "${azurerm_network_interface.internal.id}"]
   vm_size                       = "Standard_DS1_v2"
   delete_os_disk_on_termination = true
@@ -124,7 +124,7 @@ resource "azurerm_virtual_machine" "main" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
+    computer_name  = local.virtual_machine_name
     admin_username = "myadmin"
     admin_password = "Passwword1234"
   }

--- a/examples/virtual-machines/virtual_machine/openshift-origin/main.tf
+++ b/examples/virtual-machines/virtual_machine/openshift-origin/main.tf
@@ -4,23 +4,23 @@
 provider "azurerm" {
   features {}
 
-  subscription_id = "${var.subscription_id}"
-  client_id       = "${var.aad_client_id}"
-  client_secret   = "${var.aad_client_secret}"
-  tenant_id       = "${var.tenant_id}"
+  subscription_id = var.subscription_id
+  client_id       = var.aad_client_id
+  client_secret   = var.aad_client_secret
+  tenant_id       = var.tenant_id
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.resource_group_name}"
-  location = "${var.resource_group_location}"
+  name     = var.resource_group_name
+  location = var.resource_group_location
 }
 
 # ******* NETWORK SECURITY GROUPS ***********
 
 resource "azurerm_network_security_group" "primary_nsg" {
   name                = "${var.openshift_cluster_prefix}-primary-nsg"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   security_rule {
     name                       = "allow_SSH_in_all"
@@ -64,8 +64,8 @@ resource "azurerm_network_security_group" "primary_nsg" {
 
 resource "azurerm_network_security_group" "infra_nsg" {
   name                = "${var.openshift_cluster_prefix}-infra-nsg"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   security_rule {
     name                       = "allow_SSH_in_all"
@@ -109,8 +109,8 @@ resource "azurerm_network_security_group" "infra_nsg" {
 
 resource "azurerm_network_security_group" "node_nsg" {
   name                = "${var.openshift_cluster_prefix}-node-nsg"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   security_rule {
     name                       = "allow_SSH_in_all"
@@ -156,128 +156,128 @@ resource "azurerm_network_security_group" "node_nsg" {
 
 resource "azurerm_storage_account" "bastion_storage_account" {
   name                     = "${var.openshift_cluster_prefix}bsa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "primary_storage_account" {
   name                     = "${var.openshift_cluster_prefix}msa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "infra_storage_account" {
   name                     = "${var.openshift_cluster_prefix}infrasa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "nodeos_storage_account" {
   name                     = "${var.openshift_cluster_prefix}nodeossa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "nodedata_storage_account" {
   name                     = "${var.openshift_cluster_prefix}nodedatasa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "registry_storage_account" {
   name                     = "${var.openshift_cluster_prefix}regsa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 resource "azurerm_storage_account" "persistent_volume_storage_account" {
   name                     = "${var.openshift_cluster_prefix}pvsa"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_account_tier}"
-  account_replication_type = "${var.storage_account_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
 }
 
 # ******* AVAILABILITY SETS ***********
 
 resource "azurerm_availability_set" "primary" {
   name                = "primaryavailabilityset"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 }
 
 resource "azurerm_availability_set" "infra" {
   name                = "infraavailabilityset"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 }
 
 resource "azurerm_availability_set" "node" {
   name                = "nodeavailabilityset"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 }
 
 # ******* IP ADDRESSES ***********
 
 resource "azurerm_public_ip" "bastion_pip" {
-  name                         = "bastionpip"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  allocation_method = "Static"
-  domain_name_label            = "${var.openshift_cluster_prefix}-bastion"
+  name                = "bastionpip"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  allocation_method   = "Static"
+  domain_name_label   = "${var.openshift_cluster_prefix}-bastion"
 }
 
 resource "azurerm_public_ip" "openshift_primary_pip" {
-  name                         = "primarypip"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  allocation_method = "Static"
-  domain_name_label            = "${var.openshift_cluster_prefix}"
+  name                = "primarypip"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  allocation_method   = "Static"
+  domain_name_label   = var.openshift_cluster_prefix
 }
 
 resource "azurerm_public_ip" "infra_lb_pip" {
-  name                         = "infraip"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  allocation_method = "Static"
-  domain_name_label            = "${var.openshift_cluster_prefix}infrapip"
+  name                = "infraip"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  allocation_method   = "Static"
+  domain_name_label   = "${var.openshift_cluster_prefix}infrapip"
 }
 
 # ******* VNETS / SUBNETS ***********
 
 resource "azurerm_virtual_network" "vnet" {
   name                = "openshiftvnet"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   address_space       = ["10.0.0.0/8"]
   depends_on          = ["azurerm_virtual_network.vnet"]
 }
 
 resource "azurerm_subnet" "primary_subnet" {
   name                 = "primarysubnet"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["10.1.0.0/16"]
   depends_on           = ["azurerm_virtual_network.vnet"]
 }
 
 resource "azurerm_subnet" "node_subnet" {
   name                 = "nodesubnet"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["10.2.0.0/16"]
 }
 
@@ -285,26 +285,26 @@ resource "azurerm_subnet" "node_subnet" {
 
 resource "azurerm_lb" "primary_lb" {
   name                = "primaryloadbalancer"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
   depends_on          = ["azurerm_public_ip.openshift_primary_pip"]
 
   frontend_ip_configuration {
     name                 = "LoadBalancerFrontEnd"
-    public_ip_address_id = "${azurerm_public_ip.openshift_primary_pip.id}"
+    public_ip_address_id = azurerm_public_ip.openshift_primary_pip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "primary_lb" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
   name                = "loadBalancerBackEnd"
-  loadbalancer_id     = "${azurerm_lb.primary_lb.id}"
+  loadbalancer_id     = azurerm_lb.primary_lb.id
   depends_on          = ["azurerm_lb.primary_lb"]
 }
 
 resource "azurerm_lb_probe" "primary_lb" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id     = "${azurerm_lb.primary_lb.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.primary_lb.id
   name                = "8443Probe"
   port                = 8443
   interval_in_seconds = 5
@@ -314,30 +314,30 @@ resource "azurerm_lb_probe" "primary_lb" {
 }
 
 resource "azurerm_lb_rule" "primary_lb" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.primary_lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.primary_lb.id
   name                           = "OpenShiftAdminConsole"
   protocol                       = "Tcp"
   frontend_port                  = 8443
   backend_port                   = 8443
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.primary_lb.id}"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.primary_lb.id
   load_distribution              = "SourceIP"
   idle_timeout_in_minutes        = 30
-  probe_id                       = "${azurerm_lb_probe.primary_lb.id}"
+  probe_id                       = azurerm_lb_probe.primary_lb.id
   enable_floating_ip             = false
   depends_on                     = ["azurerm_lb_probe.primary_lb", "azurerm_lb.primary_lb", "azurerm_lb_backend_address_pool.primary_lb"]
 }
 
 resource "azurerm_lb_nat_rule" "primary_lb" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.primary_lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.primary_lb.id
   name                           = "${azurerm_lb.primary_lb.name}-SSH-${count.index}"
   protocol                       = "Tcp"
-  frontend_port                  = "${count.index + 2200}"
+  frontend_port                  = count.index + 2200
   backend_port                   = 22
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
-  count                          = "${var.primary_instance_count}"
+  count                          = var.primary_instance_count
   depends_on                     = ["azurerm_lb.primary_lb"]
 }
 
@@ -345,26 +345,26 @@ resource "azurerm_lb_nat_rule" "primary_lb" {
 
 resource "azurerm_lb" "infra_lb" {
   name                = "infraloadbalancer"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
   depends_on          = ["azurerm_public_ip.infra_lb_pip"]
 
   frontend_ip_configuration {
     name                 = "LoadBalancerFrontEnd"
-    public_ip_address_id = "${azurerm_public_ip.infra_lb_pip.id}"
+    public_ip_address_id = azurerm_public_ip.infra_lb_pip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "infra_lb" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
   name                = "loadBalancerBackEnd"
-  loadbalancer_id     = "${azurerm_lb.infra_lb.id}"
+  loadbalancer_id     = azurerm_lb.infra_lb.id
   depends_on          = ["azurerm_lb.infra_lb"]
 }
 
 resource "azurerm_lb_probe" "infra_lb_http_probe" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id     = "${azurerm_lb.infra_lb.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.infra_lb.id
   name                = "httpProbe"
   port                = 80
   interval_in_seconds = 5
@@ -374,8 +374,8 @@ resource "azurerm_lb_probe" "infra_lb_http_probe" {
 }
 
 resource "azurerm_lb_probe" "infra_lb_https_probe" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id     = "${azurerm_lb.infra_lb.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.infra_lb.id
   name                = "httpsProbe"
   port                = 443
   interval_in_seconds = 5
@@ -384,28 +384,28 @@ resource "azurerm_lb_probe" "infra_lb_https_probe" {
 }
 
 resource "azurerm_lb_rule" "infra_lb_http" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.infra_lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.infra_lb.id
   name                           = "OpenShiftRouterHTTP"
   protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.infra_lb.id}"
-  probe_id                       = "${azurerm_lb_probe.infra_lb_http_probe.id}"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.infra_lb.id
+  probe_id                       = azurerm_lb_probe.infra_lb_http_probe.id
   depends_on                     = ["azurerm_lb_probe.infra_lb_http_probe", "azurerm_lb.infra_lb", "azurerm_lb_backend_address_pool.infra_lb"]
 }
 
 resource "azurerm_lb_rule" "infra_lb_https" {
-  resource_group_name            = "${azurerm_resource_group.rg.name}"
-  loadbalancer_id                = "${azurerm_lb.infra_lb.id}"
+  resource_group_name            = azurerm_resource_group.rg.name
+  loadbalancer_id                = azurerm_lb.infra_lb.id
   name                           = "OpenShiftRouterHTTPS"
   protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.infra_lb.id}"
-  probe_id                       = "${azurerm_lb_probe.infra_lb_https_probe.id}"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.infra_lb.id
+  probe_id                       = azurerm_lb_probe.infra_lb_https_probe.id
   depends_on                     = ["azurerm_lb_probe.infra_lb_https_probe", "azurerm_lb_backend_address_pool.infra_lb"]
 }
 
@@ -413,28 +413,28 @@ resource "azurerm_lb_rule" "infra_lb_https" {
 
 resource "azurerm_network_interface" "bastion_nic" {
   name                      = "bastionnic${count.index}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.primary_nsg.id}"
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.primary_nsg.id
 
   ip_configuration {
     name                          = "bastionip${count.index}"
-    subnet_id                     = "${azurerm_subnet.primary_subnet.id}"
+    subnet_id                     = azurerm_subnet.primary_subnet.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.bastion_pip.id}"
+    public_ip_address_id          = azurerm_public_ip.bastion_pip.id
   }
 }
 
 resource "azurerm_network_interface" "primary_nic" {
   name                      = "primarynic${count.index}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.primary_nsg.id}"
-  count                     = "${var.primary_instance_count}"
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.primary_nsg.id
+  count                     = var.primary_instance_count
 
   ip_configuration {
     name                                    = "primaryip${count.index}"
-    subnet_id                               = "${azurerm_subnet.primary_subnet.id}"
+    subnet_id                               = azurerm_subnet.primary_subnet.id
     private_ip_address_allocation           = "Dynamic"
     load_balancer_backend_address_pools_ids = ["${azurerm_lb_backend_address_pool.primary_lb.id}"]
     load_balancer_inbound_nat_rules_ids     = ["${element(azurerm_lb_nat_rule.primary_lb.*.id, count.index)}"]
@@ -443,14 +443,14 @@ resource "azurerm_network_interface" "primary_nic" {
 
 resource "azurerm_network_interface" "infra_nic" {
   name                      = "infra_nic${count.index}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.infra_nsg.id}"
-  count                     = "${var.infra_instance_count}"
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.infra_nsg.id
+  count                     = var.infra_instance_count
 
   ip_configuration {
     name                                    = "infraip${count.index}"
-    subnet_id                               = "${azurerm_subnet.primary_subnet.id}"
+    subnet_id                               = azurerm_subnet.primary_subnet.id
     private_ip_address_allocation           = "Dynamic"
     load_balancer_backend_address_pools_ids = ["${azurerm_lb_backend_address_pool.infra_lb.id}"]
   }
@@ -458,14 +458,14 @@ resource "azurerm_network_interface" "infra_nic" {
 
 resource "azurerm_network_interface" "node_nic" {
   name                      = "node_nic${count.index}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.node_nsg.id}"
-  count                     = "${var.node_instance_count}"
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.node_nsg.id
+  count                     = var.node_instance_count
 
   ip_configuration {
     name                          = "nodeip${count.index}"
-    subnet_id                     = "${azurerm_subnet.node_subnet.id}"
+    subnet_id                     = azurerm_subnet.node_subnet.id
     private_ip_address_allocation = "Dynamic"
   }
 }
@@ -474,10 +474,10 @@ resource "azurerm_network_interface" "node_nic" {
 
 resource "azurerm_virtual_machine" "bastion" {
   name                             = "${var.openshift_cluster_prefix}-bastion-1"
-  location                         = "${azurerm_resource_group.rg.location}"
-  resource_group_name              = "${azurerm_resource_group.rg.name}"
+  location                         = azurerm_resource_group.rg.location
+  resource_group_name              = azurerm_resource_group.rg.name
   network_interface_ids            = ["${azurerm_network_interface.bastion_nic.id}"]
-  vm_size                          = "${var.bastion_vm_size}"
+  vm_size                          = var.bastion_vm_size
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
 
@@ -487,8 +487,8 @@ resource "azurerm_virtual_machine" "bastion" {
 
   os_profile {
     computer_name  = "${var.openshift_cluster_prefix}-bastion-${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.openshift_password}"
+    admin_username = var.admin_username
+    admin_password = var.openshift_password
   }
 
   os_profile_linux_config {
@@ -496,15 +496,15 @@ resource "azurerm_virtual_machine" "bastion" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${var.ssh_public_key}"
+      key_data = var.ssh_public_key
     }
   }
 
   storage_image_reference {
-    publisher = "${lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))}"
-    offer     = "${lookup(var.os_image_map, join("_offer", list(var.os_image, "")))}"
-    sku       = "${lookup(var.os_image_map, join("_sku", list(var.os_image, "")))}"
-    version   = "${lookup(var.os_image_map, join("_version", list(var.os_image, "")))}"
+    publisher = lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))
+    offer     = lookup(var.os_image_map, join("_offer", list(var.os_image, "")))
+    sku       = lookup(var.os_image_map, join("_sku", list(var.os_image, "")))
+    version   = lookup(var.os_image_map, join("_version", list(var.os_image, "")))
   }
 
   storage_os_disk {
@@ -520,14 +520,14 @@ resource "azurerm_virtual_machine" "bastion" {
 
 resource "azurerm_virtual_machine" "primary" {
   name                             = "${var.openshift_cluster_prefix}-primary-${count.index}"
-  location                         = "${azurerm_resource_group.rg.location}"
-  resource_group_name              = "${azurerm_resource_group.rg.name}"
-  availability_set_id              = "${azurerm_availability_set.primary.id}"
+  location                         = azurerm_resource_group.rg.location
+  resource_group_name              = azurerm_resource_group.rg.name
+  availability_set_id              = azurerm_availability_set.primary.id
   network_interface_ids            = ["${element(azurerm_network_interface.primary_nic.*.id, count.index)}"]
-  vm_size                          = "${var.primary_vm_size}"
+  vm_size                          = var.primary_vm_size
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
-  count                            = "${var.primary_instance_count}"
+  count                            = var.primary_instance_count
   depends_on                       = ["azurerm_virtual_machine.infra", "azurerm_virtual_machine.node"]
 
   tags = {
@@ -535,10 +535,10 @@ resource "azurerm_virtual_machine" "primary" {
   }
 
   connection {
-    host        = "${azurerm_public_ip.openshift_primary_pip.fqdn}"
-    user        = "${var.admin_username}"
+    host        = azurerm_public_ip.openshift_primary_pip.fqdn
+    user        = var.admin_username
     port        = 2200
-    private_key = "${file(var.connection_private_ssh_key_path)}"
+    private_key = file(var.connection_private_ssh_key_path)
   }
 
   provisioner "file" {
@@ -562,8 +562,8 @@ resource "azurerm_virtual_machine" "primary" {
 
   os_profile {
     computer_name  = "${var.openshift_cluster_prefix}-primary-${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.openshift_password}"
+    admin_username = var.admin_username
+    admin_password = var.openshift_password
   }
 
   os_profile_linux_config {
@@ -571,15 +571,15 @@ resource "azurerm_virtual_machine" "primary" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${var.ssh_public_key}"
+      key_data = var.ssh_public_key
     }
   }
 
   storage_image_reference {
-    publisher = "${lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))}"
-    offer     = "${lookup(var.os_image_map, join("_offer", list(var.os_image, "")))}"
-    sku       = "${lookup(var.os_image_map, join("_sku", list(var.os_image, "")))}"
-    version   = "${lookup(var.os_image_map, join("_version", list(var.os_image, "")))}"
+    publisher = lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))
+    offer     = lookup(var.os_image_map, join("_offer", list(var.os_image, "")))
+    sku       = lookup(var.os_image_map, join("_sku", list(var.os_image, "")))
+    version   = lookup(var.os_image_map, join("_version", list(var.os_image, "")))
   }
 
   storage_os_disk {
@@ -593,7 +593,7 @@ resource "azurerm_virtual_machine" "primary" {
   storage_data_disk {
     name          = "${var.openshift_cluster_prefix}-primary-docker-pool${count.index}"
     vhd_uri       = "${azurerm_storage_account.primary_storage_account.primary_blob_endpoint}vhds/${var.openshift_cluster_prefix}-primary-docker-pool${count.index}.vhd"
-    disk_size_gb  = "${var.data_disk_size}"
+    disk_size_gb  = var.data_disk_size
     create_option = "Empty"
     lun           = 0
   }
@@ -603,14 +603,14 @@ resource "azurerm_virtual_machine" "primary" {
 
 resource "azurerm_virtual_machine" "infra" {
   name                             = "${var.openshift_cluster_prefix}-infra-${count.index}"
-  location                         = "${azurerm_resource_group.rg.location}"
-  resource_group_name              = "${azurerm_resource_group.rg.name}"
-  availability_set_id              = "${azurerm_availability_set.infra.id}"
+  location                         = azurerm_resource_group.rg.location
+  resource_group_name              = azurerm_resource_group.rg.name
+  availability_set_id              = azurerm_availability_set.infra.id
   network_interface_ids            = ["${element(azurerm_network_interface.infra_nic.*.id, count.index)}"]
-  vm_size                          = "${var.infra_vm_size}"
+  vm_size                          = var.infra_vm_size
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
-  count                            = "${var.infra_instance_count}"
+  count                            = var.infra_instance_count
 
   tags = {
     displayName = "${var.openshift_cluster_prefix}-infra VM Creation"
@@ -618,12 +618,12 @@ resource "azurerm_virtual_machine" "infra" {
 
   connection {
     type                = "ssh"
-    bastion_host        = "${azurerm_public_ip.bastion_pip.fqdn}"
-    bastion_user        = "${var.admin_username}"
-    bastion_private_key = "${file(var.connection_private_ssh_key_path)}"
-    host                = "${element(azurerm_network_interface.infra_nic.*.private_ip_address, count.index)}"
-    user                = "${var.admin_username}"
-    private_key         = "${file(var.connection_private_ssh_key_path)}"
+    bastion_host        = azurerm_public_ip.bastion_pip.fqdn
+    bastion_user        = var.admin_username
+    bastion_private_key = file(var.connection_private_ssh_key_path)
+    host                = element(azurerm_network_interface.infra_nic.*.private_ip_address, count.index)
+    user                = var.admin_username
+    private_key         = file(var.connection_private_ssh_key_path)
   }
 
   provisioner "file" {
@@ -640,8 +640,8 @@ resource "azurerm_virtual_machine" "infra" {
 
   os_profile {
     computer_name  = "${var.openshift_cluster_prefix}-infra-${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.openshift_password}"
+    admin_username = var.admin_username
+    admin_password = var.openshift_password
   }
 
   os_profile_linux_config {
@@ -649,15 +649,15 @@ resource "azurerm_virtual_machine" "infra" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${var.ssh_public_key}"
+      key_data = var.ssh_public_key
     }
   }
 
   storage_image_reference {
-    publisher = "${lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))}"
-    offer     = "${lookup(var.os_image_map, join("_offer", list(var.os_image, "")))}"
-    sku       = "${lookup(var.os_image_map, join("_sku", list(var.os_image, "")))}"
-    version   = "${lookup(var.os_image_map, join("_version", list(var.os_image, "")))}"
+    publisher = lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))
+    offer     = lookup(var.os_image_map, join("_offer", list(var.os_image, "")))
+    sku       = lookup(var.os_image_map, join("_sku", list(var.os_image, "")))
+    version   = lookup(var.os_image_map, join("_version", list(var.os_image, "")))
   }
 
   storage_os_disk {
@@ -670,7 +670,7 @@ resource "azurerm_virtual_machine" "infra" {
   storage_data_disk {
     name          = "${var.openshift_cluster_prefix}-infra-docker-pool"
     vhd_uri       = "${azurerm_storage_account.infra_storage_account.primary_blob_endpoint}vhds/${var.openshift_cluster_prefix}-infra-docker-pool${count.index}.vhd"
-    disk_size_gb  = "${var.data_disk_size}"
+    disk_size_gb  = var.data_disk_size
     create_option = "Empty"
     lun           = 0
   }
@@ -680,14 +680,14 @@ resource "azurerm_virtual_machine" "infra" {
 
 resource "azurerm_virtual_machine" "node" {
   name                             = "${var.openshift_cluster_prefix}-node-${count.index}"
-  location                         = "${azurerm_resource_group.rg.location}"
-  resource_group_name              = "${azurerm_resource_group.rg.name}"
-  availability_set_id              = "${azurerm_availability_set.node.id}"
+  location                         = azurerm_resource_group.rg.location
+  resource_group_name              = azurerm_resource_group.rg.name
+  availability_set_id              = azurerm_availability_set.node.id
   network_interface_ids            = ["${element(azurerm_network_interface.node_nic.*.id, count.index)}"]
-  vm_size                          = "${var.node_vm_size}"
+  vm_size                          = var.node_vm_size
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
-  count                            = "${var.node_instance_count}"
+  count                            = var.node_instance_count
 
   tags = {
     displayName = "${var.openshift_cluster_prefix}-node VM Creation"
@@ -695,12 +695,12 @@ resource "azurerm_virtual_machine" "node" {
 
   connection {
     type                = "ssh"
-    bastion_host        = "${azurerm_public_ip.bastion_pip.fqdn}"
-    bastion_user        = "${var.admin_username}"
-    bastion_private_key = "${file(var.connection_private_ssh_key_path)}"
-    host                = "${element(azurerm_network_interface.node_nic.*.private_ip_address, count.index)}"
-    user                = "${var.admin_username}"
-    private_key         = "${file(var.connection_private_ssh_key_path)}"
+    bastion_host        = azurerm_public_ip.bastion_pip.fqdn
+    bastion_user        = var.admin_username
+    bastion_private_key = file(var.connection_private_ssh_key_path)
+    host                = element(azurerm_network_interface.node_nic.*.private_ip_address, count.index)
+    user                = var.admin_username
+    private_key         = file(var.connection_private_ssh_key_path)
   }
 
   provisioner "file" {
@@ -717,8 +717,8 @@ resource "azurerm_virtual_machine" "node" {
 
   os_profile {
     computer_name  = "${var.openshift_cluster_prefix}-node-${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.openshift_password}"
+    admin_username = var.admin_username
+    admin_password = var.openshift_password
   }
 
   os_profile_linux_config {
@@ -726,15 +726,15 @@ resource "azurerm_virtual_machine" "node" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${var.ssh_public_key}"
+      key_data = var.ssh_public_key
     }
   }
 
   storage_image_reference {
-    publisher = "${lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))}"
-    offer     = "${lookup(var.os_image_map, join("_offer", list(var.os_image, "")))}"
-    sku       = "${lookup(var.os_image_map, join("_sku", list(var.os_image, "")))}"
-    version   = "${lookup(var.os_image_map, join("_version", list(var.os_image, "")))}"
+    publisher = lookup(var.os_image_map, join("_publisher", list(var.os_image, "")))
+    offer     = lookup(var.os_image_map, join("_offer", list(var.os_image, "")))
+    sku       = lookup(var.os_image_map, join("_sku", list(var.os_image, "")))
+    version   = lookup(var.os_image_map, join("_version", list(var.os_image, "")))
   }
 
   storage_os_disk {
@@ -747,7 +747,7 @@ resource "azurerm_virtual_machine" "node" {
   storage_data_disk {
     name          = "${var.openshift_cluster_prefix}-node-docker-pool${count.index}"
     vhd_uri       = "${azurerm_storage_account.nodeos_storage_account.primary_blob_endpoint}vhds/${var.openshift_cluster_prefix}-node-docker-pool${count.index}.vhd"
-    disk_size_gb  = "${var.data_disk_size}"
+    disk_size_gb  = var.data_disk_size
     create_option = "Empty"
     lun           = 0
   }

--- a/examples/virtual-machines/virtual_machine/openshift-origin/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/openshift-origin/outputs.tf
@@ -10,17 +10,17 @@ output "openshift_primary_ssh" {
 }
 
 output "openshift_infra_load_balancer_fqdn" {
-  value = "${azurerm_public_ip.infra_lb_pip.fqdn}"
+  value = azurerm_public_ip.infra_lb_pip.fqdn
 }
 
 output "node_os_storage_account_name" {
-  value = "${azurerm_storage_account.nodeos_storage_account.name}"
+  value = azurerm_storage_account.nodeos_storage_account.name
 }
 
 output "node_data_storage_account_name" {
-  value = "${azurerm_storage_account.nodedata_storage_account.name}"
+  value = azurerm_storage_account.nodedata_storage_account.name
 }
 
 output "infra_storage_account_name" {
-  value = "${azurerm_storage_account.infra_storage_account.name}"
+  value = azurerm_storage_account.infra_storage_account.name
 }

--- a/examples/virtual-machines/virtual_machine/openshift-origin/variables.tf
+++ b/examples/virtual-machines/virtual_machine/openshift-origin/variables.tf
@@ -59,7 +59,7 @@ variable "storage_account_replication_type" {
 
 variable "os_image_map" {
   description = "os image map"
-  type        = "map"
+  type        = map(string)
 
   default = {
     centos_publisher = "Openlogic"

--- a/examples/virtual-machines/virtual_machine/provisioners/linux/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/linux/1-dependencies.tf
@@ -9,39 +9,39 @@ locals {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-publicip"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "configuration"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }

--- a/examples/virtual-machines/virtual_machine/provisioners/linux/main.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/linux/main.tf
@@ -6,9 +6,9 @@ provider "azurerm" {
 }
 
 resource "azurerm_virtual_machine" "example" {
-  name                  = "${local.virtual_machine_name}"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  name                  = local.virtual_machine_name
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 
@@ -31,9 +31,9 @@ resource "azurerm_virtual_machine" "example" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
-    admin_username = "${local.admin_username}"
-    admin_password = "${local.admin_password}"
+    computer_name  = local.virtual_machine_name
+    admin_username = local.admin_username
+    admin_password = local.admin_password
   }
 
   os_profile_linux_config {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_machine" "example" {
 
   provisioner "remote-exec" {
     connection {
-      user     = "${local.admin_username}"
-      password = "${local.admin_password}"
+      user     = local.admin_username
+      password = local.admin_password
     }
 
     inline = [

--- a/examples/virtual-machines/virtual_machine/provisioners/windows/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/windows/1-dependencies.tf
@@ -9,39 +9,39 @@ locals {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-publicip"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "configuration"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.example.id}"
+    public_ip_address_id          = azurerm_public_ip.example.id
   }
 }

--- a/examples/virtual-machines/virtual_machine/provisioners/windows/2-certificates.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/windows/2-certificates.tf
@@ -5,9 +5,9 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "example" {
   name                = "${var.prefix}keyvault"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
 
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
@@ -15,8 +15,8 @@ resource "azurerm_key_vault" "example" {
   sku_name = "standard"
 
   access_policy {
-    tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.object_id}"
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "Create",
@@ -32,7 +32,7 @@ resource "azurerm_key_vault" "example" {
 
 resource "azurerm_key_vault_certificate" "example" {
   name         = "${local.virtual_machine_name}-cert"
-  key_vault_id = "${azurerm_key_vault.example.id}"
+  key_vault_id = azurerm_key_vault.example.id
 
   certificate_policy {
     issuer_parameters {

--- a/examples/virtual-machines/virtual_machine/provisioners/windows/main.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/windows/main.tf
@@ -11,9 +11,9 @@ locals {
 }
 
 resource "azurerm_virtual_machine" "example" {
-  name                  = "${local.virtual_machine_name}"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  name                  = local.virtual_machine_name
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 
@@ -36,17 +36,17 @@ resource "azurerm_virtual_machine" "example" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
-    admin_username = "${local.admin_username}"
-    admin_password = "${local.admin_password}"
-    custom_data    = "${local.custom_data_content}"
+    computer_name  = local.virtual_machine_name
+    admin_username = local.admin_username
+    admin_password = local.admin_password
+    custom_data    = local.custom_data_content
   }
 
   os_profile_secrets {
-    source_vault_id = "${azurerm_key_vault.example.id}"
+    source_vault_id = azurerm_key_vault.example.id
 
     vault_certificates {
-      certificate_url   = "${azurerm_key_vault_certificate.example.secret_id}"
+      certificate_url   = azurerm_key_vault_certificate.example.secret_id
       certificate_store = "My"
     }
   }
@@ -68,14 +68,14 @@ resource "azurerm_virtual_machine" "example" {
       pass         = "oobeSystem"
       component    = "Microsoft-Windows-Shell-Setup"
       setting_name = "FirstLogonCommands"
-      content      = "${file("./files/FirstLogonCommands.xml")}"
+      content      = file("./files/FirstLogonCommands.xml")
     }
   }
 
   provisioner "remote-exec" {
     connection {
-      user     = "${local.admin_username}"
-      password = "${local.admin_password}"
+      user     = local.admin_username
+      password = local.admin_password
       port     = 5986
       https    = true
       timeout  = "10m"

--- a/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/main.tf
+++ b/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/main.tf
@@ -6,15 +6,15 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.resource_group}"
-  location = "${var.location}"
+  name     = var.resource_group
+  location = var.location
 }
 
 # **********************  NETWORK SECURITY GROUPS ********************** #
 resource "azurerm_network_security_group" "primary" {
-  name                = "${var.nsg_spark_primary_name}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  name                = var.nsg_spark_primary_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 
   security_rule {
     name                       = "ssh"
@@ -57,9 +57,9 @@ resource "azurerm_network_security_group" "primary" {
 }
 
 resource "azurerm_network_security_group" "secondary" {
-  name                = "${var.nsg_spark_secondary_name}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  name                = var.nsg_spark_secondary_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 
   security_rule {
     name                       = "ssh"
@@ -76,9 +76,9 @@ resource "azurerm_network_security_group" "secondary" {
 }
 
 resource "azurerm_network_security_group" "cassandra" {
-  name                = "${var.nsg_cassandra_name}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  name                = var.nsg_cassandra_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
 
   security_rule {
     name                       = "ssh"
@@ -97,112 +97,112 @@ resource "azurerm_network_security_group" "cassandra" {
 # **********************  VNET / SUBNETS ********************** #
 resource "azurerm_virtual_network" "spark" {
   name                = "vnet-spark"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  location            = "${azurerm_resource_group.rg.location}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
   address_space       = ["${var.vnet_spark_prefix}"]
 }
 
 resource "azurerm_subnet" "subnet1" {
-  name                      = "${var.vnet_spark_subnet1_name}"
-  virtual_network_name      = "${azurerm_virtual_network.spark.name}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  address_prefixes            = ["${var.vnet_spark_subnet1_prefix}"]
-  network_security_group_id = "${azurerm_network_security_group.primary.id}"
+  name                      = var.vnet_spark_subnet1_name
+  virtual_network_name      = azurerm_virtual_network.spark.name
+  resource_group_name       = azurerm_resource_group.rg.name
+  address_prefixes          = ["${var.vnet_spark_subnet1_prefix}"]
+  network_security_group_id = azurerm_network_security_group.primary.id
   depends_on                = ["azurerm_virtual_network.spark"]
 }
 
 resource "azurerm_subnet" "subnet2" {
-  name                 = "${var.vnet_spark_subnet2_name}"
-  virtual_network_name = "${azurerm_virtual_network.spark.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  name                 = var.vnet_spark_subnet2_name
+  virtual_network_name = azurerm_virtual_network.spark.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["${var.vnet_spark_subnet2_prefix}"]
 }
 
 resource "azurerm_subnet" "subnet3" {
-  name                 = "${var.vnet_spark_subnet3_name}"
-  virtual_network_name = "${azurerm_virtual_network.spark.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  name                 = var.vnet_spark_subnet3_name
+  virtual_network_name = azurerm_virtual_network.spark.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["${var.vnet_spark_subnet3_prefix}"]
 }
 
 # **********************  PUBLIC IP ADDRESSES ********************** #
 resource "azurerm_public_ip" "primary" {
-  name                         = "${var.public_ip_primary_name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  allocation_method = "Static"
+  name                = var.public_ip_primary_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
 }
 
 resource "azurerm_public_ip" "secondary" {
-  name                         = "${var.public_ip_secondary_name_prefix}${count.index}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  allocation_method = "Static"
-  count                        = "${var.vm_number_of_secondarys}"
+  name                = "${var.public_ip_secondary_name_prefix}${count.index}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  count               = var.vm_number_of_secondarys
 }
 
 resource "azurerm_public_ip" "cassandra" {
-  name                         = "${var.public_ip_cassandra_name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  allocation_method = "Static"
+  name                = var.public_ip_cassandra_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
 }
 
 # **********************  NETWORK INTERFACE ********************** #
 resource "azurerm_network_interface" "primary" {
-  name                      = "${var.nic_primary_name}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.primary.id}"
+  name                      = var.nic_primary_name
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.primary.id
   depends_on                = ["azurerm_virtual_network.spark", "azurerm_public_ip.primary", "azurerm_network_security_group.primary"]
 
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = "${azurerm_subnet.subnet1.id}"
+    subnet_id                     = azurerm_subnet.subnet1.id
     private_ip_address_allocation = "Static"
-    private_ip_address            = "${var.nic_primary_node_ip}"
-    public_ip_address_id          = "${azurerm_public_ip.primary.id}"
+    private_ip_address            = var.nic_primary_node_ip
+    public_ip_address_id          = azurerm_public_ip.primary.id
   }
 }
 
 resource "azurerm_network_interface" "secondary" {
   name                      = "${var.nic_secondary_name_prefix}${count.index}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.secondary.id}"
-  count                     = "${var.vm_number_of_secondarys}"
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.secondary.id
+  count                     = var.vm_number_of_secondarys
   depends_on                = ["azurerm_virtual_network.spark", "azurerm_public_ip.secondary", "azurerm_network_security_group.secondary"]
 
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = "${azurerm_subnet.subnet2.id}"
+    subnet_id                     = azurerm_subnet.subnet2.id
     private_ip_address_allocation = "Static"
     private_ip_address            = "${var.nic_secondary_node_ip_prefix}${5 + count.index}"
-    public_ip_address_id          = "${element(azurerm_public_ip.secondary.*.id, count.index)}"
+    public_ip_address_id          = element(azurerm_public_ip.secondary.*.id, count.index)
   }
 }
 
 resource "azurerm_network_interface" "cassandra" {
-  name                      = "${var.nic_cassandra_name}"
-  location                  = "${azurerm_resource_group.rg.location}"
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  network_security_group_id = "${azurerm_network_security_group.cassandra.id}"
+  name                      = var.nic_cassandra_name
+  location                  = azurerm_resource_group.rg.location
+  resource_group_name       = azurerm_resource_group.rg.name
+  network_security_group_id = azurerm_network_security_group.cassandra.id
   depends_on                = ["azurerm_virtual_network.spark", "azurerm_public_ip.cassandra", "azurerm_network_security_group.cassandra"]
 
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = "${azurerm_subnet.subnet3.id}"
+    subnet_id                     = azurerm_subnet.subnet3.id
     private_ip_address_allocation = "Static"
-    private_ip_address            = "${var.nic_cassandra_node_ip}"
-    public_ip_address_id          = "${azurerm_public_ip.cassandra.id}"
+    private_ip_address            = var.nic_cassandra_node_ip
+    public_ip_address_id          = azurerm_public_ip.cassandra.id
   }
 }
 
 # **********************  AVAILABILITY SET ********************** #
 resource "azurerm_availability_set" "secondary" {
-  name                         = "${var.availability_secondary_name}"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
+  name                         = var.availability_secondary_name
+  location                     = azurerm_resource_group.rg.location
+  resource_group_name          = azurerm_resource_group.rg.name
   platform_update_domain_count = 5
   platform_fault_domain_count  = 2
 }
@@ -210,78 +210,78 @@ resource "azurerm_availability_set" "secondary" {
 # **********************  STORAGE ACCOUNTS ********************** #
 resource "azurerm_storage_account" "primary" {
   name                     = "primary${var.unique_prefix}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_primary_account_tier}"
-  account_replication_type = "${var.storage_primary_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_primary_account_tier
+  account_replication_type = var.storage_primary_replication_type
 }
 
 resource "azurerm_storage_container" "primary" {
-  name                  = "${var.vm_primary_storage_account_container_name}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  storage_account_name  = "${azurerm_storage_account.primary.name}"
+  name                  = var.vm_primary_storage_account_container_name
+  resource_group_name   = azurerm_resource_group.rg.name
+  storage_account_name  = azurerm_storage_account.primary.name
   container_access_type = "private"
   depends_on            = ["azurerm_storage_account.primary"]
 }
 
 resource "azurerm_storage_account" "secondary" {
   name                     = "secondary${var.unique_prefix}${count.index}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  count                    = "${var.vm_number_of_secondarys}"
-  account_tier             = "${var.storage_secondary_account_tier}"
-  account_replication_type = "${var.storage_secondary_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  count                    = var.vm_number_of_secondarys
+  account_tier             = var.storage_secondary_account_tier
+  account_replication_type = var.storage_secondary_replication_type
 }
 
 resource "azurerm_storage_container" "secondary" {
   name                  = "${var.vm_secondary_storage_account_container_name}${count.index}"
-  storage_account_name  = "${element(azurerm_storage_account.secondary.*.name, count.index)}"
+  storage_account_name  = element(azurerm_storage_account.secondary.*.name, count.index)
   container_access_type = "private"
   depends_on            = ["azurerm_storage_account.secondary"]
 }
 
 resource "azurerm_storage_account" "cassandra" {
   name                     = "cassandra${var.unique_prefix}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_cassandra_account_tier}"
-  account_replication_type = "${var.storage_cassandra_replication_type}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_cassandra_account_tier
+  account_replication_type = var.storage_cassandra_replication_type
 }
 
 resource "azurerm_storage_container" "cassandra" {
-  name                  = "${var.vm_cassandra_storage_account_container_name}"
-  storage_account_name  = "${azurerm_storage_account.cassandra.name}"
+  name                  = var.vm_cassandra_storage_account_container_name
+  storage_account_name  = azurerm_storage_account.cassandra.name
   container_access_type = "private"
   depends_on            = ["azurerm_storage_account.cassandra"]
 }
 
 # ********************** PRIMARY VIRTUAL MACHINE ********************** #
 resource "azurerm_virtual_machine" "primary" {
-  name                  = "${var.vm_primary_name}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  location              = "${azurerm_resource_group.rg.location}"
-  vm_size               = "${var.vm_primary_vm_size}"
+  name                  = var.vm_primary_name
+  resource_group_name   = azurerm_resource_group.rg.name
+  location              = azurerm_resource_group.rg.location
+  vm_size               = var.vm_primary_vm_size
   network_interface_ids = ["${azurerm_network_interface.primary.id}"]
   depends_on            = ["azurerm_storage_account.primary", "azurerm_network_interface.primary", "azurerm_storage_container.primary"]
 
   storage_image_reference {
-    publisher = "${var.os_image_publisher}"
-    offer     = "${var.os_image_offer}"
-    sku       = "${var.os_version}"
+    publisher = var.os_image_publisher
+    offer     = var.os_image_offer
+    sku       = var.os_version
     version   = "latest"
   }
 
   storage_os_disk {
-    name          = "${var.vm_primary_os_disk_name}"
+    name          = var.vm_primary_os_disk_name
     vhd_uri       = "http://${azurerm_storage_account.primary.name}.blob.core.windows.net/${azurerm_storage_container.primary.name}/${var.vm_primary_os_disk_name}.vhd"
     create_option = "FromImage"
     caching       = "ReadWrite"
   }
 
   os_profile {
-    computer_name  = "${var.vm_primary_name}"
-    admin_username = "${var.vm_admin_username}"
-    admin_password = "${var.vm_admin_password}"
+    computer_name  = var.vm_primary_name
+    admin_username = var.vm_admin_username
+    admin_password = var.vm_admin_password
   }
 
   os_profile_linux_config {
@@ -290,9 +290,9 @@ resource "azurerm_virtual_machine" "primary" {
 
   connection {
     type     = "ssh"
-    host     = "${azurerm_public_ip.primary.ip_address}"
-    user     = "${var.vm_admin_username}"
-    password = "${var.vm_admin_password}"
+    host     = azurerm_public_ip.primary.ip_address
+    user     = var.vm_admin_username
+    password = var.vm_admin_password
   }
 
   provisioner "remote-exec" {
@@ -306,18 +306,18 @@ resource "azurerm_virtual_machine" "primary" {
 # ********************** SECONDARY VIRTUAL MACHINES ********************** #
 resource "azurerm_virtual_machine" "secondary" {
   name                  = "${var.vm_secondary_name_prefix}${count.index}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  location              = "${azurerm_resource_group.rg.location}"
-  vm_size               = "${var.vm_secondary_vm_size}"
+  resource_group_name   = azurerm_resource_group.rg.name
+  location              = azurerm_resource_group.rg.location
+  vm_size               = var.vm_secondary_vm_size
   network_interface_ids = ["${element(azurerm_network_interface.secondary.*.id, count.index)}"]
-  count                 = "${var.vm_number_of_secondarys}"
-  availability_set_id   = "${azurerm_availability_set.secondary.id}"
+  count                 = var.vm_number_of_secondarys
+  availability_set_id   = azurerm_availability_set.secondary.id
   depends_on            = ["azurerm_storage_account.secondary", "azurerm_network_interface.secondary", "azurerm_storage_container.secondary"]
 
   storage_image_reference {
-    publisher = "${var.os_image_publisher}"
-    offer     = "${var.os_image_offer}"
-    sku       = "${var.os_version}"
+    publisher = var.os_image_publisher
+    offer     = var.os_image_offer
+    sku       = var.os_version
     version   = "latest"
   }
 
@@ -330,8 +330,8 @@ resource "azurerm_virtual_machine" "secondary" {
 
   os_profile {
     computer_name  = "${var.vm_secondary_name_prefix}${count.index}"
-    admin_username = "${var.vm_admin_username}"
-    admin_password = "${var.vm_admin_password}"
+    admin_username = var.vm_admin_username
+    admin_password = var.vm_admin_password
   }
 
   os_profile_linux_config {
@@ -340,9 +340,9 @@ resource "azurerm_virtual_machine" "secondary" {
 
   connection {
     type     = "ssh"
-    host     = "${element(azurerm_public_ip.secondary.*.ip_address, count.index)}"
-    user     = "${var.vm_admin_username}"
-    password = "${var.vm_admin_password}"
+    host     = element(azurerm_public_ip.secondary.*.ip_address, count.index)
+    user     = var.vm_admin_username
+    password = var.vm_admin_password
   }
 
   provisioner "remote-exec" {
@@ -355,31 +355,31 @@ resource "azurerm_virtual_machine" "secondary" {
 
 # ********************** CASSANDRA VIRTUAL MACHINE ********************** #
 resource "azurerm_virtual_machine" "cassandra" {
-  name                  = "${var.vm_cassandra_name}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  location              = "${azurerm_resource_group.rg.location}"
-  vm_size               = "${var.vm_cassandra_vm_size}"
+  name                  = var.vm_cassandra_name
+  resource_group_name   = azurerm_resource_group.rg.name
+  location              = azurerm_resource_group.rg.location
+  vm_size               = var.vm_cassandra_vm_size
   network_interface_ids = ["${azurerm_network_interface.cassandra.id}"]
   depends_on            = ["azurerm_storage_account.cassandra", "azurerm_network_interface.cassandra", "azurerm_storage_container.cassandra"]
 
   storage_image_reference {
-    publisher = "${var.os_image_publisher}"
-    offer     = "${var.os_image_offer}"
-    sku       = "${var.os_version}"
+    publisher = var.os_image_publisher
+    offer     = var.os_image_offer
+    sku       = var.os_version
     version   = "latest"
   }
 
   storage_os_disk {
-    name          = "${var.vm_cassandra_os_disk_name}"
+    name          = var.vm_cassandra_os_disk_name
     vhd_uri       = "http://${azurerm_storage_account.cassandra.name}.blob.core.windows.net/${azurerm_storage_container.cassandra.name}/${var.vm_cassandra_os_disk_name}.vhd"
     create_option = "FromImage"
     caching       = "ReadWrite"
   }
 
   os_profile {
-    computer_name  = "${var.vm_cassandra_name}"
-    admin_username = "${var.vm_admin_username}"
-    admin_password = "${var.vm_admin_password}"
+    computer_name  = var.vm_cassandra_name
+    admin_username = var.vm_admin_username
+    admin_password = var.vm_admin_password
   }
 
   os_profile_linux_config {
@@ -388,9 +388,9 @@ resource "azurerm_virtual_machine" "cassandra" {
 
   connection {
     type     = "ssh"
-    host     = "${azurerm_public_ip.cassandra.ip_address}"
-    user     = "${var.vm_admin_username}"
-    password = "${var.vm_admin_password}"
+    host     = azurerm_public_ip.cassandra.ip_address
+    user     = var.vm_admin_username
+    password = var.vm_admin_password
   }
 
   provisioner "remote-exec" {

--- a/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/outputs.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "resource_group" {
-  value = "${var.resource_group}"
+  value = var.resource_group
 }
 
 output "primary_ip_address" {
-  value = "${azurerm_public_ip.primary.ip_address}"
+  value = azurerm_public_ip.primary.ip_address
 }
 
 output "primary_ssh_command" {

--- a/examples/virtual-machines/virtual_machine/unmanaged-disks/basic/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/unmanaged-disks/basic/1-dependencies.tf
@@ -7,45 +7,45 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
   name                = "${var.prefix}-nic"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.example.id}"
+    subnet_id                     = azurerm_subnet.example.id
     private_ip_address_allocation = "Dynamic"
   }
 }
 
 resource "azurerm_storage_account" "example" {
   name                     = "${var.prefix}stor"
-  resource_group_name      = "${azurerm_resource_group.example.name}"
-  location                 = "${azurerm_resource_group.example.location}"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_container" "example" {
   name                  = "vhds"
-  storage_account_name  = "${azurerm_storage_account.example.name}"
+  storage_account_name  = azurerm_storage_account.example.name
   container_access_type = "private"
 }

--- a/examples/virtual-machines/virtual_machine/unmanaged-disks/basic/main.tf
+++ b/examples/virtual-machines/virtual_machine/unmanaged-disks/basic/main.tf
@@ -7,8 +7,8 @@ locals {
 
 resource "azurerm_virtual_machine" "example" {
   name                  = "${var.prefix}-vm"
-  location              = "${azurerm_resource_group.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = ["${azurerm_network_interface.example.id}"]
   vm_size               = "Standard_F2"
 

--- a/examples/virtual-machines/virtual_machine/unmanaged-disks/from-existing-storage-account/main.tf
+++ b/examples/virtual-machines/virtual_machine/unmanaged-disks/from-existing-storage-account/main.tf
@@ -6,71 +6,71 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.resource_group}"
-  location = "${var.location}"
+  name     = var.resource_group
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "vnet" {
   name                = "${var.hostname}vnet"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   address_space       = ["${var.address_space}"]
 }
 
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.hostname}subnet"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
   address_prefixes     = ["${var.subnet_prefix}"]
 }
 
 resource "azurerm_public_ip" "transferpip" {
-  name                         = "transferpip"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  allocation_method = "Static"
+  name                = "transferpip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "transfernic" {
   name                = "transfernic"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   ip_configuration {
-    name                          = "${azurerm_public_ip.transferpip.name}"
-    subnet_id                     = "${azurerm_subnet.subnet.id}"
+    name                          = azurerm_public_ip.transferpip.name
+    subnet_id                     = azurerm_subnet.subnet.id
     private_ip_address_allocation = "Static"
-    public_ip_address_id          = "${azurerm_public_ip.transferpip.id}"
+    public_ip_address_id          = azurerm_public_ip.transferpip.id
     private_ip_address            = "10.0.0.5"
   }
 }
 
 resource "azurerm_public_ip" "mypip" {
-  name                         = "mypip"
-  location                     = "${azurerm_resource_group.rg.location}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  allocation_method = "Dynamic"
+  name                = "mypip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Dynamic"
 }
 
 resource "azurerm_network_interface" "mynic" {
   name                = "mynic"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   ip_configuration {
-    name                          = "${azurerm_public_ip.mypip.name}"
-    subnet_id                     = "${azurerm_subnet.subnet.id}"
+    name                          = azurerm_public_ip.mypip.name
+    subnet_id                     = azurerm_subnet.subnet.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.mypip.id}"
+    public_ip_address_id          = azurerm_public_ip.mypip.id
   }
 }
 
 resource "azurerm_storage_account" "existing" {
-  name                     = "${var.existing_storage_acct}"
-  resource_group_name      = "${var.existing_resource_group}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_existing_account_tier}"
-  account_replication_type = "${var.storage_existing_replication_type}"
+  name                     = var.existing_storage_acct
+  resource_group_name      = var.existing_resource_group
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_existing_account_tier
+  account_replication_type = var.storage_existing_replication_type
 
   lifecycle = {
     prevent_destroy = true
@@ -78,41 +78,41 @@ resource "azurerm_storage_account" "existing" {
 }
 
 resource "azurerm_storage_account" "stor" {
-  name                     = "${var.hostname}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
-  account_tier             = "${var.storage_machine_account_tier}"
-  account_replication_type = "${var.storage_machine_replication_type}"
+  name                     = var.hostname
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = var.storage_machine_account_tier
+  account_replication_type = var.storage_machine_replication_type
 }
 
 resource "azurerm_virtual_machine" "transfer" {
-  name                  = "${var.transfer_vm_name}"
-  location              = "${azurerm_resource_group.rg.location}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  vm_size               = "${var.vm_size}"
+  name                  = var.transfer_vm_name
+  location              = azurerm_resource_group.rg.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  vm_size               = var.vm_size
   network_interface_ids = ["${azurerm_network_interface.transfernic.id}"]
 
   storage_os_disk {
     name          = "${var.hostname}-osdisk"
-    image_uri     = "${var.source_img_uri}"
+    image_uri     = var.source_img_uri
     vhd_uri       = "https://${var.existing_storage_acct}.blob.core.windows.net/${var.existing_resource_group}-vhds/${var.hostname}osdisk.vhd"
-    os_type       = "${var.os_type}"
+    os_type       = var.os_type
     caching       = "ReadWrite"
     create_option = "FromImage"
   }
 
   os_profile {
-    computer_name  = "${var.hostname}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    computer_name  = var.hostname
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 }
 
 resource "azurerm_virtual_machine_extension" "script" {
   name                 = "CustomScriptExtension"
-  location             = "${azurerm_resource_group.rg.location}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
-  virtual_machine_name = "${azurerm_virtual_machine.transfer.name}"
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_machine_name = azurerm_virtual_machine.transfer.name
   publisher            = "Microsoft.Compute"
   type                 = "CustomScriptExtension"
   type_handler_version = "1.4"
@@ -127,9 +127,9 @@ SETTINGS
 
 resource "azurerm_virtual_machine_extension" "execute" {
   name                 = "CustomScriptExtension"
-  location             = "${azurerm_resource_group.rg.location}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
-  virtual_machine_name = "${azurerm_virtual_machine.transfer.name}"
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_machine_name = azurerm_virtual_machine.transfer.name
   publisher            = "Microsoft.Compute"
   type                 = "CustomScriptExtension"
   type_handler_version = "1.4"
@@ -143,10 +143,10 @@ SETTINGS
 }
 
 resource "azurerm_virtual_machine" "myvm" {
-  name                  = "${var.new_vm_name}"
-  location              = "${azurerm_resource_group.rg.location}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  vm_size               = "${var.vm_size}"
+  name                  = var.new_vm_name
+  location              = azurerm_resource_group.rg.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  vm_size               = var.vm_size
   network_interface_ids = ["${azurerm_network_interface.mynic.id}"]
   depends_on            = ["azurerm_virtual_machine_extension.execute"]
 
@@ -154,14 +154,14 @@ resource "azurerm_virtual_machine" "myvm" {
     name          = "${var.hostname}osdisk"
     image_uri     = "https://${azurerm_storage_account.stor.name}.blob.core.windows.net/vhds/${var.custom_image_name}.vhd"
     vhd_uri       = "https://${var.hostname}.blob.core.windows.net/${var.hostname}-vhds/${var.hostname}osdisk.vhd"
-    os_type       = "${var.os_type}"
+    os_type       = var.os_type
     caching       = "ReadWrite"
     create_option = "FromImage"
   }
 
   os_profile {
-    computer_name  = "${var.hostname}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    computer_name  = var.hostname
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 }

--- a/examples/virtual-machines/virtual_machine/unmanaged-disks/from-existing-storage-account/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/unmanaged-disks/from-existing-storage-account/outputs.tf
@@ -2,17 +2,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "hostname" {
-  value = "${var.hostname}"
+  value = var.hostname
 }
 
 output "ip_address" {
-  value = "${azurerm_public_ip.transferpip.ip_address}"
+  value = azurerm_public_ip.transferpip.ip_address
 }
 
 output "fqdn" {
-  value = "${azurerm_public_ip.transferpip.ip_address}"
+  value = azurerm_public_ip.transferpip.ip_address
 }
 
 output "id" {
-  value = "${azurerm_public_ip.transferpip.id}"
+  value = azurerm_public_ip.transferpip.id
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/main.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/main.tf
@@ -10,42 +10,42 @@ locals {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "${local.resource_group_name}"
+  name     = local.resource_group_name
   location = "West Europe"
 }
 
 module "network" {
   source              = "./modules/network"
-  prefix              = "${var.prefix}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
+  prefix              = var.prefix
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 }
 
 module "active-directory-domain" {
   source                        = "./modules/active-directory"
-  resource_group_name           = "${azurerm_resource_group.test.name}"
-  location                      = "${azurerm_resource_group.test.location}"
-  prefix                        = "${var.prefix}"
-  subnet_id                     = "${module.network.domain_controllers_subnet_id}"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = azurerm_resource_group.test.location
+  prefix                        = var.prefix
+  subnet_id                     = module.network.domain_controllers_subnet_id
   active_directory_domain       = "${var.prefix}.local"
-  active_directory_netbios_name = "${var.prefix}"
-  admin_username                = "${var.admin_username}"
-  admin_password                = "${var.admin_password}"
+  active_directory_netbios_name = var.prefix
+  admin_username                = var.admin_username
+  admin_password                = var.admin_password
 }
 
 module "windows-client" {
   source                    = "./modules/windows-client"
-  resource_group_name       = "${azurerm_resource_group.test.name}"
-  location                  = "${azurerm_resource_group.test.location}"
-  prefix                    = "${var.prefix}"
-  subnet_id                 = "${module.network.domain_clients_subnet_id}"
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  prefix                    = var.prefix
+  subnet_id                 = module.network.domain_clients_subnet_id
   active_directory_domain   = "${var.prefix}.local"
-  active_directory_username = "${var.admin_username}"
-  active_directory_password = "${var.admin_password}"
-  admin_username            = "${var.admin_username}"
-  admin_password            = "${var.admin_password}"
+  active_directory_username = var.admin_username
+  active_directory_password = var.admin_password
+  admin_username            = var.admin_username
+  admin_password            = var.admin_password
 }
 
 output "windows_client_public_ip" {
-  value = "${module.windows-client.public_ip_address}"
+  value = module.windows-client.public_ip_address
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/1-network-interface.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/1-network-interface.tf
@@ -3,13 +3,13 @@
 
 resource "azurerm_network_interface" "primary" {
   name                    = "${var.prefix}-dc-primary"
-  location                = "${var.location}"
-  resource_group_name     = "${var.resource_group_name}"
-  internal_dns_name_label = "${local.virtual_machine_name}"
+  location                = var.location
+  resource_group_name     = var.resource_group_name
+  internal_dns_name_label = local.virtual_machine_name
 
   ip_configuration {
     name                          = "primary"
-    subnet_id                     = "${var.subnet_id}"
+    subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Static"
     private_ip_address            = "10.0.1.4"
   }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/2-virtual-machine.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/2-virtual-machine.tf
@@ -9,9 +9,9 @@ locals {
 }
 
 resource "azurerm_virtual_machine" "domain-controller" {
-  name                          = "${local.virtual_machine_name}"
-  location                      = "${var.location}"
-  resource_group_name           = "${var.resource_group_name}"
+  name                          = local.virtual_machine_name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
   network_interface_ids         = ["${azurerm_network_interface.primary.id}"]
   vm_size                       = "Standard_F2"
   delete_os_disk_on_termination = true
@@ -31,10 +31,10 @@ resource "azurerm_virtual_machine" "domain-controller" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
-    custom_data    = "${local.custom_data_content}"
+    computer_name  = local.virtual_machine_name
+    admin_username = var.admin_username
+    admin_password = var.admin_password
+    custom_data    = local.custom_data_content
   }
 
   os_profile_windows_config {
@@ -53,7 +53,7 @@ resource "azurerm_virtual_machine" "domain-controller" {
       pass         = "oobeSystem"
       component    = "Microsoft-Windows-Shell-Setup"
       setting_name = "FirstLogonCommands"
-      content      = "${file("${path.module}/files/FirstLogonCommands.xml")}"
+      content      = file("${path.module}/files/FirstLogonCommands.xml")
     }
   }
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/3-provision-domain.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/active-directory/3-provision-domain.tf
@@ -16,9 +16,9 @@ locals {
 // this provisions a single node configuration with no redundancy.
 resource "azurerm_virtual_machine_extension" "create-active-directory-forest" {
   name                 = "create-active-directory-forest"
-  location             = "${azurerm_virtual_machine.domain-controller.location}"
-  resource_group_name  = "${var.resource_group_name}"
-  virtual_machine_name = "${azurerm_virtual_machine.domain-controller.name}"
+  location             = azurerm_virtual_machine.domain-controller.location
+  resource_group_name  = var.resource_group_name
+  virtual_machine_name = azurerm_virtual_machine.domain-controller.name
   publisher            = "Microsoft.Compute"
   type                 = "CustomScriptExtension"
   type_handler_version = "1.9"

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/network/main.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/network/main.tf
@@ -8,21 +8,21 @@
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
   dns_servers         = ["10.0.1.4", "8.8.8.8"]
 }
 
 resource "azurerm_subnet" "domain-controllers" {
   name                 = "domain-controllers"
-  resource_group_name  = "${var.resource_group_name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_subnet" "domain-clients" {
   name                 = "domain-clients"
-  resource_group_name  = "${var.resource_group_name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/network/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/network/outputs.tf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "domain_controllers_subnet_id" {
-  value = "${azurerm_subnet.domain-controllers.id}"
+  value = azurerm_subnet.domain-controllers.id
 }
 
 output "domain_clients_subnet_id" {
-  value = "${azurerm_subnet.domain-clients.id}"
+  value = azurerm_subnet.domain-clients.id
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/1-network-interface.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/1-network-interface.tf
@@ -2,22 +2,22 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_public_ip" "static" {
-  name                         = "${var.prefix}-client-ppip"
-  location                     = "${var.location}"
-  resource_group_name          = "${var.resource_group_name}"
-  allocation_method = "Static"
+  name                = "${var.prefix}-client-ppip"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "primary" {
   name                    = "${var.prefix}-client-nic"
-  location                = "${var.location}"
-  resource_group_name     = "${var.resource_group_name}"
-  internal_dns_name_label = "${local.virtual_machine_name}"
+  location                = var.location
+  resource_group_name     = var.resource_group_name
+  internal_dns_name_label = local.virtual_machine_name
 
   ip_configuration {
     name                          = "primary"
-    subnet_id                     = "${var.subnet_id}"
+    subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.static.id}"
+    public_ip_address_id          = azurerm_public_ip.static.id
   }
 }

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/2-virtual-machine.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/2-virtual-machine.tf
@@ -6,9 +6,9 @@ locals {
 }
 
 resource "azurerm_virtual_machine" "client" {
-  name                          = "${local.virtual_machine_name}"
-  location                      = "${var.location}"
-  resource_group_name           = "${var.resource_group_name}"
+  name                          = local.virtual_machine_name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
   network_interface_ids         = ["${azurerm_network_interface.primary.id}"]
   vm_size                       = "Standard_F2"
   delete_os_disk_on_termination = true
@@ -28,9 +28,9 @@ resource "azurerm_virtual_machine" "client" {
   }
 
   os_profile {
-    computer_name  = "${local.virtual_machine_name}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    computer_name  = local.virtual_machine_name
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 
   os_profile_windows_config {

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/4-join-domain.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/4-join-domain.tf
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_virtual_machine_extension" "join-domain" {
-  name                 = "${azurerm_virtual_machine.client.name}"
-  location             = "${azurerm_virtual_machine.client.location}"
-  resource_group_name  = "${var.resource_group_name}"
-  virtual_machine_name = "${azurerm_virtual_machine.client.name}"
+  name                 = azurerm_virtual_machine.client.name
+  location             = azurerm_virtual_machine.client.location
+  resource_group_name  = var.resource_group_name
+  virtual_machine_name = azurerm_virtual_machine.client.name
   publisher            = "Microsoft.Compute"
   type                 = "JsonADDomainExtension"
   type_handler_version = "1.3"

--- a/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/outputs.tf
+++ b/examples/virtual-machines/virtual_machine/vm-joined-to-active-directory/modules/windows-client/outputs.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "public_ip_address" {
-  value = "${azurerm_public_ip.static.ip_address}"
+  value = azurerm_public_ip.static.ip_address
 }

--- a/examples/virtual-machines/windows/azure-disk-encryption/main.tf
+++ b/examples/virtual-machines/windows/azure-disk-encryption/main.tf
@@ -93,12 +93,12 @@ resource "azurerm_network_interface" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/examples/virtual-machines/windows/basic-password/main.tf
+++ b/examples/virtual-machines/windows/basic-password/main.tf
@@ -37,12 +37,12 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]

--- a/examples/virtual-machines/windows/custom-data/main.tf
+++ b/examples/virtual-machines/windows/custom-data/main.tf
@@ -45,13 +45,13 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
-  custom_data                     = base64encode(local.custom_data)
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  custom_data         = base64encode(local.custom_data)
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]

--- a/examples/virtual-machines/windows/ephemeral-os-disk/main.tf
+++ b/examples/virtual-machines/windows/ephemeral-os-disk/main.tf
@@ -37,13 +37,13 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_DS3_v2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
-  custom_data                     = base64encode("Hello World!")
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_DS3_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  custom_data         = base64encode("Hello World!")
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]

--- a/examples/virtual-machines/windows/hotpatching-enabled/main.tf
+++ b/examples/virtual-machines/windows/hotpatching-enabled/main.tf
@@ -37,12 +37,12 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_F2s_v2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_F2s_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
 
   network_interface_ids = [
     azurerm_network_interface.main.id,

--- a/examples/virtual-machines/windows/user-data/main.tf
+++ b/examples/virtual-machines/windows/user-data/main.tf
@@ -37,13 +37,13 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
-  user_data                       = base64encode("Hello World!")
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  user_data           = base64encode("Hello World!")
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]

--- a/examples/virtual-machines/windows/vm-custom-extension/main.tf
+++ b/examples/virtual-machines/windows/vm-custom-extension/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes       = ["10.0.2.0/24"]
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/examples/virtual-machines/windows/vm-custom-extension/vars.tf
+++ b/examples/virtual-machines/windows/vm-custom-extension/vars.tf
@@ -3,5 +3,5 @@
 
 variable "location" {
   description = "The Azure Region in which all resources in this example should be provisioned"
-  default = "West US"
+  default     = "West US"
 }

--- a/examples/virtual-machines/windows/vm-joined-to-active-directory/modules/active-directory-domain/main.tf
+++ b/examples/virtual-machines/windows/vm-joined-to-active-directory/modules/active-directory-domain/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_virtual_machine_extension" "create-ad-forest" {
   publisher            = "Microsoft.Compute"
   type                 = "CustomScriptExtension"
   type_handler_version = "1.9"
-  settings = <<SETTINGS
+  settings             = <<SETTINGS
   {
     "commandToExecute": "powershell.exe -Command \"${local.powershell_command}\""
   }

--- a/examples/virtual-machines/windows/vm-joined-to-active-directory/modules/domain-member/variables.tf
+++ b/examples/virtual-machines/windows/vm-joined-to-active-directory/modules/domain-member/variables.tf
@@ -38,6 +38,6 @@ variable "active_directory_password" {
 }
 
 locals {
-  virtual_machine_name = join("-", [var.prefix, "client"])
+  virtual_machine_name    = join("-", [var.prefix, "client"])
   wait_for_domain_command = "while (!(Test-Connection -TargetName ${var.active_directory_domain_name} -Count 1 -Quiet) -and ($retryCount++ -le 360)) { Start-Sleep 10 }"
 }

--- a/examples/virtual-machines/windows/vm-role-assignment/main.tf
+++ b/examples/virtual-machines/windows/vm-role-assignment/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes       = ["10.0.2.0/24"]
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/examples/virtual-machines/windows/vm-role-assignment/vars.tf
+++ b/examples/virtual-machines/windows/vm-role-assignment/vars.tf
@@ -3,19 +3,19 @@
 
 variable "admin" {
   description = "Virtual Machine Admin Username"
-  default = "adminuser"
+  default     = "adminuser"
 }
 
 variable "adminPassword" {
   description = "VM Admin Password"
-  default = "P@$$w0rd1234!"
+  default     = "P@$$w0rd1234!"
 }
 variable "location" {
   description = "The Azure Region in which all resources in this example should be provisioned"
-  default = "West US"
+  default     = "West US"
 }
 
 variable "storageaccount" {
   description = "Name of the storage account"
-  default = "exampleblobname"
+  default     = "exampleblobname"
 }

--- a/examples/virtual-networks/virtual-network-gateway/basic/main.tf
+++ b/examples/virtual-networks/virtual-network-gateway/basic/main.tf
@@ -41,9 +41,9 @@ resource "azurerm_virtual_network_gateway" "example" {
   sku      = "Basic"
 
   ip_configuration {
-     name                          = "vnetGatewayConfig"
-     public_ip_address_id          = azurerm_public_ip.example.id
-     private_ip_address_allocation = "Dynamic"
-     subnet_id                     = azurerm_subnet.example.id
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.example.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
   }
 }

--- a/examples/virtual-networks/virtual-network-gateway/vpngw1/main.tf
+++ b/examples/virtual-networks/virtual-network-gateway/vpngw1/main.tf
@@ -42,9 +42,9 @@ resource "azurerm_virtual_network_gateway" "example" {
   sku      = "VpnGw1"
 
   ip_configuration {
-     name                          = "vnetGatewayConfig"
-     public_ip_address_id          = azurerm_public_ip.example.id
-     private_ip_address_allocation = "Dynamic"
-     subnet_id                     = azurerm_subnet.example.id
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.example.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
   }
 }

--- a/examples/vm-scale-set/extensions/custom-script/main.tf
+++ b/examples/vm-scale-set/extensions/custom-script/main.tf
@@ -13,14 +13,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/basic/main.tf
+++ b/examples/vm-scale-set/linux/basic/main.tf
@@ -7,7 +7,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "main" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "main" {

--- a/examples/vm-scale-set/virtual_machine_scale_set/automatic-rolling-updates/main.tf
+++ b/examples/vm-scale-set/virtual_machine_scale_set/automatic-rolling-updates/main.tf
@@ -11,61 +11,61 @@ locals {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
   name                = "${var.prefix}-publicip"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   allocation_method   = "Static"
 }
 
 resource "azurerm_lb" "example" {
   name                = "${var.prefix}lb"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   frontend_ip_configuration {
-    name                 = "${local.frontend_ip_configuration_name}"
-    public_ip_address_id = "${azurerm_public_ip.example.id}"
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.example.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "example" {
   name                = "backend"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  loadbalancer_id     = "${azurerm_lb.example.id}"
+  resource_group_name = azurerm_resource_group.example.name
+  loadbalancer_id     = azurerm_lb.example.id
 }
 
 resource "azurerm_lb_probe" "example" {
   name                = "ssh-running-probe"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  loadbalancer_id     = "${azurerm_lb.example.id}"
+  resource_group_name = azurerm_resource_group.example.name
+  loadbalancer_id     = azurerm_lb.example.id
   port                = 22
   protocol            = "Tcp"
 }
 
 resource "azurerm_lb_rule" "example" {
-  resource_group_name            = "${azurerm_resource_group.example.name}"
-  loadbalancer_id                = "${azurerm_lb.example.id}"
-  probe_id                       = "${azurerm_lb_probe.example.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.example.id}"
-  frontend_ip_configuration_name = "${local.frontend_ip_configuration_name}"
+  resource_group_name            = azurerm_resource_group.example.name
+  loadbalancer_id                = azurerm_lb.example.id
+  probe_id                       = azurerm_lb_probe.example.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.example.id
+  frontend_ip_configuration_name = local.frontend_ip_configuration_name
   name                           = "LBRule"
   protocol                       = "Tcp"
   frontend_port                  = 22
@@ -74,12 +74,12 @@ resource "azurerm_lb_rule" "example" {
 
 resource "azurerm_virtual_machine_scale_set" "example" {
   name                 = "${var.prefix}-vmss"
-  location             = "${azurerm_resource_group.example.location}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
   overprovision        = true
   upgrade_policy_mode  = "Rolling"
   automatic_os_upgrade = true
-  health_probe_id      = "${azurerm_lb_probe.example.id}"
+  health_probe_id      = azurerm_lb_probe.example.id
 
   rolling_upgrade_policy {
     max_batch_instance_percent              = 20
@@ -110,7 +110,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
     ip_configuration {
       name                                   = "internal"
-      subnet_id                              = "${azurerm_subnet.example.id}"
+      subnet_id                              = azurerm_subnet.example.id
       load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.example.id}"]
       primary                                = true
     }

--- a/examples/vm-scale-set/virtual_machine_scale_set/autoscale/main.tf
+++ b/examples/vm-scale-set/virtual_machine_scale_set/autoscale/main.tf
@@ -11,33 +11,33 @@ locals {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_virtual_machine_scale_set" "example" {
   name                = "${var.prefix}-vmss"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   upgrade_policy_mode = "Manual"
 
   sku {
     name     = "Standard_D1_v2"
     tier     = "Standard"
-    capacity = "${local.instance_count}"
+    capacity = local.instance_count
   }
 
   os_profile {
@@ -56,7 +56,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
     ip_configuration {
       name      = "internal"
-      subnet_id = "${azurerm_subnet.example.id}"
+      subnet_id = azurerm_subnet.example.id
       primary   = true
     }
   }
@@ -78,15 +78,15 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
 resource "azurerm_monitor_autoscale_setting" "example" {
   name                = "autoscale-cpu"
-  target_resource_id  = "${azurerm_virtual_machine_scale_set.example.id}"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  target_resource_id  = azurerm_virtual_machine_scale_set.example.id
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   profile {
     name = "autoscale-cpu"
 
     capacity {
-      default = "${local.instance_count}"
+      default = local.instance_count
       minimum = 0
       maximum = 1000
     }
@@ -94,7 +94,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = "${azurerm_virtual_machine_scale_set.example.id}"
+        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -114,7 +114,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = "${azurerm_virtual_machine_scale_set.example.id}"
+        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"

--- a/examples/vm-scale-set/virtual_machine_scale_set/basic/main.tf
+++ b/examples/vm-scale-set/virtual_machine_scale_set/basic/main.tf
@@ -7,27 +7,27 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-network"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "internal"
-  virtual_network_name = "${azurerm_virtual_network.example.name}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
+  virtual_network_name = azurerm_virtual_network.example.name
+  resource_group_name  = azurerm_resource_group.example.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_virtual_machine_scale_set" "example" {
   name                = "${var.prefix}-vmss"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   upgrade_policy_mode = "Manual"
 
   sku {
@@ -52,7 +52,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
     ip_configuration {
       name      = "internal"
-      subnet_id = "${azurerm_subnet.example.id}"
+      subnet_id = azurerm_subnet.example.id
       primary   = true
     }
   }

--- a/examples/vm-scale-set/windows/service-fabric/3-service-fabric.tf
+++ b/examples/vm-scale-set/windows/service-fabric/3-service-fabric.tf
@@ -9,7 +9,7 @@ resource "azurerm_service_fabric_cluster" "main" {
   upgrade_mode        = "Automatic"
   vm_image            = "Windows"
   management_endpoint = "https://${azurerm_public_ip.main.fqdn}:19080"
-  add_on_features = ["DnsService"]
+  add_on_features     = ["DnsService"]
 
   node_type {
     name                 = "primary"

--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the certificate. Changing this forces a new resource to be created.
 
+-> **NOTE:** The resource group must be the same as that which the app service plan is defined in - otherwise the certificate will not show as available for the app services.
+
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `pfx_blob` - (Optional) The base64-encoded contents of the certificate. Changing this forces a new resource to be created.


### PR DESCRIPTION
This updates the documentation for the ```azurerm_app_service_certificate``` resource in file ```website/docs/r/app_service_certificate.html.markdown```

The ```resource_group_name``` used must be the same as that which the app service plan is defined in.

If the same ```resource_group_name``` is not used then terraform will show a successful apply, however the certificate will not be accessible by the app services (and later binding to the certificate will fail).

Also - the certificate will not show in the portal but will show via ```az webapp config ssl list```.

**NOTE1** Terraform (or rather the Azure API) behaves differently than the portal.  It is possible via the portal to defne/import the certificate into any app service in any resource group and the certificate is then available to all app services - the portal must do some extra "under the covers" work that the API does not.

**NOTE2** The various terraform code in the repo has been auto-formatted via ```terraform fmt``` hence the large number of formatting changes.