### PR TITLE
provider: don't attempt to register unavailable RPs

### DIFF
--- a/internal/resourceproviders/requiring_registration.go
+++ b/internal/resourceproviders/requiring_registration.go
@@ -23,6 +23,7 @@ func DetermineWhichRequiredResourceProvidersRequireRegistration(requiredResource
 		if _, isUnregistered := (*unregisteredResourceProviders)[providerName]; !isUnregistered {
 			// some RPs may not exist in some non-public clouds, so we'll log a warning here instead of raising an error
 			log.Printf("[WARN] The required Resource Provider %q wasn't returned from the Azure API", providerName)
+			continue
 		}
 
 		requiringRegistration = append(requiringRegistration, providerName)


### PR DESCRIPTION
PR #23380 addressed issue #21785, but with that fix, when an unavailable resource provider was found, it would still be added to the list of providers to be registered, and then fail upon attempted registration.

Fixes #21785

This skips registration for providers which are neither registered nor unregistered.