### PR TITLE
azurerm_vmware_private_cloud and azurerm_vmware_cluster adding new skus to validation-#24126

### DIFF
--- a/internal/services/vmware/vmware_cluster_resource.go
+++ b/internal/services/vmware/vmware_cluster_resource.go
@@ -70,7 +70,10 @@ func resourceVmwareCluster() *pluginsdk.Resource {
 					"av36",
 					"av36t",
 					"av36p",
+					"av36pt",
 					"av52",
+					"av52t",
+					"av64",
 				}, false),
 			},
 

--- a/internal/services/vmware/vmware_private_cloud_resource.go
+++ b/internal/services/vmware/vmware_private_cloud_resource.go
@@ -63,7 +63,10 @@ func resourceVmwarePrivateCloud() *pluginsdk.Resource {
 					"av36",
 					"av36t",
 					"av36p",
+					"av36pt",
 					"av52",
+					"av52t",
+					"av64",
 				}, false),
 			},
 

--- a/website/docs/r/vmware_cluster.html.markdown
+++ b/website/docs/r/vmware_cluster.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `cluster_node_count` - (Required) The count of the VMware Cluster nodes.
 
-* `sku_name` - (Required) The cluster SKU to use. Possible values are `av20`, `av36`, `av36t`, `av36p` and `av52`. Changing this forces a new VMware Cluster to be created.
+* `sku_name` - (Required) The cluster SKU to use. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new VMware Cluster to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/vmware_private_cloud.html.markdown
+++ b/website/docs/r/vmware_private_cloud.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `network_subnet_cidr` - (Required) The subnet which should be unique across virtual network in your subscription as well as on-premise. Changing this forces a new VMware Private Cloud to be created.
 
-* `sku_name` - (Required) The Name of the SKU used for this Private Cloud. Possible values are `av20`, `av36`, `av36t`, `av36p` and `av52`. Changing this forces a new VMware Private Cloud to be created.
+* `sku_name` - (Required) The Name of the SKU used for this Private Cloud. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new VMware Private Cloud to be created.
 
 * `internet_connection_enabled` - (Optional) Is the Private Cluster connected to the internet? This field can not updated with `management_cluster.0.size` together.
 ~> **NOTE :** `internet_connection_enabled` and `management_cluster.0.size` cannot be updated at the same time.


### PR DESCRIPTION
Updated azurerm_vmware_private_cloud and azurerm_vmware_cluster sku_name validator function to allow the latest trial and av64 sku's.  

As AVS is a very expensive resource and requires quota for deployments, I don't have a subscription where I can do acceptance testing on the changes. Since the test deploys the av36 test they won't properly test the new sku's anyway. These were simple list updates on the two provider files to ensure the new skus pass validation.

Addresses issue - https://github.com/hashicorp/terraform-provider-azurerm/issues/24126