### PR TITLE
Add ability to handle Consumption in workload profile

### DIFF
--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -37,6 +37,7 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
+						consumption,
 						"D4",
 						"D8",
 						"D16",
@@ -98,9 +99,6 @@ func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []Wor
 	result := make([]WorkloadProfileModel, 0)
 
 	for _, v := range *input {
-		if strings.EqualFold(v.WorkloadProfileType, consumption) {
-			continue
-		}
 		result = append(result, WorkloadProfileModel{
 			Name:                v.Name,
 			MaximumCount:        int(pointer.From(v.MaximumCount)),


### PR DESCRIPTION
As part of #23478 workload profiles were introduced.

There is an important distinction between
`Consumption` as a type of workload profile and
`Consumption` completly apart from workload profile.

This PR is to add `Consumption` as workload profile type.

ref: https://learn.microsoft.com/en-us/azure/container-apps/workload-profiles-overview#profile-types
related also: #21747