### PR TITLE
new datasource `azurerm_stack_hci_cluster`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -144,6 +144,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		authorization.Registration{},
 		automanage.Registration{},
 		automation.Registration{},
+		azurestackhci.Registration{},
 		batch.Registration{},
 		bot.Registration{},
 		cognitive.Registration{},

--- a/internal/services/azurestackhci/registration.go
+++ b/internal/services/azurestackhci/registration.go
@@ -11,6 +11,7 @@ import (
 type Registration struct{}
 
 var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/azure-stack-hci"
@@ -38,4 +39,14 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_stack_hci_cluster": resourceArmStackHCICluster(),
 	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{
+		StackHCIClusterDataSource{},
+	}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{}
 }

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source.go
@@ -46,7 +46,6 @@ func (r StackHCIClusterDataSource) Arguments() map[string]*schema.Schema {
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
-			ForceNew:     true,
 			ValidateFunc: validate.ClusterName,
 		},
 

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source.go
@@ -116,7 +116,7 @@ func (r StackHCIClusterDataSource) Read() sdk.ResourceFunc {
 					if !utils.ResponseWasNotFound(assignmentResp.Response) && assignmentResp.Properties != nil && assignmentResp.Properties.ConfigurationProfile != nil {
 						automanageConfigId, err := autoParse.AutomanageConfigurationID(*assignmentResp.Properties.ConfigurationProfile)
 						if err != nil {
-							return err
+							return fmt.Errorf("reading configuration profile assignment: %v", err)
 						}
 						configId = automanageConfigId.ID()
 					}

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source.go
@@ -1,0 +1,132 @@
+package azurestackhci
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2023-08-01/clusters"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	autoParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/automanage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/azurestackhci/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+var _ sdk.DataSource = StackHCIClusterDataSource{}
+
+type StackHCIClusterDataSource struct{}
+
+func (r StackHCIClusterDataSource) ResourceType() string {
+	return "azurerm_stack_hci_cluster"
+}
+
+func (r StackHCIClusterDataSource) ModelObject() interface{} {
+	return &StackHCIClusterDataSourceModel{}
+}
+
+type StackHCIClusterDataSourceModel struct {
+	Name                      string                 `tfschema:"name"`
+	ResourceGroupName         string                 `tfschema:"resource_group_name"`
+	Location                  string                 `tfschema:"location"`
+	ClientId                  string                 `tfschema:"client_id"`
+	TenantId                  string                 `tfschema:"tenant_id"`
+	AutomanageConfigurationId string                 `tfschema:"automanage_configuration_id"`
+	Tags                      map[string]interface{} `tfschema:"tags"`
+}
+
+func (r StackHCIClusterDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ClusterName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (r StackHCIClusterDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"client_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tenant_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"automanage_configuration_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (r StackHCIClusterDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AzureStackHCI.Clusters
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			hciAssignmentClient := metadata.Client.Automanage.HCIAssignmentClient
+
+			var cluster StackHCIClusterDataSourceModel
+			if err := metadata.Decode(&cluster); err != nil {
+				return err
+			}
+
+			id := clusters.NewClusterID(subscriptionId, cluster.ResourceGroupName, cluster.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+
+			if model := existing.Model; model != nil {
+				cluster.Location = location.Normalize(model.Location)
+				cluster.Tags = tags.Flatten(model.Tags)
+
+				if props := model.Properties; props != nil {
+					cluster.ClientId = pointer.From(props.AadClientId)
+					cluster.TenantId = pointer.From(props.AadTenantId)
+
+					assignmentResp, err := hciAssignmentClient.Get(ctx, id.ResourceGroupName, id.ClusterName, "default")
+					if err != nil && !utils.ResponseWasNotFound(assignmentResp.Response) {
+						return err
+					}
+					configId := ""
+					if !utils.ResponseWasNotFound(assignmentResp.Response) && assignmentResp.Properties != nil && assignmentResp.Properties.ConfigurationProfile != nil {
+						automanageConfigId, err := autoParse.AutomanageConfigurationID(*assignmentResp.Properties.ConfigurationProfile)
+						if err != nil {
+							return err
+						}
+						configId = automanageConfigId.ID()
+					}
+					cluster.AutomanageConfigurationId = configId
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&cluster)
+		},
+	}
+}

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
@@ -1,0 +1,38 @@
+package azurestackhci_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type StackHCIClusterDataSource struct{}
+
+func TestAccStackHCIClusterDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").IsNotEmpty(),
+				check.That(data.ResourceName).Key("client_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("tenant_id").IsNotEmpty(),
+			),
+		},
+	})
+}
+
+func (d StackHCIClusterDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_stack_hci_cluster" "test" {
+	  name                = azurerm_stack_hci_cluster.test.name
+	  resource_group_name = azurerm_stack_hci_cluster.test.resource_group_name
+}
+`, StackHCIClusterResource{}.basic(data))
+}

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
@@ -31,8 +31,8 @@ func (d StackHCIClusterDataSource) basic(data acceptance.TestData) string {
 %s
 
 data "azurerm_stack_hci_cluster" "test" {
-	  name                = azurerm_stack_hci_cluster.test.name
-	  resource_group_name = azurerm_stack_hci_cluster.test.resource_group_name
+  name                = azurerm_stack_hci_cluster.test.name
+  resource_group_name = azurerm_stack_hci_cluster.test.resource_group_name
 }
 `, StackHCIClusterResource{}.basic(data))
 }

--- a/website/docs/d/stack_hci_cluster.html.markdown
+++ b/website/docs/d/stack_hci_cluster.html.markdown
@@ -37,9 +37,9 @@ output "client_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Azure Stack HCI Cluster. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Azure Stack HCI Cluster.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Azure Stack HCI Cluster should exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure Stack HCI Cluster exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/stack_hci_cluster.html.markdown
+++ b/website/docs/d/stack_hci_cluster.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Azure Stack HCI"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_stack_hci_cluster"
+description: |-
+  Gets information about an existing Azure Stack HCI Cluster.
+---
+
+# Data Source: azurerm_stack_hci_cluster
+
+Use this data source to access information about an existing Azure Stack HCI Cluster instance.
+
+## Example Usage
+
+```hcl
+data "azurerm_stack_hci_cluster" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+
+output "id" {
+  value = data.azurerm_stack_hci_cluster.example.id
+}
+
+output "location" {
+  value = data.azurerm_stack_hci_cluster.example.location
+}
+
+output "client_id" {
+  value = data.azurerm_stack_hci_cluster.example.client_id
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Azure Stack HCI Cluster. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure Stack HCI Cluster should exist. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Azure Stack HCI Cluster.
+
+* `location` - The Azure Region where the Azure Stack HCI Cluster exists.
+
+* `client_id` - The Client ID of the Azure Active Directory used by the Azure Stack HCI Cluster.
+
+* `tenant_id` - The Tenant ID of the Azure Active Directory used by the Azure Stack HCI Cluster.
+
+* `tags` - A mapping of tags assigned to the Azure Stack HCI Cluster.
+
+* `automanage_configuration_id` - The ID of the Automanage Configuration assigned to the Azure Stack HCI Cluster.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure Stack HCI Cluster.


### PR DESCRIPTION
```
TF_ACC=1 go test -v ./internal/services/azurestackhci -parallel 20 -run TestAccStackHCIClusterDataSource_basic -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStackHCIClusterDataSource_basic
=== PAUSE TestAccStackHCIClusterDataSource_basic
=== CONT  TestAccStackHCIClusterDataSource_basic
--- PASS: TestAccStackHCIClusterDataSource_basic (165.45s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/azurestackhci 165.461s
```