### PR TITLE
New resource: `azurerm_log_analytics_workspace_table`

### DIFF
--- a/internal/services/loganalytics/client/client.go
+++ b/internal/services/loganalytics/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
 	featureWorkspaces "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
@@ -33,6 +34,7 @@ type Client struct {
 	StorageInsightsClient      *storageinsights.StorageInsightsClient
 	QueryPackQueriesClient     *querypackqueries.QueryPackQueriesClient
 	SharedKeyWorkspacesClient  *workspaces.WorkspacesClient
+	TablesClient               *tables.TablesClient
 	WorkspaceClient            *featureWorkspaces.WorkspacesClient // 2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
 }
 
@@ -109,6 +111,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(queryPackQueriesClient.Client, o.Authorizers.ResourceManager)
 
+	tablesClient, err := tables.NewTablesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Tables client: %+v", err)
+	}
+	o.Configure(tablesClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
 		ClusterClient:              clusterClient,
 		DataExportClient:           dataExportClient,
@@ -121,6 +129,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		SolutionsClient:            solutionsClient,
 		StorageInsightsClient:      storageInsightsClient,
 		SharedKeyWorkspacesClient:  workspacesClient,
+		TablesClient:               tablesClient,
 		WorkspaceClient:            featureWorkspaceClient,
 	}, nil
 }

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -1,0 +1,212 @@
+package loganalytics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type LogAnalyticsWorkspaceTableResource struct {
+}
+
+var _ sdk.ResourceWithUpdate = LogAnalyticsWorkspaceTableResource{}
+
+type LogAnalyticsWorkspaceTableResourceModel struct {
+	Name            string `tfschema:"name"`
+	WorkspaceId     string `tfschema:"workspace_id"`
+	RetentionInDays int64  `tfschema:"retention_in_days"`
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"workspace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
+		},
+
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"retention_in_days": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
+		},
+	}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) ModelObject() interface{} {
+	return &LogAnalyticsWorkspaceTableResourceModel{}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) ResourceType() string {
+	return "azurerm_log_analytics_workspace_table"
+}
+
+func (r LogAnalyticsWorkspaceTableResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return tables.ValidateTableID
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model LogAnalyticsWorkspaceTableResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.LogAnalytics.TablesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			tableName := model.Name
+			log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace Table %s update.", tableName)
+
+			workspaceId, err := workspaces.ParseWorkspaceID(model.WorkspaceId)
+			if err != nil {
+				return fmt.Errorf("invalid workspace object ID for table %s: %s", tableName, err)
+			}
+
+			id := tables.NewTableID(subscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, tableName)
+
+			retentionInDays := model.RetentionInDays
+			updateInput := tables.Table{
+				Properties: &tables.TableProperties{
+					RetentionInDays: &retentionInDays,
+				},
+			}
+			if err := client.CreateOrUpdateThenPoll(ctx, id, updateInput); err != nil {
+				return fmt.Errorf("failed to update table %s in workspace %s in resource group %s: %s", tableName, workspaceId.WorkspaceName, workspaceId.ResourceGroupName, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.LogAnalytics.TablesClient
+			id, err := tables.ParseTableID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var state LogAnalyticsWorkspaceTableResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading Log Analytics Workspace Table %s: %v", id, err)
+			}
+
+			updateInput := tables.Table{
+				Properties: &tables.TableProperties{
+					RetentionInDays: existing.Model.Properties.RetentionInDays,
+				},
+			}
+
+			if metadata.ResourceData.HasChange("retention_in_days") {
+				updateInput.Properties.RetentionInDays = &state.RetentionInDays
+			}
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
+				return fmt.Errorf("failed to update table: %s: %+v", id.TableName, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := tables.ParseTableID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			workspaceId, err := workspaces.ParseWorkspaceID(metadata.ResourceData.Get("workspace_id").(string))
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			client := metadata.Client.LogAnalytics.TablesClient
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving Log Analytics Workspace Table %s: %+v", *id, err)
+			}
+
+			state := LogAnalyticsWorkspaceTableResourceModel{
+				Name:        id.TableName,
+				WorkspaceId: workspaceId.ID(),
+			}
+
+			if model := resp.Model; model != nil {
+				if model.Properties.RetentionInDays != nil {
+					state.RetentionInDays = *model.Properties.RetentionInDays
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r LogAnalyticsWorkspaceTableResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model LogAnalyticsWorkspaceTableResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.LogAnalytics.TablesClient
+			id, err := tables.ParseTableID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			// We do not delete the resource here, just set the retention to workspace default value, which is
+			// achieved by setting the value to `-1`
+			retentionInDays := utils.Int64(-1)
+
+			updateInput := tables.Table{
+				Properties: &tables.TableProperties{
+					RetentionInDays: retentionInDays,
+				},
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
+				return fmt.Errorf("failed to update table %s in workspace %s in resource group %s: %s", id.TableName, id.WorkspaceName, id.ResourceGroupName, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -1,0 +1,70 @@
+package loganalytics_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type LogAnalyticsWorkspaceTableResource struct{}
+
+func TestAccLogAnalyticsWorkspaceTable_updateTableRetention(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace_table", "test")
+	r := LogAnalyticsWorkspaceTableResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.updateRetention(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("name").HasValue("AppEvents"),
+				check.That(data.ResourceName).Key("retention_in_days").HasValue("7"),
+			),
+		},
+	})
+}
+
+func (t LogAnalyticsWorkspaceTableResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := tables.ParseTableID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.LogAnalytics.TablesClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("reading Log Analytics Workspace Table (%s): %+v", id.ID(), err)
+	}
+
+	return utils.Bool(resp.Model.Id != nil), nil
+}
+
+func (LogAnalyticsWorkspaceTableResource) updateRetention(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  retention_in_days   = 30
+}
+resource "azurerm_log_analytics_workspace_table" "test" {
+  name              = "AppEvents"
+  workspace_id      = azurerm_log_analytics_workspace.test.id
+  retention_in_days = 7
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/loganalytics/registration.go
+++ b/internal/services/loganalytics/registration.go
@@ -28,6 +28,7 @@ func (r Registration) Resources() []sdk.Resource {
 		LogAnalyticsQueryPackResource{},
 		LogAnalyticsQueryPackQueryResource{},
 		LogAnalyticsSolutionResource{},
+		LogAnalyticsWorkspaceTableResource{},
 	}
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/README.md
@@ -1,0 +1,130 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables` Documentation
+
+The `tables` SDK allows for interaction with the Azure Resource Manager Service `operationalinsights` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
+```
+
+
+### Client Initialization
+
+```go
+client := tables.NewTablesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `TablesClient.CancelSearch`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+read, err := client.CancelSearch(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TablesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+payload := tables.Table{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TablesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TablesClient.Get`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TablesClient.ListByWorkspace`
+
+```go
+ctx := context.TODO()
+id := tables.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue")
+
+read, err := client.ListByWorkspace(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TablesClient.Migrate`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+read, err := client.Migrate(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TablesClient.Update`
+
+```go
+ctx := context.TODO()
+id := tables.NewTableID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue", "tableValue")
+
+payload := tables.Table{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/client.go
@@ -1,0 +1,26 @@
+package tables
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TablesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewTablesClientWithBaseURI(sdkApi sdkEnv.Api) (*TablesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "tables", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating TablesClient: %+v", err)
+	}
+
+	return &TablesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/constants.go
@@ -1,0 +1,336 @@
+package tables
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ColumnDataTypeHintEnum string
+
+const (
+	ColumnDataTypeHintEnumArmPath ColumnDataTypeHintEnum = "armPath"
+	ColumnDataTypeHintEnumGuid    ColumnDataTypeHintEnum = "guid"
+	ColumnDataTypeHintEnumIP      ColumnDataTypeHintEnum = "ip"
+	ColumnDataTypeHintEnumUri     ColumnDataTypeHintEnum = "uri"
+)
+
+func PossibleValuesForColumnDataTypeHintEnum() []string {
+	return []string{
+		string(ColumnDataTypeHintEnumArmPath),
+		string(ColumnDataTypeHintEnumGuid),
+		string(ColumnDataTypeHintEnumIP),
+		string(ColumnDataTypeHintEnumUri),
+	}
+}
+
+func (s *ColumnDataTypeHintEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseColumnDataTypeHintEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseColumnDataTypeHintEnum(input string) (*ColumnDataTypeHintEnum, error) {
+	vals := map[string]ColumnDataTypeHintEnum{
+		"armpath": ColumnDataTypeHintEnumArmPath,
+		"guid":    ColumnDataTypeHintEnumGuid,
+		"ip":      ColumnDataTypeHintEnumIP,
+		"uri":     ColumnDataTypeHintEnumUri,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ColumnDataTypeHintEnum(input)
+	return &out, nil
+}
+
+type ColumnTypeEnum string
+
+const (
+	ColumnTypeEnumBoolean  ColumnTypeEnum = "boolean"
+	ColumnTypeEnumDateTime ColumnTypeEnum = "dateTime"
+	ColumnTypeEnumDynamic  ColumnTypeEnum = "dynamic"
+	ColumnTypeEnumGuid     ColumnTypeEnum = "guid"
+	ColumnTypeEnumInt      ColumnTypeEnum = "int"
+	ColumnTypeEnumLong     ColumnTypeEnum = "long"
+	ColumnTypeEnumReal     ColumnTypeEnum = "real"
+	ColumnTypeEnumString   ColumnTypeEnum = "string"
+)
+
+func PossibleValuesForColumnTypeEnum() []string {
+	return []string{
+		string(ColumnTypeEnumBoolean),
+		string(ColumnTypeEnumDateTime),
+		string(ColumnTypeEnumDynamic),
+		string(ColumnTypeEnumGuid),
+		string(ColumnTypeEnumInt),
+		string(ColumnTypeEnumLong),
+		string(ColumnTypeEnumReal),
+		string(ColumnTypeEnumString),
+	}
+}
+
+func (s *ColumnTypeEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseColumnTypeEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseColumnTypeEnum(input string) (*ColumnTypeEnum, error) {
+	vals := map[string]ColumnTypeEnum{
+		"boolean":  ColumnTypeEnumBoolean,
+		"datetime": ColumnTypeEnumDateTime,
+		"dynamic":  ColumnTypeEnumDynamic,
+		"guid":     ColumnTypeEnumGuid,
+		"int":      ColumnTypeEnumInt,
+		"long":     ColumnTypeEnumLong,
+		"real":     ColumnTypeEnumReal,
+		"string":   ColumnTypeEnumString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ColumnTypeEnum(input)
+	return &out, nil
+}
+
+type ProvisioningStateEnum string
+
+const (
+	ProvisioningStateEnumDeleting   ProvisioningStateEnum = "Deleting"
+	ProvisioningStateEnumInProgress ProvisioningStateEnum = "InProgress"
+	ProvisioningStateEnumSucceeded  ProvisioningStateEnum = "Succeeded"
+	ProvisioningStateEnumUpdating   ProvisioningStateEnum = "Updating"
+)
+
+func PossibleValuesForProvisioningStateEnum() []string {
+	return []string{
+		string(ProvisioningStateEnumDeleting),
+		string(ProvisioningStateEnumInProgress),
+		string(ProvisioningStateEnumSucceeded),
+		string(ProvisioningStateEnumUpdating),
+	}
+}
+
+func (s *ProvisioningStateEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningStateEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningStateEnum(input string) (*ProvisioningStateEnum, error) {
+	vals := map[string]ProvisioningStateEnum{
+		"deleting":   ProvisioningStateEnumDeleting,
+		"inprogress": ProvisioningStateEnumInProgress,
+		"succeeded":  ProvisioningStateEnumSucceeded,
+		"updating":   ProvisioningStateEnumUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningStateEnum(input)
+	return &out, nil
+}
+
+type SourceEnum string
+
+const (
+	SourceEnumCustomer  SourceEnum = "customer"
+	SourceEnumMicrosoft SourceEnum = "microsoft"
+)
+
+func PossibleValuesForSourceEnum() []string {
+	return []string{
+		string(SourceEnumCustomer),
+		string(SourceEnumMicrosoft),
+	}
+}
+
+func (s *SourceEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSourceEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSourceEnum(input string) (*SourceEnum, error) {
+	vals := map[string]SourceEnum{
+		"customer":  SourceEnumCustomer,
+		"microsoft": SourceEnumMicrosoft,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SourceEnum(input)
+	return &out, nil
+}
+
+type TablePlanEnum string
+
+const (
+	TablePlanEnumAnalytics TablePlanEnum = "Analytics"
+	TablePlanEnumBasic     TablePlanEnum = "Basic"
+)
+
+func PossibleValuesForTablePlanEnum() []string {
+	return []string{
+		string(TablePlanEnumAnalytics),
+		string(TablePlanEnumBasic),
+	}
+}
+
+func (s *TablePlanEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTablePlanEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTablePlanEnum(input string) (*TablePlanEnum, error) {
+	vals := map[string]TablePlanEnum{
+		"analytics": TablePlanEnumAnalytics,
+		"basic":     TablePlanEnumBasic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TablePlanEnum(input)
+	return &out, nil
+}
+
+type TableSubTypeEnum string
+
+const (
+	TableSubTypeEnumAny                     TableSubTypeEnum = "Any"
+	TableSubTypeEnumClassic                 TableSubTypeEnum = "Classic"
+	TableSubTypeEnumDataCollectionRuleBased TableSubTypeEnum = "DataCollectionRuleBased"
+)
+
+func PossibleValuesForTableSubTypeEnum() []string {
+	return []string{
+		string(TableSubTypeEnumAny),
+		string(TableSubTypeEnumClassic),
+		string(TableSubTypeEnumDataCollectionRuleBased),
+	}
+}
+
+func (s *TableSubTypeEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTableSubTypeEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTableSubTypeEnum(input string) (*TableSubTypeEnum, error) {
+	vals := map[string]TableSubTypeEnum{
+		"any":                     TableSubTypeEnumAny,
+		"classic":                 TableSubTypeEnumClassic,
+		"datacollectionrulebased": TableSubTypeEnumDataCollectionRuleBased,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TableSubTypeEnum(input)
+	return &out, nil
+}
+
+type TableTypeEnum string
+
+const (
+	TableTypeEnumCustomLog     TableTypeEnum = "CustomLog"
+	TableTypeEnumMicrosoft     TableTypeEnum = "Microsoft"
+	TableTypeEnumRestoredLogs  TableTypeEnum = "RestoredLogs"
+	TableTypeEnumSearchResults TableTypeEnum = "SearchResults"
+)
+
+func PossibleValuesForTableTypeEnum() []string {
+	return []string{
+		string(TableTypeEnumCustomLog),
+		string(TableTypeEnumMicrosoft),
+		string(TableTypeEnumRestoredLogs),
+		string(TableTypeEnumSearchResults),
+	}
+}
+
+func (s *TableTypeEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTableTypeEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTableTypeEnum(input string) (*TableTypeEnum, error) {
+	vals := map[string]TableTypeEnum{
+		"customlog":     TableTypeEnumCustomLog,
+		"microsoft":     TableTypeEnumMicrosoft,
+		"restoredlogs":  TableTypeEnumRestoredLogs,
+		"searchresults": TableTypeEnumSearchResults,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TableTypeEnum(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/id_table.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/id_table.go
@@ -1,0 +1,134 @@
+package tables
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = TableId{}
+
+// TableId is a struct representing the Resource ID for a Table
+type TableId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	WorkspaceName     string
+	TableName         string
+}
+
+// NewTableID returns a new TableId struct
+func NewTableID(subscriptionId string, resourceGroupName string, workspaceName string, tableName string) TableId {
+	return TableId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		WorkspaceName:     workspaceName,
+		TableName:         tableName,
+	}
+}
+
+// ParseTableID parses 'input' into a TableId
+func ParseTableID(input string) (*TableId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TableId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TableId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseTableIDInsensitively parses 'input' case-insensitively into a TableId
+// note: this method should only be used for API response data and not user input
+func ParseTableIDInsensitively(input string) (*TableId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TableId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TableId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *TableId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.WorkspaceName, ok = input.Parsed["workspaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", input)
+	}
+
+	if id.TableName, ok = input.Parsed["tableName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "tableName", input)
+	}
+
+	return nil
+}
+
+// ValidateTableID checks that 'input' can be parsed as a Table ID
+func ValidateTableID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTableID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Table ID
+func (id TableId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.OperationalInsights/workspaces/%s/tables/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName, id.TableName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Table ID
+func (id TableId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftOperationalInsights", "Microsoft.OperationalInsights", "Microsoft.OperationalInsights"),
+		resourceids.StaticSegment("staticWorkspaces", "workspaces", "workspaces"),
+		resourceids.UserSpecifiedSegment("workspaceName", "workspaceValue"),
+		resourceids.StaticSegment("staticTables", "tables", "tables"),
+		resourceids.UserSpecifiedSegment("tableName", "tableValue"),
+	}
+}
+
+// String returns a human-readable description of this Table ID
+func (id TableId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Workspace Name: %q", id.WorkspaceName),
+		fmt.Sprintf("Table Name: %q", id.TableName),
+	}
+	return fmt.Sprintf("Table (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/id_workspace.go
@@ -1,0 +1,125 @@
+package tables
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = WorkspaceId{}
+
+// WorkspaceId is a struct representing the Resource ID for a Workspace
+type WorkspaceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	WorkspaceName     string
+}
+
+// NewWorkspaceID returns a new WorkspaceId struct
+func NewWorkspaceID(subscriptionId string, resourceGroupName string, workspaceName string) WorkspaceId {
+	return WorkspaceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		WorkspaceName:     workspaceName,
+	}
+}
+
+// ParseWorkspaceID parses 'input' into a WorkspaceId
+func ParseWorkspaceID(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WorkspaceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := WorkspaceId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseWorkspaceIDInsensitively parses 'input' case-insensitively into a WorkspaceId
+// note: this method should only be used for API response data and not user input
+func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WorkspaceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := WorkspaceId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *WorkspaceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.WorkspaceName, ok = input.Parsed["workspaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", input)
+	}
+
+	return nil
+}
+
+// ValidateWorkspaceID checks that 'input' can be parsed as a Workspace ID
+func ValidateWorkspaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseWorkspaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Workspace ID
+func (id WorkspaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.OperationalInsights/workspaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Workspace ID
+func (id WorkspaceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftOperationalInsights", "Microsoft.OperationalInsights", "Microsoft.OperationalInsights"),
+		resourceids.StaticSegment("staticWorkspaces", "workspaces", "workspaces"),
+		resourceids.UserSpecifiedSegment("workspaceName", "workspaceValue"),
+	}
+}
+
+// String returns a human-readable description of this Workspace ID
+func (id WorkspaceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Workspace Name: %q", id.WorkspaceName),
+	}
+	return fmt.Sprintf("Workspace (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_cancelsearch.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_cancelsearch.go
@@ -1,0 +1,47 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CancelSearchOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// CancelSearch ...
+func (c TablesClient) CancelSearch(ctx context.Context, id TableId) (result CancelSearchOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/cancelSearch", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_createorupdate.go
@@ -1,0 +1,74 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// CreateOrUpdate ...
+func (c TablesClient) CreateOrUpdate(ctx context.Context, id TableId, input Table) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c TablesClient) CreateOrUpdateThenPoll(ctx context.Context, id TableId, input Table) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_delete.go
@@ -1,0 +1,71 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c TablesClient) Delete(ctx context.Context, id TableId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c TablesClient) DeleteThenPoll(ctx context.Context, id TableId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_get.go
@@ -1,0 +1,51 @@
+package tables
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Table
+}
+
+// Get ...
+func (c TablesClient) Get(ctx context.Context, id TableId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_listbyworkspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_listbyworkspace.go
@@ -1,0 +1,52 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByWorkspaceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TablesListResult
+}
+
+// ListByWorkspace ...
+func (c TablesClient) ListByWorkspace(ctx context.Context, id WorkspaceId) (result ListByWorkspaceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/tables", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_migrate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_migrate.go
@@ -1,0 +1,47 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MigrateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Migrate ...
+func (c TablesClient) Migrate(ctx context.Context, id TableId) (result MigrateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/migrate", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/method_update.go
@@ -1,0 +1,74 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Update ...
+func (c TablesClient) Update(ctx context.Context, id TableId, input Table) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c TablesClient) UpdateThenPoll(ctx context.Context, id TableId, input Table) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_column.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_column.go
@@ -1,0 +1,14 @@
+package tables
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Column struct {
+	DataTypeHint     *ColumnDataTypeHintEnum `json:"dataTypeHint,omitempty"`
+	Description      *string                 `json:"description,omitempty"`
+	DisplayName      *string                 `json:"displayName,omitempty"`
+	IsDefaultDisplay *bool                   `json:"isDefaultDisplay,omitempty"`
+	IsHidden         *bool                   `json:"isHidden,omitempty"`
+	Name             *string                 `json:"name,omitempty"`
+	Type             *ColumnTypeEnum         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_restoredlogs.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_restoredlogs.go
@@ -1,0 +1,41 @@
+package tables
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RestoredLogs struct {
+	AzureAsyncOperationId *string `json:"azureAsyncOperationId,omitempty"`
+	EndRestoreTime        *string `json:"endRestoreTime,omitempty"`
+	SourceTable           *string `json:"sourceTable,omitempty"`
+	StartRestoreTime      *string `json:"startRestoreTime,omitempty"`
+}
+
+func (o *RestoredLogs) GetEndRestoreTimeAsTime() (*time.Time, error) {
+	if o.EndRestoreTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EndRestoreTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RestoredLogs) SetEndRestoreTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EndRestoreTime = &formatted
+}
+
+func (o *RestoredLogs) GetStartRestoreTimeAsTime() (*time.Time, error) {
+	if o.StartRestoreTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartRestoreTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RestoredLogs) SetStartRestoreTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartRestoreTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_resultstatistics.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_resultstatistics.go
@@ -1,0 +1,10 @@
+package tables
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResultStatistics struct {
+	IngestedRecords *int64   `json:"ingestedRecords,omitempty"`
+	Progress        *float64 `json:"progress,omitempty"`
+	ScannedGb       *float64 `json:"scannedGb,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_schema.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_schema.go
@@ -1,0 +1,18 @@
+package tables
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Schema struct {
+	Categories      *[]string         `json:"categories,omitempty"`
+	Columns         *[]Column         `json:"columns,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	DisplayName     *string           `json:"displayName,omitempty"`
+	Labels          *[]string         `json:"labels,omitempty"`
+	Name            *string           `json:"name,omitempty"`
+	Solutions       *[]string         `json:"solutions,omitempty"`
+	Source          *SourceEnum       `json:"source,omitempty"`
+	StandardColumns *[]Column         `json:"standardColumns,omitempty"`
+	TableSubType    *TableSubTypeEnum `json:"tableSubType,omitempty"`
+	TableType       *TableTypeEnum    `json:"tableType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_searchresults.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_searchresults.go
@@ -1,0 +1,44 @@
+package tables
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SearchResults struct {
+	AzureAsyncOperationId *string `json:"azureAsyncOperationId,omitempty"`
+	Description           *string `json:"description,omitempty"`
+	EndSearchTime         *string `json:"endSearchTime,omitempty"`
+	Limit                 *int64  `json:"limit,omitempty"`
+	Query                 *string `json:"query,omitempty"`
+	SourceTable           *string `json:"sourceTable,omitempty"`
+	StartSearchTime       *string `json:"startSearchTime,omitempty"`
+}
+
+func (o *SearchResults) GetEndSearchTimeAsTime() (*time.Time, error) {
+	if o.EndSearchTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EndSearchTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *SearchResults) SetEndSearchTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EndSearchTime = &formatted
+}
+
+func (o *SearchResults) GetStartSearchTimeAsTime() (*time.Time, error) {
+	if o.StartSearchTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartSearchTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *SearchResults) SetStartSearchTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartSearchTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_table.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_table.go
@@ -1,0 +1,16 @@
+package tables
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Table struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *TableProperties       `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_tableproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_tableproperties.go
@@ -1,0 +1,19 @@
+package tables
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TableProperties struct {
+	ArchiveRetentionInDays        *int64                 `json:"archiveRetentionInDays,omitempty"`
+	LastPlanModifiedDate          *string                `json:"lastPlanModifiedDate,omitempty"`
+	Plan                          *TablePlanEnum         `json:"plan,omitempty"`
+	ProvisioningState             *ProvisioningStateEnum `json:"provisioningState,omitempty"`
+	RestoredLogs                  *RestoredLogs          `json:"restoredLogs,omitempty"`
+	ResultStatistics              *ResultStatistics      `json:"resultStatistics,omitempty"`
+	RetentionInDays               *int64                 `json:"retentionInDays,omitempty"`
+	RetentionInDaysAsDefault      *bool                  `json:"retentionInDaysAsDefault,omitempty"`
+	Schema                        *Schema                `json:"schema,omitempty"`
+	SearchResults                 *SearchResults         `json:"searchResults,omitempty"`
+	TotalRetentionInDays          *int64                 `json:"totalRetentionInDays,omitempty"`
+	TotalRetentionInDaysAsDefault *bool                  `json:"totalRetentionInDaysAsDefault,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_tableslistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/model_tableslistresult.go
@@ -1,0 +1,8 @@
+package tables
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TablesListResult struct {
+	Value *[]Table `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables/version.go
@@ -1,0 +1,12 @@
+package tables
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/tables/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -787,6 +787,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-0
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces
+github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Log Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_log_analytics_workspace_table"
+description: |-
+  Manages a Table in a Log Analytics (formally Operational Insights) Workspace.
+---
+
+# azurerm_log_analytics_workspace_table
+
+Manages a Table in a Log Analytics (formally Operational Insights) Workspace.
+
+~> **Note:** This resource does not create or destroy tables. This resource is used to update attributes (currently only retention_in_days) of the tables created when a Log Analytics Workspace is created. Deleting an azurerm_log_analytics_workspace_table resource will not delete the table. Instead, the table's retention_in_days field will be set to the value of azurerm_log_analytics_workspace retention_in_days
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+resource "azurerm_log_analytics_workspace_table" "example" {
+  workspace_id      = azurerm_log_analytics_workspace.example.id
+  name              = "AppMetrics"
+  retention_in_days = 60
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of a table in a Log Analytics Workspace.
+
+* `workspace_id` - (Required) The object ID of the Log Analytics Workspace that contains the table.
+
+* `retention_in_days` - (Required) The table's retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
+
+-> **Note:** retention_in_days will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Log Analytics Workspace Table ID.
+
+* `workspace_id` - The Workspace (or Customer) ID for the Log Analytics Workspace.
+
+* `retention_in_days` - The table's data retention in days.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Workspace.
+* `update` - (Defaults to 30 minutes) Used when updating the Log Analytics Workspace.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Log Analytics Workspace.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Log Analytics Workspace.


### PR DESCRIPTION
Reviving old PR #15462

This resource also currently only supports mangling retention. If this is ok - I can expand it to a full-blown resource over Xmas, but this should fix a very much wanted functionality requested by multiple users.

Fixes #6199

```
✗ TF_ACC=1 go test -v ./internal/services/loganalytics -timeout=1000m -run='TestAccLogAnalyticsWorkspaceTable_updateTableRetention'
=== RUN   TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== PAUSE TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== CONT  TestAccLogAnalyticsWorkspaceTable_updateTableRetention
--- PASS: TestAccLogAnalyticsWorkspaceTable_updateTableRetention (286.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	288.459s
```