### PR TITLE
fix `role_definition_id` for `data.azurerm_role_definition`

### DIFF
--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -193,8 +193,9 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := RoleDefinitionDataSourceModel{
-				Scope:            config.Scope,
-				RoleDefinitionId: pointer.From(role.ID),
+				Scope: config.Scope,
+				// Though the property is called "Name", it's UUID in fact.
+				RoleDefinitionId: pointer.From(role.Name),
 			}
 
 			state.Name = pointer.From(role.RoleName)

--- a/internal/services/authorization/role_definition_data_source_test.go
+++ b/internal/services/authorization/role_definition_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccRoleDefinitionDataSource_basic(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.basic(id, data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -46,6 +47,7 @@ func TestAccRoleDefinitionDataSource_basicByName(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.byName(id, data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -68,6 +70,7 @@ func TestAccRoleDefinitionDataSource_builtIn_contributor(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Contributor"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -95,6 +98,8 @@ func TestAccRoleDefinitionDataSource_builtIn_owner(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Owner"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -114,6 +119,7 @@ func TestAccRoleDefinitionDataSource_builtIn_reader(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Reader"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -133,6 +139,7 @@ func TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor(t *testin
 			Config: RoleDefinitionDataSource{}.builtIn("Virtual Machine Contributor"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),


### PR DESCRIPTION
test
---
```
❯ tftest authorization TestAccRoleDefinitionDataSource
=== RUN   TestAccRoleDefinitionDataSource_basic
=== PAUSE TestAccRoleDefinitionDataSource_basic
=== RUN   TestAccRoleDefinitionDataSource_basicByName
=== PAUSE TestAccRoleDefinitionDataSource_basicByName
=== RUN   TestAccRoleDefinitionDataSource_builtIn_contributor
=== PAUSE TestAccRoleDefinitionDataSource_builtIn_contributor
=== RUN   TestAccRoleDefinitionDataSource_builtIn_owner
=== PAUSE TestAccRoleDefinitionDataSource_builtIn_owner
=== RUN   TestAccRoleDefinitionDataSource_builtIn_reader
=== PAUSE TestAccRoleDefinitionDataSource_builtIn_reader
=== RUN   TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor
=== PAUSE TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor
=== CONT  TestAccRoleDefinitionDataSource_basic
=== CONT  TestAccRoleDefinitionDataSource_builtIn_owner
=== CONT  TestAccRoleDefinitionDataSource_builtIn_contributor
=== CONT  TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor
=== CONT  TestAccRoleDefinitionDataSource_builtIn_reader
=== CONT  TestAccRoleDefinitionDataSource_basicByName
--- PASS: TestAccRoleDefinitionDataSource_builtIn_reader (63.44s)
--- PASS: TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor (66.23s)
--- PASS: TestAccRoleDefinitionDataSource_builtIn_owner (66.87s)
--- PASS: TestAccRoleDefinitionDataSource_builtIn_contributor (69.97s)
--- PASS: TestAccRoleDefinitionDataSource_basic (270.06s)
--- PASS: TestAccRoleDefinitionDataSource_basicByName (847.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization	847.779s

```