### PR TITLE
`azurerm_cost_anomaly_alert` - Support for scoping alert to a specific subscription_id 

### DIFF
--- a/internal/services/costmanagement/anomaly_alert_resource.go
+++ b/internal/services/costmanagement/anomaly_alert_resource.go
@@ -44,6 +44,7 @@ func (AnomalyAlertResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
+			Computed:    true,
 			ValidateFunc: commonids.ValidateSubscriptionID,
 		},
 
@@ -231,11 +232,7 @@ func (AnomalyAlertResource) Read() sdk.ResourceFunc {
 				metadata.ResourceData.Set("name", model.Name)
 				if props := model.Properties; props != nil {
 					metadata.ResourceData.Set("display_name", props.DisplayName)
-					
-					if _, ok := metadata.ResourceData.GetOk("subscription_id"); ok {
-						metadata.ResourceData.Set("subscription_id", fmt.Sprint("/", *props.Scope))
-					} 
-					
+					metadata.ResourceData.Set("subscription_id", fmt.Sprint("/", *props.Scope))
 					metadata.ResourceData.Set("email_subject", props.Notification.Subject)
 					metadata.ResourceData.Set("email_addresses", props.Notification.To)
 					metadata.ResourceData.Set("message", props.Notification.Message)

--- a/internal/services/costmanagement/anomaly_alert_resource.go
+++ b/internal/services/costmanagement/anomaly_alert_resource.go
@@ -44,7 +44,7 @@ func (AnomalyAlertResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
-			Computed:    true,
+			Computed:     true,
 			ValidateFunc: commonids.ValidateSubscriptionID,
 		},
 

--- a/internal/services/costmanagement/anomaly_alert_resource.go
+++ b/internal/services/costmanagement/anomaly_alert_resource.go
@@ -163,10 +163,6 @@ func (r AnomalyAlertResource) Update() sdk.ResourceFunc {
 			emailAddresses := utils.ExpandStringSlice(emailAddressesRaw)
 
 			subscriptionId := metadata.ResourceData.Get("subscription_id").(string)
-			if subscriptionId == "" {
-				subscriptionId = metadata.Client.Account.SubscriptionId
-			}
-
 			viewId := views.NewScopedViewID(subscriptionId, "ms:DailyAnomalyByResourceGroup")
 
 			schedule := scheduledactions.ScheduleProperties{

--- a/internal/services/costmanagement/anomaly_alert_resource.go
+++ b/internal/services/costmanagement/anomaly_alert_resource.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -37,6 +38,13 @@ func (AnomalyAlertResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"subscription_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateSubscriptionID,
 		},
 
 		"email_subject": {
@@ -80,8 +88,10 @@ func (r AnomalyAlertResource) Create() sdk.ResourceFunc {
 		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.CostManagement.ScheduledActionsClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
-			id := scheduledactions.NewScopedScheduledActionID(fmt.Sprint("/subscriptions/", subscriptionId), metadata.ResourceData.Get("name").(string))
+
+			subscriptionId := metadata.ResourceData.Get("subscription_id").(string)
+
+			id := scheduledactions.NewScopedScheduledActionID(subscriptionId, metadata.ResourceData.Get("name").(string))
 
 			existing, err := client.GetByScope(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -94,7 +104,7 @@ func (r AnomalyAlertResource) Create() sdk.ResourceFunc {
 			emailAddressesRaw := metadata.ResourceData.Get("email_addresses").(*pluginsdk.Set).List()
 			emailAddresses := utils.ExpandStringSlice(emailAddressesRaw)
 
-			viewId := parse.NewAnomalyAlertViewID(subscriptionId, "ms:DailyAnomalyByResourceGroup")
+			viewId := views.NewScopedViewID(subscriptionId, "ms:DailyAnomalyByResourceGroup")
 
 			schedule := scheduledactions.ScheduleProperties{
 				Frequency: scheduledactions.ScheduleFrequencyDaily,
@@ -154,8 +164,12 @@ func (r AnomalyAlertResource) Update() sdk.ResourceFunc {
 			emailAddressesRaw := metadata.ResourceData.Get("email_addresses").(*pluginsdk.Set).List()
 			emailAddresses := utils.ExpandStringSlice(emailAddressesRaw)
 
-			subscriptionId := metadata.Client.Account.SubscriptionId
-			viewId := parse.NewAnomalyAlertViewID(subscriptionId, "ms:DailyAnomalyByResourceGroup")
+			subscriptionId := metadata.ResourceData.Get("subscription_id").(string)
+			if subscriptionId == "" {
+				subscriptionId = metadata.Client.Account.SubscriptionId
+			}
+
+			viewId := views.NewScopedViewID(subscriptionId, "ms:DailyAnomalyByResourceGroup")
 
 			schedule := scheduledactions.ScheduleProperties{
 				Frequency: scheduledactions.ScheduleFrequencyDaily,
@@ -212,6 +226,7 @@ func (AnomalyAlertResource) Read() sdk.ResourceFunc {
 				metadata.ResourceData.Set("name", model.Name)
 				if props := model.Properties; props != nil {
 					metadata.ResourceData.Set("display_name", props.DisplayName)
+					metadata.ResourceData.Set("subscription_id", id.Scope)
 					metadata.ResourceData.Set("email_subject", props.Notification.Subject)
 					metadata.ResourceData.Set("email_addresses", props.Notification.To)
 					metadata.ResourceData.Set("message", props.Notification.Message)

--- a/internal/services/costmanagement/anomaly_alert_resource.go
+++ b/internal/services/costmanagement/anomaly_alert_resource.go
@@ -88,9 +88,7 @@ func (r AnomalyAlertResource) Create() sdk.ResourceFunc {
 		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.CostManagement.ScheduledActionsClient
-
 			subscriptionId := metadata.ResourceData.Get("subscription_id").(string)
-
 			id := scheduledactions.NewScopedScheduledActionID(subscriptionId, metadata.ResourceData.Get("name").(string))
 
 			existing, err := client.GetByScope(ctx, id)

--- a/internal/services/costmanagement/anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/anomaly_alert_resource_test.go
@@ -35,9 +35,9 @@ func TestAccResourceAnomalyAlert_complete(t *testing.T) {
 	testResource := AnomalyAlertResource{}
 	data.ResourceTest(t, testResource, []acceptance.TestStep{
 		data.ApplyStep(testResource.completeConfig, testResource),
-		data.ImportStep("subscription_id"),
+		data.ImportStep(),
 		data.ApplyStep(testResource.updateConfig, testResource),
-		data.ImportStep("subscription_id"),
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/costmanagement/anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/anomaly_alert_resource_test.go
@@ -30,6 +30,17 @@ func TestAccResourceAnomalyAlert_update(t *testing.T) {
 	})
 }
 
+func TestAccResourceAnomalyAlert_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
+	testResource := AnomalyAlertResource{}
+	data.ResourceTest(t, testResource, []acceptance.TestStep{
+		data.ApplyStep(testResource.completeConfig, testResource),
+		data.ImportStep("subscription_id"),
+		data.ApplyStep(testResource.updateConfig, testResource),
+		data.ImportStep("subscription_id"),
+	})
+}
+
 func TestAccResourceAnomalyAlert_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
 	testResource := AnomalyAlertResource{}
@@ -59,6 +70,22 @@ provider "azurerm" {
   features {}
 }
 
+resource "azurerm_cost_anomaly_alert" "test" {
+  name            = "-acctest-%d"
+  display_name    = "acctest %d"
+  email_subject   = "Hi"
+  email_addresses = ["test@test.com", "test@hashicorp.developer"]
+  message         = "Oops, cost anomaly"
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (AnomalyAlertResource) completeConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "test" {}
 
 resource "azurerm_cost_anomaly_alert" "test" {
@@ -67,7 +94,7 @@ resource "azurerm_cost_anomaly_alert" "test" {
   subscription_id = data.azurerm_subscription.test.id
   email_subject   = "Hi"
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
-  message         = "Oops, cost anomaly"
+  message         = "Cost anomaly complete test"
 }
 `, data.RandomInteger, data.RandomInteger)
 }
@@ -80,7 +107,6 @@ func (r AnomalyAlertResource) requiresImportConfig(data acceptance.TestData) str
 resource "azurerm_cost_anomaly_alert" "import" {
   name            = azurerm_cost_anomaly_alert.test.name
   display_name    = azurerm_cost_anomaly_alert.test.display_name
-  subscription_id = azurerm_cost_anomaly_alert.test.subscription_id
   email_subject   = azurerm_cost_anomaly_alert.test.email_subject
   email_addresses = azurerm_cost_anomaly_alert.test.email_addresses
   message         = azurerm_cost_anomaly_alert.test.message
@@ -94,12 +120,9 @@ provider "azurerm" {
   features {}
 }
 
-data "azurerm_subscription" "test" {}
-
 resource "azurerm_cost_anomaly_alert" "test" {
   name            = "-acctest-%d"
   display_name    = "acctest name update %d"
-  subscription_id = data.azurerm_subscription.test.id
   email_subject   = "Hi you!"
   email_addresses = ["tester@test.com", "test2@hashicorp.developer"]
   message         = "An updated cost anomaly for you"

--- a/internal/services/costmanagement/anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/anomaly_alert_resource_test.go
@@ -59,9 +59,12 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "test" {}
+
 resource "azurerm_cost_anomaly_alert" "test" {
   name            = "-acctest-%d"
   display_name    = "acctest %d"
+  subscription_id = data.azurerm_subscription.test.id
   email_subject   = "Hi"
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
   message         = "Oops, cost anomaly"
@@ -77,6 +80,7 @@ func (r AnomalyAlertResource) requiresImportConfig(data acceptance.TestData) str
 resource "azurerm_cost_anomaly_alert" "import" {
   name            = azurerm_cost_anomaly_alert.test.name
   display_name    = azurerm_cost_anomaly_alert.test.display_name
+  subscription_id = azurerm_cost_anomaly_alert.test.subscription_id
   email_subject   = azurerm_cost_anomaly_alert.test.email_subject
   email_addresses = azurerm_cost_anomaly_alert.test.email_addresses
   message         = azurerm_cost_anomaly_alert.test.message
@@ -90,9 +94,12 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "test" {}
+
 resource "azurerm_cost_anomaly_alert" "test" {
   name            = "-acctest-%d"
   display_name    = "acctest name update %d"
+  subscription_id = data.azurerm_subscription.test.id
   email_subject   = "Hi you!"
   email_addresses = ["tester@test.com", "test2@hashicorp.developer"]
   message         = "An updated cost anomaly for you"

--- a/website/docs/r/cost_anomaly_alert.html.markdown
+++ b/website/docs/r/cost_anomaly_alert.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The display name which should be used for this Cost Anomaly Alert.
 
-* `subscription_id` - (Required) The ID of the Subscription this Cost Anomaly Alert is scoped to. Changing this forces a new resource to be created.
+* `subscription_id` - The ID of the Subscription this Cost Anomaly Alert is scoped to. Changing this forces a new resource to be created. When not supplied this defaults to the subscription configured in the provider.
 
 * `email_addresses` - (Required) Specifies a list of email addresses which the Anomaly Alerts are send to.
 

--- a/website/docs/r/cost_anomaly_alert.html.markdown
+++ b/website/docs/r/cost_anomaly_alert.html.markdown
@@ -10,12 +10,15 @@ description: |-
 
 Manages a Cost Anomaly Alert.
 
+~> **Note:** Anomaly alerts are sent based on the current access of the rule creator at the time that the email is sent. Learn more [here](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/analyze-unexpected-charges#create-an-anomaly-alert).
+
 ## Example Usage
 
 ```hcl
 resource "azurerm_cost_anomaly_alert" "example" {
   name            = "alertname"
   display_name    = "Alert DisplayName"
+  subscription_id = "/subscriptions/00000000-0000-0000-0000-000000000000"
   email_subject   = "My Test Anomaly Alert"
   email_addresses = ["example@test.net"]
 }
@@ -28,6 +31,8 @@ The following arguments are supported:
 * `name` - (Required) The name which should be used for this Cost Anomaly Alert. Changing this forces a new resource to be created. The name can contain only lowercase letters, numbers and hyphens.
 
 * `display_name` - (Required) The display name which should be used for this Cost Anomaly Alert.
+
+* `subscription_id` - (Required) The ID of the Subscription this Cost Anomaly Alert is scoped to. Changing this forces a new resource to be created.
 
 * `email_addresses` - (Required) Specifies a list of email addresses which the Anomaly Alerts are send to.
 


### PR DESCRIPTION
Fixes #23673

Added new required parameter `subscription_id` to the `azurerm_cost_anomaly_alert` resource which allows creation of alerts on subscriptions other than the one specified in the provider config. 

I'd initially hoped to make this an optional parameter and use the provider's subscription as a default but I ran in to trouble getting the read function to work appropriately under those circumstances. As such, anyone using this already would need to update their config to include the `subscription_id`.

I'm somewhat new to Go and this is my first contribution here so all feedback is appreciated :-)

Test results:
```
=== RUN   TestAccResourceAnomalyAlert_update
=== PAUSE TestAccResourceAnomalyAlert_update
=== CONT  TestAccResourceAnomalyAlert_update
--- PASS: TestAccResourceAnomalyAlert_update (124.11s)
PASS
ok      [github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement](http://github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement)        127.855s

=== RUN   TestAccResourceAnomalyAlert_requiresImport
=== PAUSE TestAccResourceAnomalyAlert_requiresImport
=== CONT  TestAccResourceAnomalyAlert_requiresImport
--- PASS: TestAccResourceAnomalyAlert_requiresImport (55.27s)
PASS
ok      [github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement](http://github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement)        58.866s
```