### PR TITLE
`azurerm_key_vault_managed_hardware_security_module`: fix purge issue

### DIFF
--- a/internal/services/keyvault/custompollers/hsm_purge_poller.go
+++ b/internal/services/keyvault/custompollers/hsm_purge_poller.go
@@ -1,0 +1,54 @@
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/managedhsms"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &hsmDownloadPoller{}
+
+func NewHSMPurgePoller(client *managedhsms.ManagedHsmsClient, id managedhsms.DeletedManagedHSMId) *hsmPurgePoller {
+	return &hsmPurgePoller{
+		client:          client,
+		purgeId:         id,
+		purgeAgainUntil: time.Now().Add(time.Minute),
+	}
+}
+
+type hsmPurgePoller struct {
+	client          *managedhsms.ManagedHsmsClient
+	purgeId         managedhsms.DeletedManagedHSMId
+	purgeAgainUntil time.Time
+}
+
+func (p *hsmPurgePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	deletedResp, err := p.client.GetDeleted(ctx, p.purgeId)
+
+	res := &pollers.PollResult{
+		PollInterval: time.Second * 20,
+		Status:       pollers.PollingStatusInProgress,
+	}
+	if response.WasNotFound(deletedResp.HttpResponse) {
+		res.Status = pollers.PollingStatusSucceeded
+		return res, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("retrieving deleted managed HSM %s: %+v", p.purgeId, err)
+	}
+
+	if time.Now().After(p.purgeAgainUntil) {
+		p.purgeAgainUntil = time.Now().Add(time.Minute)
+		purgeResp, _ := p.client.PurgeDeleted(ctx, p.purgeId)
+		if response.WasNotFound(purgeResp.HttpResponse) {
+			res.Status = pollers.PollingStatusSucceeded
+		}
+	}
+
+	return res, nil
+}

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
@@ -38,16 +38,11 @@ locals {
   assignmentTestName = "1e243909-064c-6ac3-84e9-1c8bf8d6ad52"
 }
 
-data "azurerm_key_vault_managed_hardware_security_module_role_definition" "test" {
-  name           = azurerm_key_vault_managed_hardware_security_module_role_definition.test.name
-  vault_base_url = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
-}
-
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
   vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
   name               = local.assignmentTestName
   scope              = "/keys"
-  role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.test.resource_manager_id
+  role_definition_id = azurerm_key_vault_managed_hardware_security_module_role_definition.test.resource_manager_id
   principal_id       = data.azurerm_client_config.current.object_id
 }
 `, roleDef)


### PR DESCRIPTION
There is a [API issue](https://github.com/Azure/azure-rest-api-specs/issues/27138) blocks purge managed HSM, this PR is a workaround to the issue.

**FAILED Purge**:
```
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/download
    testcase.go:120: Step 5/6 error: Error running apply: exit status 1
        Error: purging Managed H S M (Subscription: "*******"
        Resource Group Name: "acctestRG-KV-231220234745602823"
        Managed H S M Name: "kvHsm231220234745602823"): polling after PurgeDeleted: Future#WaitForCompletion: context has been cancelled: StatusCode=202 -- Original Error: context deadline exceeded
    testing_new.go:90: Error running post-test destroy, there may be dangling resources: exit status 1
```
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/f5c3e51d-c1a5-4005-a727-93bcd4a078ab)

**Pass**:

```
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/role_assign (2533.65s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/data_source (1900.20s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/basic (2298.04s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/update (1859.23s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/download (4254.26s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/role_define (2549.07s)
```