### PR TITLE
`azurerm_kubernetes_cluster` - do not pass the maintenance window start date if it's not changed

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2480,7 +2480,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     day_of_month = 5
     start_time   = "07:00"
     utc_offset   = "+01:00"
-    start_date  = "%[3]s"
+    start_date   = "%[3]s"
 
     not_allowed {
       end   = "%[4]s"

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-04-02-preview/agentpools"
@@ -2342,21 +2343,23 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func (KubernetesClusterResource) completeMaintenanceConfigAutoUpgrade(data acceptance.TestData) string {
+	startDate := time.Now().Format("2006-01-02T00:00:00Z")
+	endDate := time.Now().AddDate(0, 0, 4).Format("2006-01-02T00:00:00Z")
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
+  name                = "acctestaks%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+  dns_prefix          = "acctestaks%[2]d"
   default_node_pool {
     name       = "default"
     node_count = 1
@@ -2374,19 +2377,19 @@ resource "azurerm_kubernetes_cluster" "test" {
     week_index  = "First"
     start_time  = "07:00"
     utc_offset  = "+01:00"
-    start_date  = "2023-11-26T00:00:00Z"
+    start_date  = "%[3]s"
 
     not_allowed {
-      end   = "2023-11-30T00:00:00Z"
-      start = "2023-11-26T00:00:00Z"
+      end   = "%[4]s"
+      start = "%[3]s"
     }
     not_allowed {
-      end   = "2023-12-30T00:00:00Z"
-      start = "2023-12-26T00:00:00Z"
+      end   = "%[4]s"
+      start = "%[3]s"
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.Locations.Primary, data.RandomInteger, startDate, endDate)
 }
 
 func (KubernetesClusterResource) completeMaintenanceConfigDefault(data acceptance.TestData) string {
@@ -2444,21 +2447,23 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func (KubernetesClusterResource) completeMaintenanceConfigNodeOs(data acceptance.TestData) string {
+	startDate := time.Now().Format("2006-01-02T00:00:00Z")
+	endDate := time.Now().AddDate(0, 0, 4).Format("2006-01-02T00:00:00Z")
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
+  name                = "acctestaks%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+  dns_prefix          = "acctestaks%[2]d"
   default_node_pool {
     name       = "default"
     node_count = 1
@@ -2475,19 +2480,19 @@ resource "azurerm_kubernetes_cluster" "test" {
     day_of_month = 5
     start_time   = "07:00"
     utc_offset   = "+01:00"
-    start_date   = "2023-11-26T00:00:00Z"
+    start_date  = "%[3]s"
 
     not_allowed {
-      end   = "2023-11-30T00:00:00Z"
-      start = "2023-11-26T00:00:00Z"
+      end   = "%[4]s"
+      start = "%[3]s"
     }
     not_allowed {
-      end   = "2023-12-30T00:00:00Z"
-      start = "2023-12-26T00:00:00Z"
+      end   = "%[4]s"
+      start = "%[3]s"
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.Locations.Primary, data.RandomInteger, startDate, endDate)
 }
 
 func (KubernetesClusterResource) ultraSSD(data acceptance.TestData, ultraSSDEnabled bool) string {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22762

In the AKS maintenance window block, the `start_date` is an optional+computed field, if it's not set, the server will return the current date as a default value.

When update the maintenance window block, the `start_date`  previous default value could be invalid because the server will check whether the `start_date` is before current date.

This PR compares the `start_date`'s value with the value from server side, and only set it in the update when they're different.

```
=== RUN   TestAccKubernetesCluster_basicMaintenanceConfigAutoUpgrade
=== PAUSE TestAccKubernetesCluster_basicMaintenanceConfigAutoUpgrade
=== CONT  TestAccKubernetesCluster_basicMaintenanceConfigAutoUpgrade
--- PASS: TestAccKubernetesCluster_basicMaintenanceConfigAutoUpgrade (688.73s)
=== RUN   TestAccKubernetesCluster_updateMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_updateMaintenanceConfig
=== CONT  TestAccKubernetesCluster_updateMaintenanceConfig
--- PASS: TestAccKubernetesCluster_updateMaintenanceConfig (1134.48s)

```