### PR TITLE
`azurerm_container_registry` - Deprecate `network_rule_set.virtual_network`

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -899,7 +900,7 @@ func flattenExportPolicy(p *registries.Policies) bool {
 }
 
 func resourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -1045,6 +1046,7 @@ func resourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 					},
 
 					"virtual_network": {
+						Deprecated: " This is only used exclusively for service endpoints (which is a feature being deprecated). Users are expected to use Private Endpoints instead",
 						Type:       pluginsdk.TypeSet,
 						Optional:   true,
 						ConfigMode: pluginsdk.SchemaConfigModeAttr,
@@ -1149,4 +1151,10 @@ func resourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
+
+	if features.FourPointOhBeta() {
+		delete(schema["network_rule_set"].Elem.(*pluginsdk.Resource).Schema, "virtual_network")
+	}
+
+	return schema
 }

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -203,8 +203,6 @@ The `network_rule_set` block supports the following:
 
 * `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.
 
-* `virtual_network` - (Optional) One or more `virtual_network` blocks as defined below.
-
 ~> **NOTE:** `network_rule_set` is only supported with the `Premium` SKU at this time.
 
 ~> **NOTE:** Azure automatically configures Network Rules - to remove these you'll need to specify an `network_rule_set` block with `default_action` set to `Deny`.
@@ -216,14 +214,6 @@ The `ip_rule` block supports the following:
 * `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
 
 * `ip_range` - (Required) The CIDR block from which requests will match the rule.
-
----
-
-The `virtual_network` block supports the following:
-
-* `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
-
-* `subnet_id` - (Required) The subnet id from which requests will match the rule.
 
 ---
 


### PR DESCRIPTION
`azurerm_container_registry` - Deprecate `network_rule_set.virtual_network`.

This PR is a preparation for https://github.com/hashicorp/terraform-provider-azurerm/pull/23393.