### PR TITLE
`azurerm_container_app_environment`: add support for `workload_profiles_consumption_only_enabled`

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -120,13 +120,9 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 		},
 
 		"workload_profiles_consumption_only_enabled": {
-			Type:     pluginsdk.TypeBool,
-			Optional: true,
-			Default:  false,
-			ExactlyOneOf: []string{
-				"workload_profiles_consumption_only_enabled",
-				"workload_profile",
-			},
+			Type:        pluginsdk.TypeBool,
+			Optional:    true,
+			Default:     false,
 			Description: "Should the Container Environment only allow Consumption Workload Profiles? Defaults to `false`.",
 		},
 

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -245,22 +245,18 @@ resource "azurerm_container_app_environment" "test" {
 func (r ContainerAppEnvironmentResource) completeWithWorkloadProfileConsumptionOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-	resource_group {
-	  prevent_deletion_if_contains_resources = false
-	}
-  }
+  features {}
 }
 
 %[1]s
 
 resource "azurerm_container_app_environment" "test" {
-  name                     = "acctest-CAEnv%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  infrastructure_subnet_id = azurerm_subnet.control.id
+  name                                       = "acctest-CAEnv%[2]d"
+  resource_group_name                        = azurerm_resource_group.test.name
+  location                                   = azurerm_resource_group.test.location
+  infrastructure_subnet_id                   = azurerm_subnet.control.id
   workload_profiles_consumption_only_enabled = true
-  zone_redundancy_enabled = true
+  zone_redundancy_enabled                    = true
 
   tags = {
     Foo    = "Bar"

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -254,27 +254,6 @@ provider "azurerm" {
 
 %[1]s
 
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%[2]d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "control" {
-  name                 = "control-plane"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.0.0/23"]
-  delegation {
-    name = "acctestdelegation%[2]d"
-    service_delegation {
-      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-      name    = "Microsoft.App/environments"
-    }
-  }
-}
-
 resource "azurerm_container_app_environment" "test" {
   name                     = "acctest-CAEnv%[2]d"
   resource_group_name      = azurerm_resource_group.test.name
@@ -288,7 +267,7 @@ resource "azurerm_container_app_environment" "test" {
     secret = "sauce"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateVNet(data), data.RandomInteger)
 }
 
 func (r ContainerAppEnvironmentResource) completeWithWorkloadProfile(data acceptance.TestData) string {

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-const consumption = "Consumption"
+const Consumption = "Consumption"
 
 type WorkloadProfileModel struct {
 	MaximumCount        int    `tfschema:"maximum_count"`
@@ -25,6 +25,10 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
 		Optional: true,
+		ExactlyOneOf: []string{
+			"workload_profiles_consumption_only_enabled",
+			"workload_profile",
+		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
@@ -75,7 +79,7 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 			WorkloadProfileType: v.WorkloadProfileType,
 		}
 
-		if v.Name != consumption {
+		if v.Name != Consumption {
 			r.MaximumCount = pointer.To(int64(v.MaximumCount))
 			r.MinimumCount = pointer.To(int64(v.MinimumCount))
 		}
@@ -84,8 +88,8 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 	}
 
 	result = append(result, managedenvironments.WorkloadProfile{
-		Name:                consumption,
-		WorkloadProfileType: consumption,
+		Name:                Consumption,
+		WorkloadProfileType: Consumption,
 	})
 
 	return &result
@@ -98,7 +102,7 @@ func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []Wor
 	result := make([]WorkloadProfileModel, 0)
 
 	for _, v := range *input {
-		if strings.EqualFold(v.WorkloadProfileType, consumption) {
+		if strings.EqualFold(v.WorkloadProfileType, Consumption) {
 			continue
 		}
 		result = append(result, WorkloadProfileModel{

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -25,10 +25,6 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
 		Optional: true,
-		ExactlyOneOf: []string{
-			"workload_profiles_consumption_only_enabled",
-			"workload_profile",
-		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
+* `workload_profiles_consumption_only_enabled` - (Optional) Should the Container App Environment be created with Workload Profiles in Consumption Only Mode? Defaults to `false`.
+
 * `workload_profile` - (Optional) The profile of the workload to scope the container app execution. A `workload_profile` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
* `Consumption` workload profile can be attached alone without a dedicated workload profile.

* Test case passed. 

```
=== RUN   TestAccContainerAppEnvironment_withWorkloadProfileComsumptionOnly
=== PAUSE TestAccContainerAppEnvironment_withWorkloadProfileComsumptionOnly
=== CONT  TestAccContainerAppEnvironment_withWorkloadProfileComsumptionOnly
--- PASS: TestAccContainerAppEnvironment_withWorkloadProfileComsumptionOnly (1332.53s)
PASS
```

resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/24198, fix #24596 