### PR TITLE
`azurerm_managed_lustre_file_system`: Add `mgs_address` attribute

### DIFF
--- a/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource.go
+++ b/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource.go
@@ -27,6 +27,7 @@ type ManagedLustreFileSystemModel struct {
 	Identity            []identity.ModelUserAssigned `tfschema:"identity"`
 	EncryptionKey       []EncryptionKey              `tfschema:"encryption_key"`
 	MaintenanceWindow   []MaintenanceWindow          `tfschema:"maintenance_window"`
+	MgsAddress          string                       `tfschema:"msg_address"`
 	SkuName             string                       `tfschema:"sku_name"`
 	StorageCapacityInTb int64                        `tfschema:"storage_capacity_in_tb"`
 	SubnetId            string                       `tfschema:"subnet_id"`
@@ -229,7 +230,12 @@ func (r ManagedLustreFileSystemResource) Arguments() map[string]*pluginsdk.Schem
 }
 
 func (r ManagedLustreFileSystemResource) Attributes() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{}
+	return map[string]*pluginsdk.Schema{
+		"mgs_address": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
 }
 
 func (r ManagedLustreFileSystemResource) CustomizeDiff() sdk.ResourceFunc {
@@ -393,6 +399,9 @@ func (r ManagedLustreFileSystemResource) Read() sdk.ResourceFunc {
 					state.SubnetId = properties.FilesystemSubnet
 					state.StorageCapacityInTb = int64(properties.StorageCapacityTiB)
 					state.MaintenanceWindow = flattenManagedLustreFileSystemMaintenanceWindow(properties.MaintenanceWindow)
+					if properties.ClientInfo != nil && properties.ClientInfo.MgsAddress != nil {
+						state.MgsAddress = *properties.ClientInfo.MgsAddress
+					}
 					state.HsmSetting = flattenManagedLustreFileSystemHsmSetting(properties.Hsm)
 					state.Zones = pointer.From(model.Zones)
 					state.EncryptionKey = flattenManagedLustreFileSystemEncryptionKey(properties.EncryptionSettings)

--- a/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource.go
+++ b/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource.go
@@ -27,7 +27,7 @@ type ManagedLustreFileSystemModel struct {
 	Identity            []identity.ModelUserAssigned `tfschema:"identity"`
 	EncryptionKey       []EncryptionKey              `tfschema:"encryption_key"`
 	MaintenanceWindow   []MaintenanceWindow          `tfschema:"maintenance_window"`
-	MgsAddress          string                       `tfschema:"msg_address"`
+	MgsAddress          string                       `tfschema:"mgs_address"`
 	SkuName             string                       `tfschema:"sku_name"`
 	StorageCapacityInTb int64                        `tfschema:"storage_capacity_in_tb"`
 	SubnetId            string                       `tfschema:"subnet_id"`

--- a/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource_test.go
+++ b/internal/services/azuremanagedlustrefilesystem/managed_lustre_file_system_resource_test.go
@@ -25,6 +25,7 @@ func TestAccManagedLustreFileSystem_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mgs_address").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/managed_lustre_file_system.html.markdown
+++ b/website/docs/r/managed_lustre_file_system.html.markdown
@@ -121,6 +121,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Azure Managed Lustre File System.
 
+* `mgs_address` - IP Address of Managed Lustre File System Services.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./internal/services/azuremanagedlustrefilesystem -timeout=1000m -run='TestAccManagedLustreFileSystem_basic'
=== RUN   TestAccManagedLustreFileSystem_basic
=== PAUSE TestAccManagedLustreFileSystem_basic
=== CONT  TestAccManagedLustreFileSystem_basic
--- PASS: TestAccManagedLustreFileSystem_basic (1236.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/azuremanagedlustrefilesystem	1237.886s
```

Fixes #23743