### PR TITLE
`azurerm_dns_cname_record`: try normalize `target_resource_id` with RecordTypeID before set to state

### DIFF
--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -193,6 +193,7 @@ func resourceDnsCNameRecordRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 			targetResourceId := ""
 			if props.TargetResource != nil && props.TargetResource.Id != nil {
+				// TODO update this once https://github.com/hashicorp/go-azure-helpers/issues/189 is resolved
 				targetResourceId = *props.TargetResource.Id
 				if recordTypeID, err := recordsets.ParseRecordTypeIDInsensitively(targetResourceId); err == nil {
 					targetResourceId = recordTypeID.ID()

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -192,7 +192,7 @@ func resourceDnsCNameRecordRead(d *pluginsdk.ResourceData, meta interface{}) err
 			if props.TargetResource != nil && props.TargetResource.Id != nil {
 				targetResourceId = *props.TargetResource.Id
 			}
-			d.Set("target_resource_id", targetResourceId)
+			d.Set("target_resource_id", normalizeTargetResourceID(targetResourceId))
 
 			if err := tags.FlattenAndSet(d, props.Metadata); err != nil {
 				return err
@@ -218,4 +218,16 @@ func resourceDnsCNameRecordDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	return nil
+}
+
+func normalizeTargetResourceID(id string) string {
+	if id == "" {
+		return ""
+	}
+
+	if parsed, err := recordsets.ParseRecordTypeIDInsensitively(id); err == nil {
+		return parsed.ID()
+	}
+
+	return id
 }

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -191,8 +191,11 @@ func resourceDnsCNameRecordRead(d *pluginsdk.ResourceData, meta interface{}) err
 			targetResourceId := ""
 			if props.TargetResource != nil && props.TargetResource.Id != nil {
 				targetResourceId = *props.TargetResource.Id
+				if parsedID, err := recordsets.ParseRecordTypeIDInsensitively(targetResourceId); err == nil {
+					targetResourceId = parsedID.ID()
+				}
 			}
-			d.Set("target_resource_id", normalizeTargetResourceID(targetResourceId))
+			d.Set("target_resource_id", targetResourceId)
 
 			if err := tags.FlattenAndSet(d, props.Metadata); err != nil {
 				return err
@@ -218,16 +221,4 @@ func resourceDnsCNameRecordDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	return nil
-}
-
-func normalizeTargetResourceID(id string) string {
-	if id == "" {
-		return ""
-	}
-
-	if parsed, err := recordsets.ParseRecordTypeIDInsensitively(id); err == nil {
-		return parsed.ID()
-	}
-
-	return id
 }

--- a/internal/services/dns/dns_cname_record_resource_test.go
+++ b/internal/services/dns/dns_cname_record_resource_test.go
@@ -358,7 +358,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestrg-%d"
   location = "%s"
 }
 
@@ -392,7 +392,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestrg-%d"
   location = "%s"
 }
 
@@ -426,7 +426,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestrg-%d"
   location = "%s"
 }
 
@@ -460,7 +460,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestrg-%d"
   location = "%s"
 }
 


### PR DESCRIPTION
fixes: #24138.

There is a nother API casing issue related to this resource: https://github.com/Azure/azure-rest-api-specs/issues/6641 so change the acctest resource group name to lower case to make the acc test work.


![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/3999a193-6208-479f-bda1-bb401606142c)
