### PR TITLE
`key_vault_managed_storage_account`：fix AccTests add `time.Sleep` for recovery after destroy

### DIFF
--- a/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -119,6 +120,10 @@ func TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery(t *testing.
 		},
 		{
 			// purge true here to make sure when we end the test there's no soft-deleted items left behind
+			PreConfig: func() {
+				// old instance dns cached may cause 404 not found error, so we sleep for a while to wait
+				time.Sleep(30 * time.Second)
+			},
 			Config: r.softDeleteRecovery(data, true, "2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/internal/services/keyvault/key_vault_managed_storage_account_test.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -115,6 +116,9 @@ func TestAccKeyVaultManagedStorageAccount_recovery(t *testing.T) {
 		},
 		{
 			// purge true here to make sure when we end the test there's no soft-deleted items left behind
+			PreConfig: func() {
+				time.Sleep(30 * time.Second)
+			},
 			Config: r.softDeleteRecovery(data, true, "2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),


### PR DESCRIPTION
fix `TestAccKeyVaultManagedStorageAccount_recovery` and `TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery`. when recreating Storage Account after destroy, The data plane API may return a 404 Not Found Error. This may related to DNS cache, so we add a sleep to wait the cache expire.

```
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery
    testcase.go:113: Step 4/5 error: Error running apply: exit status 1
        Error: retrieving share properties for Storage Account (Subscription: "*******"
        Resource Group Name: "acctest-kv-RG-231216005754223367"
        Storage Account Name: "unlikely23exst2acctjk0wh"): storage.FileServicesClient#GetServiceProperties: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The specified resource does not exist.\nRequestId:3b87779f-801a-00a4-12bb-2fe308000000\nTime:2023-12-16T01:02:46.3630478Z"
=== CONT  TestAccKeyVaultManagedStorageAccount_recovery
    testcase.go:113: Step 4/5 error: Error running apply: exit status 1
        Error: retrieving share properties for Storage Account (Subscription: "*******"
        Resource Group Name: "acctest-kv-RG-231216005933293968"
        Storage Account Name: "unlikely23exst2acctfbpzp"): storage.FileServicesClient#GetServiceProperties: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The specified resource does not exist.\nRequestId:39a76ddf-601a-0005-70bb-2f485a000000\nTime:2023-12-16T01:03:34.7632967Z"

```

**Test result**:
```
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery (701.48s)
--- PASS: TestAccKeyVaultManagedStorageAccount_recovery (641.82s)
PASS
```