### PR TITLE
`azurerm_eventhub_cluster`: Remove `ForceNew` from `sku_name`

### DIFF
--- a/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/internal/services/eventhub/eventhub_cluster_resource.go
@@ -63,7 +63,6 @@ func resourceEventHubCluster() *pluginsdk.Resource {
 			"sku_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
 					regexp.MustCompile(`^Dedicated_[1-9][0-9]*$`),
 					"SKU name must match /^Dedicated_[1-9][0-9]*$/.",

--- a/website/docs/r/eventhub_cluster.html.markdown
+++ b/website/docs/r/eventhub_cluster.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The SKU name of the EventHub Cluster. The only supported value at this time is `Dedicated_1`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) The SKU name of the EventHub Cluster. The only supported value at this time is `Dedicated_1`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
EventHub Clusters support scaling by API these days.