### PR TITLE
azurerm_mssql_server_microsoft_support_auditing_policy - only include storage endpoint in payload if set

### DIFF
--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
@@ -112,9 +112,12 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicyCreateUpdate(d *pluginsdk.
 
 	params := sql.ServerDevOpsAuditingSettings{
 		ServerDevOpsAuditSettingsProperties: &sql.ServerDevOpsAuditSettingsProperties{
-			StorageEndpoint:             utils.String(d.Get("blob_storage_endpoint").(string)),
 			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
 		},
+	}
+
+	if v := d.Get("blob_storage_endpoint").(string); v != "" {
+		params.ServerDevOpsAuditSettingsProperties.StorageEndpoint = utils.String(v)
 	}
 
 	if d.Get("enabled").(bool) {


### PR DESCRIPTION
fixes

```
Error: updataing managed instance security alert policy: sql.ManagedServerSecurityAlertPoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="DataSecurityInvalidUserSuppliedParameter" Message="storageAccountAccessKey parameter can not be null when storageEndpoint parameter is not null\r\nParameter name: storageAccountAccessKey"
│
│   with azurerm_mssql_managed_instance_security_alert_policy.example,
│   on main.tf line 201, in resource "azurerm_mssql_managed_instance_security_alert_policy" "example":
│    1: resource "azurerm_mssql_managed_instance_security_alert_policy" "example" {
```