### PR TITLE
`azurerm_redis_cache` - support `storage_account_subscription_id` property

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -158,6 +158,10 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
+						"storage_account_subscription_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -224,6 +224,11 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Optional: true,
 							Default:  true,
 						},
+						"storage_account_subscription_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsUUID,
+						},
 					},
 				},
 			},
@@ -883,6 +888,10 @@ func expandRedisConfiguration(d *pluginsdk.ResourceData) (*redis.RedisCommonProp
 		value := isAuthNotRequiredAsString(authEnabled)
 		output.Authnotrequired = utils.String(value)
 	}
+
+	if v := raw["storage_account_subscription_id"].(string); v != "" {
+		output.StorageSubscriptionId = pointer.To(v)
+	}
 	return output, nil
 }
 
@@ -1020,6 +1029,8 @@ func flattenRedisConfiguration(input *redis.RedisCommonPropertiesRedisConfigurat
 	if v := input.Authnotrequired; v != nil {
 		outputs["enable_authentication"] = isAuthRequiredAsBool(*v)
 	}
+
+	outputs["storage_account_subscription_id"] = pointer.From(input.StorageSubscriptionId)
 
 	return []interface{}{outputs}, nil
 }

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -808,13 +808,14 @@ resource "azurerm_redis_cache" "test" {
   enable_non_ssl_port = false
 
   redis_configuration {
-    rdb_backup_enabled            = true
-    rdb_backup_frequency          = 60
-    rdb_backup_max_snapshot_count = 1
-    rdb_storage_connection_string = azurerm_storage_account.test.primary_connection_string
+    rdb_backup_enabled              = true
+    rdb_backup_frequency            = 60
+    rdb_backup_max_snapshot_count   = 1
+    rdb_storage_connection_string   = azurerm_storage_account.test.primary_connection_string
+    storage_account_subscription_id = "%s"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.Client().SubscriptionID)
 }
 
 func (RedisCacheResource) aofBackupDisabled(data acceptance.TestData) string {

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -108,6 +108,8 @@ A `redis_configuration` block exports the following:
 
 ~> **Note:** There's a bug in the Redis API where the original storage connection string isn't being returned, which [is being tracked in this issue](https://github.com/Azure/azure-rest-api-specs/issues/3037). In the interim you can use [the `ignore_changes` attribute to ignore changes to this field](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changess) e.g.:
 
+* `storage_account_subscription_id` - The ID of the Subscription containing the Storage Account.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -156,6 +156,8 @@ redis_configuration {
 
 ~> **NOTE:** There's a bug in the Redis API where the original storage connection string isn't being returned, which [is being tracked in this issue](https://github.com/Azure/azure-rest-api-specs/issues/3037). In the interim you can use [the `ignore_changes` attribute to ignore changes to this field](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changess) e.g.:
 
+* `storage_account_subscription_id` - (Optional) The ID of the Subscription containing the Storage Account.
+
 ```hcl
 resource "azurerm_redis_cache" "example" {
   # ...


### PR DESCRIPTION
Support [storage-subscription-id ](https://github.com/Azure/azure-rest-api-specs/blob/cb798ffa99c193a88388f358965f377fde3699e8/specification/redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json#L1968C20-L1968C20) for resource `azurerm_redis_cache`.

Test result:
PASS: TestAccRedisCache_BackupEnabled (1250.69s)
