### PR TITLE
Connections object needs to be treated differently

### DIFF
--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -654,9 +654,15 @@ func expandLogicAppWorkflowParameters(input map[string]interface{}, paramDefs ma
 			value = v
 		}
 
-		output[k] = workflows.WorkflowParameter{
-			Type:  &t,
-			Value: &value,
+		if k == "$connections" {
+			output[k] = workflows.WorkflowParameter{
+				Value: &value,
+			}
+		} else {
+			output[k] = workflows.WorkflowParameter{
+				Type:  &t,
+				Value: &value,
+			}
 		}
 	}
 

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -447,11 +447,6 @@ resource "azurerm_logic_app_workflow" "test" {
       foo = "foo"
     })
     "$connections" : jsonencode({
-      "smtp" : {
-        "connectionId" : "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Web/connections/zzz",
-        "connectionName" : "smtp",
-        "id" : "/subscriptions/xxx/providers/Microsoft.Web/locations/yyy/managedApis/smtp"
-      }
     })
   }
 }

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -422,6 +422,9 @@ resource "azurerm_logic_app_workflow" "test" {
     secobj = jsonencode({
       type = "SecureObject"
     })
+    $connections = jsonencode({
+      type = "Object"
+    })
   }
 
   parameters = {
@@ -442,6 +445,13 @@ resource "azurerm_logic_app_workflow" "test" {
     secstr = "value"
     secobj = jsonencode({
       foo = "foo"
+    })
+    "$connections": jsonencode({
+      "smtp": {
+        "connectionId": "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Web/connections/zzz",
+        "connectionName": "smtp",
+        "id": "/subscriptions/xxx/providers/Microsoft.Web/locations/yyy/managedApis/smtp"
+      }
     })
   }
 }

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -422,7 +422,7 @@ resource "azurerm_logic_app_workflow" "test" {
     secobj = jsonencode({
       type = "SecureObject"
     })
-    $connections = jsonencode({
+    "$connections" = jsonencode({
       type = "Object"
     })
   }
@@ -446,11 +446,11 @@ resource "azurerm_logic_app_workflow" "test" {
     secobj = jsonencode({
       foo = "foo"
     })
-    "$connections": jsonencode({
-      "smtp": {
-        "connectionId": "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Web/connections/zzz",
-        "connectionName": "smtp",
-        "id": "/subscriptions/xxx/providers/Microsoft.Web/locations/yyy/managedApis/smtp"
+    "$connections" : jsonencode({
+      "smtp" : {
+        "connectionId" : "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Web/connections/zzz",
+        "connectionName" : "smtp",
+        "id" : "/subscriptions/xxx/providers/Microsoft.Web/locations/yyy/managedApis/smtp"
       }
     })
   }


### PR DESCRIPTION
When the `$connections` parameter is added the API connection for Service Bus Receive don't work.  This is the only change I needed to make to fix permissions in the Azure portal to get them working.  I'm not sure if this is the best route, but it is the first I came up with.  Type is not a required parameter in the Go SDK, but is being required by this function in the Terraform Provider. 

I have filed an issue with Azure support, but don't have high hopes that the issue will be fixed on that side.

Other possible solutions:

- Add flag that could specify not to add the Type attribute
- Add a parameter that silently specifies the type, but is not sent to the API