### PR TITLE
`azurerm_hpc_cache_nfs_target` - support `verification_timer_in_seconds` and `write_back_timer_in_seconds` properties

### DIFF
--- a/internal/services/storagecache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource.go
@@ -5,6 +5,7 @@ package storagecache
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"log"
 	"time"
 
@@ -115,6 +116,18 @@ func resourceHPCCacheNFSTarget() *pluginsdk.Resource {
 					"WRITE_WORKLOAD_CLOUDWS",
 				}, false),
 			},
+
+			"verification_timer_in_seconds": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 31536000),
+			},
+
+			"write_back_timer_in_seconds": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 31536000),
+			},
 		},
 	}
 }
@@ -151,6 +164,14 @@ func resourceHPCCacheNFSTargetCreateOrUpdate(d *pluginsdk.ResourceData, meta int
 				UsageModel: pointer.To(d.Get("usage_model").(string)),
 			},
 		},
+	}
+
+	if v, ok := d.GetOk("verification_timer_in_seconds"); ok {
+		param.Properties.BlobNfs.VerificationTimer = utils.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("write_back_timer_in_seconds"); ok {
+		param.Properties.BlobNfs.WriteBackTimer = utils.Int64(int64(v.(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
@@ -194,6 +215,8 @@ func resourceHPCCacheNFSTargetRead(d *pluginsdk.ResourceData, meta interface{}) 
 			if nfs3 := props.Nfs3; nfs3 != nil {
 				d.Set("target_host_name", nfs3.Target)
 				d.Set("usage_model", nfs3.UsageModel)
+				d.Set("verification_timer_in_seconds", pointer.From(nfs3.VerificationTimer))
+				d.Set("write_back_timer_in_seconds", pointer.From(nfs3.WriteBackTimer))
 			}
 			if err := d.Set("namespace_junction", flattenNamespaceJunctions(props.Junctions)); err != nil {
 				return fmt.Errorf(`error setting "namespace_junction"(%q): %+v`, id, err)

--- a/internal/services/storagecache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource.go
@@ -167,11 +167,11 @@ func resourceHPCCacheNFSTargetCreateOrUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("verification_timer_in_seconds"); ok {
-		param.Properties.BlobNfs.VerificationTimer = utils.Int64(int64(v.(int)))
+		param.Properties.Nfs3.VerificationTimer = utils.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("write_back_timer_in_seconds"); ok {
-		param.Properties.BlobNfs.WriteBackTimer = utils.Int64(int64(v.(int)))
+		param.Properties.Nfs3.WriteBackTimer = utils.Int64(int64(v.(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {

--- a/internal/services/storagecache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource.go
@@ -5,7 +5,6 @@ package storagecache
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"log"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceHPCCacheNFSTarget() *pluginsdk.Resource {

--- a/internal/services/storagecache/hpc_cache_nfs_target_resource_test.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource_test.go
@@ -46,21 +46,21 @@ func TestAccHPCCacheNFSTarget_usageModel(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.usageModel(data, "READ_HEAVY_CHECK_180"),
+			Config: r.usageModelReadHeavyCheck180(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.usageModel(data, "READ_WRITE"),
+			Config: r.usageModelReadWrite(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.usageModel(data, "READ_ONLY"),
+			Config: r.usageModelReadOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -193,7 +193,7 @@ resource "azurerm_hpc_cache_nfs_target" "test" {
 `, r.cacheTemplate(data), data.RandomString)
 }
 
-func (r HPCCacheNFSTargetResource) usageModel(data acceptance.TestData, modelName string) string {
+func (r HPCCacheNFSTargetResource) usageModelReadHeavyCheck180(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -202,18 +202,73 @@ resource "azurerm_hpc_cache_nfs_target" "test" {
   resource_group_name = azurerm_resource_group.test.name
   cache_name          = azurerm_hpc_cache.test.name
   target_host_name    = azurerm_linux_virtual_machine.test.private_ip_address
-  usage_model         = "%s"
+  usage_model         = "READ_HEAVY_CHECK_180"
+
   namespace_junction {
     namespace_path = "/nfs/a1"
     nfs_export     = "/export/a"
     target_path    = "1"
   }
+
   namespace_junction {
     namespace_path = "/nfs/b"
     nfs_export     = "/export/b"
   }
 }
-`, r.cacheTemplate(data), data.RandomString, modelName)
+`, r.cacheTemplate(data), data.RandomString)
+}
+
+func (r HPCCacheNFSTargetResource) usageModelReadWrite(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache_nfs_target" "test" {
+  name                          = "acctest-HPCCTGT-%s"
+  resource_group_name           = azurerm_resource_group.test.name
+  cache_name                    = azurerm_hpc_cache.test.name
+  target_host_name              = azurerm_linux_virtual_machine.test.private_ip_address
+  usage_model                   = "READ_WRITE"
+  verification_timer_in_seconds = 29000
+  write_back_timer_in_seconds   = 3700
+
+  namespace_junction {
+    namespace_path = "/nfs/a1"
+    nfs_export     = "/export/a"
+    target_path    = "1"
+  }
+
+  namespace_junction {
+    namespace_path = "/nfs/b"
+    nfs_export     = "/export/b"
+  }
+}
+`, r.cacheTemplate(data), data.RandomString)
+}
+
+func (r HPCCacheNFSTargetResource) usageModelReadOnly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache_nfs_target" "test" {
+  name                          = "acctest-HPCCTGT-%s"
+  resource_group_name           = azurerm_resource_group.test.name
+  cache_name                    = azurerm_hpc_cache.test.name
+  target_host_name              = azurerm_linux_virtual_machine.test.private_ip_address
+  usage_model                   = "READ_ONLY"
+  verification_timer_in_seconds = 30000
+
+  namespace_junction {
+    namespace_path = "/nfs/a1"
+    nfs_export     = "/export/a"
+    target_path    = "1"
+  }
+
+  namespace_junction {
+    namespace_path = "/nfs/b"
+    nfs_export     = "/export/b"
+  }
+}
+`, r.cacheTemplate(data), data.RandomString)
 }
 
 func (r HPCCacheNFSTargetResource) namespaceJunction(data acceptance.TestData) string {

--- a/website/docs/r/hpc_cache_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_nfs_target.html.markdown
@@ -143,6 +143,10 @@ The following arguments are supported:
 
 * `namespace_junction` - (Required) Can be specified multiple times to define multiple `namespace_junction`. Each `namespace_junction` block supports fields documented below.
 
+* `verification_timer_in_seconds` - (Optional) The amount of time the cache waits before it checks the back-end storage for file updates. Possible values are between `1` and `31536000`.
+
+* `write_back_timer_in_seconds` - (Optional) The amount of time the cache waits after the last file change before it copies the changed file to back-end storage. Possible values are between `1` and `31536000`.
+
 ---
 
 A `namespace_junction` block supports the following:


### PR DESCRIPTION
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/e1ca6685-e96f-4d99-b59e-d532b95234fb)
