### PR TITLE
`azurerm_scheduled_query_rules_alert`, `azurerm_scheduled_query_rules_log` - mark `data_source_id` as forceNew

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -101,6 +101,7 @@ func resourceMonitorScheduledQueryRulesAlert() *pluginsdk.Resource {
 			"data_source_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
 			"auto_mitigation_enabled": {

--- a/internal/services/monitor/monitor_scheduled_query_rules_log_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_log_resource.go
@@ -114,6 +114,7 @@ func resourceMonitorScheduledQueryRulesLog() *pluginsdk.Resource {
 			"data_source_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
 			"description": {

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance. Changing this forces a new resource to be created.
 * `location` - (Required) Specifies the Azure Region where the resource should exist. Changing this forces a new resource to be created.
-* `data_source_id` - (Required) The resource URI over which log search query is to be run.
+* `data_source_id` - (Required) The resource URI over which log search query is to be run. Changing this forces a new resource to be created.
 * `frequency` - (Required) Frequency (in minutes) at which rule condition should be evaluated. Values must be between 5 and 1440 (inclusive).
 * `query` - (Required) Log search query.
 * `time_window` - (Required) Time window for which data needs to be fetched for query (must be greater than or equal to `frequency`). Values must be between 5 and 2880 (inclusive).

--- a/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
@@ -86,11 +86,11 @@ resource "azurerm_monitor_scheduled_query_rules_log" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created. 
+* `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance. Changing this forces a new resource to be created.
 * `location` - (Required) Specifies the Azure Region where the resource should exist. Changing this forces a new resource to be created.
 * `criteria` - (Required) A `criteria` block as defined below.
-* `data_source_id` - (Required) The resource URI over which log search query is to be run.
+* `data_source_id` - (Required) The resource URI over which log search query is to be run. Changing this forces a new resource to be created.
 * `authorized_resource_ids` - (Optional) A list of IDs of Resources referred into query.
 * `description` - (Optional) The description of the scheduled query rule.
 * `enabled` - (Optional) Whether this scheduled query rule is enabled. Default is `true`.


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/24304

updating the `data_source_id` will be rejected by API: 
```
│ Error: creating or updating Monitor Scheduled Query Rule (Subscription: "xxx"
│ Resource Group Name: "wt-sqr-resources"
│ Scheduled Query Rule Name: "example"): scheduledqueryrules.ScheduledQueryRulesClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Scope can not be updated"
│
│   with azurerm_monitor_scheduled_query_rules_alert.example,
│   on main.tf line 30, in resource "azurerm_monitor_scheduled_query_rules_alert" "example":
│   30: resource "azurerm_monitor_scheduled_query_rules_alert" "example" {
```