### PR TITLE
`azurerm_log_analytics_workspace` -  support for the  `immediate_data_purge_on_30_days_enabled ` property

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -154,7 +154,7 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				ValidateFunc: datacollectionrules.ValidateDataCollectionRuleID,
 			},
 
-			"immediate_purge_data_on_30_days_enabled": {
+			"immediate_data_purge_on_30_days_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 			},
@@ -308,7 +308,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	// The `ImmediatePurgeDataOn30Days` are not returned before it has been set
 	// nolint : staticcheck
-	if v, ok := d.GetOkExists("immediate_purge_data_on_30_days_enabled"); ok {
+	if v, ok := d.GetOkExists("immediate_data_purge_on_30_days_enabled"); ok {
 		parameters.Properties.Features.ImmediatePurgeDataOn30Days = utils.Bool(v.(bool))
 	}
 
@@ -476,7 +476,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("allow_resource_only_permissions", allowResourceOnlyPermissions)
 			d.Set("local_authentication_disabled", disableLocalAuth)
-			d.Set("immediate_purge_data_on_30_days_enabled", purgeDataOnThirtyDays)
+			d.Set("immediate_data_purge_on_30_days_enabled", purgeDataOnThirtyDays)
 
 			defaultDataCollectionRuleResourceId := ""
 			if props.DefaultDataCollectionRuleResourceId != nil {

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -154,6 +154,11 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				ValidateFunc: datacollectionrules.ValidateDataCollectionRuleID,
 			},
 
+			"immediate_purge_data_on_30_days_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"workspace_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -299,6 +304,12 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		parameters.Properties.WorkspaceCapping = &workspaces.WorkspaceCapping{
 			DailyQuotaGb: utils.Float(dailyQuotaGb.(float64)),
 		}
+	}
+
+	// The `ImmediatePurgeDataOn30Days` are not returned before it has been set
+	// nolint : staticcheck
+	if v, ok := d.GetOkExists("immediate_purge_data_on_30_days_enabled"); ok {
+		parameters.Properties.Features.ImmediatePurgeDataOn30Days = utils.Bool(v.(bool))
 	}
 
 	propName := "reservation_capacity_in_gb_per_day"
@@ -457,18 +468,15 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 
 			allowResourceOnlyPermissions := true
 			disableLocalAuth := false
+			purgeDataOnThirtyDays := false
 			if features := props.Features; features != nil {
-				v := features.EnableLogAccessUsingOnlyResourcePermissions
-				if v != nil {
-					allowResourceOnlyPermissions = *v
-				}
-				d := features.DisableLocalAuth
-				if d != nil {
-					disableLocalAuth = *d
-				}
+				allowResourceOnlyPermissions = pointer.From(features.EnableLogAccessUsingOnlyResourcePermissions)
+				disableLocalAuth = pointer.From(features.DisableLocalAuth)
+				purgeDataOnThirtyDays = pointer.From(features.ImmediatePurgeDataOn30Days)
 			}
 			d.Set("allow_resource_only_permissions", allowResourceOnlyPermissions)
 			d.Set("local_authentication_disabled", disableLocalAuth)
+			d.Set("immediate_purge_data_on_30_days_enabled", purgeDataOnThirtyDays)
 
 			defaultDataCollectionRuleResourceId := ""
 			if props.DefaultDataCollectionRuleResourceId != nil {

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -332,6 +332,32 @@ func TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth(t *testing.T) {
 	})
 }
 
+func TestAccLogAnalyticsWorkspace_ToggleImmediatelyPurgeDataOn30Days(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
+	r := LogAnalyticsWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withImmediatePurgeDataOn30Days(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.withImmediatePurgeDataOn30Days(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.withImmediatePurgeDataOn30Days(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccLogAnalyticsWorkspace_updateSku(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
 	r := LogAnalyticsWorkspaceResource{}
@@ -938,4 +964,26 @@ resource "azurerm_log_analytics_workspace" "test" {
   data_collection_rule_id = "%[3]s"
 }
 `, data.RandomInteger, data.Locations.Primary, ruleID)
+}
+
+func (LogAnalyticsWorkspaceResource) withImmediatePurgeDataOn30Days(data acceptance.TestData, enable bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                                    = "acctestLAW-%d"
+  location                                = azurerm_resource_group.test.location
+  resource_group_name                     = azurerm_resource_group.test.name
+  sku                                     = "PerGB2018"
+  retention_in_days                       = 30
+  immediate_purge_data_on_30_days_enabled = %[4]t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enable)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -983,7 +983,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name                     = azurerm_resource_group.test.name
   sku                                     = "PerGB2018"
   retention_in_days                       = 30
-  immediate_purge_data_on_30_days_enabled = %[4]t
+  immediate_data_purge_on_30_days_enabled = %[4]t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enable)
 }

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `data_collection_rule_id` - (Optional) The ID of the Data Collection Rule to use for this workspace.
 
-* `immediate_purge_data_on_30_days_enabled` - (Optional) Whether to remove the data in the Log Analytics Workspace immediately after 30 days.
+* `immediate_data_purge_on_30_days_enabled` - (Optional) Whether to remove the data in the Log Analytics Workspace immediately after 30 days.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `data_collection_rule_id` - (Optional) The ID of the Data Collection Rule to use for this workspace.
 
+* `immediate_purge_data_on_30_days_enabled` - (Optional) Whether to remove the data in the Log Analytics Workspace immediately after 30 days.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> **NOTE:** If a `azurerm_log_analytics_workspace` is connected to a `azurerm_log_analytics_cluster` via a `azurerm_log_analytics_linked_service` you will not be able to modify the workspaces `sku` field until the link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource. All other fields are modifiable while the workspace is linked to a cluster.


### PR DESCRIPTION
test
---
```
 tftest loganalytics TestAccLogAnalyticsWorkspace                 
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:96: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== RUN   TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== RUN   TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== RUN   TestAccLogAnalyticsWorkspace_ToggleImmediatelyPurgeDataOn30Days
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleImmediatelyPurgeDataOn30Days
=== RUN   TestAccLogAnalyticsWorkspace_updateSku
=== PAUSE TestAccLogAnalyticsWorkspace_updateSku
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== RUN   TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
=== RUN   TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== RUN   TestAccLogAnalyticsWorkspace_toggleIdentity
=== PAUSE TestAccLogAnalyticsWorkspace_toggleIdentity
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
=== CONT  TestAccLogAnalyticsWorkspace_withUserAssignedIdentity
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
=== CONT  TestAccLogAnalyticsWorkspace_toggleIdentity
--- PASS: TestAccLogAnalyticsWorkspace_basic (182.87s)
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (194.57s)
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (197.15s)
=== CONT  TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity
--- PASS: TestAccLogAnalyticsWorkspace_withUserAssignedIdentity (224.19s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleImmediatelyPurgeDataOn30Days
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (262.99s)
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (262.99s)
=== CONT  TestAccLogAnalyticsWorkspace_updateSku
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule (298.40s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
--- PASS: TestAccLogAnalyticsWorkspace_toggleIdentity (356.94s)
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
--- PASS: TestAccLogAnalyticsWorkspace_withSystemAssignedIdentity (188.90s)
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (251.24s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (242.74s)
=== CONT  TestAccLogAnalyticsWorkspace_complete
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (190.64s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleImmediatelyPurgeDataOn30Days (275.79s)
--- PASS: TestAccLogAnalyticsWorkspace_updateSku (250.02s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth (257.85s)
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (189.14s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (244.26s)
--- PASS: TestAccLogAnalyticsWorkspace_complete (181.05s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission (279.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	713.637s
```