### PR TITLE
dependencies: updating to v0.20231214.1220802 of github.com/hashicorp/go-azure-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.65.0
-	github.com/hashicorp/go-azure-sdk v0.20231214.1160726
+	github.com/hashicorp/go-azure-sdk v0.20231214.1220802
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.65.0 h1:aOZV7HcxvqAlnaWJ/Fhfu321dXLs++TyBIVelWOb/8w=
 github.com/hashicorp/go-azure-helpers v0.65.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
-github.com/hashicorp/go-azure-sdk v0.20231214.1160726 h1:hTJZK/hhcm8ysaPidA4jSMB6iqHqKcxTLEJzI+B5/Tc=
-github.com/hashicorp/go-azure-sdk v0.20231214.1160726/go.mod h1:69DSA+VMovHYJyQkRuUP3BCgwlEFrKvzeIHKi9m5xzY=
+github.com/hashicorp/go-azure-sdk v0.20231214.1220802 h1:8bRaPuWFrjwGMx3gNnB4sECigPABXkf/4fuhBedVcqU=
+github.com/hashicorp/go-azure-sdk v0.20231214.1220802/go.mod h1:69DSA+VMovHYJyQkRuUP3BCgwlEFrKvzeIHKi9m5xzY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
@@ -33,7 +33,7 @@ func AzureChina() *Environment {
 	env.Postgresql = PostgresqlAPI("postgres.database.chinacloudapi.cn").withResourceIdentifier("https://ossrdbms-aad.database.chinacloudapi.cn")
 	env.ServiceBus = ServiceBusAPI("https://servicebus.chinacloudapi.cn", "servicebus.chinacloudapi.cn")
 	env.Sql = SqlAPI("database.chinacloudapi.cn").withResourceIdentifier("https://database.chinacloudapi.cn")
-	env.Storage = StorageAPI("core.chinacloudapi.cn").withResourceIdentifier("https://core.chinacloudapi.cn")
+	env.Storage = StorageAPI("core.chinacloudapi.cn").withResourceIdentifier("https://storage.azure.com")
 	env.Synapse = SynapseAPI("dev.azuresynapse.azure.cn")
 	env.TrafficManager = TrafficManagerAPI("trafficmanager.cn")
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20231214.1160726
+# github.com/hashicorp/go-azure-sdk v0.20231214.1220802
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
```
provider: fix an authentication issue with Azure Storage when running in Azure China cloud
```

Related: https://github.com/hashicorp/go-azure-sdk/pull/781