### PR TITLE
`azurerm_orchestrated_virtual_machine_scale_set` - fix update errors when running Hotpatch-compatible images

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -163,6 +163,13 @@ func TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchi
 			),
 		},
 		data.ImportStep("os_profile.0.windows_configuration.0.admin_password"),
+		{
+			Config: r.windowsHotpatchingEnabledUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.windows_configuration.0.admin_password"),
 	})
 }
 
@@ -499,6 +506,93 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
       "port"        = "80"
       "requestPath" = "/"
     })
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) windowsHotpatchingEnabledUpdate(data acceptance.TestData) string {
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "Standard_F2s_v2"
+
+  # Orchestrated VMSS allocation will timeout at service side due to extension, set instances to 0 to avoid the timeout
+  instances = 0
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    windows_configuration {
+      computer_name_prefix = "testvm"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      patch_mode          = "AutomaticByPlatform"
+      hotpatching_enabled = true
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-azure-edition-core"
+    version   = "latest"
+  }
+
+  extension {
+    name                               = "HealthExtension"
+    publisher                          = "Microsoft.ManagedServices"
+    type                               = "ApplicationHealthWindows"
+    type_handler_version               = "1.0"
+    auto_upgrade_minor_version_enabled = true
+
+    settings = jsonencode({
+      "protocol"    = "http"
+      "port"        = "80"
+      "requestPath" = "/"
+    })
+  }
+
+  tags = {
+    value = "update"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))


### PR DESCRIPTION
## Steps to Reproduce
1. Create a `azurerm_orchestrated_virtual_machine_scale_set` instance with a hotpatch-compatible image
2. Update the `tags` value in .tf
3. Run `terraform apply` to update the `azurerm_orchestrated_virtual_machine_scale_set` resource

## Expected Behaviour

`terraform apply` runs successfully

## Actual Behaviour

Azure Service returns error of `"'EnableHotpatching' must be set to 'true' on Virtual Machine Scale Sets running Hotpatch-compatible images."`

## Root Cause

When running Hotpatch-compatible images, the PATCH API requires `EnableHotpatching=true` set in the message body. But the provider sends an empty `patchSettings`.

<img width="224" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/18022931-d2ce-449b-9d8b-5f1f7722b619">


## Test Result

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows (289.74s)
PASS