### PR TITLE
azurerm_synapse_role_assignment: New parameter `principal_type`

### DIFF
--- a/internal/services/synapse/synapse_role_assignment_resource.go
+++ b/internal/services/synapse/synapse_role_assignment_resource.go
@@ -70,6 +70,17 @@ func resourceSynapseRoleAssignment() *pluginsdk.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 
+			"principal_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"User",
+					"Group",
+					"ServicePrincipal",
+				}, false),
+			},
+
 			"role_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
@@ -165,6 +176,12 @@ func resourceSynapseRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interfa
 		PrincipalID: &principalID,
 		Scope:       utils.String(scope),
 	}
+
+	if v, ok := d.GetOk("principal_type"); ok {
+		principalType := v.(string)
+		roleAssignment.PrincipalType = &principalType
+	}
+
 	resp, err := client.CreateRoleAssignment(ctx, roleAssignment, uuid)
 	if err != nil {
 		return fmt.Errorf("creating Synapse RoleAssignment %q: %+v", roleName, err)
@@ -224,6 +241,12 @@ func resourceSynapseRoleAssignmentRead(d *pluginsdk.ResourceData, meta interface
 		principalID = resp.PrincipalID.String()
 	}
 	d.Set("principal_id", principalID)
+
+	principalType := ""
+	if resp.PrincipalType != nil {
+		principalType = *resp.PrincipalType
+	}
+	d.Set("principal_type", principalType)
 
 	synapseWorkspaceId := ""
 	synapseSparkPoolId := ""

--- a/website/docs/r/synapse_role_assignment.html.markdown
+++ b/website/docs/r/synapse_role_assignment.html.markdown
@@ -82,6 +82,10 @@ The following arguments are supported:
 
 * `principal_id` - (Required) The ID of the Principal (User, Group or Service Principal) to assign the Synapse Role Definition to. Changing this forces a new resource to be created.
 
+* `principal_type` (Optional) The Type of the Principal. One of `User`, `Group` or `ServicePrincipal`. Changing this forces a new resource to be created.
+
+-> **NOTE:** While `principal_type` is optional, it's still recommended to set this value, as some Synapse use-cases may not work correctly if this is not specified. Service Principals for example can't run SQL statements using `Entra ID` authentication if `principal_type` is not set to `ServicePrincipal`.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
Some Synapse use-cases are not working if we don't specify the type of the principal during the role assignment, therefore this PR allows us set the property via `principal_type`.

One use case that is not working for us:
If the `principalType` is not set in Azure (aka `null`), we couldn't authenticate to the SQL DBs with a Bearer token.
We found out that the SIDs are not set correctly if the principalType is not set to `ServicePrincipal`.

I thought about detecting the type automatically, but this could cause issues in multi tenant scenarios.