### PR TITLE
`azurerm_security_center_setting` - Allow `Sentinel` to be the valid `setting_name`

### DIFF
--- a/internal/services/securitycenter/security_center_setting_resource.go
+++ b/internal/services/securitycenter/security_center_setting_resource.go
@@ -46,6 +46,10 @@ func resourceSecurityCenterSetting() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"MCAS",
 					"WDATP",
+					"Sentinel",
+
+					// TODO 4.0: Remove this per the swagger definition:
+					//           https://github.com/Azure/azure-rest-api-specs/blob/b52464f520b77222ac8b0bdeb80a030c0fdf5b1b/specification/security/resource-manager/Microsoft.Security/stable/2021-06-01/settings.json#L285
 					"SENTINEL",
 				}, false),
 			},
@@ -146,7 +150,7 @@ func expandSecurityCenterSetting(name string, enabled bool) (security.BasicSetti
 				Enabled: &enabled,
 			},
 		}, nil
-	case "SENTINEL":
+	case "SENTINEL", "Sentinel":
 		return security.AlertSyncSettings{
 			AlertSyncSettingProperties: &security.AlertSyncSettingProperties{
 				Enabled: &enabled,

--- a/internal/services/securitycenter/security_center_setting_resource.go
+++ b/internal/services/securitycenter/security_center_setting_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -20,6 +21,17 @@ import (
 // TODO: this resource should be split into data_export_setting and alert_sync_setting
 
 func resourceSecurityCenterSetting() *pluginsdk.Resource {
+	validSettingName := []string{
+		"MCAS",
+		"WDATP",
+		"Sentinel",
+	}
+	if !features.FourPointOhBeta() {
+		// This is for backward compatibility.. The swagger defines the valid enum to be "Sensinel" (see below), so this ("SENTINEL") shall be removed since 4.0.
+		// https://github.com/Azure/azure-rest-api-specs/blob/b52464f520b77222ac8b0bdeb80a030c0fdf5b1b/specification/security/resource-manager/Microsoft.Security/stable/2021-06-01/settings.json#L285
+		validSettingName = append(validSettingName, "SENTINEL")
+	}
+
 	return &pluginsdk.Resource{
 		Create: resourceSecurityCenterSettingUpdate,
 		Read:   resourceSecurityCenterSettingRead,
@@ -40,18 +52,10 @@ func resourceSecurityCenterSetting() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"setting_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"MCAS",
-					"WDATP",
-					"Sentinel",
-
-					// TODO 4.0: Remove this per the swagger definition:
-					//           https://github.com/Azure/azure-rest-api-specs/blob/b52464f520b77222ac8b0bdeb80a030c0fdf5b1b/specification/security/resource-manager/Microsoft.Security/stable/2021-06-01/settings.json#L285
-					"SENTINEL",
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(validSettingName, false),
 			},
 			"enabled": {
 				Type:     pluginsdk.TypeBool,

--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -71,12 +71,12 @@ func testAccSecurityCenterSetting_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.cfg("SENTINEL", true),
+			Config: r.cfg("Sentinel", true),
 			Check:  acceptance.ComposeTestCheckFunc(),
 		},
 		data.ImportStep(),
 		{
-			Config: r.cfg("SENTINEL", false),
+			Config: r.cfg("Sentinel", false),
 			Check:  acceptance.ComposeTestCheckFunc(),
 		},
 		data.ImportStep(),

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_security_center_setting" "example" {
 
 The following arguments are supported:
 
-* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP` and `SENTINEL`. Changing this forces a new resource to be created.
+* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP` and `Sentinel`. Changing this forces a new resource to be created.
 * `enabled` - (Required) Boolean flag to enable/disable data access.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR adds a new valid `setting_name` as `Sentinel`, as is defined by the swagger: https://github.com/Azure/azure-rest-api-specs/blob/4e11f9198d3500bb47fffe805ffa7c25a1a4bc46/specification/security/resource-manager/Microsoft.Security/stable/2021-06-01/settings.json#L285, which was overlooked in the prior PR (#19126) when this was introduced. Though both `Sentinel` and `SENTINEL` can work, it would be better to align with the API spec. The `SENTINEL` is still kept until v4.0.

Fix #24203