### PR TITLE
`azurerm_container_app` - Add validations for the `ingress.0.traffic_weight`

### DIFF
--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -441,10 +441,10 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 						if tw.LatestRevision {
 							latestRevCount++
 							if tw.RevisionSuffix != "" {
-								return fmt.Errorf("`ingress.%[1]d.traffic_weight.%[1]d.revision_suffix` conflicts with `ingress.%[1]d.traffic_weight.%[1]d.latest_revision`", i)
+								return fmt.Errorf("`ingress.0.traffic_weight.%[1]d.revision_suffix` conflicts with `ingress.0.traffic_weight.%[1]d.latest_revision`", i)
 							}
 						} else if tw.RevisionSuffix == "" {
-							return fmt.Errorf("`ingress.%[1]d.traffic_weight.%[1]d.revision_suffix` is not specified", i)
+							return fmt.Errorf("`ingress.0.traffic_weight.%[1]d.revision_suffix` is not specified", i)
 						}
 					}
 					if latestRevCount > 1 {

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -443,10 +443,8 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 							if tw.RevisionSuffix != "" {
 								return fmt.Errorf("`ingress.%[1]d.traffic_weight.%[1]d.revision_suffix` conflicts with `ingress.%[1]d.traffic_weight.%[1]d.latest_revision`", i)
 							}
-						} else {
-							if tw.RevisionSuffix == "" {
-								return fmt.Errorf("`ingress.%[1]d.traffic_weight.%[1]d.revision_suffix` is not specified", i)
-							}
+						} else if tw.RevisionSuffix == "" {
+							return fmt.Errorf("`ingress.%[1]d.traffic_weight.%[1]d.revision_suffix` is not specified", i)
 						}
 					}
 					if latestRevCount > 1 {

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -419,9 +419,9 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 			// Ingress traffic weight validations
 			if len(app.Ingress) != 0 {
 				ingress := app.Ingress[0]
-				if old, _ := metadata.ResourceDiff.GetChange("name"); old == "" {
+				if metadata.ResourceDiff.HasChange("name") {
 					// Validation for create time
-					// (Above is a trick to tell whether this is for a new create apply, as for existing resource, the "name" is always not empty)
+					// (Above is a trick to tell whether this is for a new create apply, as the "name" is a force new property)
 					if len(ingress.TrafficWeights) != 0 {
 						if len(ingress.TrafficWeights) > 1 {
 							return fmt.Errorf("at most one `ingress.0.traffic_weight` can be specified during creation")

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -301,39 +301,24 @@ func TestAccContainerAppResource_removeDaprAppPort(t *testing.T) {
 	})
 }
 
-func TestAccContainerAppResource_secretRemoveShouldFail(t *testing.T) {
+func TestAccContainerAppResource_secretFail(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.completeUpdate(data, "rev1"),
+			Config: r.secretBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config:      r.complete(data, "rev2"),
+			Config:      r.secretRemove(data),
 			ExpectError: regexp.MustCompile("cannot remove secrets from Container Apps at this time"),
 		},
-	})
-}
-
-func TestAccContainerAppResource_secretRemoveWithAddShouldFail(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
-	r := ContainerAppResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.completeUpdate(data, "rev1"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config:      r.completeChangedSecret(data, "rev2"),
+			Config:      r.secretChangeName(data),
 			ExpectError: regexp.MustCompile("previously configured secret"),
 		},
 	})
@@ -1252,114 +1237,6 @@ resource "azurerm_container_app" "test" {
 `, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
 }
 
-func (r ContainerAppResource) completeChangedSecret(data acceptance.TestData, revisionSuffix string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_container_app" "test" {
-  name                         = "acctest-capp-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  container_app_environment_id = azurerm_container_app_environment.test.id
-  revision_mode                = "Multiple"
-
-  template {
-    container {
-      name  = "acctest-cont-%[2]d"
-      image = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
-
-      cpu    = 0.5
-      memory = "1Gi"
-
-      readiness_probe {
-        transport               = "HTTP"
-        port                    = 5000
-        path                    = "/uptime"
-        timeout                 = 2
-        failure_count_threshold = 1
-        success_count_threshold = 1
-
-        header {
-          name  = "Cache-Control"
-          value = "no-cache"
-        }
-      }
-
-      liveness_probe {
-        transport = "HTTP"
-        port      = 5000
-        path      = "/health"
-
-        header {
-          name  = "Cache-Control"
-          value = "no-cache"
-        }
-
-        initial_delay           = 5
-        timeout                 = 2
-        failure_count_threshold = 3
-      }
-
-      startup_probe {
-        transport               = "TCP"
-        port                    = 5000
-        timeout                 = 5
-        failure_count_threshold = 1
-      }
-    }
-
-    min_replicas = 1
-    max_replicas = 4
-
-    revision_suffix = "%[3]s"
-  }
-
-  ingress {
-    allow_insecure_connections = true
-    external_enabled           = true
-    target_port                = 5000
-    transport                  = "auto"
-
-    traffic_weight {
-      latest_revision = true
-      percentage      = 20
-    }
-
-    traffic_weight {
-      revision_suffix = "rev1"
-      percentage      = 80
-    }
-  }
-
-  registry {
-    server               = azurerm_container_registry.test.login_server
-    username             = azurerm_container_registry.test.admin_username
-    password_secret_name = "registry-password"
-  }
-
-  secret {
-    name  = "registry-password"
-    value = azurerm_container_registry.test.admin_password
-  }
-
-  secret {
-    name  = "pickle"
-    value = "morty"
-  }
-
-  dapr {
-    app_id       = "acctest-cont-%[2]d"
-    app_port     = 5000
-    app_protocol = "http"
-  }
-
-  tags = {
-    foo     = "Bar"
-    accTest = "1"
-  }
-}
-`, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
-}
-
 func (r ContainerAppResource) completeUpdate(data acceptance.TestData, revisionSuffix string) string {
 	return fmt.Sprintf(`
 %s
@@ -1559,12 +1436,7 @@ resource "azurerm_container_app" "test" {
 
     traffic_weight {
       latest_revision = true
-      percentage      = 20
-    }
-
-    traffic_weight {
-      revision_suffix = "rev1"
-      percentage      = 80
+      percentage      = 100
     }
   }
 
@@ -1875,6 +1747,97 @@ resource "azurerm_container_app" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, trafficBlock)
+}
+
+func (r ContainerAppResource) secretBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  secret {
+    name  = "foo"
+    value = "bar"
+  }
+
+  secret {
+    name  = "rick"
+    value = "morty"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) secretRemove(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  secret {
+    name  = "foo"
+    value = "bar"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) secretChangeName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  secret {
+    name  = "foo"
+    value = "bar"
+  }
+
+  secret {
+    name  = "pickle"
+    value = "morty"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r ContainerAppResource) trafficBlockMoreThanOne() string {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -345,8 +345,6 @@ An `ingress` block supports the following:
 
 * `traffic_weight` - (Required) One or more `traffic_weight` blocks as detailed below.
 
-~> **Note:** `traffic_weight` can only be specified when `revision_mode` is set to `Multiple`.
-
 * `transport` - (Optional) The transport method for the Ingress. Possible values are `auto`, `http`, `http2` and `tcp`. Defaults to `auto`.
 
 ---

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -343,7 +343,7 @@ An `ingress` block supports the following:
 
 ~> **Note:** `exposed_port` can only be specified when `transport` is set to `tcp`.
 
-* `traffic_weight` - (Required) A `traffic_weight` block as detailed below.
+* `traffic_weight` - (Required) One or more `traffic_weight` blocks as detailed below.
 
 ~> **Note:** `traffic_weight` can only be specified when `revision_mode` is set to `Multiple`.
 
@@ -370,6 +370,8 @@ A `traffic_weight` block supports the following:
 * `latest_revision` - (Optional) This traffic Weight relates to the latest stable Container Revision.
 
 * `revision_suffix` - (Optional) The suffix string to which this `traffic_weight` applies.
+
+~> **Note:** During creation, the `latest_revision` must be set to `true`, and the `revision_suffix` shall not be specified.
 
 * `percentage` - (Required) The percentage of traffic which should be sent this revision.
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -367,11 +367,11 @@ A `traffic_weight` block supports the following:
 
 * `label` - (Optional) The label to apply to the revision as a name prefix for routing traffic.
 
-* `latest_revision` - (Optional) This traffic Weight relates to the latest stable Container Revision.
+* `latest_revision` - (Optional) This traffic Weight applies to the latest stable Container Revision. At most only one `traffic_weight` block can have the `latest_revision` set to `true`.
 
 * `revision_suffix` - (Optional) The suffix string to which this `traffic_weight` applies.
 
-~> **Note:** During creation, the `latest_revision` must be set to `true`, and the `revision_suffix` shall not be specified.
+~> **Note:** `latest_revision` conflicts with `revision_suffix`, which means you shall either set `latest_revision` to `true` or specify `revision_suffix`. Especially for creation, there shall only be one `traffic_weight`, with the `latest_revision` set to `true`, and leave the `revision_suffix` empty.
 
 * `percentage` - (Required) The percentage of traffic which should be sent this revision.
 


### PR DESCRIPTION
This PR adds create/update time validation for the `azurerm_container_app`, in that:

- `latest_revision` (`true`) conflicts with `revision_suffix` (non-empty) in any case, but exactly one of them should be specified
- At most one `traffic_weight` can have `latest_revision` set to `true`. Especially for creation, the `latest_revision` has to be `true`, and only one `traffic_weight` block can be specified

This also removes a confusion line in the document saying that the `traffic_weight` can't be set if `revision_mode` is `Single`, since the `traffic_weight` is set to `Required` (I assume this is to prefer explicit, instead of either using the O+C trick, or let user specify it in the `ignore_changes`).

Fix #20435