### PR TITLE
certificate_id an optional argument of azurerm_container_app resource

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -331,8 +331,9 @@ func ContainerAppIngressCustomDomainSchema() *pluginsdk.Schema {
 
 				"certificate_id": {
 					Type:         pluginsdk.TypeString,
-					Required:     true,
+					Optional:     true,
 					ValidateFunc: managedenvironments.ValidateCertificateID,
+					Description:  "The ID of the Certificate. Only to be passed when `certificate_binding_type` is set to `SniEnabled`",
 				},
 
 				"name": {
@@ -382,11 +383,16 @@ func expandContainerAppIngressCustomDomain(input []CustomDomain) *[]containerapp
 	result := make([]containerapps.CustomDomain, 0)
 	for _, v := range input {
 		customDomain := containerapps.CustomDomain{
-			Name:          v.Name,
-			CertificateId: pointer.To(v.CertificateId),
+			Name: v.Name,
 		}
 		bindingType := containerapps.BindingType(v.CertBinding)
 		customDomain.BindingType = &bindingType
+
+		// certificate_id is only need for sni domains according to
+		// https://learn.microsoft.com/en-us/azure/container-apps/custom-domains-certificates
+		if bindingType == containerapps.BindingTypeSniEnabled {
+			customDomain.CertificateId = pointer.To(v.CertificateId)
+		}
 
 		result = append(result, customDomain)
 	}

--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -104,7 +104,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_app_service_custom_hostname_binding", *existing.ID)
 		}
 	}

--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -104,7 +104,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if existing.ID != nil && *existing.ID != "" {
 			return tf.ImportAsExistsError("azurerm_app_service_custom_hostname_binding", *existing.ID)
 		}
 	}

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -355,7 +355,7 @@ A `custom_domain` block supports the following:
 
 * `certificate_binding_type` - (Optional) The Binding type. Possible values include `Disabled` and `SniEnabled`. Defaults to `Disabled`.
 
-* `certificate_id` - (Required) The ID of the Container App Environment Certificate.
+* `certificate_id` - (Optional) The ID of the Container App Environment Certificate. Only to be passed when `certificate_binding_type` is set to `SniEnabled`.
 
 * `name` - (Required) The hostname of the Certificate. Must be the CN or a named SAN in the certificate.
 


### PR DESCRIPTION
This fixes #24110 

Current `azurerm_container_app` resource has `ingress` block which has `custom_domain` which mandates `certificate_id` to be a required field even when `certificate_binding_type` set to `Disabled` by default. This contradicts with the documentation [here](https://learn.microsoft.com/en-us/azure/container-apps/custom-domains-managed-certificates?pivots=azure-portal) for Azure managed certificates. 

This PR aims to set `certificate_id` as `Optional` & only required when `certificate_binding_type` set to `SniEnabled`. 