### PR TITLE
Revert "`azurerm_storage_account`: Plan time name validation (#23799)"

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	azautorest "github.com/Azure/go-autorest/autorest"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -1230,25 +1229,6 @@ func resourceStorageAccount() *pluginsdk.Resource {
 		},
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
-				client := v.(*clients.Client).Storage.AccountsClient
-				// The `name` only changes for the new resource creation scenario, in which case we will further check the name availability.
-				if d.HasChange("name") {
-					_, name := d.GetChange("name")
-					resp, err := client.CheckNameAvailability(ctx, storage.AccountCheckNameAvailabilityParameters{
-						Name: pointer.To(name.(string)),
-						Type: pointer.To("Microsoft.Storage/storageAccounts"),
-					})
-					if err != nil {
-						return err
-					}
-					if ok := resp.NameAvailable; ok != nil && !(*ok) {
-						errmsg := fmt.Sprintf("`name` is not available: [%s]", resp.Reason)
-						if msg := resp.Message; msg != nil {
-							errmsg += " " + *msg
-						}
-						return fmt.Errorf(errmsg)
-					}
-				}
 				if d.HasChange("account_kind") {
 					accountKind, changedKind := d.GetChange("account_kind")
 


### PR DESCRIPTION
This reverts commit 828f8cfbb8157f05d22cb5c87682751dc1ab32b4.

Fix: https://github.com/hashicorp/terraform-provider-azurerm/issues/24113

The reason to revert the PR is that if the resource is tainted and marked to be replaced, the `CustomizeDiff` will be invoked during the next terraform plan/apply, and complaining the name has existed, since the resource hasn't be deleted yet. I've tried to find whether there is anything we can use during the `CustomizeDiff` to see whether this is a replacement operation, but I didn't manage to find one:
- No suspicious property found in the protocol: https://github.com/hashicorp/terraform-plugin-go/blob/60527eec1cda096a2d5a3da0fe82b575026be807/tfprotov5/internal/tfplugin5/tfplugin5.proto#L311
- Tried to get the prior state, but for this case it is nil at that point (same as a new creation)