### PR TITLE
Update TTL minimum value to 0

### DIFF
--- a/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -75,7 +75,7 @@ func resourcePrivateDnsCNameRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(0, 2147483647),
 			},
 
 			"fqdn": {


### PR DESCRIPTION
Because Azure APIs allows to do set TTL to 0 the provider should allow the same.