### PR TITLE
Add `image_names` to `azurerm_shared_image_gallery` data source

### DIFF
--- a/internal/services/compute/shared_image_gallery_data_source_test.go
+++ b/internal/services/compute/shared_image_gallery_data_source_test.go
@@ -44,6 +44,21 @@ func TestAccDataSourceSharedImageGallery_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceSharedImageGallery_imageNames(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_gallery", "test")
+	r := SharedImageGalleryDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.imageNames(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("image_names.#").HasValue("1"),
+			),
+		},
+	})
+}
+
 func (SharedImageGalleryDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -64,4 +79,15 @@ data "azurerm_shared_image_gallery" "test" {
   resource_group_name = azurerm_shared_image_gallery.test.resource_group_name
 }
 `, SharedImageGalleryResource{}.complete(data))
+}
+
+func (SharedImageGalleryDataSource) imageNames(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image_gallery" "test" {
+  name                = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.basic(data))
 }

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -36,6 +36,8 @@ The following attributes are exported:
 
 * `description` - A description for the Shared Image Gallery.
 
+* `image_names` - A list of Shared Image names within this Shared Image Gallery.
+
 * `unique_name` - The unique name assigned to the Shared Image Gallery.
 
 * `tags` - A mapping of tags which are assigned to the Shared Image Gallery.


### PR DESCRIPTION
Adding a list of image names to the shared image gallery data source