### PR TITLE
`azurerm_storage_blob` - `Page` blob supports `source_content`

### DIFF
--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -150,6 +151,15 @@ func resourceStorageBlob() *pluginsdk.Resource {
 			},
 
 			"metadata": MetaDataComputedSchema(),
+		},
+
+		CustomizeDiff: func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
+			if content := diff.Get("source_content"); content != "" && diff.Get("type") == "Page" {
+				if len(content.(string))%512 != 0 {
+					return fmt.Errorf(`"source" must be aligned to 512-byte boundary for "type" set to "Page"`)
+				}
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
This PR supports `Page` type of `azurerm_storage_blob` for `source_content`, with a plan time validation on the size of it to ensure it is aligned by 512-byte boundary. Otherwise, the API will raise error.

Fix #24144

## Test

```shell
$ TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageBlob_pageFromInlineContent'
=== RUN   TestAccStorageBlob_pageFromInlineContent
=== PAUSE TestAccStorageBlob_pageFromInlineContent
=== CONT  TestAccStorageBlob_pageFromInlineContent
--- PASS: TestAccStorageBlob_pageFromInlineContent (226.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       226.367s
```