### PR TITLE
`azurerm_data_protection_backup_policy_postgresql`, `azurerm_data_protection_backup_policy_disk`:  support new property `time_zone`

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backuppolicies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	helperValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -121,6 +123,13 @@ func resourceDataProtectionBackupPolicyDisk() *schema.Resource {
 					},
 				},
 			},
+
+			"time_zone": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -147,7 +156,7 @@ func resourceDataProtectionBackupPolicyDiskCreate(d *schema.ResourceData, meta i
 
 	taggingCriteria := expandBackupPolicyDiskTaggingCriteriaArray(d.Get("retention_rule").([]interface{}))
 	policyRules := make([]backuppolicies.BasePolicyRule, 0)
-	policyRules = append(policyRules, expandBackupPolicyDiskAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), taggingCriteria)...)
+	policyRules = append(policyRules, expandBackupPolicyDiskAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), d.Get("time_zone").(string), taggingCriteria)...)
 	policyRules = append(policyRules, expandBackupPolicyDiskDefaultAzureRetentionRule(d.Get("default_retention_duration")))
 	policyRules = append(policyRules, expandBackupPolicyDiskAzureRetentionRuleArray(d.Get("retention_rule").([]interface{}))...)
 	parameters := backuppolicies.BaseBackupPolicyResource{
@@ -199,6 +208,7 @@ func resourceDataProtectionBackupPolicyDiskRead(d *schema.ResourceData, meta int
 				if err := d.Set("retention_rule", flattenBackupPolicyDiskRetentionRuleArray(&props.PolicyRules)); err != nil {
 					return fmt.Errorf("setting `retention_rule`: %+v", err)
 				}
+				d.Set("time_zone", flattenBackupPolicyDiskBackupTimeZone(&props.PolicyRules))
 			}
 		}
 	}
@@ -225,7 +235,7 @@ func resourceDataProtectionBackupPolicyDiskDelete(d *schema.ResourceData, meta i
 	return nil
 }
 
-func expandBackupPolicyDiskAzureBackupRuleArray(input []interface{}, taggingCriteria *[]backuppolicies.TaggingCriteria) []backuppolicies.BasePolicyRule {
+func expandBackupPolicyDiskAzureBackupRuleArray(input []interface{}, timeZone string, taggingCriteria *[]backuppolicies.TaggingCriteria) []backuppolicies.BasePolicyRule {
 	results := make([]backuppolicies.BasePolicyRule, 0)
 
 	results = append(results, backuppolicies.AzureBackupRule{
@@ -240,6 +250,7 @@ func expandBackupPolicyDiskAzureBackupRuleArray(input []interface{}, taggingCrit
 		Trigger: backuppolicies.ScheduleBasedTriggerContext{
 			Schedule: backuppolicies.BackupSchedule{
 				RepeatingTimeIntervals: *utils.ExpandStringSlice(input),
+				TimeZone:               pointer.To(timeZone),
 			},
 			TaggingCriteria: *taggingCriteria,
 		},
@@ -346,6 +357,22 @@ func flattenBackupPolicyDiskBackupRuleArray(input *[]backuppolicies.BasePolicyRu
 		}
 	}
 	return make([]interface{}, 0)
+}
+
+func flattenBackupPolicyDiskBackupTimeZone(input *[]backuppolicies.BasePolicyRule) string {
+	if input == nil {
+		return ""
+	}
+	for _, item := range *input {
+		if backupRule, ok := item.(backuppolicies.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if scheduleBasedTrigger, ok := backupRule.Trigger.(backuppolicies.ScheduleBasedTriggerContext); ok {
+					return pointer.From(scheduleBasedTrigger.Schedule.TimeZone)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func flattenBackupPolicyDiskDefaultRetentionRuleDuration(input *[]backuppolicies.BasePolicyRule) interface{} {

--- a/internal/services/dataprotection/data_protection_backup_policy_disk_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_disk_resource_test.go
@@ -162,6 +162,7 @@ resource "azurerm_data_protection_backup_policy_disk" "test" {
   vault_id                        = azurerm_data_protection_backup_vault.test.id
   backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
   default_retention_duration      = "P7D"
+  time_zone                       = "W. Europe Standard Time"
 
   retention_rule {
     name     = "Daily"

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backuppolicies"
@@ -175,6 +176,13 @@ func resourceDataProtectionBackupPolicyPostgreSQL() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"time_zone": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -207,7 +215,7 @@ func resourceDataProtectionBackupPolicyPostgreSQLCreate(d *pluginsdk.ResourceDat
 	}
 
 	policyRules := make([]backuppolicies.BasePolicyRule, 0)
-	policyRules = append(policyRules, expandBackupPolicyPostgreSQLAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), taggingCriteria)...)
+	policyRules = append(policyRules, expandBackupPolicyPostgreSQLAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), d.Get("time_zone").(string), taggingCriteria)...)
 	policyRules = append(policyRules, expandBackupPolicyPostgreSQLDefaultAzureRetentionRule(d.Get("default_retention_duration")))
 	policyRules = append(policyRules, expandBackupPolicyPostgreSQLAzureRetentionRuleArray(d.Get("retention_rule").([]interface{}))...)
 	parameters := backuppolicies.BaseBackupPolicyResource{
@@ -260,6 +268,7 @@ func resourceDataProtectionBackupPolicyPostgreSQLRead(d *pluginsdk.ResourceData,
 				if err := d.Set("retention_rule", flattenBackupPolicyPostgreSQLRetentionRuleArray(&props.PolicyRules)); err != nil {
 					return fmt.Errorf("setting `retention_rule`: %+v", err)
 				}
+				d.Set("time_zone", flattenBackupPolicyPostgreSQLBackupTimeZone(&props.PolicyRules))
 			}
 		}
 	}
@@ -286,7 +295,7 @@ func resourceDataProtectionBackupPolicyPostgreSQLDelete(d *pluginsdk.ResourceDat
 	return nil
 }
 
-func expandBackupPolicyPostgreSQLAzureBackupRuleArray(input []interface{}, taggingCriteria *[]backuppolicies.TaggingCriteria) []backuppolicies.BasePolicyRule {
+func expandBackupPolicyPostgreSQLAzureBackupRuleArray(input []interface{}, timeZone string, taggingCriteria *[]backuppolicies.TaggingCriteria) []backuppolicies.BasePolicyRule {
 	results := make([]backuppolicies.BasePolicyRule, 0)
 	results = append(results, backuppolicies.AzureBackupRule{
 		Name: "BackupIntervals",
@@ -300,6 +309,7 @@ func expandBackupPolicyPostgreSQLAzureBackupRuleArray(input []interface{}, taggi
 		Trigger: backuppolicies.ScheduleBasedTriggerContext{
 			Schedule: backuppolicies.BackupSchedule{
 				RepeatingTimeIntervals: *utils.ExpandStringSlice(input),
+				TimeZone:               pointer.To(timeZone),
 			},
 			TaggingCriteria: *taggingCriteria,
 		},
@@ -453,6 +463,22 @@ func flattenBackupPolicyPostgreSQLBackupRuleArray(input *[]backuppolicies.BasePo
 		}
 	}
 	return make([]interface{}, 0)
+}
+
+func flattenBackupPolicyPostgreSQLBackupTimeZone(input *[]backuppolicies.BasePolicyRule) string {
+	if input == nil {
+		return ""
+	}
+	for _, item := range *input {
+		if backupRule, ok := item.(backuppolicies.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if scheduleBasedTrigger, ok := backupRule.Trigger.(backuppolicies.ScheduleBasedTriggerContext); ok {
+					return pointer.From(scheduleBasedTrigger.Schedule.TimeZone)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func flattenBackupPolicyPostgreSQLDefaultRetentionRuleDuration(input *[]backuppolicies.BasePolicyRule) interface{} {

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_resource_test.go
@@ -169,6 +169,8 @@ resource "azurerm_data_protection_backup_policy_postgresql" "test" {
 
   backup_repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
   default_retention_duration      = "P4M"
+  time_zone                       = "India Standard Time"
+
   retention_rule {
     name     = "weekly"
     duration = "P6M"

--- a/website/docs/r/data_protection_backup_policy_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_disk.html.markdown
@@ -32,6 +32,7 @@ resource "azurerm_data_protection_backup_policy_disk" "example" {
 
   backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
   default_retention_duration      = "P7D"
+  time_zone                       = "W. Europe Standard Time"
 
   retention_rule {
     name     = "Daily"
@@ -65,9 +66,9 @@ The following arguments are supported:
 
 * `default_retention_duration` - (Required) The duration of default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Disk to be created.
 
----
-
 * `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy Disk to be created.
+
+* `time_zone` - (Optional) Specifies the Time Zone which should be used by the backup schedule. Changing this forces a new Backup Policy Disk to be created.
 
 ---
 

--- a/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
@@ -32,8 +32,8 @@ resource "azurerm_data_protection_backup_policy_postgresql" "example" {
   vault_name          = azurerm_data_protection_backup_vault.example.name
 
   backup_repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
-
-  default_retention_duration = "P4M"
+  time_zone                       = "India Standard Time"
+  default_retention_duration      = "P4M"
 
   retention_rule {
     name     = "weekly"
@@ -81,9 +81,9 @@ The following arguments are supported:
   
 * `default_retention_duration` - (Required) The duration of default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy PostgreSQL to be created.
 
----
-
 * `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy PostgreSQL to be created.
+
+* `time_zone` - (Optional) Specifies the Time Zone which should be used by the backup schedule. Changing this forces a new Backup Policy Disk to be created.
 
 ---
 


### PR DESCRIPTION
Swagger: https://github.com/Azure/azure-rest-api-specs/blob/2ed14f56c48ffbf9b173f33e0b7dd92d253532d9/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-05-01/dataprotection.json#L4766C10-L4766C18

