### PR TITLE
`azurerm_kubernetes_cluster` - support for the `support_plan` property

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1058,6 +1058,36 @@ func TestAccKubernetesCluster_gpuInstance(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_supportPlanKubernetesOfficial(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.supportPlanKubernetesOfficial(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_supportPlanAKSLongTermSupport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.supportPlanAKSLongTermSupport(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KubernetesClusterResource) basicAvailabilitySetConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -3148,4 +3178,64 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
   `, data.Locations.Primary, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) supportPlanKubernetesOfficial(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name       = "default"
+    vm_size    = "Standard_DS2_v2"
+    node_count = 1
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+  support_plan = "KubernetesOfficial"
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) supportPlanAKSLongTermSupport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+  default_node_pool {
+    name       = "default"
+    vm_size    = "Standard_DS2_v2"
+    node_count = 1
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+  support_plan = "AKSLongTermSupport"
+  sku_tier     = "Premium"
+}
+`, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1444,6 +1444,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"support_plan": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  string(managedclusters.KubernetesSupportPlanKubernetesOfficial),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(managedclusters.KubernetesSupportPlanKubernetesOfficial),
 					string(managedclusters.KubernetesSupportPlanAKSLongTermSupport),

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2830,7 +2830,7 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("setting `kube_admin_config`: %+v", err)
 			}
 
-			d.Set("support_plan", pointer.From(supportPlan))
+			d.Set("support_plan", pointer.From(props.SupportPlan))
 		}
 
 		identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2829,7 +2829,11 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("setting `kube_admin_config`: %+v", err)
 			}
 
-			d.Set("support_plan", props.SupportPlan)
+			supportPlan := ""
+			if props.SupportPlan != nil {
+				supportPlan = string(*props.SupportPlan)
+			}
+			d.Set("support_plan", supportPlan)
 		}
 
 		identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2830,11 +2830,7 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("setting `kube_admin_config`: %+v", err)
 			}
 
-			supportPlan := ""
-			if props.SupportPlan != nil {
-				supportPlan = string(*props.SupportPlan)
-			}
-			d.Set("support_plan", supportPlan)
+			d.Set("support_plan", pointer.From(supportPlan))
 		}
 
 		identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -247,11 +247,13 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 !> **Note:** A migration scenario from `service_principal` to `identity` is supported. When upgrading `service_principal` to `identity`, your cluster's control plane and addon pods will switch to use managed identity, but the kubelets will keep using your configured `service_principal` until you upgrade your Node Pool.
 
-* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free`, and `Standard` (which includes the Uptime SLA). Defaults to `Free`.
+* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free`, `Standard` (which includes the Uptime SLA) and `Premium`. Defaults to `Free`.
 
 -> **Note:** Whilst the AKS API previously supported the `Paid` SKU - the AKS API introduced a breaking change in API Version `2023-02-01` (used in v3.51.0 and later) where the value `Paid` must now be set to `Standard`.
 
 * `storage_profile` - (Optional) A `storage_profile` block as defined below.
+
+* `support_plan` - (Optional) Specifies the support plan which should be used for this Kubernetes Cluster. Possible values are `KubernetesOfficial` and `AKSLongTermSupport`. Defaults to `KubernetesOfficial`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/23972

```
=== RUN   TestAccKubernetesCluster_supportPlanKubernetesOfficial
=== PAUSE TestAccKubernetesCluster_supportPlanKubernetesOfficial
=== CONT  TestAccKubernetesCluster_supportPlanKubernetesOfficial
--- PASS: TestAccKubernetesCluster_supportPlanKubernetesOfficial (771.80s)
=== RUN   TestAccKubernetesCluster_supportPlanAKSLongTermSupport
=== PAUSE TestAccKubernetesCluster_supportPlanAKSLongTermSupport
=== CONT  TestAccKubernetesCluster_supportPlanAKSLongTermSupport
--- PASS: TestAccKubernetesCluster_supportPlanAKSLongTermSupport (721.93s)
```