### PR TITLE
`azurerm_lb_backend_address_pool_address` - fix acctest failure

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -103,6 +103,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // Lab Service is only available in certain locations
         "labservice" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus", "westus", false)),
 
+        // load balancer global tire Public IP is only available in
+        "loadbalancer" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus", false)),
+
         // Log Analytics Clusters have a max deployments of 2 - parallelism set to 1 or `importTest` fails
         "loganalytics" to testConfiguration(parallelism = 1),
 

--- a/internal/services/loadbalancer/backend_address_pool_address_resource_test.go
+++ b/internal/services/loadbalancer/backend_address_pool_address_resource_test.go
@@ -373,6 +373,7 @@ resource "azurerm_public_ip" "backend-ip-cr" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  sku_tier            = "Global"
 }
 
 resource "azurerm_lb" "backend-lb-R1" {


### PR DESCRIPTION
Fix the following acctest failure.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/7698fcc0-8125-418d-85b0-eff0af63a32d)

Test Result:
PASS: TestAccBackendAddressPoolAddress_globalLbUpdate (341.34s)