### PR TITLE
`azurerm_logic_app_standard` - fix a crash

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -183,7 +183,7 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 						return "~3"
 					}
 					return "~4"
-				},
+				}(),
 			},
 
 			"tags": tags.Schema(),

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -29,7 +30,12 @@ func TestAccLogicAppStandard_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data.ResourceName, "kind", "functionapp,workflowapp"),
-				check.That(data.ResourceName).Key("version").HasValue("~4"),
+				func() pluginsdk.TestCheckFunc {
+					if features.FourPointOhBeta() {
+						return check.That(data.ResourceName).Key("version").HasValue("~4")
+					}
+					return check.That(data.ResourceName).Key("version").HasValue("~3")
+				}(),
 				check.That(data.ResourceName).Key("outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("possible_outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("custom_domain_verification_id").Exists(),


### PR DESCRIPTION
just a fix for crash:
```
panic: Error reading level config: '' expected type 'string', got unconvertible type 'func() interface {}'
```

<img width="379" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/2e2bfe62-4177-4ac5-a97e-c7695589d47f">
