### PR TITLE
#24242: Preserve public_network_access_enabled during refresh

### DIFF
--- a/internal/services/bot/bot_service_resource_base.go
+++ b/internal/services/bot/bot_service_resource_base.go
@@ -402,7 +402,7 @@ func (br botBaseResource) readFunc() sdk.ResourceFunc {
 				metadata.ResourceData.Set("local_authentication_enabled", localAuthEnabled)
 
 				publicNetworkAccessEnabled := true
-				if v := props.PublicNetworkAccess; v != botservice.PublicNetworkAccessDisabled {
+				if v := props.PublicNetworkAccess; v != botservice.PublicNetworkAccessEnabled {
 					publicNetworkAccessEnabled = false
 				}
 				metadata.ResourceData.Set("public_network_access_enabled", publicNetworkAccessEnabled)


### PR DESCRIPTION
Fixes #24242 

In `readFunc` of `azurerm_bot_service_azure_bot` resource there is a bug setting `public_network_access_enabled` to `false` even though when it's set to `true`. 