### PR TITLE
Documentation update - `mssql_failover_group` working example

### DIFF
--- a/website/docs/r/mssql_failover_group.html.markdown
+++ b/website/docs/r/mssql_failover_group.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_mssql_server" "primary" {
 resource "azurerm_mssql_server" "secondary" {
   name                         = "mssqlserver-secondary"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = azurerm_resource_group.example.location
+  location                     = "North Europe"
   version                      = "12.0"
   administrator_login          = "missadministrator"
   administrator_login_password = "thisIsKat12"


### PR DESCRIPTION
Updating the example for `mssql_failover_group` to be a working example.

The existing example deploys both servers to the same region. This is not supported when creating a failover group. 

The API returns an error
```
│ Error: creating Failover Group: (Name "sql" / Server Name "mssqlserver-primary" / Resource Group "database-rg"): sql.FailoverGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidFailoverGroupRegion" Message="Secondary server specified in a Failover Group cannot reside in the same region."
```
