### PR TITLE
`azurerm_dev_test_linux_virtual_machine`, `azurerm_dev_test_windows_virtual_machine`: Make `storage_type` `ForceNew = true` to reflect real API requirement

### DIFF
--- a/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
@@ -83,6 +83,7 @@ func resourceArmDevTestLinuxVirtualMachine() *pluginsdk.Resource {
 			"storage_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Standard",
 					"Premium",

--- a/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource_test.go
@@ -106,32 +106,6 @@ func TestAccDevTestLinuxVirtualMachine_inboundNatRules(t *testing.T) {
 	})
 }
 
-func TestAccDevTestLinuxVirtualMachine_updateStorage(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_dev_test_linux_virtual_machine", "test")
-	r := DevTestLinuxVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.storage(data, "Standard"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_type").HasValue("Standard"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
-			),
-		},
-		{
-			Config: r.storage(data, "Premium"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_type").HasValue("Premium"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
-			),
-		},
-	})
-}
-
 func (DevTestLinuxVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {

--- a/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource_test.go
@@ -243,33 +243,6 @@ resource "azurerm_dev_test_linux_virtual_machine" "test" {
 `, template, data.RandomInteger)
 }
 
-func (DevTestLinuxVirtualMachineResource) storage(data acceptance.TestData, storageType string) string {
-	template := DevTestLinuxVirtualMachineResource{}.template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_dev_test_linux_virtual_machine" "test" {
-  name                   = "acctestvm-vm%d"
-  lab_name               = azurerm_dev_test_lab.test.name
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  size                   = "Standard_B1ms"
-  username               = "acct5stU5er"
-  password               = "Pa$w0rd1234!"
-  lab_virtual_network_id = azurerm_dev_test_virtual_network.test.id
-  lab_subnet_name        = azurerm_dev_test_virtual_network.test.subnet[0].name
-  storage_type           = "%s"
-
-  gallery_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-}
-`, template, data.RandomInteger, storageType)
-}
-
 func (DevTestLinuxVirtualMachineResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
@@ -91,6 +91,7 @@ func resourceArmDevTestWindowsVirtualMachine() *pluginsdk.Resource {
 			"storage_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Standard",
 					"Premium",

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
@@ -83,32 +83,6 @@ func TestAccDevTestWindowsVirtualMachine_inboundNatRules(t *testing.T) {
 	})
 }
 
-func TestAccDevTestWindowsVirtualMachine_updateStorage(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_dev_test_windows_virtual_machine", "test")
-	r := DevTestVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.storage(data, "Standard"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_image_reference.0.publisher").HasValue("MicrosoftWindowsServer"),
-				check.That(data.ResourceName).Key("storage_type").HasValue("Standard"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
-			),
-		},
-		{
-			Config: r.storage(data, "Premium"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_image_reference.0.publisher").HasValue("MicrosoftWindowsServer"),
-				check.That(data.ResourceName).Key("storage_type").HasValue("Premium"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
-			),
-		},
-	})
-}
-
 func (DevTestVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
@@ -190,32 +190,6 @@ resource "azurerm_dev_test_windows_virtual_machine" "test" {
 `, r.template(data), data.RandomInteger%1000000)
 }
 
-func (r DevTestVirtualMachineResource) storage(data acceptance.TestData, storageType string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_dev_test_windows_virtual_machine" "test" {
-  name                   = "acctestvm%d"
-  lab_name               = azurerm_dev_test_lab.test.name
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  size                   = "Standard_B1ms"
-  username               = "acct5stU5er"
-  password               = "Pa$w0rd1234!"
-  lab_virtual_network_id = azurerm_dev_test_virtual_network.test.id
-  lab_subnet_name        = azurerm_dev_test_virtual_network.test.subnet[0].name
-  storage_type           = "%s"
-
-  gallery_image_reference {
-    offer     = "WindowsServer"
-    publisher = "MicrosoftWindowsServer"
-    sku       = "2012-Datacenter"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger%1000000, storageType)
-}
-
 func (DevTestVirtualMachineResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_F2`. Changing this forces a new resource to be created.
 
-* `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`.
+* `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`. Chaning this forces a new resource to be created.
 
 * `username` - (Required) The Username associated with the local administrator on this Virtual Machine. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_F2`. Changing this forces a new resource to be created.
 
-* `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`.
+* `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`. Changing this forces a new resource to be created.
 
 * `username` - (Required) The Username associated with the local administrator on this Virtual Machine. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
* Service team confirmed that `storage_type` is no longer updateable, making it force new to reflect the API behavior.