### PR TITLE
`azurerm_iothub` - fix a bug for `local_auth_enabled`

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -797,6 +798,31 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of %q: %+v", id, err)
+	}
+
+	// When the `local_authentication_enabled` updated, GET on the resource is returned with 404 for a while.
+	// Tracked on https://github.com/Azure/azure-rest-api-specs/issues/27183
+	timeout, _ := ctx.Deadline()
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{"404"},
+		Target:  []string{"200"},
+		Refresh: func() (result interface{}, state string, err error) {
+			resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					return resp, strconv.Itoa(resp.StatusCode), nil
+				}
+				return resp, strconv.Itoa(resp.StatusCode), err
+			}
+			return resp, strconv.Itoa(resp.StatusCode), nil
+		},
+		Delay:        1 * time.Minute,
+		PollInterval: 1 * time.Minute,
+		Timeout:      time.Until(timeout),
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for creation/update of %q: %+v", id, err)
 	}
 


### PR DESCRIPTION
GET on the resource might be returned with 404 just after an update. tracked on https://github.com/Azure/azure-rest-api-specs/issues/27183

which might cause the following error:
```
 Error: Provider produced inconsistent result after apply
        When applying changes to azurerm_iothub.test, provider
        "provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced an
        unexpected new value: Root resource was present, but now absent.
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

test
---
```
❯ tftest iothub TestAccIotHub_                   
=== RUN   TestAccIotHub_basic
=== PAUSE TestAccIotHub_basic
=== RUN   TestAccIotHub_networkRulesSet
=== PAUSE TestAccIotHub_networkRulesSet
=== RUN   TestAccIotHub_requiresImport
=== PAUSE TestAccIotHub_requiresImport
=== RUN   TestAccIotHub_standard
=== PAUSE TestAccIotHub_standard
=== RUN   TestAccIotHub_customRoutes
=== PAUSE TestAccIotHub_customRoutes
=== RUN   TestAccIotHub_enrichments
=== PAUSE TestAccIotHub_enrichments
=== RUN   TestAccIotHub_removeEndpointsAndRoutes
=== PAUSE TestAccIotHub_removeEndpointsAndRoutes
=== RUN   TestAccIotHub_fileUpload
=== PAUSE TestAccIotHub_fileUpload
=== RUN   TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
=== PAUSE TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
=== RUN   TestAccIotHub_fileUploadAuthenticationTypeUpdate
=== PAUSE TestAccIotHub_fileUploadAuthenticationTypeUpdate
=== RUN   TestAccIotHub_withDifferentEndpointResourceGroup
=== PAUSE TestAccIotHub_withDifferentEndpointResourceGroup
=== RUN   TestAccIotHub_fallbackRoute
=== PAUSE TestAccIotHub_fallbackRoute
=== RUN   TestAccIotHub_publicAccess
=== PAUSE TestAccIotHub_publicAccess
=== RUN   TestAccIotHub_minTLSVersion
=== PAUSE TestAccIotHub_minTLSVersion
=== RUN   TestAccIotHub_LocalAuth
=== PAUSE TestAccIotHub_LocalAuth
=== RUN   TestAccIotHub_cloudToDevice
=== PAUSE TestAccIotHub_cloudToDevice
=== RUN   TestAccIotHub_identitySystemAssigned
=== PAUSE TestAccIotHub_identitySystemAssigned
=== RUN   TestAccIotHub_identitySystemAssignedUserAssigned
=== PAUSE TestAccIotHub_identitySystemAssignedUserAssigned
=== RUN   TestAccIotHub_identityUserAssigned
=== PAUSE TestAccIotHub_identityUserAssigned
=== RUN   TestAccIotHub_identityUpdate
=== PAUSE TestAccIotHub_identityUpdate
=== RUN   TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
=== PAUSE TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
=== RUN   TestAccIotHub_endpointAuthenticationTypeUpdate
=== PAUSE TestAccIotHub_endpointAuthenticationTypeUpdate
=== CONT  TestAccIotHub_basic
=== CONT  TestAccIotHub_fallbackRoute
=== CONT  TestAccIotHub_identitySystemAssignedUserAssigned
=== CONT  TestAccIotHub_endpointAuthenticationTypeUpdate
=== CONT  TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity
=== CONT  TestAccIotHub_identityUpdate
=== CONT  TestAccIotHub_identityUserAssigned
=== CONT  TestAccIotHub_LocalAuth
--- PASS: TestAccIotHub_identitySystemAssignedUserAssigned (366.54s)
=== CONT  TestAccIotHub_identitySystemAssigned
--- PASS: TestAccIotHub_basic (383.15s)
=== CONT  TestAccIotHub_cloudToDevice
--- PASS: TestAccIotHub_fallbackRoute (384.18s)
=== CONT  TestAccIotHub_minTLSVersion
--- PASS: TestAccIotHub_identityUserAssigned (524.71s)
=== CONT  TestAccIotHub_removeEndpointsAndRoutes
--- PASS: TestAccIotHub_LocalAuth (640.15s)
=== CONT  TestAccIotHub_withDifferentEndpointResourceGroup
--- PASS: TestAccIotHub_identitySystemAssigned (385.52s)
=== CONT  TestAccIotHub_fileUploadAuthenticationTypeUpdate
--- PASS: TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity (779.22s)
=== CONT  TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity
--- PASS: TestAccIotHub_minTLSVersion (410.00s)
=== CONT  TestAccIotHub_fileUpload
--- PASS: TestAccIotHub_cloudToDevice (493.98s)
=== CONT  TestAccIotHub_publicAccess
--- PASS: TestAccIotHub_identityUpdate (902.01s)
=== CONT  TestAccIotHub_standard
--- PASS: TestAccIotHub_withDifferentEndpointResourceGroup (502.72s)
=== CONT  TestAccIotHub_enrichments
--- PASS: TestAccIotHub_removeEndpointsAndRoutes (688.02s)
=== CONT  TestAccIotHub_customRoutes
--- PASS: TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity (469.46s)
=== CONT  TestAccIotHub_requiresImport
--- PASS: TestAccIotHub_endpointAuthenticationTypeUpdate (1267.08s)
=== CONT  TestAccIotHub_networkRulesSet
--- PASS: TestAccIotHub_standard (378.09s)
--- PASS: TestAccIotHub_fileUpload (543.96s)
--- PASS: TestAccIotHub_publicAccess (622.98s)
--- PASS: TestAccIotHub_requiresImport (373.54s)
--- PASS: TestAccIotHub_fileUploadAuthenticationTypeUpdate (901.71s)
--- PASS: TestAccIotHub_enrichments (523.31s)
--- PASS: TestAccIotHub_customRoutes (549.55s)
--- PASS: TestAccIotHub_networkRulesSet (505.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub	1773.128s
```