### PR TITLE
#24906 : Change of condition to fix panics of azurerm_app_service_custom_hostname_binding

### DIFF
--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -104,7 +104,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if existing.ID != nil && *existing.ID != "" {
 			return tf.ImportAsExistsError("azurerm_app_service_custom_hostname_binding", *existing.ID)
 		}
 	}


### PR DESCRIPTION
Change of condition to fix panics during import of non-existing resources. My guess is that Azure API sometimes doesn't reliable gives the information of ARM resources due to eventual consistency (some lag in replicating ARM metadata to other Azure regions). 

Doesn't happen always but intermittently. 

The snippet is copied from various resources. One example [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/83be143cdc3d35d366eae54fa1f35e16f9f7e20a/internal/services/policy/exemption_resource.go#L123-L125).

Fixes #24096