### PR TITLE
Move `azurerm_security_center_setting` to `go-azure-sdk`

### DIFF
--- a/internal/services/securitycenter/client/client.go
+++ b/internal/services/securitycenter/client/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
@@ -22,7 +23,7 @@ type Client struct {
 	WorkspaceClient                     *security.WorkspaceSettingsClient
 	AdvancedThreatProtectionClient      *security.AdvancedThreatProtectionClient
 	AutoProvisioningClient              *security.AutoProvisioningSettingsClient
-	SettingClient                       *security.SettingsClient
+	SettingClient                       *settings.SettingsClient
 	AutomationsClient                   *automations.AutomationsClient
 	ServerVulnerabilityAssessmentClient *security.ServerVulnerabilityAssessmentClient
 	DefenderForStorageClient            *defenderforstorage.DefenderForStorageClient
@@ -58,7 +59,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	AutoProvisioningClient := security.NewAutoProvisioningSettingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
 	o.ConfigureClient(&AutoProvisioningClient.Client, o.ResourceManagerAuthorizer)
 
-	SettingClient := security.NewSettingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
+	SettingClient := settings.NewSettingsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&SettingClient.Client, o.ResourceManagerAuthorizer)
 
 	AutomationsClient := automations.NewAutomationsClientWithBaseURI(o.ResourceManagerEndpoint)

--- a/internal/services/securitycenter/security_center_setting_resource.go
+++ b/internal/services/securitycenter/security_center_setting_resource.go
@@ -7,11 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -21,11 +20,8 @@ import (
 // TODO: this resource should be split into data_export_setting and alert_sync_setting
 
 func resourceSecurityCenterSetting() *pluginsdk.Resource {
-	validSettingName := []string{
-		"MCAS",
-		"WDATP",
-		"Sentinel",
-	}
+	validSettingName := settings.PossibleValuesForSettingName()
+
 	if !features.FourPointOhBeta() {
 		// This is for backward compatibility.. The swagger defines the valid enum to be "Sensinel" (see below), so this ("SENTINEL") shall be removed since 4.0.
 		// https://github.com/Azure/azure-rest-api-specs/blob/b52464f520b77222ac8b0bdeb80a030c0fdf5b1b/specification/security/resource-manager/Microsoft.Security/stable/2021-06-01/settings.json#L285
@@ -71,27 +67,30 @@ func resourceSecurityCenterSettingUpdate(d *pluginsdk.ResourceData, meta interfa
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewSettingID(subscriptionId, d.Get("setting_name").(string))
+	id := settings.NewSettingID(subscriptionId, settings.SettingName(d.Get("setting_name").(string)))
 
 	if d.IsNewResource() {
-		// TODO: switch back when Swagger/API bug has been fixed:
-		// https://github.com/Azure/azure-sdk-for-go/issues/12724 (`Enabled` field missing)
-		existing, err := azuresdkhacks.GetSecurityCenterSetting(ctx, client, id.Name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
 			return fmt.Errorf("checking for presence of existing %s: %v", id, err)
 		}
 
-		if existing.DataExportSettingProperties != nil && existing.DataExportSettingProperties.Enabled != nil && *existing.DataExportSettingProperties.Enabled {
-			return tf.ImportAsExistsError("azurerm_security_center_setting", id.ID())
+		if existing.Model != nil {
+			if alertSyncSettings, ok := (*existing.Model).(settings.AlertSyncSettings); ok && alertSyncSettings.Properties != nil && alertSyncSettings.Properties.Enabled {
+				return tf.ImportAsExistsError("azurerm_security_center_setting", id.ID())
+			}
+			if dataExportSettings, ok := (*existing.Model).(settings.DataExportSettings); ok && dataExportSettings.Properties != nil && dataExportSettings.Properties.Enabled {
+				return tf.ImportAsExistsError("azurerm_security_center_setting", id.ID())
+			}
 		}
 	}
 
-	setting, err := expandSecurityCenterSetting(id.Name, d.Get("enabled").(bool))
+	setting, err := expandSecurityCenterSetting(id.SettingName, d.Get("enabled").(bool))
 	if err != nil {
 		return err
 	}
 
-	if _, err := client.Update(ctx, id.Name, setting); err != nil {
+	if _, err := client.Update(ctx, id, setting); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -104,22 +103,26 @@ func resourceSecurityCenterSettingRead(d *pluginsdk.ResourceData, meta interface
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SettingID(d.Id())
+	id, err := settings.ParseSettingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	// TODO: switch to back when Swagger/API bug has been fixed:
-	// https://github.com/Azure/azure-sdk-for-go/issues/12724 (`Enabled` field missing)
-	resp, err := azuresdkhacks.GetSecurityCenterSetting(ctx, client, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	if properties := resp.DataExportSettingProperties; properties != nil {
-		d.Set("enabled", properties.Enabled)
+	if resp.Model != nil {
+		if alertSyncSettings, ok := (*resp.Model).(settings.AlertSyncSettings); ok && alertSyncSettings.Properties != nil {
+			d.Set("enabled", alertSyncSettings.Properties.Enabled)
+		}
+		if dataExportSettings, ok := (*resp.Model).(settings.DataExportSettings); ok && dataExportSettings.Properties != nil {
+			d.Set("enabled", dataExportSettings.Properties.Enabled)
+		}
 	}
-	d.Set("setting_name", id.Name)
+
+	d.Set("setting_name", id.SettingName)
 
 	return nil
 }
@@ -129,35 +132,39 @@ func resourceSecurityCenterSettingDelete(d *pluginsdk.ResourceData, meta interfa
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SettingID(d.Id())
+	id, err := settings.ParseSettingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	setting, err := expandSecurityCenterSetting(id.Name, false)
+	setting, err := expandSecurityCenterSetting(id.SettingName, false)
 	if err != nil {
 		return err
 	}
 
-	if _, err := client.Update(ctx, id.Name, setting); err != nil {
+	if _, err := client.Update(ctx, *id, setting); err != nil {
 		return fmt.Errorf("disabling %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func expandSecurityCenterSetting(name string, enabled bool) (security.BasicSetting, error) {
+func expandSecurityCenterSetting(name settings.SettingName, enabled bool) (settings.Setting, error) {
 	switch name {
-	case "MCAS", "WDATP":
-		return security.DataExportSettings{
-			DataExportSettingProperties: &security.DataExportSettingProperties{
-				Enabled: &enabled,
+	case settings.SettingNameMCAS,
+		settings.SettingNameWDATP,
+		settings.SettingNameWDATPEXCLUDELINUXPUBLICPREVIEW,
+		settings.SettingNameWDATPUNIFIEDSOLUTION:
+		return settings.DataExportSettings{
+			Properties: &settings.DataExportSettingProperties{
+				Enabled: enabled,
 			},
 		}, nil
-	case "SENTINEL", "Sentinel":
-		return security.AlertSyncSettings{
-			AlertSyncSettingProperties: &security.AlertSyncSettingProperties{
-				Enabled: &enabled,
+	case "SENTINEL",
+		settings.SettingNameSentinel:
+		return settings.AlertSyncSettings{
+			Properties: &settings.AlertSyncSettingProperties{
+				Enabled: enabled,
 			},
 		}, nil
 	default:

--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/azuresdkhacks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -104,48 +102,71 @@ func testAccSecurityCenterSetting_requiresImport(t *testing.T) {
 }
 
 func (SecurityCenterSettingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.SettingID(state.ID)
+	id, err := settings.ParseSettingID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: switch back when Swagger/API bug has been fixed:
-	// https://github.com/Azure/azure-sdk-for-go/issues/12724 (`Enabled` field missing)
-	resp, err := azuresdkhacks.GetSecurityCenterSetting(ctx, clients.SecurityCenter.SettingClient, id.Name)
+	resp, err := clients.SecurityCenter.SettingClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("checking for presence of existing %s: %v", id, err)
 	}
 
-	return utils.Bool(resp.DataExportSettingProperties != nil && resp.DataExportSettingProperties.Enabled != nil && *resp.DataExportSettingProperties.Enabled), nil
+	if resp.Model == nil {
+		return utils.Bool(false), nil
+	}
+
+	if alertSyncSettings, ok := (*resp.Model).(settings.AlertSyncSettings); ok {
+		if alertSyncSettings.Properties == nil {
+			return utils.Bool(false), nil
+		}
+		return utils.Bool(alertSyncSettings.Properties.Enabled), nil
+	}
+	if dataExportSettings, ok := (*resp.Model).(settings.DataExportSettings); ok {
+		if dataExportSettings.Properties == nil {
+			return utils.Bool(false), nil
+		}
+		return utils.Bool(dataExportSettings.Properties.Enabled), nil
+	}
+
+	return utils.Bool(false), nil
 }
 
 func (SecurityCenterSettingResource) Destroy(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	client := clients.SecurityCenter.SettingClient
-	id, err := parse.SettingID(state.ID)
+	id, err := settings.ParseSettingID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	setting := security.DataExportSettings{
-		DataExportSettingProperties: &security.DataExportSettingProperties{
-			Enabled: utils.Bool(false),
+	setting := settings.DataExportSettings{
+		Properties: &settings.DataExportSettingProperties{
+			Enabled: false,
 		},
-		Kind: security.KindDataExportSettings,
 	}
 
-	if _, err := client.Update(ctx, id.Name, setting); err != nil {
+	if _, err := client.Update(ctx, *id, setting); err != nil {
 		return nil, fmt.Errorf("disabling %s: %+v", id, err)
 	}
 
-	// TODO: switch back when Swagger/API bug has been fixed:
-	// https://github.com/Azure/azure-sdk-for-go/issues/12724 (`Enabled` field missing)
-	resp, err := azuresdkhacks.GetSecurityCenterSetting(ctx, client, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("checking for presence of existing %s: %v", id, err)
 	}
 
-	if resp.DataExportSettingProperties == nil || resp.DataExportSettingProperties.Enabled == nil || *resp.DataExportSettingProperties.Enabled {
+	if resp.Model == nil {
 		return utils.Bool(false), nil
+	}
+
+	if alertSyncSettings, ok := (*resp.Model).(settings.AlertSyncSettings); ok {
+		if alertSyncSettings.Properties == nil || !alertSyncSettings.Properties.Enabled {
+			return utils.Bool(false), nil
+		}
+	}
+	if dataExportSettings, ok := (*resp.Model).(settings.DataExportSettings); ok {
+		if dataExportSettings.Properties == nil || !dataExportSettings.Properties.Enabled {
+			return utils.Bool(false), nil
+		}
 	}
 
 	return utils.Bool(true), nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/README.md
@@ -1,0 +1,74 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings` Documentation
+
+The `settings` SDK allows for interaction with the Azure Resource Manager Service `security` (API Version `2022-05-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
+```
+
+
+### Client Initialization
+
+```go
+client := settings.NewSettingsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `SettingsClient.Get`
+
+```go
+ctx := context.TODO()
+id := settings.NewSettingID("12345678-1234-9876-4563-123456789012", "MCAS")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SettingsClient.List`
+
+```go
+ctx := context.TODO()
+id := settings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `SettingsClient.Update`
+
+```go
+ctx := context.TODO()
+id := settings.NewSettingID("12345678-1234-9876-4563-123456789012", "MCAS")
+
+payload := settings.Setting{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/client.go
@@ -1,0 +1,18 @@
+package settings
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SettingsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewSettingsClientWithBaseURI(endpoint string) SettingsClient {
+	return SettingsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/constants.go
@@ -1,0 +1,74 @@
+package settings
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SettingKind string
+
+const (
+	SettingKindAlertSuppressionSetting SettingKind = "AlertSuppressionSetting"
+	SettingKindAlertSyncSettings       SettingKind = "AlertSyncSettings"
+	SettingKindDataExportSettings      SettingKind = "DataExportSettings"
+)
+
+func PossibleValuesForSettingKind() []string {
+	return []string{
+		string(SettingKindAlertSuppressionSetting),
+		string(SettingKindAlertSyncSettings),
+		string(SettingKindDataExportSettings),
+	}
+}
+
+func parseSettingKind(input string) (*SettingKind, error) {
+	vals := map[string]SettingKind{
+		"alertsuppressionsetting": SettingKindAlertSuppressionSetting,
+		"alertsyncsettings":       SettingKindAlertSyncSettings,
+		"dataexportsettings":      SettingKindDataExportSettings,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SettingKind(input)
+	return &out, nil
+}
+
+type SettingName string
+
+const (
+	SettingNameMCAS                           SettingName = "MCAS"
+	SettingNameSentinel                       SettingName = "Sentinel"
+	SettingNameWDATP                          SettingName = "WDATP"
+	SettingNameWDATPEXCLUDELINUXPUBLICPREVIEW SettingName = "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW"
+	SettingNameWDATPUNIFIEDSOLUTION           SettingName = "WDATP_UNIFIED_SOLUTION"
+)
+
+func PossibleValuesForSettingName() []string {
+	return []string{
+		string(SettingNameMCAS),
+		string(SettingNameSentinel),
+		string(SettingNameWDATP),
+		string(SettingNameWDATPEXCLUDELINUXPUBLICPREVIEW),
+		string(SettingNameWDATPUNIFIEDSOLUTION),
+	}
+}
+
+func parseSettingName(input string) (*SettingName, error) {
+	vals := map[string]SettingName{
+		"mcas":                               SettingNameMCAS,
+		"sentinel":                           SettingNameSentinel,
+		"wdatp":                              SettingNameWDATP,
+		"wdatp_exclude_linux_public_preview": SettingNameWDATPEXCLUDELINUXPUBLICPREVIEW,
+		"wdatp_unified_solution":             SettingNameWDATPUNIFIEDSOLUTION,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SettingName(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/id_setting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/id_setting.go
@@ -1,0 +1,124 @@
+package settings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = SettingId{}
+
+// SettingId is a struct representing the Resource ID for a Setting
+type SettingId struct {
+	SubscriptionId string
+	SettingName    SettingName
+}
+
+// NewSettingID returns a new SettingId struct
+func NewSettingID(subscriptionId string, settingName SettingName) SettingId {
+	return SettingId{
+		SubscriptionId: subscriptionId,
+		SettingName:    settingName,
+	}
+}
+
+// ParseSettingID parses 'input' into a SettingId
+func ParseSettingID(input string) (*SettingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(SettingId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SettingId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseSettingIDInsensitively parses 'input' case-insensitively into a SettingId
+// note: this method should only be used for API response data and not user input
+func ParseSettingIDInsensitively(input string) (*SettingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(SettingId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SettingId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *SettingId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if v, ok := input.Parsed["settingName"]; true {
+		if !ok {
+			return resourceids.NewSegmentNotSpecifiedError(id, "settingName", input)
+		}
+
+		settingName, err := parseSettingName(v)
+		if err != nil {
+			return fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.SettingName = *settingName
+	}
+
+	return nil
+}
+
+// ValidateSettingID checks that 'input' can be parsed as a Setting ID
+func ValidateSettingID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSettingID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Setting ID
+func (id SettingId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Security/settings/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, string(id.SettingName))
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Setting ID
+func (id SettingId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftSecurity", "Microsoft.Security", "Microsoft.Security"),
+		resourceids.StaticSegment("staticSettings", "settings", "settings"),
+		resourceids.ConstantSegment("settingName", PossibleValuesForSettingName(), "MCAS"),
+	}
+}
+
+// String returns a human-readable description of this Setting ID
+func (id SettingId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Setting Name: %q", string(id.SettingName)),
+	}
+	return fmt.Sprintf("Setting (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_get_autorest.go
@@ -1,0 +1,77 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Setting
+}
+
+// Get ...
+func (c SettingsClient) Get(ctx context.Context, id SettingId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c SettingsClient) preparerForGet(ctx context.Context, id SettingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c SettingsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	var respObj json.RawMessage
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	if err != nil {
+		return
+	}
+	model, err := unmarshalSettingImplementation(respObj)
+	if err != nil {
+		return
+	}
+	result.Model = &model
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_list_autorest.go
@@ -1,0 +1,197 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Setting
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []Setting
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c SettingsClient) List(ctx context.Context, id commonids.SubscriptionId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c SettingsClient) preparerForList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Security/settings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c SettingsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c SettingsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []json.RawMessage `json:"value"`
+		NextLink *string           `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	temp := make([]Setting, 0)
+	for i, v := range respObj.Values {
+		val, err := unmarshalSettingImplementation(v)
+		if err != nil {
+			err = fmt.Errorf("unmarshalling item %d for Setting (%q): %+v", i, v, err)
+			return result, err
+		}
+		temp = append(temp, val)
+	}
+	result.Model = &temp
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "settings.SettingsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c SettingsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, SettingOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c SettingsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate SettingOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]Setting, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/method_update_autorest.go
@@ -1,0 +1,78 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Setting
+}
+
+// Update ...
+func (c SettingsClient) Update(ctx context.Context, id SettingId, input Setting) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "settings.SettingsClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c SettingsClient) preparerForUpdate(ctx context.Context, id SettingId, input Setting) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c SettingsClient) responderForUpdate(resp *http.Response) (result UpdateOperationResponse, err error) {
+	var respObj json.RawMessage
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	if err != nil {
+		return
+	}
+	model, err := unmarshalSettingImplementation(respObj)
+	if err != nil {
+		return
+	}
+	result.Model = &model
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_alertsyncsettingproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_alertsyncsettingproperties.go
@@ -1,0 +1,8 @@
+package settings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AlertSyncSettingProperties struct {
+	Enabled bool `json:"enabled"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_alertsyncsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_alertsyncsettings.go
@@ -1,0 +1,44 @@
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ Setting = AlertSyncSettings{}
+
+type AlertSyncSettings struct {
+	Properties *AlertSyncSettingProperties `json:"properties,omitempty"`
+
+	// Fields inherited from Setting
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+var _ json.Marshaler = AlertSyncSettings{}
+
+func (s AlertSyncSettings) MarshalJSON() ([]byte, error) {
+	type wrapper AlertSyncSettings
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AlertSyncSettings: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AlertSyncSettings: %+v", err)
+	}
+	decoded["kind"] = "AlertSyncSettings"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AlertSyncSettings: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_dataexportsettingproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_dataexportsettingproperties.go
@@ -1,0 +1,8 @@
+package settings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataExportSettingProperties struct {
+	Enabled bool `json:"enabled"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_dataexportsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_dataexportsettings.go
@@ -1,0 +1,44 @@
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ Setting = DataExportSettings{}
+
+type DataExportSettings struct {
+	Properties *DataExportSettingProperties `json:"properties,omitempty"`
+
+	// Fields inherited from Setting
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+var _ json.Marshaler = DataExportSettings{}
+
+func (s DataExportSettings) MarshalJSON() ([]byte, error) {
+	type wrapper DataExportSettings
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DataExportSettings: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DataExportSettings: %+v", err)
+	}
+	decoded["kind"] = "DataExportSettings"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DataExportSettings: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_setting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/model_setting.go
@@ -1,0 +1,61 @@
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Setting interface {
+}
+
+// RawSettingImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSettingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
+func unmarshalSettingImplementation(input []byte) (Setting, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling Setting into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["kind"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AlertSyncSettings") {
+		var out AlertSyncSettings
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AlertSyncSettings: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DataExportSettings") {
+		var out DataExportSettings
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DataExportSettings: %+v", err)
+		}
+		return out, nil
+	}
+
+	out := RawSettingImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/predicates.go
@@ -1,0 +1,12 @@
+package settings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SettingOperationPredicate struct {
+}
+
+func (p SettingOperationPredicate) Matches(input Setting) bool {
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/version.go
@@ -1,0 +1,12 @@
+package settings
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-05-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/settings/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -884,6 +884,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/services
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/sharedprivatelinkresources
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata
+github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings
 github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_security_center_setting" "example" {
 
 The following arguments are supported:
 
-* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP` and `Sentinel`. Changing this forces a new resource to be created.
+* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP`, `WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW`, `WDATP_UNIFIED_SOLUTION`  and `Sentinel`. Changing this forces a new resource to be created.
 * `enabled` - (Required) Boolean flag to enable/disable data access.
 
 ## Attributes Reference


### PR DESCRIPTION
Updating the `azurerm_security_center_setting` to use `go-azure-sdk` in order to make the new setting names available 