### PR TITLE
`azurerm_spring_cloud_api_portal` - split to create/update functions

### DIFF
--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -144,7 +144,7 @@ func resourceSpringCloudAPIPortalCreate(d *pluginsdk.ResourceData, meta interfac
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for existing %s: %+v", id, err)
+			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 	}
 	if !utils.ResponseWasNotFound(existing.Response) {
@@ -153,10 +153,10 @@ func resourceSpringCloudAPIPortalCreate(d *pluginsdk.ResourceData, meta interfac
 
 	service, err := servicesClient.Get(ctx, springId.ResourceGroup, springId.SpringName)
 	if err != nil {
-		return fmt.Errorf("checking for presence of existing Spring Cloud Service %q (Resource Group %q): %+v", springId.SpringName, springId.ResourceGroup, err)
+		return fmt.Errorf("checking for presence of existing %s: %+v", springId, err)
 	}
 	if service.Sku == nil || service.Sku.Name == nil || service.Sku.Tier == nil {
-		return fmt.Errorf("invalid `sku` for Spring Cloud Service %q (Resource Group %q)", springId.SpringName, springId.ResourceGroup)
+		return fmt.Errorf("invalid `sku` for %s", springId)
 	}
 
 	apiPortalResource := appplatform.APIPortalResource{
@@ -174,11 +174,11 @@ func resourceSpringCloudAPIPortalCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
+		return fmt.Errorf("waiting for update of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -200,20 +200,20 @@ func resourceSpringCloudAPIPortalUpdate(d *pluginsdk.ResourceData, meta interfac
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("retreiving %s: %+v", id, err)
+			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 	}
 	if utils.ResponseWasNotFound(existing.Response) {
-		return fmt.Errorf("retreiving %s: resource was not found", id)
+		return fmt.Errorf("retrieving %s: resource was not found", id)
 	}
 
 	if existing.Properties == nil {
-		return fmt.Errorf("retreiving %s: properties are nil", id)
+		return fmt.Errorf("retrieving %s: properties are nil", id)
 	}
 	properties := existing.Properties
 
 	if existing.Sku == nil {
-		return fmt.Errorf("retreiving %s: sku is nil", id)
+		return fmt.Errorf("retrieving %s: sku is nil", id)
 	}
 	sku := existing.Sku
 
@@ -243,11 +243,11 @@ func resourceSpringCloudAPIPortalUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
+		return fmt.Errorf("waiting for update of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/migration"
@@ -22,9 +23,9 @@ import (
 
 func resourceSpringCloudAPIPortal() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceSpringCloudAPIPortalCreateUpdate,
+		Create: resourceSpringCloudAPIPortalCreate,
 		Read:   resourceSpringCloudAPIPortalRead,
-		Update: resourceSpringCloudAPIPortalCreateUpdate,
+		Update: resourceSpringCloudAPIPortalUpdate,
 		Delete: resourceSpringCloudAPIPortalDelete,
 
 		SchemaVersion: 1,
@@ -126,7 +127,8 @@ func resourceSpringCloudAPIPortal() *pluginsdk.Resource {
 		},
 	}
 }
-func resourceSpringCloudAPIPortalCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+
+func resourceSpringCloudAPIPortalCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).AppPlatform.APIPortalClient
 	servicesClient := meta.(*clients.Client).AppPlatform.ServicesClient
@@ -139,16 +141,14 @@ func resourceSpringCloudAPIPortalCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 	id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
-		}
+	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_spring_cloud_api_portal", id.ID())
+			return fmt.Errorf("checking for existing %s: %+v", id, err)
 		}
+	}
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_spring_cloud_api_portal", id.ID())
 	}
 
 	service, err := servicesClient.Get(ctx, springId.ResourceGroup, springId.SpringName)
@@ -171,6 +171,75 @@ func resourceSpringCloudAPIPortalCreateUpdate(d *pluginsdk.ResourceData, meta in
 			Tier:     service.Sku.Tier,
 			Capacity: utils.Int32(int32(d.Get("instance_count").(int))),
 		},
+	}
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceSpringCloudAPIPortalRead(d, meta)
+}
+
+func resourceSpringCloudAPIPortalUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).AppPlatform.APIPortalClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	springId, err := parse.SpringCloudServiceID(d.Get("spring_cloud_service_id").(string))
+	if err != nil {
+		return err
+	}
+	id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, d.Get("name").(string))
+
+	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("retreiving %s: %+v", id, err)
+		}
+	}
+	if utils.ResponseWasNotFound(existing.Response) {
+		return fmt.Errorf("retreiving %s: resource was not found", id)
+	}
+
+	if existing.Properties == nil {
+		return fmt.Errorf("retreiving %s: properties are nil", id)
+	}
+	properties := existing.Properties
+
+	if existing.Sku == nil {
+		return fmt.Errorf("retreiving %s: sku is nil", id)
+	}
+	sku := existing.Sku
+
+	if d.HasChange("gateway_ids") {
+		properties.GatewayIds = utils.ExpandStringSlice(d.Get("gateway_ids").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("https_only_enabled") {
+		properties.HTTPSOnly = pointer.To(d.Get("https_only_enabled").(bool))
+	}
+
+	if d.HasChange("public_network_access_enabled") {
+		properties.Public = pointer.To(d.Get("public_network_access_enabled").(bool))
+	}
+
+	if d.HasChange("sso") {
+		properties.SsoProperties = expandAPIPortalSsoProperties(d.Get("sso").([]interface{}))
+	}
+
+	if d.HasChange("instance_count") {
+		sku.Capacity = pointer.To(int32(d.Get("instance_count").(int)))
+	}
+
+	apiPortalResource := appplatform.APIPortalResource{
+		Properties: properties,
+		Sku:        sku,
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
 	if err != nil {


### PR DESCRIPTION
```
=== RUN   TestAccSpringCloudAPIPortal_basic
=== PAUSE TestAccSpringCloudAPIPortal_basic
=== CONT  TestAccSpringCloudAPIPortal_basic
=== RUN   TestAccSpringCloudAPIPortal_requiresImport
=== PAUSE TestAccSpringCloudAPIPortal_requiresImport
=== CONT  TestAccSpringCloudAPIPortal_requiresImport
=== RUN   TestAccSpringCloudAPIPortal_complete
=== PAUSE TestAccSpringCloudAPIPortal_complete
=== CONT  TestAccSpringCloudAPIPortal_complete
=== RUN   TestAccSpringCloudAPIPortal_update
=== PAUSE TestAccSpringCloudAPIPortal_update
=== CONT  TestAccSpringCloudAPIPortal_update
--- PASS: TestAccSpringCloudAPIPortal_requiresImport (846.38s)
--- PASS: TestAccSpringCloudAPIPortal_update (849.44s)
--- PASS: TestAccSpringCloudAPIPortal_complete (904.65s)
--- PASS: TestAccSpringCloudAPIPortal_basic (1033.62s)
PASS

```