### PR TITLE
`azurerm_private_dns_cname_record` - update the validation of `ttl`

### DIFF
--- a/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -75,7 +75,7 @@ func resourcePrivateDnsCNameRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(0, 2147483647),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_cname_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource_test.go
@@ -177,7 +177,7 @@ resource "azurerm_private_dns_cname_record" "test" {
   name                = "acctestcname%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
-  ttl                 = 300
+  ttl                 = 0
   record              = "test.contoso.com"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/private_dns_cname_record.html.markdown
+++ b/website/docs/r/private_dns_cname_record.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
-* `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
+* `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds. Possible values are between `0` and `2147483647`.
 
 * `record` - (Required) The target of the CNAME.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/23917

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/85342e2b-3d77-4b9f-b8e7-97019581ceea)