### PR TITLE
New data source: `azurerm_monitor_workspace`

### DIFF
--- a/internal/services/monitor/monitor_workspace_data_source.go
+++ b/internal/services/monitor/monitor_workspace_data_source.go
@@ -22,6 +22,15 @@ type WorkspaceDataSource struct{}
 
 var _ sdk.DataSource = WorkspaceDataSource{}
 
+type WorkspaceDataSourceModel struct {
+	Name                       string            `tfschema:"name"`
+	ResourceGroupName          string            `tfschema:"resource_group_name"`
+	QueryEndpoint              string            `tfschema:"query_endpoint"`
+	PublicNetworkAccessEnabled bool              `tfschema:"public_network_access_enabled"`
+	Location                   string            `tfschema:"location"`
+	Tags                       map[string]string `tfschema:"tags"`
+}
+
 func (d WorkspaceDataSource) ModelObject() interface{} {
 	return &WorkspaceDataSource{}
 }
@@ -66,7 +75,7 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 			client := metadata.Client.Monitor.WorkspacesClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			var state WorkspaceResourceModel
+			var state WorkspaceDataSourceModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -101,7 +110,7 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 
 			metadata.SetID(id)
 
-			return metadata.Encode(&WorkspaceResourceModel{
+			return metadata.Encode(&WorkspaceDataSourceModel{
 				Location:                   location,
 				Name:                       id.AccountName,
 				PublicNetworkAccessEnabled: enablePublicNetWorkAccess,

--- a/internal/services/monitor/monitor_workspace_data_source.go
+++ b/internal/services/monitor/monitor_workspace_data_source.go
@@ -1,0 +1,114 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type WorkspaceDataSource struct{}
+
+var _ sdk.DataSource = WorkspaceDataSource{}
+
+func (d WorkspaceDataSource) ModelObject() interface{} {
+	return &WorkspaceDataSource{}
+}
+
+func (d WorkspaceDataSource) ResourceType() string {
+	return "azurerm_monitor_workspace"
+}
+
+func (d WorkspaceDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (d WorkspaceDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"query_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Monitor.WorkspacesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state WorkspaceResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := azuremonitorworkspaces.NewAccountID(subscriptionId, state.ResourceGroupName, state.Name)
+			metadata.Logger.Infof("retrieving %s", id)
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			var enablePublicNetWorkAccess bool
+			var location, queryEndpoint string
+			var tag map[string]string
+
+			if model := resp.Model; model != nil {
+				location = azure.NormalizeLocation(model.Location)
+				tag = pointer.From(model.Tags)
+
+				if props := model.Properties; props != nil {
+					if props.PublicNetworkAccess != nil {
+						enablePublicNetWorkAccess = azuremonitorworkspaces.PublicNetworkAccessEnabled == *props.PublicNetworkAccess
+					}
+					if props.Metrics != nil && props.Metrics.PrometheusQueryEndpoint != nil {
+						queryEndpoint = *props.Metrics.PrometheusQueryEndpoint
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&WorkspaceResourceModel{
+				Location:                   location,
+				Name:                       id.AccountName,
+				PublicNetworkAccessEnabled: enablePublicNetWorkAccess,
+				QueryEndpoint:              queryEndpoint,
+				ResourceGroupName:          id.ResourceGroupName,
+				Tags:                       tag,
+			})
+		},
+	}
+}

--- a/internal/services/monitor/monitor_workspace_data_source.go
+++ b/internal/services/monitor/monitor_workspace_data_source.go
@@ -76,7 +76,7 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}

--- a/internal/services/monitor/monitor_workspace_data_source_test.go
+++ b/internal/services/monitor/monitor_workspace_data_source_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package monitor_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type MonitorWorkspaceDataSource struct{}
+
+func TestAccMonitorWorkspaceDataSourceDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_monitor_workspace", "test")
+	d := MonitorWorkspaceDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+			),
+		},
+	})
+}
+
+func (d MonitorWorkspaceDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_monitor_workspace" "test" {
+  name                = azurerm_monitor_workspace.test.name
+  resource_group_name = azurerm_monitor_workspace.test.resource_group_name
+}
+`, WorkspaceTestResource{}.complete(data))
+}

--- a/internal/services/monitor/registration.go
+++ b/internal/services/monitor/registration.go
@@ -23,6 +23,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		DataCollectionEndpointDataSource{},
 		DataCollectionRuleDataSource{},
+		WorkspaceDataSource{},
 	}
 }
 

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Monitor"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_monitor_data_collection_endpoint"
+description: |-
+  Get information about the specified Workspace.
+
+---
+
+# Data Source: azurerm_monitor_workspace
+
+Use this data source to access information about an existing Workspace.
+
+## Example Usage
+
+```hcl
+data "azurerm_monitor_workspace" "example" {
+  name                = "example-workspace"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+output "query_endpoint" {
+  value = data.azurerm_monitor_workspace.example.query_endpoint
+}
+```
+
+## Argument Reference
+
+* `name` - Specifies the name of the Workspace.
+
+* `resource_group_name` - Specifies the name of the resource group the Workspace is located in.
+
+## Attributes Reference
+
+* `id` - The ID of the Resource.
+
+* `kind` - The kind of the Workspace. Possible values are `Linux` and `Windows`.
+
+* `location` - The Azure Region where the Workspace is located.
+
+* `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
+
+* `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed. Possible values are `true` and `false`.
+
+* `tags` - A mapping of tags which should be assigned to the Data Collection Endpoint.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Workspace.

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -40,7 +40,7 @@ output "query_endpoint" {
 
 * `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
 
-* `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed. Possible values are `true` and `false`.
+* `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed.
 
 * `tags` - A mapping of tags which should be assigned to the Data Collection Endpoint.
 

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -42,7 +42,7 @@ output "query_endpoint" {
 
 * `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed.
 
-* `tags` - A mapping of tags which should be assigned to the Data Collection Endpoint.
+* `tags` - A mapping of tags that are assigned to the Workspace.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #23905

```
$ TF_ACC=1 go test -v ./internal/services/monitor -timeout=1000m -run='TestAccMonitorWorkspaceDataSourceDataSource_complete'
=== RUN   TestAccMonitorWorkspaceDataSourceDataSource_complete
=== PAUSE TestAccMonitorWorkspaceDataSourceDataSource_complete
=== CONT  TestAccMonitorWorkspaceDataSourceDataSource_complete
--- PASS: TestAccMonitorWorkspaceDataSourceDataSource_complete (164.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor	166.554s
```