### PR TITLE
`azurerm_spring_cloud_api_portal` - change to a typed resource

### DIFF
--- a/internal/services/springcloud/registration.go
+++ b/internal/services/springcloud/registration.go
@@ -43,7 +43,6 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_spring_cloud_active_deployment":        resourceSpringCloudActiveDeployment(),
-		"azurerm_spring_cloud_api_portal":               resourceSpringCloudAPIPortal(),
 		"azurerm_spring_cloud_api_portal_custom_domain": resourceSpringCloudAPIPortalCustomDomain(),
 		"azurerm_spring_cloud_app":                      resourceSpringCloudApp(),
 		"azurerm_spring_cloud_app_cosmosdb_association": resourceSpringCloudAppCosmosDBAssociation(),
@@ -72,6 +71,7 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		SpringCloudGatewayResource{},
 		SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource{},
+		SpringCloudAPIPortalResource{},
 		SpringCloudAcceleratorResource{},
 		SpringCloudApplicationLiveViewResource{},
 		SpringCloudDevToolPortalResource{},

--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -4,336 +4,388 @@
 package springcloud
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/appplatform/2023-05-01-preview/appplatform"
 )
 
-func resourceSpringCloudAPIPortal() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Create: resourceSpringCloudAPIPortalCreate,
-		Read:   resourceSpringCloudAPIPortalRead,
-		Update: resourceSpringCloudAPIPortalUpdate,
-		Delete: resourceSpringCloudAPIPortalDelete,
+type SpringCloudAPIPortalModel struct {
+	Name                       string              `tfschema:"name"`
+	SpringCloudServiceId       string              `tfschema:"spring_cloud_service_id"`
+	GatewayIds                 []string            `tfschema:"gateway_ids"`
+	HttpsOnlyEnabled           bool                `tfschema:"https_only_enabled"`
+	InstanceCount              int                 `tfschema:"instance_count"`
+	PublicNetworkAccessEnabled bool                `tfschema:"public_network_access_enabled"`
+	Sso                        []ApiPortalSsoModel `tfschema:"sso"`
+	Url                        string              `tfschema:"url"`
+}
 
-		SchemaVersion: 1,
-		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
-			0: migration.SpringCloudApiPortalV0ToV1{},
-		}),
+type ApiPortalSsoModel struct {
+	ClientId     string   `tfschema:"client_id"`
+	ClientSecret string   `tfschema:"client_secret"`
+	IssuerUri    string   `tfschema:"issuer_uri"`
+	Scope        []string `tfschema:"scope"`
+}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
-			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
+type SpringCloudAPIPortalResource struct{}
+
+var _ sdk.ResourceWithUpdate = SpringCloudAPIPortalResource{}
+var _ sdk.ResourceWithStateMigration = SpringCloudAPIPortalResource{}
+
+func (s SpringCloudAPIPortalResource) ResourceType() string {
+	return "azurerm_spring_cloud_api_portal"
+}
+
+func (s SpringCloudAPIPortalResource) ModelObject() interface{} {
+	return &SpringCloudAPIPortalModel{}
+}
+
+func (s SpringCloudAPIPortalResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.SpringCloudAPIPortalID
+}
+
+func (s SpringCloudAPIPortalResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"default",
+			}, false),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.SpringCloudAPIPortalID(id)
-			return err
-		}),
+		"spring_cloud_service_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.SpringCloudServiceID,
+		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"default",
-				}, false),
-			},
-
-			"spring_cloud_service_id": {
+		"gateway_ids": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.SpringCloudServiceID,
+				ValidateFunc: validate.SpringCloudGatewayID,
 			},
+		},
 
-			"gateway_ids": {
-				Type:     pluginsdk.TypeSet,
-				Optional: true,
-				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: validate.SpringCloudGatewayID,
-				},
-			},
+		"https_only_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
 
-			"https_only_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
+		"instance_count": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Default:      1,
+			ValidateFunc: validation.IntBetween(1, 500),
+		},
 
-			"instance_count": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ValidateFunc: validation.IntBetween(1, 500),
-			},
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
 
-			"public_network_access_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
+		"sso": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"client_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
 
-			"sso": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"client_id": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
+					"client_secret": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
 
-						"client_secret": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
+					"issuer_uri": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
 
-						"issuer_uri": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
-
-						"scope": {
-							Type:     pluginsdk.TypeSet,
-							Optional: true,
-							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-							},
+					"scope": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
 						},
 					},
 				},
 			},
-
-			"url": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
 
-func resourceSpringCloudAPIPortalCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).AppPlatform.APIPortalClient
-	servicesClient := meta.(*clients.Client).AppPlatform.ServicesClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	springId, err := parse.SpringCloudServiceID(d.Get("spring_cloud_service_id").(string))
-	if err != nil {
-		return err
-	}
-	id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, d.Get("name").(string))
-
-	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("retrieving %s: %+v", id, err)
-		}
-	}
-	if !utils.ResponseWasNotFound(existing.Response) {
-		return tf.ImportAsExistsError("azurerm_spring_cloud_api_portal", id.ID())
-	}
-
-	service, err := servicesClient.Get(ctx, springId.ResourceGroup, springId.SpringName)
-	if err != nil {
-		return fmt.Errorf("checking for presence of existing %s: %+v", springId, err)
-	}
-	if service.Sku == nil || service.Sku.Name == nil || service.Sku.Tier == nil {
-		return fmt.Errorf("invalid `sku` for %s", springId)
-	}
-
-	apiPortalResource := appplatform.APIPortalResource{
-		Properties: &appplatform.APIPortalProperties{
-			GatewayIds:    utils.ExpandStringSlice(d.Get("gateway_ids").(*pluginsdk.Set).List()),
-			HTTPSOnly:     utils.Bool(d.Get("https_only_enabled").(bool)),
-			Public:        utils.Bool(d.Get("public_network_access_enabled").(bool)),
-			SsoProperties: expandAPIPortalSsoProperties(d.Get("sso").([]interface{})),
-		},
-		Sku: &appplatform.Sku{
-			Name:     service.Sku.Name,
-			Tier:     service.Sku.Tier,
-			Capacity: utils.Int32(int32(d.Get("instance_count").(int))),
+func (s SpringCloudAPIPortalResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
 		},
 	}
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
-	if err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	return resourceSpringCloudAPIPortalRead(d, meta)
 }
 
-func resourceSpringCloudAPIPortalUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).AppPlatform.APIPortalClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	springId, err := parse.SpringCloudServiceID(d.Get("spring_cloud_service_id").(string))
-	if err != nil {
-		return err
+func (s SpringCloudAPIPortalResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.SpringCloudApiPortalV0ToV1{},
+		},
 	}
-	id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, d.Get("name").(string))
-
-	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("retrieving %s: %+v", id, err)
-		}
-	}
-	if utils.ResponseWasNotFound(existing.Response) {
-		return fmt.Errorf("retrieving %s: resource was not found", id)
-	}
-
-	if existing.Properties == nil {
-		return fmt.Errorf("retrieving %s: properties are nil", id)
-	}
-	properties := existing.Properties
-
-	if existing.Sku == nil {
-		return fmt.Errorf("retrieving %s: sku is nil", id)
-	}
-	sku := existing.Sku
-
-	if d.HasChange("gateway_ids") {
-		properties.GatewayIds = utils.ExpandStringSlice(d.Get("gateway_ids").(*pluginsdk.Set).List())
-	}
-
-	if d.HasChange("https_only_enabled") {
-		properties.HTTPSOnly = pointer.To(d.Get("https_only_enabled").(bool))
-	}
-
-	if d.HasChange("public_network_access_enabled") {
-		properties.Public = pointer.To(d.Get("public_network_access_enabled").(bool))
-	}
-
-	if d.HasChange("sso") {
-		properties.SsoProperties = expandAPIPortalSsoProperties(d.Get("sso").([]interface{}))
-	}
-
-	if d.HasChange("instance_count") {
-		sku.Capacity = pointer.To(int32(d.Get("instance_count").(int)))
-	}
-
-	apiPortalResource := appplatform.APIPortalResource{
-		Properties: properties,
-		Sku:        sku,
-	}
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
-	if err != nil {
-		return fmt.Errorf("updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	return resourceSpringCloudAPIPortalRead(d, meta)
 }
 
-func resourceSpringCloudAPIPortalRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppPlatform.APIPortalClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (s SpringCloudAPIPortalResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model SpringCloudAPIPortalModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
 
-	id, err := parse.SpringCloudAPIPortalID(d.Id())
-	if err != nil {
-		return err
-	}
+			client := metadata.Client.AppPlatform.APIPortalClient
+			servicesClient := metadata.Client.AppPlatform.ServicesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] appplatform %q does not exist - removing from state", d.Id())
-			d.SetId("")
+			springId, err := parse.SpringCloudServiceID(model.SpringCloudServiceId)
+			if err != nil {
+				return err
+			}
+			id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, model.Name)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("retrieving %s: %+v", id, err)
+				}
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return tf.ImportAsExistsError("azurerm_spring_cloud_api_portal", id.ID())
+			}
+
+			service, err := servicesClient.Get(ctx, springId.ResourceGroup, springId.SpringName)
+			if err != nil {
+				return fmt.Errorf("checking for presence of existing %s: %+v", springId, err)
+			}
+			if service.Sku == nil || service.Sku.Name == nil || service.Sku.Tier == nil {
+				return fmt.Errorf("invalid `sku` for %s", springId)
+			}
+
+			apiPortalResource := appplatform.APIPortalResource{
+				Properties: &appplatform.APIPortalProperties{
+					GatewayIds:    pointer.To(model.GatewayIds),
+					HTTPSOnly:     pointer.To(model.HttpsOnlyEnabled),
+					Public:        pointer.To(model.PublicNetworkAccessEnabled),
+					SsoProperties: expandAPIPortalSsoProperties(model.Sso),
+				},
+				Sku: &appplatform.Sku{
+					Name:     service.Sku.Name,
+					Tier:     service.Sku.Tier,
+					Capacity: pointer.To(int32(model.InstanceCount)),
+				},
+			}
+			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
+			if err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for update of %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
 			return nil
-		}
-		return fmt.Errorf("retrieving %s: %+v", id, err)
+		},
 	}
-	d.Set("name", id.ApiPortalName)
-	d.Set("spring_cloud_service_id", parse.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroup, id.SpringName).ID())
-	if resp.Sku != nil {
-		d.Set("instance_count", resp.Sku.Capacity)
-	}
-	if props := resp.Properties; props != nil {
-		d.Set("gateway_ids", flattenSpringCloudAPIPortalGatewayIds(props.GatewayIds))
-		d.Set("https_only_enabled", props.HTTPSOnly)
-		d.Set("public_network_access_enabled", props.Public)
-		if err := d.Set("sso", flattenAPIPortalSsoProperties(props.SsoProperties, d.Get("sso").([]interface{}))); err != nil {
-			return fmt.Errorf("setting `sso`: %+v", err)
-		}
-		d.Set("url", props.URL)
-	}
-	return nil
 }
 
-func resourceSpringCloudAPIPortalDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppPlatform.APIPortalClient
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (s SpringCloudAPIPortalResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model SpringCloudAPIPortalModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
 
-	id, err := parse.SpringCloudAPIPortalID(d.Id())
-	if err != nil {
-		return err
-	}
+			client := metadata.Client.AppPlatform.APIPortalClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
-	if err != nil {
-		return fmt.Errorf("deleting %s: %+v", id, err)
-	}
+			springId, err := parse.SpringCloudServiceID(model.SpringCloudServiceId)
+			if err != nil {
+				return err
+			}
+			id := parse.NewSpringCloudAPIPortalID(subscriptionId, springId.ResourceGroup, springId.SpringName, model.Name)
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of %s: %+v", id, err)
+			existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("retrieving %s: %+v", id, err)
+				}
+			}
+			if utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("retrieving %s: resource was not found", id)
+			}
+
+			if existing.Properties == nil {
+				return fmt.Errorf("retrieving %s: properties are nil", id)
+			}
+			properties := existing.Properties
+
+			if existing.Sku == nil {
+				return fmt.Errorf("retrieving %s: sku is nil", id)
+			}
+			sku := existing.Sku
+
+			if metadata.ResourceData.HasChange("gateway_ids") {
+				properties.GatewayIds = pointer.To(model.GatewayIds)
+			}
+
+			if metadata.ResourceData.HasChange("https_only_enabled") {
+				properties.HTTPSOnly = pointer.To(model.HttpsOnlyEnabled)
+			}
+
+			if metadata.ResourceData.HasChange("public_network_access_enabled") {
+				properties.Public = pointer.To(model.PublicNetworkAccessEnabled)
+			}
+
+			if metadata.ResourceData.HasChange("sso") {
+				properties.SsoProperties = expandAPIPortalSsoProperties(model.Sso)
+			}
+
+			if metadata.ResourceData.HasChange("instance_count") {
+				sku.Capacity = pointer.To(int32(model.InstanceCount))
+			}
+
+			apiPortalResource := appplatform.APIPortalResource{
+				Properties: properties,
+				Sku:        sku,
+			}
+			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, apiPortalResource)
+			if err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for update of %s: %+v", id, err)
+			}
+
+			return nil
+		},
 	}
-	return nil
 }
 
-func expandAPIPortalSsoProperties(input []interface{}) *appplatform.SsoProperties {
-	if len(input) == 0 || input[0] == nil {
+func (s SpringCloudAPIPortalResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppPlatform.APIPortalClient
+
+			id, err := parse.SpringCloudAPIPortalID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					log.Printf("[INFO] %q does not exist - removing from state", id.ID())
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			springId := parse.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroup, id.SpringName)
+
+			var model SpringCloudAPIPortalModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			state := SpringCloudAPIPortalModel{
+				Name:                 id.ApiPortalName,
+				SpringCloudServiceId: springId.ID(),
+			}
+			if resp.Sku != nil {
+				state.InstanceCount = int(pointer.From(resp.Sku.Capacity))
+			}
+			if props := resp.Properties; props != nil {
+				state.GatewayIds = flattenSpringCloudAPIPortalGatewayIds(props.GatewayIds)
+				state.HttpsOnlyEnabled = pointer.From(props.HTTPSOnly)
+				state.PublicNetworkAccessEnabled = pointer.From(props.Public)
+				state.Sso = flattenAPIPortalSsoProperties(props.SsoProperties, model.Sso)
+				state.Url = pointer.From(props.URL)
+			}
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (s SpringCloudAPIPortalResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppPlatform.APIPortalClient
+
+			id, err := parse.SpringCloudAPIPortalID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			future, err := client.Delete(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName)
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for deletion of %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandAPIPortalSsoProperties(input []ApiPortalSsoModel) *appplatform.SsoProperties {
+	if len(input) == 0 {
 		return nil
 	}
-	v := input[0].(map[string]interface{})
+	v := input[0]
 	return &appplatform.SsoProperties{
-		Scope:        utils.ExpandStringSlice(v["scope"].(*pluginsdk.Set).List()),
-		ClientID:     utils.String(v["client_id"].(string)),
-		ClientSecret: utils.String(v["client_secret"].(string)),
-		IssuerURI:    utils.String(v["issuer_uri"].(string)),
+		Scope:        pointer.To(v.Scope),
+		ClientID:     pointer.To(v.ClientId),
+		ClientSecret: pointer.To(v.ClientSecret),
+		IssuerURI:    pointer.To(v.IssuerUri),
 	}
 }
 
-func flattenAPIPortalSsoProperties(input *appplatform.SsoProperties, old []interface{}) []interface{} {
+func flattenAPIPortalSsoProperties(input *appplatform.SsoProperties, old []ApiPortalSsoModel) []ApiPortalSsoModel {
 	if input == nil {
-		return make([]interface{}, 0)
+		return make([]ApiPortalSsoModel, 0)
 	}
 
-	oldItems := make(map[string]map[string]interface{})
+	oldItems := make(map[string]ApiPortalSsoModel)
 	for _, item := range old {
-		v := item.(map[string]interface{})
-		if name, ok := v["issuer_uri"]; ok {
-			oldItems[name.(string)] = v
+		if item.IssuerUri != "" {
+			oldItems[item.IssuerUri] = item
 		}
 	}
 
@@ -344,19 +396,19 @@ func flattenAPIPortalSsoProperties(input *appplatform.SsoProperties, old []inter
 	var clientId string
 	var clientSecret string
 	if oldItem, ok := oldItems[issuerUri]; ok {
-		if value, ok := oldItem["client_id"]; ok {
-			clientId = value.(string)
+		if oldItem.ClientId != "" {
+			clientId = oldItem.ClientId
 		}
-		if value, ok := oldItem["client_secret"]; ok {
-			clientSecret = value.(string)
+		if oldItem.ClientSecret != "" {
+			clientSecret = oldItem.ClientSecret
 		}
 	}
-	return []interface{}{
-		map[string]interface{}{
-			"client_id":     clientId,
-			"client_secret": clientSecret,
-			"issuer_uri":    issuerUri,
-			"scope":         utils.FlattenStringSlice(input.Scope),
+	return []ApiPortalSsoModel{
+		{
+			ClientId:     clientId,
+			ClientSecret: clientSecret,
+			IssuerUri:    issuerUri,
+			Scope:        pointer.From(input.Scope),
 		},
 	}
 }


### PR DESCRIPTION
```
=== RUN   TestAccSpringCloudAPIPortal_basic
=== PAUSE TestAccSpringCloudAPIPortal_basic
=== CONT  TestAccSpringCloudAPIPortal_basic
--- PASS: TestAccSpringCloudAPIPortal_basic (628.56s)
=== RUN   TestAccSpringCloudAPIPortal_requiresImport
=== PAUSE TestAccSpringCloudAPIPortal_requiresImport
=== CONT  TestAccSpringCloudAPIPortal_requiresImport
--- PASS: TestAccSpringCloudAPIPortal_requiresImport (641.84s)
=== RUN   TestAccSpringCloudAPIPortal_complete
=== PAUSE TestAccSpringCloudAPIPortal_complete
=== CONT  TestAccSpringCloudAPIPortal_complete
--- PASS: TestAccSpringCloudAPIPortal_complete (793.86s)
=== RUN   TestAccSpringCloudAPIPortal_update
=== PAUSE TestAccSpringCloudAPIPortal_update
=== CONT  TestAccSpringCloudAPIPortal_update
--- PASS: TestAccSpringCloudAPIPortal_update (871.08s)
PASS

```