### PR TITLE
fix typo in import example

### DIFF
--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -102,5 +102,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Cognitive Services Account Deployment can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_cognitive_deployment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.CognitiveServices/accounts/account1/deployments/deployment1
+terraform import azurerm_cognitive_deployment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.CognitiveServices/accounts/account1
 ```


### PR DESCRIPTION
```shell
terraform import module.openai.azurerm_cognitive_account.this /subscriptions/****/resourceGroups/dashboards/providers/Microsoft.CognitiveServices/accounts/instance1/deployments/gpt-4-openai-deployment
module.openai.data.azurerm_resource_group.this: Reading...
module.openai.data.azurerm_resource_group.this: Read complete after 1s [id=/subscriptions/****/resourceGroups/dashboards]
module.openai.azurerm_cognitive_account.this: Importing from ID "/subscriptions/****/resourceGroups/dashboards/providers/Microsoft.CognitiveServices/accounts/instance1/deployments/gpt-4-openai-deployment"...
╷
│ Error: parsing "/subscriptions/****/resourceGroups/dashboards/providers/Microsoft.CognitiveServices/accounts/instance1/deployments/gpt-4-openai-deployment"
: unexpected segment "deployments/gpt-4-openai-deployment" present at the end of the URI
(input "/subscriptions/****/resourceGroups/dashboards/providers/Microsoft.CognitiveServices/accounts/instance1/deployments/gpt-4-openai-deployment")
│ 
│ 
╵
```