### PR TITLE
Migrate to `go-azure-sdk` for `azurerm_security_center_automation`

### DIFF
--- a/internal/services/securitycenter/client/client.go
+++ b/internal/services/securitycenter/client/client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
@@ -22,7 +23,7 @@ type Client struct {
 	AdvancedThreatProtectionClient      *security.AdvancedThreatProtectionClient
 	AutoProvisioningClient              *security.AutoProvisioningSettingsClient
 	SettingClient                       *security.SettingsClient
-	AutomationsClient                   *security.AutomationsClient
+	AutomationsClient                   *automations.AutomationsClient
 	ServerVulnerabilityAssessmentClient *security.ServerVulnerabilityAssessmentClient
 	DefenderForStorageClient            *defenderforstorage.DefenderForStorageClient
 }
@@ -60,7 +61,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	SettingClient := security.NewSettingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
 	o.ConfigureClient(&SettingClient.Client, o.ResourceManagerAuthorizer)
 
-	AutomationsClient := security.NewAutomationsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
+	AutomationsClient := automations.NewAutomationsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&AutomationsClient.Client, o.ResourceManagerAuthorizer)
 
 	ServerVulnerabilityAssessmentClient := security.NewServerVulnerabilityAssessmentClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)

--- a/internal/services/securitycenter/security_center_automation_resource_test.go
+++ b/internal/services/securitycenter/security_center_automation_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -217,13 +218,14 @@ func (t SecurityCenterAutomationResource) Exists(ctx context.Context, clients *c
 	if err != nil {
 		return nil, err
 	}
+	automationId := automations.NewAutomationID(id.SubscriptionId, id.ResourceGroup, id.Name)
 
-	resp, err := clients.SecurityCenter.AutomationsClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.SecurityCenter.AutomationsClient.Get(ctx, automationId)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.AutomationProperties != nil), nil
+	return utils.Bool(resp.Model.Properties != nil), nil
 }
 
 func (SecurityCenterAutomationResource) logicApp(data acceptance.TestData) string {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/README.md
@@ -1,0 +1,128 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations` Documentation
+
+The `automations` SDK allows for interaction with the Azure Resource Manager Service `security` (API Version `2019-01-01-preview`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations"
+```
+
+
+### Client Initialization
+
+```go
+client := automations.NewAutomationsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutomationsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := automations.NewAutomationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "automationValue")
+
+payload := automations.Automation{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutomationsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := automations.NewAutomationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "automationValue")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutomationsClient.Get`
+
+```go
+ctx := context.TODO()
+id := automations.NewAutomationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "automationValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutomationsClient.List`
+
+```go
+ctx := context.TODO()
+id := automations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AutomationsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := automations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AutomationsClient.Validate`
+
+```go
+ctx := context.TODO()
+id := automations.NewAutomationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "automationValue")
+
+payload := automations.Automation{
+	// ...
+}
+
+
+read, err := client.Validate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/client.go
@@ -1,0 +1,18 @@
+package automations
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewAutomationsClientWithBaseURI(endpoint string) AutomationsClient {
+	return AutomationsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/constants.go
@@ -1,0 +1,175 @@
+package automations
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ActionType string
+
+const (
+	ActionTypeEventHub  ActionType = "EventHub"
+	ActionTypeLogicApp  ActionType = "LogicApp"
+	ActionTypeWorkspace ActionType = "Workspace"
+)
+
+func PossibleValuesForActionType() []string {
+	return []string{
+		string(ActionTypeEventHub),
+		string(ActionTypeLogicApp),
+		string(ActionTypeWorkspace),
+	}
+}
+
+func parseActionType(input string) (*ActionType, error) {
+	vals := map[string]ActionType{
+		"eventhub":  ActionTypeEventHub,
+		"logicapp":  ActionTypeLogicApp,
+		"workspace": ActionTypeWorkspace,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ActionType(input)
+	return &out, nil
+}
+
+type EventSource string
+
+const (
+	EventSourceAlerts                                 EventSource = "Alerts"
+	EventSourceAssessments                            EventSource = "Assessments"
+	EventSourceAssessmentsSnapshot                    EventSource = "AssessmentsSnapshot"
+	EventSourceRegulatoryComplianceAssessment         EventSource = "RegulatoryComplianceAssessment"
+	EventSourceRegulatoryComplianceAssessmentSnapshot EventSource = "RegulatoryComplianceAssessmentSnapshot"
+	EventSourceSecureScoreControls                    EventSource = "SecureScoreControls"
+	EventSourceSecureScoreControlsSnapshot            EventSource = "SecureScoreControlsSnapshot"
+	EventSourceSecureScores                           EventSource = "SecureScores"
+	EventSourceSecureScoresSnapshot                   EventSource = "SecureScoresSnapshot"
+	EventSourceSubAssessments                         EventSource = "SubAssessments"
+	EventSourceSubAssessmentsSnapshot                 EventSource = "SubAssessmentsSnapshot"
+)
+
+func PossibleValuesForEventSource() []string {
+	return []string{
+		string(EventSourceAlerts),
+		string(EventSourceAssessments),
+		string(EventSourceAssessmentsSnapshot),
+		string(EventSourceRegulatoryComplianceAssessment),
+		string(EventSourceRegulatoryComplianceAssessmentSnapshot),
+		string(EventSourceSecureScoreControls),
+		string(EventSourceSecureScoreControlsSnapshot),
+		string(EventSourceSecureScores),
+		string(EventSourceSecureScoresSnapshot),
+		string(EventSourceSubAssessments),
+		string(EventSourceSubAssessmentsSnapshot),
+	}
+}
+
+func parseEventSource(input string) (*EventSource, error) {
+	vals := map[string]EventSource{
+		"alerts":                                 EventSourceAlerts,
+		"assessments":                            EventSourceAssessments,
+		"assessmentssnapshot":                    EventSourceAssessmentsSnapshot,
+		"regulatorycomplianceassessment":         EventSourceRegulatoryComplianceAssessment,
+		"regulatorycomplianceassessmentsnapshot": EventSourceRegulatoryComplianceAssessmentSnapshot,
+		"securescorecontrols":                    EventSourceSecureScoreControls,
+		"securescorecontrolssnapshot":            EventSourceSecureScoreControlsSnapshot,
+		"securescores":                           EventSourceSecureScores,
+		"securescoressnapshot":                   EventSourceSecureScoresSnapshot,
+		"subassessments":                         EventSourceSubAssessments,
+		"subassessmentssnapshot":                 EventSourceSubAssessmentsSnapshot,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EventSource(input)
+	return &out, nil
+}
+
+type Operator string
+
+const (
+	OperatorContains             Operator = "Contains"
+	OperatorEndsWith             Operator = "EndsWith"
+	OperatorEquals               Operator = "Equals"
+	OperatorGreaterThan          Operator = "GreaterThan"
+	OperatorGreaterThanOrEqualTo Operator = "GreaterThanOrEqualTo"
+	OperatorLesserThan           Operator = "LesserThan"
+	OperatorLesserThanOrEqualTo  Operator = "LesserThanOrEqualTo"
+	OperatorNotEquals            Operator = "NotEquals"
+	OperatorStartsWith           Operator = "StartsWith"
+)
+
+func PossibleValuesForOperator() []string {
+	return []string{
+		string(OperatorContains),
+		string(OperatorEndsWith),
+		string(OperatorEquals),
+		string(OperatorGreaterThan),
+		string(OperatorGreaterThanOrEqualTo),
+		string(OperatorLesserThan),
+		string(OperatorLesserThanOrEqualTo),
+		string(OperatorNotEquals),
+		string(OperatorStartsWith),
+	}
+}
+
+func parseOperator(input string) (*Operator, error) {
+	vals := map[string]Operator{
+		"contains":             OperatorContains,
+		"endswith":             OperatorEndsWith,
+		"equals":               OperatorEquals,
+		"greaterthan":          OperatorGreaterThan,
+		"greaterthanorequalto": OperatorGreaterThanOrEqualTo,
+		"lesserthan":           OperatorLesserThan,
+		"lesserthanorequalto":  OperatorLesserThanOrEqualTo,
+		"notequals":            OperatorNotEquals,
+		"startswith":           OperatorStartsWith,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Operator(input)
+	return &out, nil
+}
+
+type PropertyType string
+
+const (
+	PropertyTypeBoolean PropertyType = "Boolean"
+	PropertyTypeInteger PropertyType = "Integer"
+	PropertyTypeNumber  PropertyType = "Number"
+	PropertyTypeString  PropertyType = "String"
+)
+
+func PossibleValuesForPropertyType() []string {
+	return []string{
+		string(PropertyTypeBoolean),
+		string(PropertyTypeInteger),
+		string(PropertyTypeNumber),
+		string(PropertyTypeString),
+	}
+}
+
+func parsePropertyType(input string) (*PropertyType, error) {
+	vals := map[string]PropertyType{
+		"boolean": PropertyTypeBoolean,
+		"integer": PropertyTypeInteger,
+		"number":  PropertyTypeNumber,
+		"string":  PropertyTypeString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PropertyType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/id_automation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/id_automation.go
@@ -1,0 +1,125 @@
+package automations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = AutomationId{}
+
+// AutomationId is a struct representing the Resource ID for a Automation
+type AutomationId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AutomationName    string
+}
+
+// NewAutomationID returns a new AutomationId struct
+func NewAutomationID(subscriptionId string, resourceGroupName string, automationName string) AutomationId {
+	return AutomationId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AutomationName:    automationName,
+	}
+}
+
+// ParseAutomationID parses 'input' into a AutomationId
+func ParseAutomationID(input string) (*AutomationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AutomationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutomationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutomationIDInsensitively parses 'input' case-insensitively into a AutomationId
+// note: this method should only be used for API response data and not user input
+func ParseAutomationIDInsensitively(input string) (*AutomationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AutomationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutomationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutomationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.AutomationName, ok = input.Parsed["automationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "automationName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutomationID checks that 'input' can be parsed as a Automation ID
+func ValidateAutomationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutomationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Automation ID
+func (id AutomationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Security/automations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AutomationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Automation ID
+func (id AutomationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftSecurity", "Microsoft.Security", "Microsoft.Security"),
+		resourceids.StaticSegment("staticAutomations", "automations", "automations"),
+		resourceids.UserSpecifiedSegment("automationName", "automationValue"),
+	}
+}
+
+// String returns a human-readable description of this Automation ID
+func (id AutomationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Automation Name: %q", id.AutomationName),
+	}
+	return fmt.Sprintf("Automation (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_createorupdate_autorest.go
@@ -1,0 +1,69 @@
+package automations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Automation
+}
+
+// CreateOrUpdate ...
+func (c AutomationsClient) CreateOrUpdate(ctx context.Context, id AutomationId, input Automation) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c AutomationsClient) preparerForCreateOrUpdate(ctx context.Context, id AutomationId, input Automation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_delete_autorest.go
@@ -1,0 +1,66 @@
+package automations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c AutomationsClient) Delete(ctx context.Context, id AutomationId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c AutomationsClient) preparerForDelete(ctx context.Context, id AutomationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForDelete(resp *http.Response) (result DeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_get_autorest.go
@@ -1,0 +1,68 @@
+package automations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Automation
+}
+
+// Get ...
+func (c AutomationsClient) Get(ctx context.Context, id AutomationId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c AutomationsClient) preparerForGet(ctx context.Context, id AutomationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_list_autorest.go
@@ -1,0 +1,187 @@
+package automations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Automation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []Automation
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c AutomationsClient) List(ctx context.Context, id commonids.SubscriptionId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c AutomationsClient) preparerForList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Security/automations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c AutomationsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []Automation `json:"value"`
+		NextLink *string      `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c AutomationsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, AutomationOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AutomationsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate AutomationOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]Automation, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_listbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package automations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Automation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByResourceGroupOperationResponse, error)
+}
+
+type ListByResourceGroupCompleteResult struct {
+	Items []Automation
+}
+
+func (r ListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp ListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByResourceGroup ...
+func (c AutomationsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp ListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c AutomationsClient) preparerForListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Security/automations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByResourceGroupWithNextLink prepares the ListByResourceGroup request with the given nextLink token.
+func (c AutomationsClient) preparerForListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []Automation `json:"value"`
+		NextLink *string      `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByResourceGroupComplete retrieves all of the results into a single object
+func (c AutomationsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, AutomationOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AutomationsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate AutomationOperationPredicate) (resp ListByResourceGroupCompleteResult, err error) {
+	items := make([]Automation, 0)
+
+	page, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_validate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/method_validate_autorest.go
@@ -1,0 +1,70 @@
+package automations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ValidateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *AutomationValidationStatus
+}
+
+// Validate ...
+func (c AutomationsClient) Validate(ctx context.Context, id AutomationId, input Automation) (result ValidateOperationResponse, err error) {
+	req, err := c.preparerForValidate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Validate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Validate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForValidate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "automations.AutomationsClient", "Validate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForValidate prepares the Validate request.
+func (c AutomationsClient) preparerForValidate(ctx context.Context, id AutomationId, input Automation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/validate", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForValidate handles the response to the Validate request. The method always
+// closes the http.Response Body.
+func (c AutomationsClient) responderForValidate(resp *http.Response) (result ValidateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automation.go
@@ -1,0 +1,15 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Automation struct {
+	Etag       *string               `json:"etag,omitempty"`
+	Id         *string               `json:"id,omitempty"`
+	Kind       *string               `json:"kind,omitempty"`
+	Location   *string               `json:"location,omitempty"`
+	Name       *string               `json:"name,omitempty"`
+	Properties *AutomationProperties `json:"properties,omitempty"`
+	Tags       *map[string]string    `json:"tags,omitempty"`
+	Type       *string               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationaction.go
@@ -1,0 +1,69 @@
+package automations
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationAction interface {
+}
+
+// RawAutomationActionImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAutomationActionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
+func unmarshalAutomationActionImplementation(input []byte) (AutomationAction, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutomationAction into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["actionType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "EventHub") {
+		var out AutomationActionEventHub
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutomationActionEventHub: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "LogicApp") {
+		var out AutomationActionLogicApp
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutomationActionLogicApp: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Workspace") {
+		var out AutomationActionWorkspace
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutomationActionWorkspace: %+v", err)
+		}
+		return out, nil
+	}
+
+	out := RawAutomationActionImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactioneventhub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactioneventhub.go
@@ -1,0 +1,43 @@
+package automations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutomationAction = AutomationActionEventHub{}
+
+type AutomationActionEventHub struct {
+	ConnectionString   *string `json:"connectionString,omitempty"`
+	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
+	SasPolicyName      *string `json:"sasPolicyName,omitempty"`
+
+	// Fields inherited from AutomationAction
+}
+
+var _ json.Marshaler = AutomationActionEventHub{}
+
+func (s AutomationActionEventHub) MarshalJSON() ([]byte, error) {
+	type wrapper AutomationActionEventHub
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutomationActionEventHub: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutomationActionEventHub: %+v", err)
+	}
+	decoded["actionType"] = "EventHub"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutomationActionEventHub: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactionlogicapp.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactionlogicapp.go
@@ -1,0 +1,42 @@
+package automations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutomationAction = AutomationActionLogicApp{}
+
+type AutomationActionLogicApp struct {
+	LogicAppResourceId *string `json:"logicAppResourceId,omitempty"`
+	Uri                *string `json:"uri,omitempty"`
+
+	// Fields inherited from AutomationAction
+}
+
+var _ json.Marshaler = AutomationActionLogicApp{}
+
+func (s AutomationActionLogicApp) MarshalJSON() ([]byte, error) {
+	type wrapper AutomationActionLogicApp
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutomationActionLogicApp: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutomationActionLogicApp: %+v", err)
+	}
+	decoded["actionType"] = "LogicApp"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutomationActionLogicApp: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactionworkspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationactionworkspace.go
@@ -1,0 +1,41 @@
+package automations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutomationAction = AutomationActionWorkspace{}
+
+type AutomationActionWorkspace struct {
+	WorkspaceResourceId *string `json:"workspaceResourceId,omitempty"`
+
+	// Fields inherited from AutomationAction
+}
+
+var _ json.Marshaler = AutomationActionWorkspace{}
+
+func (s AutomationActionWorkspace) MarshalJSON() ([]byte, error) {
+	type wrapper AutomationActionWorkspace
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutomationActionWorkspace: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutomationActionWorkspace: %+v", err)
+	}
+	decoded["actionType"] = "Workspace"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutomationActionWorkspace: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationproperties.go
@@ -1,0 +1,55 @@
+package automations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationProperties struct {
+	Actions     *[]AutomationAction `json:"actions,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	IsEnabled   *bool               `json:"isEnabled,omitempty"`
+	Scopes      *[]AutomationScope  `json:"scopes,omitempty"`
+	Sources     *[]AutomationSource `json:"sources,omitempty"`
+}
+
+var _ json.Unmarshaler = &AutomationProperties{}
+
+func (s *AutomationProperties) UnmarshalJSON(bytes []byte) error {
+	type alias AutomationProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into AutomationProperties: %+v", err)
+	}
+
+	s.Description = decoded.Description
+	s.IsEnabled = decoded.IsEnabled
+	s.Scopes = decoded.Scopes
+	s.Sources = decoded.Sources
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling AutomationProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["actions"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Actions into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]AutomationAction, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalAutomationActionImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Actions' for 'AutomationProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Actions = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationruleset.go
@@ -1,0 +1,8 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationRuleSet struct {
+	Rules *[]AutomationTriggeringRule `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationscope.go
@@ -1,0 +1,9 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationScope struct {
+	Description *string `json:"description,omitempty"`
+	ScopePath   *string `json:"scopePath,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationsource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationsource.go
@@ -1,0 +1,9 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationSource struct {
+	EventSource *EventSource         `json:"eventSource,omitempty"`
+	RuleSets    *[]AutomationRuleSet `json:"ruleSets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationtriggeringrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationtriggeringrule.go
@@ -1,0 +1,11 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationTriggeringRule struct {
+	ExpectedValue *string       `json:"expectedValue,omitempty"`
+	Operator      *Operator     `json:"operator,omitempty"`
+	PropertyJPath *string       `json:"propertyJPath,omitempty"`
+	PropertyType  *PropertyType `json:"propertyType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationvalidationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/model_automationvalidationstatus.go
@@ -1,0 +1,9 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationValidationStatus struct {
+	IsValid *bool   `json:"isValid,omitempty"`
+	Message *string `json:"message,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/predicates.go
@@ -1,0 +1,42 @@
+package automations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomationOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Kind     *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p AutomationOperationPredicate) Matches(input Automation) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/version.go
@@ -1,0 +1,12 @@
+package automations
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2019-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/automations/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -880,6 +880,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/adminkeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/querykeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/services
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/sharedprivatelinkresources
+github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings


### PR DESCRIPTION
I recently ran into this issue https://github.com/hashicorp/terraform-provider-azurerm/issues/18919 so thought I would have a go at moving this resource over to `go-azure-sdk` which does have the additional sources.

I've run the tests locally and all seems well. However, I have changed one of the allowed values for `type` to `Workspace` from `LogAnalytics` and I wasn't sure if this constituted a breaking change

Thanks in advance