### PR TITLE
`azurerm_iothub_device_update_account`- `sku` forces new

### DIFF
--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -21,9 +21,7 @@ import (
 
 type IotHubDeviceUpdateAccountResource struct{}
 
-var (
-	_ sdk.ResourceWithUpdate = IotHubDeviceUpdateAccountResource{}
-)
+var _ sdk.ResourceWithUpdate = IotHubDeviceUpdateAccountResource{}
 
 type IotHubDeviceUpdateAccountModel struct {
 	Name                       string            `tfschema:"name"`
@@ -58,6 +56,7 @@ func (r IotHubDeviceUpdateAccountResource) Arguments() map[string]*pluginsdk.Sch
 
 		"sku": {
 			Type:     pluginsdk.TypeString,
+			ForceNew: true,
 			Optional: true,
 			Default:  deviceupdates.SKUStandard,
 			ValidateFunc: validation.StringInSlice([]string{
@@ -253,10 +252,6 @@ func (r IotHubDeviceUpdateAccountResource) Update() sdk.ResourceFunc {
 					publicNetworkAccess = deviceupdates.PublicNetworkAccessDisabled
 				}
 				existing.Properties.PublicNetworkAccess = &publicNetworkAccess
-			}
-
-			if metadata.ResourceData.HasChange("sku") {
-				existing.Properties.Sku = &model.Sku
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/iothub/iothub_device_update_account_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_account_resource_test.go
@@ -120,27 +120,6 @@ func TestAccIotHubDeviceUpdateAccount_publicNetworkAccess(t *testing.T) {
 	})
 }
 
-func TestAccIotHubDeviceUpdateAccount_sku(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
-	r := IotHubDeviceUpdateAccountResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.sku(data, "Free"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.sku(data, "Standard"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccIotHubDeviceUpdateAccount_tags(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
 	r := IotHubDeviceUpdateAccountResource{}
@@ -332,21 +311,6 @@ resource "azurerm_iothub_device_update_account" "test" {
   public_network_access_enabled = %t
 }
 `, template, data.RandomString, enabled)
-}
-
-func (r IotHubDeviceUpdateAccountResource) sku(data acceptance.TestData, sku string) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_iothub_device_update_account" "test" {
-  name                = "acc-dua-%s"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku = "%s"
-}
-`, template, data.RandomString, sku)
 }
 
 func (r IotHubDeviceUpdateAccountResource) tags(data acceptance.TestData) string {

--- a/website/docs/r/iothub_device_update_account.html.markdown
+++ b/website/docs/r/iothub_device_update_account.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Specifies whether the public network access is enabled for the IoT Hub Device Update Account. Possible values are `true` and `false`. Defaults to `true`.
 
-* `sku` - (Optional) Sku of the IoT Hub Device Update Account. Possible values are `Free` and `Standard`. Defaults to `Standard`.
+* `sku` - (Optional) Sku of the IoT Hub Device Update Account. Possible values are `Free` and `Standard`. Defaults to `Standard`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the IoT Hub Device Update Account.
 


### PR DESCRIPTION
the `sku` property is not allowed to change on the service side:
```
{
    "error": {
        "code": "AccountValidationFailed",
        "details": [
            {
                "code": "AccountSkuChangeNotAllowed",
                "message": "Account SKU change is not allowed after creation"
            }
        ],
        "message": "ValidationException"
    }
}
```

So update it to force new

test
---
```
❯ tftest iothub TestAccIotHubDeviceUpdateAccount    
=== RUN   TestAccIotHubDeviceUpdateAccount_basic
=== PAUSE TestAccIotHubDeviceUpdateAccount_basic
=== RUN   TestAccIotHubDeviceUpdateAccount_complete
=== PAUSE TestAccIotHubDeviceUpdateAccount_complete
=== RUN   TestAccIotHubDeviceUpdateAccount_requiresImport
=== PAUSE TestAccIotHubDeviceUpdateAccount_requiresImport
=== RUN   TestAccIotHubDeviceUpdateAccount_identity
=== PAUSE TestAccIotHubDeviceUpdateAccount_identity
=== RUN   TestAccIotHubDeviceUpdateAccount_publicNetworkAccess
=== PAUSE TestAccIotHubDeviceUpdateAccount_publicNetworkAccess
=== RUN   TestAccIotHubDeviceUpdateAccount_sku
=== PAUSE TestAccIotHubDeviceUpdateAccount_sku
=== RUN   TestAccIotHubDeviceUpdateAccount_tags
=== PAUSE TestAccIotHubDeviceUpdateAccount_tags
=== CONT  TestAccIotHubDeviceUpdateAccount_basic
=== CONT  TestAccIotHubDeviceUpdateAccount_publicNetworkAccess
=== CONT  TestAccIotHubDeviceUpdateAccount_requiresImport
=== CONT  TestAccIotHubDeviceUpdateAccount_tags
=== CONT  TestAccIotHubDeviceUpdateAccount_complete
=== CONT  TestAccIotHubDeviceUpdateAccount_identity
=== CONT  TestAccIotHubDeviceUpdateAccount_sku
--- PASS: TestAccIotHubDeviceUpdateAccount_requiresImport (394.16s)
--- PASS: TestAccIotHubDeviceUpdateAccount_complete (422.90s)
--- PASS: TestAccIotHubDeviceUpdateAccount_basic (449.18s)
--- PASS: TestAccIotHubDeviceUpdateAccount_publicNetworkAccess (561.35s)
--- PASS: TestAccIotHubDeviceUpdateAccount_tags (573.41s)
--- PASS: TestAccIotHubDeviceUpdateAccount_sku (626.16s)
--- PASS: TestAccIotHubDeviceUpdateAccount_identity (847.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub	847.243s
```