### PR TITLE
`azurerm_iothub` -  split create and update function

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -876,6 +876,9 @@ func resourceIotHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("endpoint") {
+		if prop.Routing == nil {
+			prop.Routing = &devices.RoutingProperties{}
+		}
 		prop.Routing.Endpoints, err = expandIoTHubEndpoints(d, subscriptionId)
 		if err != nil {
 			return fmt.Errorf("expanding `endpoint`: %+v", err)

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -70,9 +71,9 @@ func suppressWhenAny(fs ...pluginsdk.SchemaDiffSuppressFunc) pluginsdk.SchemaDif
 
 func resourceIotHub() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceIotHubCreateUpdate,
+		Create: resourceIotHubCreate,
 		Read:   resourceIotHubRead,
-		Update: resourceIotHubCreateUpdate,
+		Update: resourceIotHubUpdate,
 		Delete: resourceIotHubDelete,
 
 		SchemaVersion: 1,
@@ -661,7 +662,7 @@ func resourceIotHub() *pluginsdk.Resource {
 	}
 }
 
-func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).IoTHub.ResourceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -683,18 +684,15 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_iothub", id.ID())
 		}
-	}
+		res, err := client.CheckNameAvailability(ctx, devices.OperationInputs{Name: &id.Name})
+		if err != nil {
+			return fmt.Errorf("An error occurred checking if the IoTHub name was unique: %+v", err)
+		}
 
-	res, err := client.CheckNameAvailability(ctx, devices.OperationInputs{
-		Name: &id.Name,
-	})
-	if err != nil {
-		return fmt.Errorf("An error occurred checking if the IoTHub name was unique: %+v", err)
-	}
-
-	if !*res.NameAvailable {
-		if _, err = client.Get(ctx, id.ResourceGroup, id.Name); err != nil {
-			return fmt.Errorf("An IoTHub already exists with the name %q - please choose an alternate name: %s", id.Name, string(res.Reason))
+		if !*res.NameAvailable {
+			if _, err = client.Get(ctx, id.ResourceGroup, id.Name); err == nil {
+				return fmt.Errorf("An IoTHub already exists with the name %q - please choose an alternate name: %s", id.Name, string(res.Reason))
+			}
 		}
 	}
 
@@ -720,6 +718,7 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if _, ok := d.GetOk("endpoint"); ok {
+		var err error
 		routingProperties.Endpoints, err = expandIoTHubEndpoints(d, subscriptionId)
 		if err != nil {
 			return fmt.Errorf("expanding `endpoint`: %+v", err)
@@ -793,11 +792,180 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, props, "")
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %q: %+v", id, err)
+		return fmt.Errorf("waiting for creation of %q: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceIotHubRead(d, meta)
+}
+
+func resourceIotHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).IoTHub.ResourceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+	id, err := parse.IotHubID(d.Id())
+	if err != nil {
+		return fmt.Errorf("parsing %s: %+v", id, err)
+	}
+
+	locks.ByName(id.Name, IothubResourceName)
+	defer locks.UnlockByName(id.Name, IothubResourceName)
+
+	iothub, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("reading %s: %+v", id, err)
+	}
+
+	if iothub.Properties == nil {
+		return fmt.Errorf("reading %s: properties was nil", id)
+	}
+
+	prop := *iothub.Properties
+
+	if d.HasChange("sku") {
+		iothub.Sku = expandIoTHubSku(d)
+	}
+
+	if d.HasChange("identity") {
+		identity, err := expandIotHubIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+		iothub.Identity = identity
+	}
+
+	if d.HasChange("tags") {
+		iothub.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if d.HasChange("route") {
+		if prop.Routing == nil {
+			prop.Routing = &devices.RoutingProperties{}
+		}
+		prop.Routing.Routes = expandIoTHubRoutes(d)
+	}
+
+	if d.HasChange("enrichment") {
+		if prop.Routing == nil {
+			prop.Routing = &devices.RoutingProperties{}
+		}
+		prop.Routing.Enrichments = expandIoTHubEnrichments(d)
+	}
+
+	if d.HasChange("fallback_route") {
+		if prop.Routing == nil {
+			prop.Routing = &devices.RoutingProperties{}
+		}
+		if _, ok := d.GetOk("fallback_route"); ok {
+			prop.Routing.FallbackRoute = expandIoTHubFallbackRoute(d)
+		} else {
+			prop.Routing.FallbackRoute = &devices.FallbackRouteProperties{
+				Source:        utils.String(string(devices.RoutingSourceDeviceMessages)),
+				Condition:     utils.String("true"),
+				EndpointNames: &[]string{"events"},
+				IsEnabled:     utils.Bool(true),
+			}
+		}
+	}
+
+	if d.HasChange("endpoint") {
+		prop.Routing.Endpoints, err = expandIoTHubEndpoints(d, subscriptionId)
+		if err != nil {
+			return fmt.Errorf("expanding `endpoint`: %+v", err)
+		}
+	}
+
+	if d.HasChange("file_upload") {
+		storageEndpoints, messagingEndpoints, enableFileUploadNotifications, err := expandIoTHubFileUpload(d)
+		if err != nil {
+			return fmt.Errorf("expanding `file_upload`: %+v", err)
+		}
+		prop.StorageEndpoints = storageEndpoints
+		prop.MessagingEndpoints = messagingEndpoints
+		prop.EnableFileUploadNotifications = &enableFileUploadNotifications
+	}
+
+	if d.HasChange("cloud_to_device") {
+		cloudToDeviceProperties := &devices.CloudToDeviceProperties{}
+		if _, ok := d.GetOk("cloud_to_device"); ok {
+			cloudToDeviceProperties = expandIoTHubCloudToDevice(d)
+		}
+		prop.CloudToDevice = cloudToDeviceProperties
+	}
+
+	if d.HasChange("network_rule_set") {
+		if _, ok := d.GetOk("network_rule_set"); ok {
+			prop.NetworkRuleSets = expandNetworkRuleSetProperties(d)
+		} else {
+			prop.NetworkRuleSets = &devices.NetworkRuleSetProperties{}
+		}
+	}
+
+	if d.HasChange("public_network_access_enabled") {
+		// nolint staticcheck
+		if v, ok := d.GetOkExists("public_network_access_enabled"); ok {
+			enabled := devices.PublicNetworkAccessDisabled
+			if v.(bool) {
+				enabled = devices.PublicNetworkAccessEnabled
+			}
+			prop.PublicNetworkAccess = enabled
+		}
+	}
+
+	if d.HasChange("event_hub_retention_in_days") {
+		retention, retentionOk := d.GetOk("event_hub_retention_in_days")
+		if prop.EventHubEndpoints == nil {
+			prop.EventHubEndpoints = make(map[string]*devices.EventHubProperties)
+		}
+		eh, ok := prop.EventHubEndpoints["events"]
+		if !ok {
+			prop.EventHubEndpoints["events"] = &devices.EventHubProperties{}
+		}
+		eh.RetentionTimeInDays = nil
+		if retentionOk {
+			eh.RetentionTimeInDays = pointer.To(int64(retention.(int)))
+		}
+	}
+
+	if d.HasChange("event_hub_partition_count") {
+		partition, partitionOk := d.GetOk("event_hub_partition_count")
+		if prop.EventHubEndpoints == nil {
+			prop.EventHubEndpoints = make(map[string]*devices.EventHubProperties)
+		}
+		if eh, ok := prop.EventHubEndpoints["events"]; ok {
+			eh.PartitionCount = nil
+			if partitionOk {
+				eh.PartitionCount = pointer.To(int32(partition.(int)))
+			}
+		}
+	}
+
+	if d.HasChange("local_authentication_enabled") {
+		prop.DisableLocalAuth = pointer.To(!d.Get("local_authentication_enabled").(bool))
+	}
+
+	if d.HasChange("min_tls_version") {
+		prop.MinTLSVersion = nil
+		if v, ok := d.GetOk("min_tls_version"); ok {
+			prop.MinTLSVersion = pointer.To(v.(string))
+		}
+	}
+
+	iothub.Properties = &prop
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, iothub, "")
+	if err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update of %q: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -1768,7 +1936,6 @@ func fileUploadConnectionStringDiffSuppress(k, old, new string, d *pluginsdk.Res
 		sort.Strings(newSplit)
 
 		if len(oldSplit) != len(newSplit) {
-			return false
 		}
 
 		for i := range oldSplit {

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -1939,6 +1939,7 @@ func fileUploadConnectionStringDiffSuppress(k, old, new string, d *pluginsdk.Res
 		sort.Strings(newSplit)
 
 		if len(oldSplit) != len(newSplit) {
+			return false
 		}
 
 		for i := range oldSplit {


### PR DESCRIPTION
The combained `createupdate` function also cause a bug when there is a endpoint attached to the iothub which is not supported by `azurerm_iothub`. So splitting the function also helps fixing the bug.

Then a thought about `endpoint` block, the scheme of it is a comabination of `azurerm_iothub_endpoint_xxx`, it's a bit complex, and duplicate with those resources, so maybe we can deprecate that block and let users only use `azurerm_iothub_endpoint_xxx` resources?

Test
---
```
❯ tftest iothub TestAccIotHub_                                  
=== RUN   TestAccIotHub_basic
=== PAUSE TestAccIotHub_basic
=== RUN   TestAccIotHub_networkRulesSet
=== PAUSE TestAccIotHub_networkRulesSet
=== RUN   TestAccIotHub_requiresImport
=== PAUSE TestAccIotHub_requiresImport
=== RUN   TestAccIotHub_standard
=== PAUSE TestAccIotHub_standard
=== RUN   TestAccIotHub_customRoutes
=== PAUSE TestAccIotHub_customRoutes
=== RUN   TestAccIotHub_enrichments
=== PAUSE TestAccIotHub_enrichments
=== RUN   TestAccIotHub_removeEndpointsAndRoutes
=== PAUSE TestAccIotHub_removeEndpointsAndRoutes
=== RUN   TestAccIotHub_fileUpload
=== PAUSE TestAccIotHub_fileUpload
=== RUN   TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
=== PAUSE TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
=== RUN   TestAccIotHub_fileUploadAuthenticationTypeUpdate
=== PAUSE TestAccIotHub_fileUploadAuthenticationTypeUpdate
=== RUN   TestAccIotHub_withDifferentEndpointResourceGroup
=== PAUSE TestAccIotHub_withDifferentEndpointResourceGroup
=== RUN   TestAccIotHub_fallbackRoute
=== PAUSE TestAccIotHub_fallbackRoute
=== RUN   TestAccIotHub_publicAccess
=== PAUSE TestAccIotHub_publicAccess
=== RUN   TestAccIotHub_minTLSVersion
=== PAUSE TestAccIotHub_minTLSVersion
=== RUN   TestAccIotHub_LocalAuth
=== PAUSE TestAccIotHub_LocalAuth
=== RUN   TestAccIotHub_cloudToDevice
=== PAUSE TestAccIotHub_cloudToDevice
=== RUN   TestAccIotHub_identitySystemAssigned
=== PAUSE TestAccIotHub_identitySystemAssigned
=== RUN   TestAccIotHub_identitySystemAssignedUserAssigned
=== PAUSE TestAccIotHub_identitySystemAssignedUserAssigned
=== RUN   TestAccIotHub_identityUserAssigned
=== PAUSE TestAccIotHub_identityUserAssigned
=== RUN   TestAccIotHub_identityUpdate
=== PAUSE TestAccIotHub_identityUpdate
=== RUN   TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
=== PAUSE TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
=== RUN   TestAccIotHub_endpointAuthenticationTypeUpdate
=== PAUSE TestAccIotHub_endpointAuthenticationTypeUpdate
=== CONT  TestAccIotHub_basic
=== CONT  TestAccIotHub_fallbackRoute
=== CONT  TestAccIotHub_removeEndpointsAndRoutes
=== CONT  TestAccIotHub_fileUploadAuthenticationTypeUpdate
=== CONT  TestAccIotHub_withDifferentEndpointResourceGroup
=== CONT  TestAccIotHub_endpointAuthenticationTypeUpdate
=== CONT  TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
=== CONT  TestAccIotHub_fileUpload
--- PASS: TestAccIotHub_fallbackRoute (345.60s)
=== CONT  TestAccIotHub_enrichments
--- PASS: TestAccIotHub_basic (347.77s)
=== CONT  TestAccIotHub_requiresImport
--- PASS: TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity (472.11s)
=== CONT  TestAccIotHub_identitySystemAssigned
--- PASS: TestAccIotHub_fileUpload (479.68s)
=== CONT  TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
--- PASS: TestAccIotHub_withDifferentEndpointResourceGroup (516.12s)
=== CONT  TestAccIotHub_identityUpdate
--- PASS: TestAccIotHub_requiresImport (337.82s)
=== CONT  TestAccIotHub_identityUserAssigned
--- PASS: TestAccIotHub_identitySystemAssigned (333.03s)
=== CONT  TestAccIotHub_identitySystemAssignedUserAssigned
--- PASS: TestAccIotHub_fileUploadAuthenticationTypeUpdate (822.61s)
=== CONT  TestAccIotHub_LocalAuth
--- PASS: TestAccIotHub_enrichments (535.28s)
=== CONT  TestAccIotHub_cloudToDevice
--- PASS: TestAccIotHub_removeEndpointsAndRoutes (893.09s)
=== CONT  TestAccIotHub_minTLSVersion
--- PASS: TestAccIotHub_identityUserAssigned (350.47s)
=== CONT  TestAccIotHub_publicAccess
--- PASS: TestAccIotHub_identitySystemAssignedUserAssigned (352.32s)
=== CONT  TestAccIotHub_customRoutes
--- PASS: TestAccIotHub_identityUpdate (667.13s)
=== CONT  TestAccIotHub_networkRulesSet
--- PASS: TestAccIotHub_minTLSVersion (299.79s)
=== CONT  TestAccIotHub_standard
--- PASS: TestAccIotHub_cloudToDevice (363.95s)
--- PASS: TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity (833.31s)
--- PASS: TestAccIotHub_LocalAuth (511.90s)
--- PASS: TestAccIotHub_endpointAuthenticationTypeUpdate (1377.94s)
--- PASS: TestAccIotHub_standard (295.57s)
--- PASS: TestAccIotHub_publicAccess (503.56s)
--- PASS: TestAccIotHub_networkRulesSet (401.75s)
--- PASS: TestAccIotHub_customRoutes (534.29s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub        1
691.826s
```

an added test case
---
```
❯ tftest iothub TestAccIotHub_cosmosDBRouteUpdate
=== RUN   TestAccIotHub_cosmosDBRouteUpdate
=== PAUSE TestAccIotHub_cosmosDBRouteUpdate
=== CONT  TestAccIotHub_cosmosDBRouteUpdate
--- PASS: TestAccIotHub_cosmosDBRouteUpdate (1182.50s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub        1
182.563s
```