### PR TITLE
`azurerm_tenant_template_deployment`, `azurerm_management_group_template_deployment`, `azurerm_subscription_template_deployment`, `azurerm_resource_group_template_deployment` - fix updating `template_spec_version_id`

### DIFF
--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -247,6 +247,10 @@ func managementGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, 
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
 			ID: utils.String(d.Get("template_spec_version_id").(string)),
 		}
+
+		if d.Get("template_spec_version_id").(string) != "" {
+			deployment.Properties.Template = nil
+		}
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -242,6 +242,10 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, me
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
 			ID: utils.String(d.Get("template_spec_version_id").(string)),
 		}
+
+		if d.Get("template_spec_version_id").(string) != "" {
+			deployment.Properties.Template = nil
+		}
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -232,6 +232,10 @@ func subscriptionTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, met
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
 			ID: utils.String(d.Get("template_spec_version_id").(string)),
 		}
+
+		if d.Get("template_spec_version_id").(string) != "" {
+			deployment.Properties.Template = nil
+		}
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -233,6 +233,10 @@ func tenantTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, meta inte
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
 			ID: utils.String(d.Get("template_spec_version_id").(string)),
 		}
+
+		if d.Get("template_spec_version_id").(string) != "" {
+			deployment.Properties.Template = nil
+		}
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/24050
fix while updating `template_spec_version_id`, the `deployment.Properties.Template` and `deployment.Properties.TemplateLink` are both set in the API request, results to a conflict.

My local test can work, but to reproduce the update in acctest, seems we need to create a new template spec in the test sub with different version as the one defined in https://github.com/hashicorp/terraform-provider-azurerm/blob/2d85390a1d3f7c900409e23cdfd767f9165d3fec/internal/services/resource/resource_group_template_deployment_resource_test.go#L374-L379