### PR TITLE
`cognitive_account` datasource: add identity block to attributes

### DIFF
--- a/internal/services/cognitive/cognitive_account_data_source.go
+++ b/internal/services/cognitive/cognitive_account_data_source.go
@@ -5,6 +5,7 @@ package cognitive
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -67,6 +68,8 @@ func dataSourceCognitiveAccount() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -112,6 +115,14 @@ func dataSourceCognitiveAccountRead(d *pluginsdk.ResourceData, meta interface{})
 				d.Set("qna_runtime_endpoint", apiProps.QnaRuntimeEndpoint)
 			}
 			d.Set("endpoint", props.Endpoint)
+		}
+
+		flattenedIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		if err := d.Set("identity", flattenedIdentity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
 		return tags.FlattenAndSet(d, model.Tags)

--- a/internal/services/cognitive/cognitive_account_data_source.go
+++ b/internal/services/cognitive/cognitive_account_data_source.go
@@ -69,7 +69,7 @@ func dataSourceCognitiveAccount() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
-			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
 
 			"tags": commonschema.Tags(),
 		},

--- a/internal/services/cognitive/cognitive_account_data_source.go
+++ b/internal/services/cognitive/cognitive_account_data_source.go
@@ -5,8 +5,9 @@ package cognitive
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"

--- a/internal/services/cognitive/cognitive_account_data_source_test.go
+++ b/internal/services/cognitive/cognitive_account_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccCognitiveAccountDataSource_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("kind").HasValue("Face"),
-				//check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
 			),
@@ -39,7 +39,7 @@ func TestAccCognitiveAccountDataSource_identity(t *testing.T) {
 			Config: r.identity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("kind").HasValue("Face"),
-				//check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
 				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
@@ -61,13 +61,6 @@ resource "azurerm_cognitive_account" "test" {
 
   tags = {
     Acceptance = "Test"
-  }
-
-# remove
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
   }
 }
 
@@ -96,13 +89,6 @@ resource "azurerm_cognitive_account" "test" {
   tags = {
     Acceptance = "Test"
   }
-
-# remove
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 
 data "azurerm_cognitive_account" "test" {
@@ -121,13 +107,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-
-	#remove
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/cognitive/cognitive_account_data_source_test.go
+++ b/internal/services/cognitive/cognitive_account_data_source_test.go
@@ -22,9 +22,27 @@ func TestAccCognitiveAccountDataSource_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("kind").HasValue("Face"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				//check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccCognitiveAccountDataSource_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cognitive_account", "test")
+	r := CognitiveAccountDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.identity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("kind").HasValue("Face"),
+				//check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("primary_access_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
 			),
 		},
 	})
@@ -44,6 +62,47 @@ resource "azurerm_cognitive_account" "test" {
   tags = {
     Acceptance = "Test"
   }
+
+# remove
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+data "azurerm_cognitive_account" "test" {
+  name                = azurerm_cognitive_account.test.name
+  resource_group_name = azurerm_cognitive_account.test.resource_group_name
+}
+`, CognitiveAccountDataSource{}.template(data), data.RandomInteger)
+}
+
+func (CognitiveAccountDataSource) identity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "Face"
+  sku_name            = "S0"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Acceptance = "Test"
+  }
+
+# remove
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 data "azurerm_cognitive_account" "test" {
@@ -62,6 +121,13 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+
+	#remove
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `identity` - A `identity` block as defined below.
+
 * `location` - The Azure location where the Cognitive Services Account exists
 
 * `kind` - The kind of the Cognitive Services Account
@@ -50,6 +52,18 @@ The following attributes are exported:
 * `secondary_access_key` - The secondary access key of the Cognitive Services Account
 
 * `tags` - A mapping of tags to assigned to the resource.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - The type of Managed Service Identity that is configured on this Cognitive Account.
+
+* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Cognitive Account.
+
+* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Cognitive Account.
+
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Cognitive Account.
 
 ## Timeouts
 


### PR DESCRIPTION
We need the SystemAssignedIdentities principal id in order to set RBAC roles for an OpenAI service instance.


This exposes the identity block in the `cognitive_account` datasource.

Tested it locally and everything seems to work fine