### PR TITLE
Datasource `azurerm_kusto_cluster` - Supports exporting `identity` block

### DIFF
--- a/internal/services/kusto/kusto_cluster_data_source.go
+++ b/internal/services/kusto/kusto_cluster_data_source.go
@@ -79,11 +79,11 @@ func dataSourceKustoClusterRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(&resp.Model.Location))
 
-		identity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		identityMap, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {
 			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
-		if err := d.Set("identity", identity); err != nil {
+		if err := d.Set("identity", identityMap); err != nil {
 			return fmt.Errorf("setting `identity`: %s", err)
 		}
 

--- a/internal/services/kusto/kusto_cluster_data_source.go
+++ b/internal/services/kusto/kusto_cluster_data_source.go
@@ -5,11 +5,11 @@ package kusto
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusters"

--- a/internal/services/kusto/kusto_cluster_data_source_test.go
+++ b/internal/services/kusto/kusto_cluster_data_source_test.go
@@ -21,6 +21,7 @@ func TestAccKustoClusterDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(KustoClusterResource{}),
 				check.That(data.ResourceName).Key("uri").IsSet(),
 				check.That(data.ResourceName).Key("data_ingestion_uri").IsSet(),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsSet(),
 			),
 		},
 	})
@@ -34,5 +35,5 @@ data "azurerm_kusto_cluster" "test" {
   name                = azurerm_kusto_cluster.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, KustoClusterResource{}.basic(data))
+`, KustoClusterResource{}.identitySystemAssigned(data))
 }

--- a/website/docs/d/kusto_cluster.html.markdown
+++ b/website/docs/d/kusto_cluster.html.markdown
@@ -37,6 +37,20 @@ The following attributes are exported:
 
 * `data_ingestion_uri` - The Kusto Cluster URI to be used for data ingestion.
 
+* `identity` - An `identity` block as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - The type of Managed Service Identity that is configured on this Kusto Cluster.
+
+* `identity_ids` - A list of User Assigned Managed Identity IDs to be assigned to this Kusto Cluster.
+
+* `principal_id` - The Principal ID associated with this System Assigned Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this System Assigned Managed Service Identity.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
`azurerm_kusto_cluster` 

- Supports exporting `identity` in datasource.
- Change test case.
- Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24293

Testing Evidence:

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccKustoClusterDataSource_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccKustoClusterDataSource_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccKustoClusterDataSource_basic\E$ #gosetup
=== RUN   TestAccKustoClusterDataSource_basic
=== PAUSE TestAccKustoClusterDataSource_basic
=== CONT  TestAccKustoClusterDataSource_basic
--- PASS: TestAccKustoClusterDataSource_basic (1309.95s)
PASS


Process finished with the exit code 0

```

