### PR TITLE
`azurerm_storage_share_file`: report error instead of panic when use a empty file

### DIFF
--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -175,6 +175,10 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %+v", fileName, storageShareID.Name, storageShareID.AccountName, err)
 		}
 
+		if info.Size() == 0 {
+			return fmt.Errorf("file %q (File Share %q / Account %q) is empty", fileName, storageShareID.Name, storageShareID.AccountName)
+		}
+
 		input.ContentLength = info.Size()
 	}
 

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -115,6 +116,23 @@ func TestAccAzureRMStorageShareFile_withFile(t *testing.T) {
 			),
 		},
 		data.ImportStep("source"),
+	})
+}
+
+func TestAccAzureRMStorageShareFile_withEmptyFile(t *testing.T) {
+	sourceBlob, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatalf("Failed to create local source blob file")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_file", "test")
+	r := StorageShareFileResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withFile(data, sourceBlob.Name()),
+			ExpectError: regexp.MustCompile(`Error: file .* is empty`),
+		},
 	})
 }
 

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -51,6 +51,8 @@ The following arguments are supported:
 
 * `source` - (Optional) An absolute path to a file on the local system. Changing this forces a new resource to be created.
 
+~> **Note** The file specified with `source` can not be empty.
+
 * `content_type` - (Optional) The content type of the share file. Defaults to `application/octet-stream`.
 
 * `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes #24171.

Actually we cannot upload a empty file with the API or it will respond error as `error putting bytes: 'input.EndBytes' must be greater than 0`