### PR TITLE
`azurerm_network_manager_deployment` - tolerate serveral times of NotFound when waiting for creation.

### DIFF
--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -352,8 +352,9 @@ func resourceManagerDeploymentWaitForFinished(ctx context.Context, client *netwo
 		Refresh: func() (interface{}, string, error) {
 			result, state, err := resourceManagerDeploymentResultRefreshFunc(ctx, client, managerDeploymentId)()
 			if state == "NotFound" {
+				// the deployment might not found after initial commit, https://github.com/Azure/azure-rest-api-specs/issues/27327
 				// to serve NotFoundChecks, return nil result
-				return nil, "NotFound", err
+				return nil, state, err
 			}
 			return result, state, err
 		},

--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -343,10 +343,12 @@ func resourceManagerDeploymentWaitForDeleted(ctx context.Context, client *networ
 
 func resourceManagerDeploymentWaitForFinished(ctx context.Context, client *networkmanagers.NetworkManagersClient, managerDeploymentId *parse.ManagerDeploymentId, d time.Duration) error {
 	state := &pluginsdk.StateChangeConf{
-		MinTimeout: 30 * time.Second,
-		Delay:      10 * time.Second,
-		Pending:    []string{"NotStarted", "Deploying"},
-		Target:     []string{"Deployed"},
+		MinTimeout:     30 * time.Second,
+		Delay:          10 * time.Second,
+		Pending:        []string{"NotStarted", "Deploying"},
+		Target:         []string{"Deployed"},
+		NotFoundChecks: 20,
+		Timeout:        d,
 		Refresh: func() (interface{}, string, error) {
 			result, state, err := resourceManagerDeploymentResultRefreshFunc(ctx, client, managerDeploymentId)()
 			if state == "NotFound" {
@@ -355,8 +357,6 @@ func resourceManagerDeploymentWaitForFinished(ctx context.Context, client *netwo
 			}
 			return result, state, err
 		},
-		NotFoundChecks: 20,
-		Timeout:        d,
 	}
 
 	_, err := state.WaitForStateContext(ctx)

--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -389,7 +389,7 @@ func resourceManagerDeploymentResultRefreshFunc(ctx context.Context, client *net
 		}
 
 		if resp.Model.Value == nil || len(*resp.Model.Value) == 0 || *(*resp.Model.Value)[0].ConfigurationIds == nil || len(*(*resp.Model.Value)[0].ConfigurationIds) == 0 {
-			log.Printf("[DEBUG] retrieving Deployment %s: retrival succeeds however the specific deployment not found", *id)
+			log.Printf("[DEBUG] retrieving %s: listing deployments succeeds however the specific deployment was not found", *id)
 			return resp, "NotFound", nil
 		}
 

--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -21,7 +21,7 @@ type ManagerResource struct{}
 
 func TestAccNetworkManager(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to
-	// Azure only being happy about provisioning one network manager per subscription at once
+	// Azure only being happy about provisioning one (connectivity or securityAdmin) network manager per subscription at once
 	// (which our test suite can't easily work around)
 
 	testCases := map[string]map[string]func(t *testing.T){


### PR DESCRIPTION
tolerate serveral times of NotFound when waiting for creation.