### PR TITLE
`azurerm_virtual_machine_data_disk_attachment`: Ignore VM applications

### DIFF
--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
@@ -175,6 +175,8 @@ func resourceVirtualMachineDataDiskAttachmentCreateUpdate(d *pluginsdk.ResourceD
 	virtualMachine.Identity = nil
 	// fixes #1600
 	virtualMachine.Resources = nil
+	// fixes #24145
+	virtualMachine.ApplicationProfile = nil
 
 	// if there's too many disks we get a 409 back with:
 	//   `The maximum number of data disks allowed to be attached to a VM of this size is 1.`
@@ -284,6 +286,8 @@ func resourceVirtualMachineDataDiskAttachmentDelete(d *pluginsdk.ResourceData, m
 	virtualMachine.Identity = nil
 	// fixes #1600
 	virtualMachine.Resources = nil
+	// fixes #24145
+	virtualMachine.ApplicationProfile = nil
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineName, virtualMachine)
 	if err != nil {

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
@@ -191,6 +191,25 @@ func TestAccVirtualMachineDataDiskAttachment_virtualMachineExtension(t *testing.
 	})
 }
 
+func TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_data_disk_attachment", "test")
+	r := VirtualMachineDataDiskAttachmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.virtualMachineApplicationPrep(data),
+		},
+		{
+			Config: r.virtualMachineApplicationComplete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_machine_id").Exists(),
+				check.That(data.ResourceName).Key("managed_disk_id").Exists(),
+				check.That("azurerm_linux_virtual_machine.test").Key("gallery_application.0.order").HasValue("0"),
+			),
+		},
+	})
+}
+
 func (t VirtualMachineDataDiskAttachmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.DataDiskID(state.ID)
 	if err != nil {
@@ -732,4 +751,166 @@ resource "azurerm_virtual_machine_data_disk_attachment" "test" {
   caching            = "ReadWrite"
 }
 `, r.virtualMachineExtensionPrep(data), data.RandomInteger)
+}
+
+func (VirtualMachineDataDiskAttachmentResource) virtualMachineApplicationPrep(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "ACCTESTGAL%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_gallery_application" "test" {
+  name              = "acc-app%[1]d"
+  gallery_id        = azurerm_shared_image_gallery.test.id
+  location          = azurerm_resource_group.test.location
+  supported_os_type = "Linux"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "stacc%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "container"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "scripts"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content         = "exit 0"
+}
+
+resource "azurerm_gallery_application_version" "test" {
+  name                   = "0.0.1"
+  gallery_application_id = azurerm_gallery_application.test.id
+  location               = azurerm_gallery_application.test.location
+
+  manage_action {
+    install = "exit 0"
+    remove  = "exit 0"
+  }
+
+  source {
+    media_link = azurerm_storage_blob.test.id
+  }
+
+  target_region {
+    name                   = azurerm_gallery_application.test.location
+    regional_replica_count = 1
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                  = "acctestvm%[1]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  network_interface_ids = [azurerm_network_interface.test.id]
+  size                  = "Standard_F4"
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  admin_username                  = "tfuser123"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+
+  os_disk {
+    name                 = "myosdisk1"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  gallery_application {
+    version_id = azurerm_gallery_application_version.test.id
+    order      = 0
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r VirtualMachineDataDiskAttachmentResource) virtualMachineApplicationComplete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctest%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "11"
+  caching            = "ReadWrite"
+}
+`, r.virtualMachineApplicationPrep(data), data.RandomInteger)
 }


### PR DESCRIPTION
If a Virtual Machine has VM application configured from a different subscription, `azurerm_virtual_machine_data_disk_attachment` can result into a RBAC permission error, if the current SPN does not have read permissions of the VM application

The issue appears, because `azurerm_virtual_machine_data_disk_attachment` fully override the whole VM resource instead partially patch disk block only.

To mitigate the issue, `gallery_application` will be set to nil before updating the VM resource. The pattern is already used for the identity property.

```
% make acctests SERVICE=compute TESTARGS='-run=TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/compute -run=TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication
=== PAUSE TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication
=== CONT  TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication
--- PASS: TestAccVirtualMachineDataDiskAttachment_virtualMachineApplication (757.75s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       761.263s
```
