### PR TITLE
Documentation update for `azurerm_windows_virtual_machine_scale_set`

### DIFF
--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -56,6 +56,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
   instances           = 1
   admin_password      = "P@55w0rd1234!"
   admin_username      = "adminuser"
+  computer_name_prefix = "vm-" 
 
   source_image_reference {
     publisher = "MicrosoftWindowsServer"

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -16,7 +16,7 @@ Manages a Windows Virtual Machine Scale Set.
 
 -> **NOTE:** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
--> **NOTE:** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#features).
+-> **NOTE:** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block).
 
 -> **NOTE:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
 
@@ -49,14 +49,14 @@ resource "azurerm_subnet" "internal" {
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "example" {
-  name                = "example-vmss"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
-  sku                 = "Standard_F2"
-  instances           = 1
-  admin_password      = "P@55w0rd1234!"
-  admin_username      = "adminuser"
-  computer_name_prefix = "vm-" 
+  name                 = "example-vmss"
+  resource_group_name  = azurerm_resource_group.example.name
+  location             = azurerm_resource_group.example.location
+  sku                  = "Standard_F2"
+  instances            = 1
+  admin_password       = "P@55w0rd1234!"
+  admin_username       = "adminuser"
+  computer_name_prefix = "vm-"
 
   source_image_reference {
     publisher = "MicrosoftWindowsServer"


### PR DESCRIPTION
Updates two things

- The Features documentation has changed URL, so updating to the new URL
- The example no longer works by copy/pasting, you get the error below. Updated the example so it works

```
Error: unable to assume default computer name prefix "computer_name_prefix" can be at most 9 characters, got 12. Please adjust the "name", or specify an explicit "computer_name_prefix"
│ 
│   with azurerm_windows_virtual_machine_scale_set.example,
│   on test-vmss.tf line 15, in resource "azurerm_windows_virtual_machine_scale_set" "example":
│   15: resource "azurerm_windows_virtual_machine_scale_set" "example" {
```