### PR TITLE
`azurerm_cosmosdb_postgresql_cluster` - Mark `coordinator_storage_quota_in_mb` and `coordinator_vcore_count` as `optional`

### DIFF
--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -376,13 +376,14 @@ func (r CosmosDbPostgreSQLClusterResource) Create() sdk.ResourceFunc {
 				parameters.Properties.SourceLocation = &model.SourceLocation
 			}
 
-			if v := model.SourceResourceId; v != "" {
+			switch {
+			case model.SourceResourceId != "":
 				parameters.Properties.SourceResourceId = &model.SourceResourceId
-			} else if model.AdministratorLoginPassword == "" {
+			case model.AdministratorLoginPassword == "":
 				return fmt.Errorf("`administrator_login_password` is required when `source_resource_id` isn't set")
-			} else if model.CoordinatorStorageQuotaInMb == 0 {
+			case model.CoordinatorStorageQuotaInMb == 0:
 				return fmt.Errorf("`coordinator_storage_quota_in_mb` is required when `source_resource_id` isn't set")
-			} else if model.CoordinatorVCoreCount == 0 {
+			case model.CoordinatorVCoreCount == 0:
 				return fmt.Errorf("`coordinator_vcore_count` is required when `source_resource_id` isn't set")
 			}
 

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -83,30 +83,6 @@ func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Sch
 
 		"location": commonschema.Location(),
 
-		"coordinator_storage_quota_in_mb": {
-			Type:     pluginsdk.TypeInt,
-			Required: true,
-			ValidateFunc: validation.All(
-				validation.IntBetween(32768, 16777216),
-				validation.IntDivisibleBy(1024),
-			),
-		},
-
-		"coordinator_vcore_count": {
-			Type:     pluginsdk.TypeInt,
-			Required: true,
-			ValidateFunc: validation.IntInSlice([]int{
-				1,
-				2,
-				4,
-				8,
-				16,
-				32,
-				64,
-				96,
-			}),
-		},
-
 		"node_count": {
 			Type:     pluginsdk.TypeInt,
 			Required: true,
@@ -163,6 +139,30 @@ func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Sch
 				"GeneralPurpose",
 				"MemoryOptimized",
 			}, false),
+		},
+
+		"coordinator_storage_quota_in_mb": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			ValidateFunc: validation.All(
+				validation.IntBetween(32768, 16777216),
+				validation.IntDivisibleBy(1024),
+			),
+		},
+
+		"coordinator_vcore_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			ValidateFunc: validation.IntInSlice([]int{
+				1,
+				2,
+				4,
+				8,
+				16,
+				32,
+				64,
+				96,
+			}),
 		},
 
 		"ha_enabled": {
@@ -380,6 +380,10 @@ func (r CosmosDbPostgreSQLClusterResource) Create() sdk.ResourceFunc {
 				parameters.Properties.SourceResourceId = &model.SourceResourceId
 			} else if model.AdministratorLoginPassword == "" {
 				return fmt.Errorf("`administrator_login_password` is required when `source_resource_id` isn't set")
+			} else if model.CoordinatorStorageQuotaInMb == 0 {
+				return fmt.Errorf("`coordinator_storage_quota_in_mb` is required when `source_resource_id` isn't set")
+			} else if model.CoordinatorVCoreCount == 0 {
+				return fmt.Errorf("`coordinator_vcore_count` is required when `source_resource_id` isn't set")
 			}
 
 			// If `shards_on_coordinator_enabled` isn't set, API would set it to `true` when `node_count` is `0`.
@@ -445,10 +449,18 @@ func (r CosmosDbPostgreSQLClusterResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("coordinator_storage_quota_in_mb") {
+				if model.SourceResourceId == "" && model.CoordinatorStorageQuotaInMb == 0 {
+					return fmt.Errorf("`coordinator_storage_quota_in_mb` is required when `source_resource_id` isn't set")
+				}
+
 				parameters.Properties.CoordinatorStorageQuotaInMb = &model.CoordinatorStorageQuotaInMb
 			}
 
 			if metadata.ResourceData.HasChange("coordinator_vcore_count") {
+				if model.SourceResourceId == "" && model.CoordinatorVCoreCount == 0 {
+					return fmt.Errorf("`coordinator_vcore_count` is required when `source_resource_id` isn't set")
+				}
+
 				parameters.Properties.CoordinatorVCores = &model.CoordinatorVCoreCount
 			}
 

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -106,7 +106,7 @@ func TestAccCosmosDbPostgreSQLCluster_withSourceCluster(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password", "source_location", "source_resource_id", "point_in_time_in_utc", "coordinator_storage_quota_in_mb", "coordinator_vcore_count"),
+		data.ImportStep("administrator_login_password", "source_location", "source_resource_id", "point_in_time_in_utc"),
 	})
 }
 
@@ -264,6 +264,10 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test2" {
   source_resource_id   = azurerm_cosmosdb_postgresql_cluster.test.id
   point_in_time_in_utc = azurerm_cosmosdb_postgresql_cluster.test.earliest_restore_time
   node_count           = 0
+
+  lifecycle {
+    ignore_changes = ["coordinator_storage_quota_in_mb", "coordinator_vcore_count"]
+  }
 }
 `, r.basic(data), data.RandomInteger)
 }

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -106,7 +106,7 @@ func TestAccCosmosDbPostgreSQLCluster_withSourceCluster(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password", "source_location", "source_resource_id", "point_in_time_in_utc"),
+		data.ImportStep("administrator_login_password", "source_location", "source_resource_id", "point_in_time_in_utc", "coordinator_storage_quota_in_mb", "coordinator_vcore_count"),
 	})
 }
 
@@ -263,10 +263,7 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test2" {
   source_location      = azurerm_cosmosdb_postgresql_cluster.test.location
   source_resource_id   = azurerm_cosmosdb_postgresql_cluster.test.id
   point_in_time_in_utc = azurerm_cosmosdb_postgresql_cluster.test.earliest_restore_time
-
-  coordinator_storage_quota_in_mb = 131072
-  coordinator_vcore_count         = 2
-  node_count                      = 0
+  node_count           = 0
 }
 `, r.basic(data), data.RandomInteger)
 }

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -39,12 +39,6 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Azure Cosmos DB for PostgreSQL Cluster should exist. Changing this forces a new resource to be created.
 
-* `coordinator_storage_quota_in_mb` - (Required) The coordinator storage allowed for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608`, `16777216`, and `33554432`.
-
--> **NOTE:** More information on [the types of compute resources available for CosmosDB can be found in the product documentation](https://learn.microsoft.com/azure/cosmos-db/postgresql/resources-compute)
-
-* `coordinator_vcore_count` - (Required) The coordinator vCore count for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64` and `96`.
-
 * `node_count` - (Required) The worker node count of the Azure Cosmos DB for PostgreSQL Cluster. Possible value is between `0` and `20` except `1`.
 
 * `administrator_login_password` - (Optional) The password of the administrator login. This is required when `source_resource_id` is not set.
@@ -54,6 +48,12 @@ The following arguments are supported:
 * `coordinator_public_ip_access_enabled` - (Optional) Is public access enabled on coordinator? Defaults to `true`.
 
 * `coordinator_server_edition` - (Optional) The edition of the coordinator server. Possible values are `BurstableGeneralPurpose`, `BurstableMemoryOptimized`, `GeneralPurpose` and `MemoryOptimized`. Defaults to `GeneralPurpose`.
+
+* `coordinator_storage_quota_in_mb` - (Optional) The coordinator storage allowed for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608`, `16777216`, and `33554432`.
+
+-> **NOTE:** More information on [the types of compute resources available for CosmosDB can be found in the product documentation](https://learn.microsoft.com/azure/cosmos-db/postgresql/resources-compute)
+
+* `coordinator_vcore_count` - (Optional) The coordinator vCore count for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64` and `96`.
 
 * `ha_enabled` - (Optional) Is high availability enabled for the Azure Cosmos DB for PostgreSQL cluster? Defaults to `false`.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/23923

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/f57a403e-3a31-405a-9b5c-e643b7e332c9)