### PR TITLE
`d/private_dns_zone`: refactoring to use the `ListBySubscription` API rather than the Resources API

### DIFF
--- a/internal/services/privatedns/client/helpers.go
+++ b/internal/services/privatedns/client/helpers.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2020-06-01/privatezones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
+)
+
+func (c *Client) FindPrivateDnsZoneId(ctx context.Context, resourceGroupsClient *resourcegroups.ResourceGroupsClient, subscriptionId commonids.SubscriptionId, name string) (*privatezones.PrivateDnsZoneId, error) {
+	opts := privatezones.DefaultListOperationOptions()
+	results, err := c.PrivateZonesClient.ListComplete(ctx, subscriptionId, opts)
+	if err != nil {
+		return nil, fmt.Errorf("listing the Private DNS Zones within %s: %+v", subscriptionId, err)
+	}
+
+	for _, item := range results.Items {
+		if item.Id == nil {
+			continue
+		}
+
+		itemId := *item.Id
+		parsed, err := privatezones.ParsePrivateDnsZoneIDInsensitively(itemId)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a Private DNS Zone ID: %+v", itemId, err)
+		}
+
+		if parsed.PrivateDnsZoneName != name {
+			continue
+		}
+
+		// however the Resource Group name isn't necessarily cased correctly, so now that we've found the Resource
+		// Group name let's pull the canonical casing from the Resource Groups API
+		resourceGroupId := commonids.NewResourceGroupID(parsed.SubscriptionId, parsed.ResourceGroupName)
+		resp, err := resourceGroupsClient.Get(ctx, resourceGroupId)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving %s: %+v", resourceGroupId, err)
+		}
+		if model := resp.Model; model != nil && model.Name != nil {
+			parsed.ResourceGroupName = *model.Name
+		}
+		return parsed, nil
+	}
+
+	return nil, fmt.Errorf("No Private DNS Zones found with name: %q", name)
+}

--- a/internal/services/resource/client/client.go
+++ b/internal/services/resource/client/client.go
@@ -14,29 +14,32 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2021-07-01/features"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-02-01/templatespecversions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	DeploymentsClient                   *resources.DeploymentsClient
 	DeploymentScriptsClient             *deploymentscripts.DeploymentScriptsClient
 	FeaturesClient                      *features.FeaturesClient
-	GroupsClient                        *resources.GroupsClient
 	LocksClient                         *managementlocks.ManagementLocksClient
 	PrivateLinkAssociationClient        *privatelinkassociation.PrivateLinkAssociationClient
+	ResourceGroupsClient                *resourcegroups.ResourceGroupsClient
 	ResourceManagementPrivateLinkClient *resourcemanagementprivatelink.ResourceManagementPrivateLinkClient
 	ResourceProvidersClient             *providers.ProvidersClient
-	ResourcesClient                     *resources.Client
-	TagsClient                          *resources.TagsClient
 	TemplateSpecsVersionsClient         *templatespecversions.TemplateSpecVersionsClient
 
-	options *common.ClientOptions
+	// TODO: these SDK clients use `Azure/azure-sdk-for-go` - we should migrate to `hashicorp/go-azure-sdk`
+	// (above) as time allows.
+	DeploymentsClient *resources.DeploymentsClient
+	ResourcesClient   *resources.Client
+	TagsClient        *resources.TagsClient
+	options           *common.ClientOptions
+
+	// Note that the Groups Client which requires additional coordination
+	GroupsClient *resources.GroupsClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
-	deploymentsClient := resources.NewDeploymentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&deploymentsClient.Client, o.ResourceManagerAuthorizer)
-
 	deploymentScriptsClient, err := deploymentscripts.NewDeploymentScriptsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building DeploymentScripts client: %+v", err)
@@ -49,8 +52,11 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(featuresClient.Client, o.Authorizers.ResourceManager)
 
-	groupsClient := resources.NewGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&groupsClient.Client, o.ResourceManagerAuthorizer)
+	resourceGroupsClient, err := resourcegroups.NewResourceGroupsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Features client: %+v", err)
+	}
+	o.Configure(resourceGroupsClient.Client, o.Authorizers.ResourceManager)
 
 	locksClient, err := managementlocks.NewManagementLocksClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
@@ -76,32 +82,39 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(resourceProvidersClient.Client, o.Authorizers.ResourceManager)
 
-	resourcesClient := resources.NewClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&resourcesClient.Client, o.ResourceManagerAuthorizer)
-
 	templateSpecsVersionsClient, err := templatespecversions.NewTemplateSpecVersionsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building TemplateSpecVersions client: %+v", err)
 	}
 	o.Configure(templateSpecsVersionsClient.Client, o.Authorizers.ResourceManager)
 
+	// NOTE: these clients use `Azure/azure-sdk-for-go` and can be removed in time
+	deploymentsClient := resources.NewDeploymentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&deploymentsClient.Client, o.ResourceManagerAuthorizer)
+	groupsClient := resources.NewGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&groupsClient.Client, o.ResourceManagerAuthorizer)
+	resourcesClient := resources.NewClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&resourcesClient.Client, o.ResourceManagerAuthorizer)
 	tagsClient := resources.NewTagsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&tagsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		GroupsClient:                        &groupsClient,
+		// These come from `hashicorp/go-azure-sdk`
 		DeploymentsClient:                   &deploymentsClient,
 		DeploymentScriptsClient:             deploymentScriptsClient,
 		FeaturesClient:                      featuresClient,
 		LocksClient:                         locksClient,
 		PrivateLinkAssociationClient:        privateLinkAssociationClient,
 		ResourceManagementPrivateLinkClient: resourceManagementPrivateLinkClient,
+		ResourceGroupsClient:                resourceGroupsClient,
 		ResourceProvidersClient:             resourceProvidersClient,
-		ResourcesClient:                     &resourcesClient,
-		TagsClient:                          &tagsClient,
 		TemplateSpecsVersionsClient:         templateSpecsVersionsClient,
 
-		options: o,
+		// These use `Azure/azure-sdk-for-go`
+		GroupsClient:    &groupsClient,
+		ResourcesClient: &resourcesClient,
+		TagsClient:      &tagsClient,
+		options:         o,
 	}, nil
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/README.md
@@ -1,0 +1,157 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups` Documentation
+
+The `resourcegroups` SDK allows for interaction with the Azure Resource Manager Service `resources` (API Version `2023-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
+```
+
+
+### Client Initialization
+
+```go
+client := resourcegroups.NewResourceGroupsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ResourceGroupsClient.CheckExistence`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+read, err := client.CheckExistence(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+payload := resourcegroups.ResourceGroup{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+if err := client.DeleteThenPoll(ctx, id, resourcegroups.DefaultDeleteOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.ExportTemplate`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+payload := resourcegroups.ExportTemplateRequest{
+	// ...
+}
+
+
+if err := client.ExportTemplateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.Get`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.List`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id, resourcegroups.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, resourcegroups.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.ResourcesListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ResourcesListByResourceGroup(ctx, id, resourcegroups.DefaultResourcesListByResourceGroupOperationOptions())` can be used to do batched pagination
+items, err := client.ResourcesListByResourceGroupComplete(ctx, id, resourcegroups.DefaultResourcesListByResourceGroupOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ResourceGroupsClient.Update`
+
+```go
+ctx := context.TODO()
+id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+payload := resourcegroups.ResourceGroupPatchable{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/client.go
@@ -1,0 +1,26 @@
+package resourcegroups
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceGroupsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewResourceGroupsClientWithBaseURI(sdkApi sdkEnv.Api) (*ResourceGroupsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "resourcegroups", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ResourceGroupsClient: %+v", err)
+	}
+
+	return &ResourceGroupsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_checkexistence.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_checkexistence.go
@@ -1,0 +1,47 @@
+package resourcegroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckExistenceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// CheckExistence ...
+func (c ResourceGroupsClient) CheckExistence(ctx context.Context, id commonids.ResourceGroupId) (result CheckExistenceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodHead,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_createorupdate.go
@@ -1,0 +1,57 @@
+package resourcegroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ResourceGroup
+}
+
+// CreateOrUpdate ...
+func (c ResourceGroupsClient) CreateOrUpdate(ctx context.Context, id commonids.ResourceGroupId, input ResourceGroup) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_delete.go
@@ -1,0 +1,99 @@
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteOperationOptions struct {
+	ForceDeletionTypes *string
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeleteOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeleteOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ForceDeletionTypes != nil {
+		out.Append("forceDeletionTypes", fmt.Sprintf("%v", *o.ForceDeletionTypes))
+	}
+	return &out
+}
+
+// Delete ...
+func (c ResourceGroupsClient) Delete(ctx context.Context, id commonids.ResourceGroupId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ResourceGroupsClient) DeleteThenPoll(ctx context.Context, id commonids.ResourceGroupId, options DeleteOperationOptions) error {
+	result, err := c.Delete(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_exporttemplate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_exporttemplate.go
@@ -1,0 +1,75 @@
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExportTemplateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ExportTemplate ...
+func (c ResourceGroupsClient) ExportTemplate(ctx context.Context, id commonids.ResourceGroupId, input ExportTemplateRequest) (result ExportTemplateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/exportTemplate", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ExportTemplateThenPoll performs ExportTemplate then polls until it's completed
+func (c ResourceGroupsClient) ExportTemplateThenPoll(ctx context.Context, id commonids.ResourceGroupId, input ExportTemplateRequest) error {
+	result, err := c.ExportTemplate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ExportTemplate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ExportTemplate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_get.go
@@ -1,0 +1,52 @@
+package resourcegroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ResourceGroup
+}
+
+// Get ...
+func (c ResourceGroupsClient) Get(ctx context.Context, id commonids.ResourceGroupId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_list.go
@@ -1,0 +1,122 @@
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ResourceGroup
+}
+
+type ListCompleteResult struct {
+	Items []ResourceGroup
+}
+
+type ListOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// List ...
+func (c ResourceGroupsClient) List(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/resourceGroups", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ResourceGroup `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c ResourceGroupsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, ResourceGroupOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ResourceGroupsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions, predicate ResourceGroupOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]ResourceGroup, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_resourceslistbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_resourceslistbyresourcegroup.go
@@ -1,0 +1,126 @@
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourcesListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]GenericResourceExpanded
+}
+
+type ResourcesListByResourceGroupCompleteResult struct {
+	Items []GenericResourceExpanded
+}
+
+type ResourcesListByResourceGroupOperationOptions struct {
+	Expand *string
+	Filter *string
+	Top    *int64
+}
+
+func DefaultResourcesListByResourceGroupOperationOptions() ResourcesListByResourceGroupOperationOptions {
+	return ResourcesListByResourceGroupOperationOptions{}
+}
+
+func (o ResourcesListByResourceGroupOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ResourcesListByResourceGroupOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ResourcesListByResourceGroupOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// ResourcesListByResourceGroup ...
+func (c ResourceGroupsClient) ResourcesListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options ResourcesListByResourceGroupOperationOptions) (result ResourcesListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/resources", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]GenericResourceExpanded `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ResourcesListByResourceGroupComplete retrieves all the results into a single object
+func (c ResourceGroupsClient) ResourcesListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId, options ResourcesListByResourceGroupOperationOptions) (ResourcesListByResourceGroupCompleteResult, error) {
+	return c.ResourcesListByResourceGroupCompleteMatchingPredicate(ctx, id, options, GenericResourceExpandedOperationPredicate{})
+}
+
+// ResourcesListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ResourceGroupsClient) ResourcesListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, options ResourcesListByResourceGroupOperationOptions, predicate GenericResourceExpandedOperationPredicate) (result ResourcesListByResourceGroupCompleteResult, err error) {
+	items := make([]GenericResourceExpanded, 0)
+
+	resp, err := c.ResourcesListByResourceGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ResourcesListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/method_update.go
@@ -1,0 +1,56 @@
+package resourcegroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ResourceGroup
+}
+
+// Update ...
+func (c ResourceGroupsClient) Update(ctx context.Context, id commonids.ResourceGroupId, input ResourceGroupPatchable) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_erroradditionalinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_erroradditionalinfo.go
@@ -1,0 +1,9 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorAdditionalInfo struct {
+	Info *interface{} `json:"info,omitempty"`
+	Type *string      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_errorresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_errorresponse.go
@@ -1,0 +1,12 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorResponse struct {
+	AdditionalInfo *[]ErrorAdditionalInfo `json:"additionalInfo,omitempty"`
+	Code           *string                `json:"code,omitempty"`
+	Details        *[]ErrorResponse       `json:"details,omitempty"`
+	Message        *string                `json:"message,omitempty"`
+	Target         *string                `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_exporttemplaterequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_exporttemplaterequest.go
@@ -1,0 +1,9 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExportTemplateRequest struct {
+	Options   *string   `json:"options,omitempty"`
+	Resources *[]string `json:"resources,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_genericresourceexpanded.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_genericresourceexpanded.go
@@ -1,0 +1,54 @@
+package resourcegroups
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericResourceExpanded struct {
+	ChangedTime       *string                            `json:"changedTime,omitempty"`
+	CreatedTime       *string                            `json:"createdTime,omitempty"`
+	ExtendedLocation  *edgezones.Model                   `json:"extendedLocation,omitempty"`
+	Id                *string                            `json:"id,omitempty"`
+	Identity          *identity.SystemAndUserAssignedMap `json:"identity,omitempty"`
+	Kind              *string                            `json:"kind,omitempty"`
+	Location          *string                            `json:"location,omitempty"`
+	ManagedBy         *string                            `json:"managedBy,omitempty"`
+	Name              *string                            `json:"name,omitempty"`
+	Plan              *Plan                              `json:"plan,omitempty"`
+	Properties        *interface{}                       `json:"properties,omitempty"`
+	ProvisioningState *string                            `json:"provisioningState,omitempty"`
+	Sku               *Sku                               `json:"sku,omitempty"`
+	Tags              *map[string]string                 `json:"tags,omitempty"`
+	Type              *string                            `json:"type,omitempty"`
+}
+
+func (o *GenericResourceExpanded) GetChangedTimeAsTime() (*time.Time, error) {
+	if o.ChangedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ChangedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *GenericResourceExpanded) SetChangedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ChangedTime = &formatted
+}
+
+func (o *GenericResourceExpanded) GetCreatedTimeAsTime() (*time.Time, error) {
+	if o.CreatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *GenericResourceExpanded) SetCreatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_plan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_plan.go
@@ -1,0 +1,12 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Plan struct {
+	Name          *string `json:"name,omitempty"`
+	Product       *string `json:"product,omitempty"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     *string `json:"publisher,omitempty"`
+	Version       *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroup.go
@@ -1,0 +1,14 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceGroup struct {
+	Id         *string                  `json:"id,omitempty"`
+	Location   string                   `json:"location"`
+	ManagedBy  *string                  `json:"managedBy,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *ResourceGroupProperties `json:"properties,omitempty"`
+	Tags       *map[string]string       `json:"tags,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroupexportresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroupexportresult.go
@@ -1,0 +1,9 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceGroupExportResult struct {
+	Error    *ErrorResponse `json:"error,omitempty"`
+	Template *interface{}   `json:"template,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegrouppatchable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegrouppatchable.go
@@ -1,0 +1,11 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceGroupPatchable struct {
+	ManagedBy  *string                  `json:"managedBy,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *ResourceGroupProperties `json:"properties,omitempty"`
+	Tags       *map[string]string       `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroupproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_resourcegroupproperties.go
@@ -1,0 +1,8 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceGroupProperties struct {
+	ProvisioningState *string `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/model_sku.go
@@ -1,0 +1,13 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Capacity *int64  `json:"capacity,omitempty"`
+	Family   *string `json:"family,omitempty"`
+	Model    *string `json:"model,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Size     *string `json:"size,omitempty"`
+	Tier     *string `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/predicates.go
@@ -1,0 +1,95 @@
+package resourcegroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericResourceExpandedOperationPredicate struct {
+	ChangedTime       *string
+	CreatedTime       *string
+	Id                *string
+	Kind              *string
+	Location          *string
+	ManagedBy         *string
+	Name              *string
+	Properties        *interface{}
+	ProvisioningState *string
+	Type              *string
+}
+
+func (p GenericResourceExpandedOperationPredicate) Matches(input GenericResourceExpanded) bool {
+
+	if p.ChangedTime != nil && (input.ChangedTime == nil || *p.ChangedTime != *input.ChangedTime) {
+		return false
+	}
+
+	if p.CreatedTime != nil && (input.CreatedTime == nil || *p.CreatedTime != *input.CreatedTime) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.ManagedBy != nil && (input.ManagedBy == nil || *p.ManagedBy != *input.ManagedBy) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Properties != nil && (input.Properties == nil || *p.Properties != *input.Properties) {
+		return false
+	}
+
+	if p.ProvisioningState != nil && (input.ProvisioningState == nil || *p.ProvisioningState != *input.ProvisioningState) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type ResourceGroupOperationPredicate struct {
+	Id        *string
+	Location  *string
+	ManagedBy *string
+	Name      *string
+	Type      *string
+}
+
+func (p ResourceGroupOperationPredicate) Matches(input ResourceGroup) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.ManagedBy != nil && (input.ManagedBy == nil || *p.ManagedBy != *input.ManagedBy) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/version.go
@@ -1,0 +1,12 @@
+package resourcegroups
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-07-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/resourcegroups/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -865,6 +865,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/resources/2021-07-01/features
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-02-01/templatespecversions
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers
+github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/adminkeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/querykeys


### PR DESCRIPTION
Similar to #24023 and #24019 this PR refactors the Private DNS Zone data source to use the ListBySubscription API rather than listing on the Resources API.

This should both improve reliability, since we're no longer hitting the Resources API (which can serve stale data) but also removes another usage of `Azure/azure-sdk-for-go`

Note that we're having to hit the `ResourceGroups` API to return the canonical casing for the Resource Group name, due to a bug in the Private DNS API.