### PR TITLE
`azurerm_linux_function_app` - Set default docker registry url

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1595,7 +1595,7 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_URL", dockerConfig.RegistryURL, false)
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_USERNAME", dockerConfig.RegistryUsername, false)
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_PASSWORD", dockerConfig.RegistryPassword, false)
-			var dockerUrl string
+			var dockerUrl string = dockerConfig.RegistryURL
 			for _, prefix := range urlSchemes {
 				if strings.HasPrefix(dockerConfig.RegistryURL, prefix) {
 					dockerUrl = strings.TrimPrefix(dockerConfig.RegistryURL, prefix)


### PR DESCRIPTION
Currently when you don't specify a https protocol in the value of `DOCKER_REGISTRY_SERVER_URL`.

You get returned an empty string resulting in the `DOCKER_CUSTOM_IMAGE_NAME` to be returned as: `DOCKER|/image-name:tag"`.

This results in an invalid docker pull on an azure function app during the deployment of the function app - all the response from all functions will return a 503.

Fixes: #16585 

