### PR TITLE
`azurerm_log_analytics_workspace_table ` : support `plan` property

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -37,7 +37,7 @@ func (r LogAnalyticsWorkspaceTableResource) CustomizeDiff() sdk.ResourceFunc {
 
 			if string(tables.TablePlanEnumBasic) == rd.Get("plan").(string) {
 				if _, ok := rd.GetOk("retention_in_days"); ok {
-					return fmt.Errorf("cannot set retention_in_days as it is immutable on Basic plan")
+					return fmt.Errorf("cannot set retention_in_days because the retention is fixed at eight days on Basic plan")
 				}
 			}
 

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -37,7 +37,7 @@ func (r LogAnalyticsWorkspaceTableResource) CustomizeDiff() sdk.ResourceFunc {
 
 			if string(tables.TablePlanEnumBasic) == rd.Get("plan").(string) {
 				if _, ok := rd.GetOk("retention_in_days"); ok {
-					return fmt.Errorf("cannot set retention_in_days as it is immutabl on Basic plan")
+					return fmt.Errorf("cannot set retention_in_days as it is immutable on Basic plan")
 				}
 			}
 

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
@@ -19,11 +20,30 @@ type LogAnalyticsWorkspaceTableResource struct {
 }
 
 var _ sdk.ResourceWithUpdate = LogAnalyticsWorkspaceTableResource{}
+var _ sdk.ResourceWithCustomizeDiff = LogAnalyticsWorkspaceTableResource{}
 
 type LogAnalyticsWorkspaceTableResourceModel struct {
 	Name            string `tfschema:"name"`
 	WorkspaceId     string `tfschema:"workspace_id"`
+	Plan            string `tfschema:"plan"`
 	RetentionInDays int64  `tfschema:"retention_in_days"`
+}
+
+func (r LogAnalyticsWorkspaceTableResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			rd := metadata.ResourceDiff
+
+			if string(tables.TablePlanEnumBasic) == rd.Get("plan").(string) {
+				if _, ok := rd.GetOk("retention_in_days"); ok {
+					return fmt.Errorf("cannot set retention_in_days as it is immutabl on Basic plan")
+				}
+			}
+
+			return nil
+		},
+	}
 }
 
 func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Schema {
@@ -39,9 +59,19 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 			Required: true,
 		},
 
+		"plan": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(tables.TablePlanEnumAnalytics),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(tables.TablePlanEnumAnalytics),
+				string(tables.TablePlanEnumBasic),
+			}, false),
+		},
+
 		"retention_in_days": {
 			Type:         pluginsdk.TypeInt,
-			Required:     true,
+			Optional:     true,
 			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
 		},
 	}
@@ -84,11 +114,14 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 
 			id := tables.NewTableID(subscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, tableName)
 
-			retentionInDays := model.RetentionInDays
 			updateInput := tables.Table{
 				Properties: &tables.TableProperties{
-					RetentionInDays: &retentionInDays,
+					Plan: pointer.To(tables.TablePlanEnum(model.Plan)),
 				},
+			}
+
+			if model.Plan == string(tables.TablePlanEnumAnalytics) {
+				updateInput.Properties.RetentionInDays = pointer.To(model.RetentionInDays)
 			}
 			if err := client.CreateOrUpdateThenPoll(ctx, id, updateInput); err != nil {
 				return fmt.Errorf("failed to update table %s in workspace %s in resource group %s: %s", tableName, workspaceId.WorkspaceName, workspaceId.ResourceGroupName, err)
@@ -120,17 +153,30 @@ func (r LogAnalyticsWorkspaceTableResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("reading Log Analytics Workspace Table %s: %v", id, err)
 			}
 
-			updateInput := tables.Table{
-				Properties: &tables.TableProperties{
-					RetentionInDays: existing.Model.Properties.RetentionInDays,
-				},
-			}
+			if model := existing.Model; model != nil {
+				if props := model.Properties; props != nil {
+					updateInput := tables.Table{
+						Properties: &tables.TableProperties{
+							Plan: props.Plan,
+						},
+					}
 
-			if metadata.ResourceData.HasChange("retention_in_days") {
-				updateInput.Properties.RetentionInDays = &state.RetentionInDays
-			}
-			if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
-				return fmt.Errorf("failed to update table: %s: %+v", id.TableName, err)
+					if metadata.ResourceData.HasChange("plan") {
+						updateInput.Properties.Plan = pointer.To(tables.TablePlanEnum(state.Plan))
+					}
+
+					if state.Plan == string(tables.TablePlanEnumAnalytics) {
+						updateInput.Properties.RetentionInDays = existing.Model.Properties.RetentionInDays
+
+						if metadata.ResourceData.HasChange("retention_in_days") {
+							updateInput.Properties.RetentionInDays = pointer.To(state.RetentionInDays)
+						}
+					}
+
+					if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
+						return fmt.Errorf("failed to update table: %s: %+v", id.TableName, err)
+					}
+				}
 			}
 
 			return nil
@@ -168,8 +214,11 @@ func (r LogAnalyticsWorkspaceTableResource) Read() sdk.ResourceFunc {
 			}
 
 			if model := resp.Model; model != nil {
-				if model.Properties.RetentionInDays != nil {
-					state.RetentionInDays = *model.Properties.RetentionInDays
+				if props := model.Properties; props != nil {
+					if pointer.From(props.Plan) == tables.TablePlanEnumAnalytics {
+						state.RetentionInDays = pointer.From(props.RetentionInDays)
+					}
+					state.Plan = string(pointer.From(props.Plan))
 				}
 			}
 

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 -> **Note:** `retention_in_days` will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
 
--> **Note:** The `retention_in_days` cannot be specified when the `plan` is `Basic` because it is immutable.
+-> **Note:** The `retention_in_days` cannot be specified when `plan` is `Basic` because the retention is fixed at eight days.
 
 ## Attributes Reference
 

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `workspace_id` - (Required) The object ID of the Log Analytics Workspace that contains the table.
 
-* `plan` - (Optional) Specify the system how to handle and charge the logs ingested to the table. Possible values are `Analytics` and `Basic. Defaults to `Analytics`.
+* `plan` - (Optional) Specify the system how to handle and charge the logs ingested to the table. Possible values are `Analytics` and `Basic`. Defaults to `Analytics`.
 
 -> **Note:** The `name` of tables currently support `Basic` plan can be found in [this article](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/basic-logs-configure?tabs=portal-1#supported-tables) for further details.
 

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `plan` - (Optional) Specify the system how to handle and charge the logs ingested to the table. Possible values are `Analytics` and `Basic`. Defaults to `Analytics`.
 
--> **Note:** The `name` of tables currently support `Basic` plan can be found in [this article](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/basic-logs-configure?tabs=portal-1#supported-tables) for further details.
+-> **Note:** The `name` of tables currently supported by the `Basic` plan can be found [here](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/basic-logs-configure?tabs=portal-1#supported-tables).
 
 * `retention_in_days` - (Optional) The table's retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -41,9 +41,15 @@ The following arguments are supported:
 
 * `workspace_id` - (Required) The object ID of the Log Analytics Workspace that contains the table.
 
-* `retention_in_days` - (Required) The table's retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
+* `plan` - (Optional) Specify the system how to handle and charge the logs ingested to the table. Possible values are `Analytics` and `Basic. Defaults to `Analytics`.
 
--> **Note:** retention_in_days will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
+-> **Note:** The `name` of tables currently support `Basic` plan can be found in [this article](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/basic-logs-configure?tabs=portal-1#supported-tables) for further details.
+
+* `retention_in_days` - (Optional) The table's retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
+
+-> **Note:** `retention_in_days` will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
+
+-> **Note:** The `retention_in_days` cannot be specified when the `plan` is `Basic` because it is immutable.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Swagger: https://github.com/Azure/azure-rest-api-specs/blob/d1eb3c20113d1018f25a8d97fdfa5f8bb5c659ea/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/stable/2022-10-01/Tables.json#L730

- Change `retention_in_days` to `optional` because API does not accept setting this value in `Basic` plan.

- There is no test case for updating `plan` since changing the `plan` is limited to once a week.

Test results:
PASS: TestAccLogAnalyticsWorkspaceTable_plan (267.83s)
PASS: TestAccLogAnalyticsWorkspaceTable_updateTableRetention (253.40s)

Fix #16889 