### PR TITLE
`azurerm_function_app_hybrid_connection`: populate the sendKeyValue when creating the web app hybrid connection

### DIFF
--- a/internal/services/appservice/function_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource.go
@@ -163,13 +163,18 @@ func (r FunctionAppHybridConnectionResource) Create() sdk.ResourceFunc {
 				return tf.ImportAsExistsError(r.ResourceType(), *existing.ID)
 			}
 
+			key, err := helpers.GetSendKeyValue(ctx, metadata, id, appHybridConn.SendKeyName)
+			if err != nil {
+				return err
+			}
+
 			envelope := web.HybridConnection{
 				HybridConnectionProperties: &web.HybridConnectionProperties{
 					RelayArmURI:  utils.String(relayId.ID()),
 					Hostname:     utils.String(appHybridConn.HostName),
 					Port:         utils.Int32(int32(appHybridConn.HostPort)),
 					SendKeyName:  utils.String(appHybridConn.SendKeyName),
-					SendKeyValue: utils.String(""),
+					SendKeyValue: utils.String(*key),
 				},
 			}
 


### PR DESCRIPTION
When creating a new web app hybrid connection, the `sendKeyValue` is not populated. This results in the hybrid connection appearing to be connected and healthy in the Azure portal, but attempting to use it results in connection errors (unable to connect to the on-prem endpoint).

Adapted from #23761 to fix #13054 for Function Apps