### PR TITLE
`azurerm_cosmosdb_account` - Change the order of updating `capabilities`

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -927,30 +927,6 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	var capabilities *[]documentdb.Capability
 	if existing.DatabaseAccountGetProperties.Capabilities != nil {
 		capabilities = existing.DatabaseAccountGetProperties.Capabilities
-		if d.HasChange("capabilities") {
-			log.Printf("[INFO] Updating AzureRM Cosmos DB Account: Updating 'Capabilities'")
-
-			newCapabilities := expandAzureRmCosmosDBAccountCapabilities(d)
-			updateParameters := documentdb.DatabaseAccountUpdateParameters{
-				DatabaseAccountUpdateProperties: &documentdb.DatabaseAccountUpdateProperties{
-					Capabilities: newCapabilities,
-				},
-			}
-
-			// Update Database 'capabilities'...
-			future, err := client.Update(ctx, id.ResourceGroup, id.Name, updateParameters)
-			if err != nil {
-				return fmt.Errorf("updating CosmosDB Account %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
-
-			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting for the CosmosDB Account %q (Resource Group %q) to finish updating: %+v", id.Name, id.ResourceGroup, err)
-			}
-
-			capabilities = newCapabilities
-		} else {
-			log.Printf("[INFO] [SKIP] AzureRM Cosmos DB Account: Updating 'Capabilities' [NO CHANGE]")
-		}
 	}
 
 	// backup must be updated independently
@@ -1280,6 +1256,31 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 		} else {
 			log.Printf("[INFO] [SKIP] AzureRM Cosmos DB Account: Updating 'DefaultIdentity' [NO CHANGE]")
+		}
+	}
+
+	if existing.DatabaseAccountGetProperties.Capabilities != nil {
+		if d.HasChange("capabilities") {
+			log.Printf("[INFO] Updating AzureRM Cosmos DB Account: Updating 'Capabilities'")
+
+			newCapabilities := expandAzureRmCosmosDBAccountCapabilities(d)
+			updateParameters := documentdb.DatabaseAccountUpdateParameters{
+				DatabaseAccountUpdateProperties: &documentdb.DatabaseAccountUpdateProperties{
+					Capabilities: newCapabilities,
+				},
+			}
+
+			// Update Database 'capabilities'...
+			future, err := client.Update(ctx, id.ResourceGroup, id.Name, updateParameters)
+			if err != nil {
+				return fmt.Errorf("updating CosmosDB Account %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+
+			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for the CosmosDB Account %q (Resource Group %q) to finish updating: %+v", id.Name, id.ResourceGroup, err)
+			}
+		} else {
+			log.Printf("[INFO] [SKIP] AzureRM Cosmos DB Account: Updating 'Capabilities' [NO CHANGE]")
 		}
 	}
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -157,6 +157,28 @@ func TestAccCosmosDBAccount_customerManagedKeyWithIdentity(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDBAccount_mongoDBCapabilities(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicMongoDB(data, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateMongoDBVersionCapabilities(data, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCosmosDBAccount_keyVaultUriUpdateConsistancy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
 	r := CosmosDBAccountResource{}
@@ -3556,6 +3578,45 @@ resource "azurerm_cosmosdb_account" "test" {
     ignore_changes = [
       capabilities
     ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(consistency))
+}
+
+func (CosmosDBAccountResource) updateMongoDBVersionCapabilities(data acceptance.TestData, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                 = "acctest-ca-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  offer_type           = "Standard"
+  kind                 = "MongoDB"
+  mongo_server_version = "4.2"
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  capabilities {
+    name = "EnableMongo16MBDocumentSupport"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(consistency))

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -157,7 +157,7 @@ func TestAccCosmosDBAccount_customerManagedKeyWithIdentity(t *testing.T) {
 	})
 }
 
-func TestAccCosmosDBAccount_mongoDBCapabilities(t *testing.T) {
+func TestAccCosmosDBAccount_updateMongoDBVersionCapabilities(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
 	r := CosmosDBAccountResource{}
 


### PR DESCRIPTION
The purpose of this PR:

-  Changed the order of updating `capabilities` to fix failure when updating `mongo_server_version`  and `capabilities` at the same time(Fix #23986).

-  When updating a specified value other than  `capabilities`, replace the new capabilities value with the existing capabilities value, since capabilities needs to be updated separately through patches.

Test result:
PASS: TestAccCosmosDBAccount_updateMongoDBVersionCapabilities (996.38s)

