### PR TITLE
Add missing documentation of public_network_access_enabled

### DIFF
--- a/website/docs/r/bot_service_azure_bot.html.markdown
+++ b/website/docs/r/bot_service_azure_bot.html.markdown
@@ -90,6 +90,8 @@ The following arguments are supported:
 
 * `streaming_endpoint_enabled` - (Optional) Is the streaming endpoint enabled for this Azure Bot Service. Defaults to `false`.
 
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to this Azure Bot Service.
 
 ## Attributes Reference


### PR DESCRIPTION
Add missing documentation of `public_network_access_enabled` of `azurerm_bot_service_azure_bot` resource. 

This has been missed in previous commits of fixing #24242.