### PR TITLE
`azurerm_nginx_deployment`: add default value for capacity

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -100,6 +100,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"capacity": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
+			Default:      20,
 			ValidateFunc: validation.IntPositive,
 		},
 

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 ---
 
-* `capacity` - (Optional) Specify the number of NGINX capacity units for this NGINX deployment.
+* `capacity` - (Optional) Specify the number of NGINX capacity units for this NGINX deployment. Defaults to `20`.
 
 -> **Note** For more information on NGINX capacity units, please refer to the [NGINX scaling guidance documentation](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/)
 


### PR DESCRIPTION
The Server will set capacity as 20 units from [related documents](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/#nginx-capacity-unit-ncu). This is also fix acctest for:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/32fa202b-e489-4df0-8ab1-10d5ef6f1da9)
