### PR TITLE
`azurerm_bot_service_azure_bot`: remove setting LuisKey from `public_network_access_enabled` attribute

### DIFF
--- a/internal/services/bot/bot_service_resource_base.go
+++ b/internal/services/bot/bot_service_resource_base.go
@@ -290,7 +290,6 @@ func (br botBaseResource) updateFunc() sdk.ResourceFunc {
 				} else {
 					existing.Properties.PublicNetworkAccess = botservice.PublicNetworkAccessDisabled
 				}
-				existing.Properties.LuisKey = utils.String(metadata.ResourceData.Get("public_network_access_enabled").(string))
 			}
 
 			if metadata.ResourceData.HasChange("streaming_endpoint_enabled") {


### PR DESCRIPTION
Fixes: #24163

@katbyte  The line seems like a copy+paste issue introduced by https://github.com/hashicorp/terraform-provider-azurerm/pull/24125 

It breaks our builds (see #24163 ).

If it was by purpose the should change the code to make it work

