### PR TITLE
#24282: Support additional_unattend_content part of azurerm_orchestra…

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -65,8 +65,7 @@ func OrchestratedVirtualMachineScaleSetWindowsConfigurationSchema() *pluginsdk.S
 
 				"computer_name_prefix": computerPrefixWindowsSchema(),
 
-				// I am only commenting this out as this is going to be supported in the next release of the API in October 2021
-				// "additional_unattend_content": additionalUnattendContentSchema(),
+				"additional_unattend_content": additionalUnattendContentSchema(),
 
 				// TODO 4.0: change this from enable_* to *_enabled
 				"enable_automatic_updates": {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -929,8 +929,9 @@ func expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(i
 			osProfile.Secrets = expandWindowsSecrets(secrets)
 		}
 
-		// I am only commenting this out as this is going to be supported in the next release of the API in October 2021
-		// winConfig.AdditionalUnattendContent = expandWindowsConfigurationAdditionalUnattendContent(input["additional_unattend_content"].([]interface{}))
+		if additionalUnattendContents := input["additional_unattend_content"].([]interface{}); len(additionalUnattendContents) > 0 {
+			winConfig.AdditionalUnattendContent = expandWindowsConfigurationAdditionalUnattendContent(input["additional_unattend_content"].([]interface{}))
+		}
 		winConfig.EnableAutomaticUpdates = utils.Bool(input["enable_automatic_updates"].(bool))
 		winConfig.ProvisionVMAgent = utils.Bool(input["provision_vm_agent"].(bool))
 		winRmListenersRaw := input["winrm_listener"].(*pluginsdk.Set).List()
@@ -997,25 +998,24 @@ func expandOrchestratedVirtualMachineScaleSetOsProfileWithLinuxConfiguration(inp
 	return &osProfile
 }
 
-// I am only commenting this out as this is going to be supported in the next release of the API version 2021-10-01
-// func expandWindowsConfigurationAdditionalUnattendContent(input []interface{}) *[]compute.AdditionalUnattendContent {
-// 	output := make([]compute.AdditionalUnattendContent, 0)
+func expandWindowsConfigurationAdditionalUnattendContent(input []interface{}) *[]compute.AdditionalUnattendContent {
+	output := make([]compute.AdditionalUnattendContent, 0)
 
-// 	for _, v := range input {
-// 		raw := v.(map[string]interface{})
+	for _, v := range input {
+		raw := v.(map[string]interface{})
 
-// 		output = append(output, compute.AdditionalUnattendContent{
-// 			SettingName: compute.SettingNames(raw["setting"].(string)),
-// 			Content:     utils.String(raw["content"].(string)),
+		output = append(output, compute.AdditionalUnattendContent{
+			SettingName: compute.SettingNames(raw["setting"].(string)),
+			Content:     utils.String(raw["content"].(string)),
 
-// 			// no other possible values
-// 			PassName:      compute.PassNamesOobeSystem,
-// 			ComponentName: compute.ComponentNamesMicrosoftWindowsShellSetup,
-// 		})
-// 	}
+			// no other possible values
+			PassName:      compute.PassNamesOobeSystem,
+			ComponentName: compute.ComponentNamesMicrosoftWindowsShellSetup,
+		})
+	}
 
-// 	return &output
-// }
+	return &output
+}
 
 func ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compute.VirtualMachineScaleSetNetworkConfiguration, error) {
 	output := make([]compute.VirtualMachineScaleSetNetworkConfiguration, 0)
@@ -1702,10 +1702,9 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *comput
 		output["computer_name_prefix"] = *v
 	}
 
-	// I am only commenting this out as this is going to be supported in the next release of the API in October 2021
-	// if v := winConfig.AdditionalUnattendContent; v != nil {
-	// 	output["additional_unattend_content"] = flattenWindowsConfigurationAdditionalUnattendContent(winConfig)
-	// }
+	if v := winConfig.AdditionalUnattendContent; v != nil {
+		output["additional_unattend_content"] = flattenWindowsConfigurationAdditionalUnattendContent(winConfig, d)
+	}
 
 	if v := winConfig.EnableAutomaticUpdates; v != nil {
 		output["enable_automatic_updates"] = *v
@@ -1908,24 +1907,38 @@ func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]compute.VirtualM
 	return output
 }
 
-// I am only commenting this out as this is going to be supported in the next release of the API in October 2021
-// func flattenWindowsConfigurationAdditionalUnattendContent(input *compute.WindowsConfiguration) []interface{} {
-// 	if input == nil {
-// 		return []interface{}{}
-// 	}
+func flattenWindowsConfigurationAdditionalUnattendContent(input *compute.WindowsConfiguration, d *pluginsdk.ResourceData) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
 
-// 	output := make([]interface{}, 0)
-// 	for _, v := range *input.AdditionalUnattendContent {
-// 		// content isn't returned by the API since it's sensitive data so we need to look it up later
-// 		// where we can pull it out of the state file.
-// 		output = append(output, map[string]interface{}{
-// 			"content": "",
-// 			"setting": string(v.SettingName),
-// 		})
-// 	}
+	existing := make([]interface{}, 0)
+	if v, ok := d.GetOk("os_profile.0.windows_configuration.0.additional_unattend_content"); ok {
+		existing = v.([]interface{})
+	}
 
-// 	return output
-// }
+	output := make([]interface{}, 0)
+	for i, v := range *input.AdditionalUnattendContent {
+		// content isn't returned by the API since it's sensitive data so we need to pull from the state file.
+		content := ""
+		if len(existing) > i {
+			existingVal := existing[i]
+			existingRaw, ok := existingVal.(map[string]interface{})
+			if ok {
+				contentRaw, ok := existingRaw["content"]
+				if ok {
+					content = contentRaw.(string)
+				}
+			}
+		}
+		output = append(output, map[string]interface{}{
+			"content": content,
+			"setting": string(v.SettingName),
+		})
+	}
+
+	return output
+}
 
 func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachineScaleSetOSDisk) []interface{} {
 	if input == nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -266,8 +266,6 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 			},
 
 			"priority_mix": OrchestratedVirtualMachineScaleSetPriorityMixPolicySchema(),
-
-			"additional_unattend_content": additionalUnattendContentSchema(),
 		},
 	}
 }
@@ -405,9 +403,6 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	extensionOperationsEnabled := d.Get("extension_operations_enabled").(bool)
 	osProfileRaw := d.Get("os_profile").([]interface{})
 
-	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
-	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
-
 	if len(osProfileRaw) > 0 {
 		osProfile := osProfileRaw[0].(map[string]interface{})
 		winConfigRaw = osProfile["windows_configuration"].([]interface{})
@@ -424,6 +419,8 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			provisionVMAgent := winConfig["provision_vm_agent"].(bool)
 			patchAssessmentMode := winConfig["patch_assessment_mode"].(string)
 			vmssOsProfile = expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(winConfig, customData)
+			additionalUnattendContentRaw := winConfig["additional_unattend_content"].([]interface{})
+			additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
 
 			if len(additionalUnattendContentRaw) > 0 {
 				vmssOsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -419,12 +419,6 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			provisionVMAgent := winConfig["provision_vm_agent"].(bool)
 			patchAssessmentMode := winConfig["patch_assessment_mode"].(string)
 			vmssOsProfile = expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(winConfig, customData)
-			additionalUnattendContentRaw := winConfig["additional_unattend_content"].([]interface{})
-			additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
-
-			if len(additionalUnattendContentRaw) > 0 {
-				vmssOsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
-			}
 
 			// if the Computer Prefix Name was not defined use the computer name
 			if vmssOsProfile.ComputerNamePrefix == nil || len(*vmssOsProfile.ComputerNamePrefix) == 0 {
@@ -1307,12 +1301,6 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 		}
 		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 		d.Set("user_data_base64", profile.UserData)
-
-		if windows := profile.OsProfile.WindowsConfiguration; windows != nil {
-			if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(windows.AdditionalUnattendContent, d)); err != nil {
-				return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
-			}
-		}
 	}
 
 	if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -266,6 +266,8 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 			},
 
 			"priority_mix": OrchestratedVirtualMachineScaleSetPriorityMixPolicySchema(),
+
+			"additional_unattend_content": additionalUnattendContentSchema(),
 		},
 	}
 }
@@ -403,6 +405,9 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	extensionOperationsEnabled := d.Get("extension_operations_enabled").(bool)
 	osProfileRaw := d.Get("os_profile").([]interface{})
 
+	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
+	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
+
 	if len(osProfileRaw) > 0 {
 		osProfile := osProfileRaw[0].(map[string]interface{})
 		winConfigRaw = osProfile["windows_configuration"].([]interface{})
@@ -419,6 +424,10 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			provisionVMAgent := winConfig["provision_vm_agent"].(bool)
 			patchAssessmentMode := winConfig["patch_assessment_mode"].(string)
 			vmssOsProfile = expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(winConfig, customData)
+
+			if len(additionalUnattendContentRaw) > 0 {
+				vmssOsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
+			}
 
 			// if the Computer Prefix Name was not defined use the computer name
 			if vmssOsProfile.ComputerNamePrefix == nil || len(*vmssOsProfile.ComputerNamePrefix) == 0 {
@@ -1301,6 +1310,12 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 		}
 		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 		d.Set("user_data_base64", profile.UserData)
+
+		if windows := profile.OsProfile.WindowsConfiguration; windows != nil {
+			if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(windows.AdditionalUnattendContent, d)); err != nil {
+				return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
+			}
+		}
 	}
 
 	if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -1089,9 +1089,9 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
         protocol = "Http"
       }
 
-      additional_unattend_content {        
+      additional_unattend_content {
         setting = "FirstLogonCommands"
-        content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"        
+        content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"
       }
 
     }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -191,7 +191,21 @@ func TestAccOrchestratedVirtualMachineScaleSet_basicWindows(t *testing.T) {
 			Config: r.basicWindows(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("os_profile.0.windows_configuration.0.additional_unattend_content.0.setting").HasValue("AutoLogon"),
+			),
+		},
+	})
+}
+
+func TestAccOrchestratedVirtualMachineScaleSet_otherAdditionalUnattendContent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherAdditionalUnattendContent(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_profile.0.windows_configuration.0.additional_unattend_content.0.setting").HasValue("FirstLogonCommands"),
 			),
 		},
 	})
@@ -1002,10 +1016,84 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
         protocol = "Http"
       }
 
-      additional_unattend_content {
-        content = "<UserAccounts><AdministratorPassword><Value>Jasdfds164</Value><PlainText>true</PlainText></AdministratorPassword></UserAccounts>"
-        setting = "AutoLogon"
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
       }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter-Server-Core"
+    version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) otherAdditionalUnattendContent(data acceptance.TestData) string {
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name  = "Standard_D1_v2"
+  instances = 2
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    windows_configuration {
+      computer_name_prefix = "testvm"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      enable_automatic_updates = true
+      provision_vm_agent       = true
+      timezone                 = "W. Europe Standard Time"
+
+      winrm_listener {
+        protocol = "Http"
+      }
+
+      additional_unattend_content {        
+        setting = "FirstLogonCommands"
+        content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"        
+      }
+
     }
   }
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -191,7 +191,7 @@ func TestAccOrchestratedVirtualMachineScaleSet_basicWindows(t *testing.T) {
 			Config: r.basicWindows(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("additional_unattend_content.0.setting").HasValue("AutoLogon"),
+				check.That(data.ResourceName).Key("os_profile.0.windows_configuration.0.additional_unattend_content.0.setting").HasValue("AutoLogon"),
 			),
 		},
 	})
@@ -988,11 +988,6 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 
   platform_fault_domain_count = 2
 
-  additional_unattend_content {
-    content = "<UserAccounts><AdministratorPassword><Value>Jasdfds164</Value><PlainText>true</PlainText></AdministratorPassword></UserAccounts>"
-    setting = "AutoLogon"
-  }
-
   os_profile {
     windows_configuration {
       computer_name_prefix = "testvm"
@@ -1005,6 +1000,11 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 
       winrm_listener {
         protocol = "Http"
+      }
+
+      additional_unattend_content {
+        content = "<UserAccounts><AdministratorPassword><Value>Jasdfds164</Value><PlainText>true</PlainText></AdministratorPassword></UserAccounts>"
+        setting = "AutoLogon"
       }
     }
   }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -191,6 +191,7 @@ func TestAccOrchestratedVirtualMachineScaleSet_basicWindows(t *testing.T) {
 			Config: r.basicWindows(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("additional_unattend_content.0.setting").HasValue("AutoLogon"),
 			),
 		},
 	})
@@ -986,6 +987,11 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   instances = 2
 
   platform_fault_domain_count = 2
+
+  additional_unattend_content {
+    content = "<UserAccounts><AdministratorPassword><Value>Jasdfds164</Value><PlainText>true</PlainText></AdministratorPassword></UserAccounts>"
+    setting = "AutoLogon"
+  }
 
   os_profile {
     windows_configuration {

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -51,8 +51,6 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `additional_capabilities` - (Optional) An `additional_capabilities` block as defined below.
 
-* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below. Changing this forces a new resource to be created.
-
 * `encryption_at_host_enabled` - (Optional) Should disks attached to this Virtual Machine Scale Set be encrypted by enabling Encryption at Host?
 
 * `instances` - (Optional) The number of Virtual Machines in the Orcestrated Virtual Machine Scale Set.
@@ -131,14 +129,6 @@ An `additional_capabilities` block supports the following:
 
 ---
 
-An `additional_unattend_content` block supports the following:
-
-* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
-
-* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
-
----
-
 An `os_profile` block supports the following:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Orchestrated Virtual Machine Scale Set.
@@ -181,6 +171,8 @@ A `windows_configuration` block supports the following:
 
 * `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below. Changing this forces a new resource to be created.
 
+* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below. Changing this forces a new resource to be created.
+
 ---
 
 A `linux_configuration` block supports the following:
@@ -218,6 +210,14 @@ A `secret` block supports the following:
 * `certificate` - (Required) One or more `certificate` blocks as defined below.
 
 -> **NOTE:** The schema of the `certificate` block is slightly different depending on if you are provisioning a `windows_configuration` or a `linux_configuration`.
+
+---
+
+An `additional_unattend_content` block supports the following:
+
+* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
+
+* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -51,6 +51,8 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `additional_capabilities` - (Optional) An `additional_capabilities` block as defined below.
 
+* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below. Changing this forces a new resource to be created.
+
 * `encryption_at_host_enabled` - (Optional) Should disks attached to this Virtual Machine Scale Set be encrypted by enabling Encryption at Host?
 
 * `instances` - (Optional) The number of Virtual Machines in the Orcestrated Virtual Machine Scale Set.
@@ -126,6 +128,14 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 An `additional_capabilities` block supports the following:
 
 * `ultra_ssd_enabled` - (Optional) Should the capacity to enable Data Disks of the `UltraSSD_LRS` storage account type be supported on this Orchestrated Virtual Machine Scale Set? Defaults to `false`. Changing this forces a new resource to be created.
+
+---
+
+An `additional_unattend_content` block supports the following:
+
+* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
+
+* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Support `additional_unattend_content` part of `azurerm_orchestrated_virtual_machine_scale_set` resource. 

Fixes #24282 