### PR TITLE
[Bug fix] - `azurerm_pim_active_role_assignment` and `azurerm_pim_eligible_role_assignment` - Filter role assignment on scope 

### DIFF
--- a/internal/services/authorization/pim_active_role_assignment_resource.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	// nolint: staticcheck
@@ -180,7 +181,8 @@ func (r PimActiveRoleAssignmentResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("listing role assignments on scope %s: %+v", id, err)
 			}
 			for _, item := range items.Items {
-				if *item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect {
+				if *item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect &&
+					strings.EqualFold(*item.Properties.Scope, id.Scope) {
 					return metadata.ResourceRequiresImport(r.ResourceType(), id)
 				}
 			}
@@ -262,8 +264,10 @@ func (r PimActiveRoleAssignmentResource) Read() sdk.ResourceFunc {
 			}
 			var instance *roleassignmentscheduleinstances.RoleAssignmentScheduleInstance
 			for _, item := range items.Items {
-				if *item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect {
+				if *item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect &&
+					strings.EqualFold(*item.Properties.Scope, id.Scope) {
 					instance = &item
+					break
 				}
 			}
 			if instance == nil {
@@ -629,9 +633,11 @@ func waitForActiveRoleAssignment(ctx context.Context, client *roleassignmentsche
 
 		for _, item := range items.Items {
 			if *item.Properties.RoleDefinitionId == roleDefinitionId &&
-				*item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect {
+				*item.Properties.MemberType == roleassignmentscheduleinstances.MemberTypeDirect &&
+				strings.EqualFold(*item.Properties.Scope, scope) {
 				state = "Found"
 				result = item
+				break
 			}
 		}
 

--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	// nolint: staticcheck
@@ -180,7 +181,8 @@ func (r PimEligibleRoleAssignmentResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("listing role assignments on scope %s: %+v", id, err)
 			}
 			for _, item := range items.Items {
-				if *item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect {
+				if *item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect &&
+					strings.EqualFold(*item.Properties.Scope, id.Scope) {
 					return metadata.ResourceRequiresImport(r.ResourceType(), id)
 				}
 			}
@@ -262,8 +264,10 @@ func (r PimEligibleRoleAssignmentResource) Read() sdk.ResourceFunc {
 			}
 			var instance *roleeligibilityscheduleinstances.RoleEligibilityScheduleInstance
 			for _, item := range items.Items {
-				if *item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect {
+				if *item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect &&
+					strings.EqualFold(*item.Properties.Scope, id.Scope) {
 					instance = &item
+					break
 				}
 			}
 			if instance == nil {
@@ -629,9 +633,11 @@ func waitForEligibleRoleAssignmentSchedule(ctx context.Context, client *roleelig
 
 		for _, item := range items.Items {
 			if *item.Properties.RoleDefinitionId == roleDefinitionId &&
-				*item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect {
+				*item.Properties.MemberType == roleeligibilityscheduleinstances.MemberTypeDirect &&
+				strings.EqualFold(*item.Properties.Scope, scope) {
 				state = "Found"
 				result = item
+				break
 			}
 		}
 


### PR DESCRIPTION
Fixes #23111 
The low level resource role assignments can be obtained by the upper level resources, the role assignment should filtered by the `principal ID`, `role definition ID` and `scope`, otherwise the role assignment will treated as assigned but actually not.