### PR TITLE
`azurerm_cosmosdb_cassandra_datacenter` - expose `seed_node_ip_addresses` property

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -114,8 +114,7 @@ func resourceCassandraDatacenter() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: validation.IsIPv4Address,
+					Type: pluginsdk.TypeString,
 				},
 			},
 		},

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -109,6 +109,15 @@ func resourceCassandraDatacenter() *pluginsdk.Resource {
 				Optional: true,
 				Default:  true,
 			},
+
+			"seed_node_ip_addresses": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.IsIPv4Address,
+				},
+			},
 		},
 	}
 
@@ -226,6 +235,10 @@ func resourceCassandraDatacenterRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("disk_sku", props.DiskSku)
 			d.Set("sku_name", props.Sku)
 			d.Set("availability_zones_enabled", props.AvailabilityZone)
+
+			if err := d.Set("seed_node_ip_addresses", flattenCassandraDatacenterSeedNodes(props.SeedNodes)); err != nil {
+				return fmt.Errorf("setting `seed_node_ip_addresses`: %+v", err)
+			}
 		}
 	}
 	return nil
@@ -318,4 +331,19 @@ func cassandraDatacenterStateRefreshFunc(ctx context.Context, client *managedcas
 		}
 		return nil, "", fmt.Errorf("unable to read provisioning state")
 	}
+}
+
+func flattenCassandraDatacenterSeedNodes(input *[]managedcassandras.SeedNode) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		if item.IPAddress != nil {
+			results = append(results, item.IPAddress)
+		}
+	}
+
+	return results
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -29,6 +29,7 @@ func testAccCassandraDatacenter_basic(t *testing.T) {
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("seed_node_ip_addresses.#").HasValue("3"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -29,7 +29,6 @@ func testAccCassandraDatacenter_basic(t *testing.T) {
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").IsNotEmpty(),
-				check.That(data.ResourceName).Key("seed_node_ip_addresses").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -29,6 +29,7 @@ func testAccCassandraDatacenter_basic(t *testing.T) {
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("seed_node_ip_addresses").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
@@ -12,16 +12,16 @@ import (
 func TestAccCassandraSequential(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to all below TCs sharing same sp
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
-		//"cluster": {
-		//	"basic":          testAccCassandraCluster_basic,
-		//	"complete":       testAccCassandraCluster_complete,
-		//	"update":         testAccCassandraCluster_update,
-		//	"requiresImport": testAccCassandraCluster_requiresImport,
-		//},
+		"cluster": {
+			"basic":          testAccCassandraCluster_basic,
+			"complete":       testAccCassandraCluster_complete,
+			"update":         testAccCassandraCluster_update,
+			"requiresImport": testAccCassandraCluster_requiresImport,
+		},
 		"dataCenter": {
-			"basic": testAccCassandraDatacenter_basic,
-			//"update":    testAccCassandraDatacenter_update,
-			//"updateSku": testAccCassandraDatacenter_updateSku,
+			"basic":     testAccCassandraDatacenter_basic,
+			"update":    testAccCassandraDatacenter_update,
+			"updateSku": testAccCassandraDatacenter_updateSku,
 		},
 	})
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
@@ -12,16 +12,16 @@ import (
 func TestAccCassandraSequential(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to all below TCs sharing same sp
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
-		"cluster": {
-			"basic":          testAccCassandraCluster_basic,
-			"complete":       testAccCassandraCluster_complete,
-			"update":         testAccCassandraCluster_update,
-			"requiresImport": testAccCassandraCluster_requiresImport,
-		},
+		//"cluster": {
+		//	"basic":          testAccCassandraCluster_basic,
+		//	"complete":       testAccCassandraCluster_complete,
+		//	"update":         testAccCassandraCluster_update,
+		//	"requiresImport": testAccCassandraCluster_requiresImport,
+		//},
 		"dataCenter": {
-			"basic":     testAccCassandraDatacenter_basic,
-			"update":    testAccCassandraDatacenter_update,
-			"updateSku": testAccCassandraDatacenter_updateSku,
+			"basic": testAccCassandraDatacenter_basic,
+			//"update":    testAccCassandraDatacenter_update,
+			//"updateSku": testAccCassandraDatacenter_updateSku,
 		},
 	})
 }

--- a/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
@@ -112,6 +112,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Cassandra Datacenter.
 
+* `seed_node_ip_address` - A list of IP Address for the seed nodes in this Cassandra Datacenter. 
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
@@ -112,7 +112,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Cassandra Datacenter.
 
-* `seed_node_ip_address` - A list of IP Address for the seed nodes in this Cassandra Datacenter. 
+* `seed_node_ip_addresses` - A list of IP Address for the seed nodes in this Cassandra Datacenter. 
 
 ## Timeouts
 


### PR DESCRIPTION
Service team and customer is requesting the feature of exposing the property "seed_node_ip_addresses".

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/374f6bdf-200f-4a39-8041-d577ed9ffe54)
