### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20231213.1160254`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
-	github.com/hashicorp/go-azure-helpers v0.64.0
-	github.com/hashicorp/go-azure-sdk v0.20231212.1221926
+	github.com/hashicorp/go-azure-helpers v0.65.0
+	github.com/hashicorp/go-azure-sdk v0.20231213.1160254
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,10 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.64.0 h1:JNTt0F7tbApmpmF9hzNq2TN1lduOiXJFkMFoAPVctK8=
-github.com/hashicorp/go-azure-helpers v0.64.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
-github.com/hashicorp/go-azure-sdk v0.20231212.1221926 h1:bqQtHOucPaEaHZ25oibL3gHVPqTM4uiw5U4mJ5kO7dM=
-github.com/hashicorp/go-azure-sdk v0.20231212.1221926/go.mod h1:b5nMCVXXrqnjFGBmtpJZ0lFvghDm+FiuWmjjAMFu6Ug=
+github.com/hashicorp/go-azure-helpers v0.65.0 h1:aOZV7HcxvqAlnaWJ/Fhfu321dXLs++TyBIVelWOb/8w=
+github.com/hashicorp/go-azure-helpers v0.65.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
+github.com/hashicorp/go-azure-sdk v0.20231213.1160254 h1:e7wZ3lvtnM6hSgIAIEm0jdKx68k3rke417aNFQq+C6I=
+github.com/hashicorp/go-azure-sdk v0.20231213.1160254/go.mod h1:69DSA+VMovHYJyQkRuUP3BCgwlEFrKvzeIHKi9m5xzY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/bot_service.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/bot_service.go
@@ -1,0 +1,127 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package commonids
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = BotServiceId{}
+
+// BotServiceId is a struct representing the Resource ID for a Bot Service
+type BotServiceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	BotServiceName    string
+}
+
+// NewBotServiceID returns a new BotServiceId struct
+func NewBotServiceID(subscriptionId string, resourceGroupName string, botServiceName string) BotServiceId {
+	return BotServiceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		BotServiceName:    botServiceName,
+	}
+}
+
+// ParseBotServiceID parses 'input' into a BotServiceId
+func ParseBotServiceID(input string) (*BotServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(BotServiceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := BotServiceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.BotServiceName, ok = parsed.Parsed["botServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "botServiceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseBotServiceIDInsensitively parses 'input' case-insensitively into a BotServiceId
+// note: this method should only be used for API response data and not user input
+func ParseBotServiceIDInsensitively(input string) (*BotServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(BotServiceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := BotServiceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.BotServiceName, ok = parsed.Parsed["botServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "botServiceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateBotServiceID checks that 'input' can be parsed as a Bot Service ID
+func ValidateBotServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseBotServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Bot Service ID
+func (id BotServiceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.BotService/botServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.BotServiceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Bot Service ID
+func (id BotServiceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftBotService", "Microsoft.BotService", "Microsoft.BotService"),
+		resourceids.StaticSegment("staticBotServices", "botServices", "botServices"),
+		resourceids.UserSpecifiedSegment("botServiceName", "botServiceValue"),
+	}
+}
+
+// String returns a human-readable description of this Bot Service ID
+func (id BotServiceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Bot Service Name: %q", id.BotServiceName),
+	}
+	return fmt.Sprintf("Bot Service (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/bot_service_channel.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/bot_service_channel.go
@@ -1,0 +1,235 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package commonids
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = BotServiceChannelId{}
+
+// BotServiceChannelId is a struct representing the Resource ID for a Bot Service Channel
+type BotServiceChannelId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	BotServiceName    string
+	ChannelType       BotServiceChannelType
+}
+
+// NewBotServiceChannelID returns a new BotServiceChannelId struct
+func NewBotServiceChannelID(subscriptionId string, resourceGroupName string, botServiceName string, channelType BotServiceChannelType) BotServiceChannelId {
+	return BotServiceChannelId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		BotServiceName:    botServiceName,
+		ChannelType:       channelType,
+	}
+}
+
+// ParseBotServiceChannelID parses 'input' into a BotServiceChannelId
+func ParseBotServiceChannelID(input string) (*BotServiceChannelId, error) {
+	parser := resourceids.NewParserFromResourceIdType(BotServiceChannelId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := BotServiceChannelId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.BotServiceName, ok = parsed.Parsed["botServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "botServiceName", *parsed)
+	}
+
+	if v, ok := parsed.Parsed["channelType"]; true {
+		if !ok {
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "channelType", *parsed)
+		}
+
+		channelType, err := parseBotServiceChannelType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ChannelType = *channelType
+	}
+
+	return &id, nil
+}
+
+// ParseBotServiceChannelIDInsensitively parses 'input' case-insensitively into a BotServiceChannelId
+// note: this method should only be used for API response data and not user input
+func ParseBotServiceChannelIDInsensitively(input string) (*BotServiceChannelId, error) {
+	parser := resourceids.NewParserFromResourceIdType(BotServiceChannelId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := BotServiceChannelId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.BotServiceName, ok = parsed.Parsed["botServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "botServiceName", *parsed)
+	}
+
+	if v, ok := parsed.Parsed["channelType"]; true {
+		if !ok {
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "channelType", *parsed)
+		}
+
+		channelType, err := parseBotServiceChannelType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ChannelType = *channelType
+	}
+
+	return &id, nil
+}
+
+// ValidateBotServiceChannelID checks that 'input' can be parsed as a Bot Service Channel ID
+func ValidateBotServiceChannelID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseBotServiceChannelID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Bot Service Channel ID
+func (id BotServiceChannelId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.BotService/botServices/%s/channels/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.BotServiceName, id.ChannelType)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Bot Service Channel ID
+func (id BotServiceChannelId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftBotService", "Microsoft.BotService", "Microsoft.BotService"),
+		resourceids.StaticSegment("staticBotServices", "botServices", "botServices"),
+		resourceids.UserSpecifiedSegment("botServiceName", "botServiceValue"),
+		resourceids.StaticSegment("staticChannels", "channels", "channels"),
+		resourceids.ConstantSegment("channelType", PossibleValuesForBotServiceChannelType(), string(AcsChatBotServiceChannelType)),
+	}
+}
+
+// String returns a human-readable description of this Bot Service Channel ID
+func (id BotServiceChannelId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Bot Service Name: %q", id.BotServiceName),
+		fmt.Sprintf("Channel Type: %q", id.ChannelType),
+	}
+	return fmt.Sprintf("Bot Service Channel (%s)", strings.Join(components, "\n"))
+}
+
+type BotServiceChannelType = string
+
+const (
+	AcsChatBotServiceChannelType          BotServiceChannelType = "AcsChatChannel"
+	AlexaBotServiceChannelType            BotServiceChannelType = "AlexaChannel"
+	DirectLineBotServiceChannelType       BotServiceChannelType = "DirectLineChannel"
+	DirectLineSpeechBotServiceChannelType BotServiceChannelType = "DirectLineSpeechChannel"
+	EmailBotServiceChannelType            BotServiceChannelType = "EmailChannel"
+	FacebookBotServiceChannelType         BotServiceChannelType = "FacebookChannel"
+	KikChannelBotServiceChannelType       BotServiceChannelType = "KikChannel"
+	LineBotServiceChannelType             BotServiceChannelType = "LineChannel"
+	M365ExtensionsBotServiceChannelType   BotServiceChannelType = "M365Extensions"
+	MsTeamsBotServiceChannelType          BotServiceChannelType = "MsTeamsChannel"
+	OmniChannelBotServiceChannelType      BotServiceChannelType = "OmniChannel"
+	OutlookBotServiceChannelType          BotServiceChannelType = "OutlookChannel"
+	SearchAssistantBotServiceChannelType  BotServiceChannelType = "SearchAssistant"
+	SkypeBotServiceChannelType            BotServiceChannelType = "SkypeChannel"
+	SlackBotServiceChannelType            BotServiceChannelType = "SlackChannel"
+	SmsBotServiceChannelType              BotServiceChannelType = "SmsChannel"
+	TelegramBotServiceChannelType         BotServiceChannelType = "TelegramChannel"
+	TelephonyBotServiceChannelType        BotServiceChannelType = "TelephonyChannel"
+	WebChatBotServiceChannelType          BotServiceChannelType = "WebChatChannel"
+)
+
+func parseBotServiceChannelType(input string) (*BotServiceChannelType, error) {
+	vals := map[string]BotServiceChannelType{
+		"AcsChatChannel":          AcsChatBotServiceChannelType,
+		"AlexaChannel":            AlexaBotServiceChannelType,
+		"DirectLineChannel":       DirectLineBotServiceChannelType,
+		"DirectLineSpeechChannel": DirectLineSpeechBotServiceChannelType,
+		"EmailChannel":            EmailBotServiceChannelType,
+		"KikChannel":              FacebookBotServiceChannelType,
+		"FacebookChannel":         KikChannelBotServiceChannelType,
+		"LineChannel":             LineBotServiceChannelType,
+		"M365Extensions":          M365ExtensionsBotServiceChannelType,
+		"MsTeamsChannel":          MsTeamsBotServiceChannelType,
+		"Omnichannel":             OmniChannelBotServiceChannelType,
+		"OutlookChannel":          OutlookBotServiceChannelType,
+		"SearchAssistant":         SearchAssistantBotServiceChannelType,
+		"SkypeChannel":            SkypeBotServiceChannelType,
+		"SlackChannel":            SlackBotServiceChannelType,
+		"SmsChannel":              SmsBotServiceChannelType,
+		"TelegramChannel":         TelegramBotServiceChannelType,
+		"TelephonyChannel":        TelephonyBotServiceChannelType,
+		"WebChatChannel":          WebChatBotServiceChannelType,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := BotServiceChannelType(input)
+	return &out, nil
+}
+
+func PossibleValuesForBotServiceChannelType() []string {
+	return []string{
+		string(AcsChatBotServiceChannelType),
+		string(AlexaBotServiceChannelType),
+		string(DirectLineBotServiceChannelType),
+		string(DirectLineSpeechBotServiceChannelType),
+		string(EmailBotServiceChannelType),
+		string(FacebookBotServiceChannelType),
+		string(KikChannelBotServiceChannelType),
+		string(LineBotServiceChannelType),
+		string(M365ExtensionsBotServiceChannelType),
+		string(MsTeamsBotServiceChannelType),
+		string(OmniChannelBotServiceChannelType),
+		string(OutlookBotServiceChannelType),
+		string(SearchAssistantBotServiceChannelType),
+		string(SkypeBotServiceChannelType),
+		string(SlackBotServiceChannelType),
+		string(SmsBotServiceChannelType),
+		string(TelegramBotServiceChannelType),
+		string(TelephonyBotServiceChannelType),
+		string(WebChatBotServiceChannelType),
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/dev_center.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/dev_center.go
@@ -1,0 +1,126 @@
+//Copyright (c) HashiCorp, Inc.
+//SPDX-License-Identifier: MPL-2.0
+
+package commonids
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DevCenterId{}
+
+// DevCenterId is a struct representing the Resource ID for a Dev Center
+type DevCenterId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	DevCenterName     string
+}
+
+// NewDevCenterID returns a new DevCenterId struct
+func NewDevCenterID(subscriptionId string, resourceGroupName string, devCenterName string) DevCenterId {
+	return DevCenterId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		DevCenterName:     devCenterName,
+	}
+}
+
+// ParseDevCenterID parses 'input' into a DevCenterId
+func ParseDevCenterID(input string) (*DevCenterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DevCenterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DevCenterId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.DevCenterName, ok = parsed.Parsed["devCenterName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "devCenterName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseDevCenterIDInsensitively parses 'input' case-insensitively into a DevCenterId
+// note: this method should only be used for API response data and not user input
+func ParseDevCenterIDInsensitively(input string) (*DevCenterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DevCenterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DevCenterId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.DevCenterName, ok = parsed.Parsed["devCenterName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "devCenterName", *parsed)
+	}
+
+	return &id, nil
+}
+
+func ValidateDevCenterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected string, got %T", input))
+		return
+	}
+
+	if _, err := ParseDevCenterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted dev center ID
+func (id DevCenterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DevCenter/devCenters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.DevCenterName)
+}
+
+// String returns a human-readable representation of the dev center ID
+func (id DevCenterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription ID %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name %q", id.ResourceGroupName),
+		fmt.Sprintf("Dev Center Name %q", id.DevCenterName),
+	}
+	return fmt.Sprintf("Dev Center (%s)", strings.Join(components, "\n"))
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Dev Center ID
+func (id DevCenterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroup"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDevCenter", "Microsoft.DevCenter", "Microsoft.DevCenter"),
+		resourceids.StaticSegment("staticDevCenters", "devCenters", "devCenters"),
+		resourceids.UserSpecifiedSegment("devCenterName", "devCenterValue"),
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
@@ -170,6 +170,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"AuthorizeReplication": pollers.PollingStatusInProgress,
 			// NetAppVolumeReplication @ 2023-05-01 returns `BreakReplication` during breaking replication
 			"BreakReplication": pollers.PollingStatusInProgress,
+			// Mysql @ 2022-01-01 returns `CancelInProgress` during Update
+			"CancelInProgress": pollers.PollingStatusInProgress,
 			// CostManagement@2021-10-01 returns `Completed` rather than `Succeeded`: https://github.com/Azure/azure-sdk-for-go/issues/20342
 			"Completed": pollers.PollingStatusSucceeded,
 			// ContainerRegistry@2019-06-01-preview returns `Creating` rather than `InProgress` during creation

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -137,7 +137,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.64.0
+# github.com/hashicorp/go-azure-helpers v0.65.0
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/eventhub
@@ -157,7 +157,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20231212.1221926
+# github.com/hashicorp/go-azure-sdk v0.20231213.1160254
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20231213.1160254` - further details can be found in a comment.