### PR TITLE
`data.azurerm_role_definition` - fix the issue where the value of properties `role_definition_id` and `scope` are set to empty

### DIFF
--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -156,7 +155,6 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			defId := config.RoleDefinitionId
 
 			// search by name
-			var id parse.RoleDefinitionID
 			var role authorization.RoleDefinition
 			if config.Name != "" {
 				// Accounting for eventual consistency
@@ -195,8 +193,8 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := RoleDefinitionDataSourceModel{
-				Scope:            id.Scope,
-				RoleDefinitionId: id.RoleID,
+				Scope:            config.Scope,
+				RoleDefinitionId: pointer.From(role.ID),
 			}
 
 			state.Name = pointer.From(role.RoleName)


### PR DESCRIPTION
Currently, the properties `role_definition_id` and `scope` of resource `data.azurerm_role_definition`  are set to empty value as `id` has not been assigned a value.

Fix #24200.