### PR TITLE
docs note: `azurerm_cognitive_account`, not all `kind` support `storage` block

### DIFF
--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -138,6 +138,8 @@ A `storage` block supports the following:
 
 * `identity_client_id` - (Optional) The client ID of the managed identity associated with the storage resource.
 
+~> **NOTE:** Not all `kind` support a `storage` block. For example the `kind` `OpenAI` does not support it.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
docs note: `azurerm_cognitive_account`, not all `kind` support `storage` block

This needs more visibility: a lot of folks are testing OpenAI on Azure, and it is confusing what to do about the storage block.