### PR TITLE
#24087 : Return error when use_system_assigned_identity and user_assigned_identity_id are set in azurerm_recovery_services_vault resource

### DIFF
--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -86,7 +86,7 @@ An `encryption` block supports the following:
 
 * `user_assigned_identity_id` - (Optional) Specifies the user assigned identity ID to be used.
 
-* `use_system_assigned_identity` - (Optional) Indicate that system assigned identity should be used or not. Defaults to `true`.
+* `use_system_assigned_identity` - (Optional) Indicate that system assigned identity should be used or not. Defaults to `true`. Must be set to `false` when `user_assigned_identity_id` is set.
 
 !> **Note:** `use_system_assigned_identity` only be able to set to `false` for **new** vaults. Any vaults containing existing items registered or attempted to be registered to it are not supported. Details can be found in [the document](https://learn.microsoft.com/en-us/azure/backup/encryption-at-rest-with-cmk?tabs=portal#before-you-start)
 


### PR DESCRIPTION
Disable `use_system_assigned_identity` to `false` when `user_assigned_identity_id` is set in `encryption` block. 

Targeting the fix of #24087