### PR TITLE
`azurerm_new_relic_monitor` - fix failed testcase

### DIFF
--- a/internal/services/newrelic/new_relic_monitor_resource_test.go
+++ b/internal/services/newrelic/new_relic_monitor_resource_test.go
@@ -6,6 +6,7 @@ package newrelic_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -56,13 +57,24 @@ func TestAccNewRelicMonitor_requiresImport(t *testing.T) {
 }
 
 func TestAccNewRelicMonitor_complete(t *testing.T) {
+	const AccountIdEnv = "ARM_ACCTEST_NEW_RELIC_ACCOUNT_ID"
+	const OrgIdEnv = "ARM_ACCTEST_NEW_RELIC_ORG_ID"
+
+	accountId := os.Getenv(AccountIdEnv)
+	orgId := os.Getenv(OrgIdEnv)
+
+	if accountId == "" || orgId == "" {
+		t.Skipf("Acceptance test skipped unless env '%s' and '%s' set", AccountIdEnv, OrgIdEnv)
+		return
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
 	email := "b9ba4f77-5e63-4f1e-9445-b982d35f635b@example.com"
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, effectiveDate, email),
+			Config: r.complete(data, effectiveDate, email, accountId, orgId),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -145,48 +157,33 @@ resource "azurerm_new_relic_monitor" "import" {
 `, config)
 }
 
-func (r NewRelicMonitorResource) complete(data acceptance.TestData, effectiveDate string, email string) string {
+func (r NewRelicMonitorResource) complete(data acceptance.TestData, effectiveDate string, email string, accountId string, orgId string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%[1]s
 
-resource "azurerm_new_relic_monitor" "org" {
-  name                = "acctest-nrmo-%[2]d"
+resource "azurerm_new_relic_monitor" "test" {
+  name                = "acctest-nrm-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
-  location            = "%[3]s"
+  location            = azurerm_resource_group.test.location
   plan {
-    effective_date = "%[4]s"
+    billing_cycle  = "MONTHLY"
+    effective_date = "%[3]s"
+    plan_id        = "newrelic-pay-as-you-go-free-live"
+    usage_type     = "PAYG"
   }
   user {
-    email        = "%[5]s"
+    email        = "%[4]s"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
   }
-}
-
-resource "azurerm_new_relic_monitor" "test" {
-  name                = "acctest-nrm-%[2]d"
-  resource_group_name = azurerm_new_relic_monitor.org.resource_group_name
-  location            = azurerm_new_relic_monitor.org.location
-  plan {
-    billing_cycle  = azurerm_new_relic_monitor.org.plan[0].billing_cycle
-    effective_date = "%[4]s"
-    plan_id        = azurerm_new_relic_monitor.org.plan[0].plan_id
-    usage_type     = azurerm_new_relic_monitor.org.plan[0].usage_type
-  }
-  user {
-    email        = azurerm_new_relic_monitor.org.user[0].email
-    first_name   = azurerm_new_relic_monitor.org.user[0].first_name
-    last_name    = azurerm_new_relic_monitor.org.user[0].last_name
-    phone_number = azurerm_new_relic_monitor.org.user[0].phone_number
-  }
-  account_creation_source = azurerm_new_relic_monitor.org.account_creation_source
-  account_id              = azurerm_new_relic_monitor.org.account_id
+  account_creation_source = "LIFTR"
+  account_id              = "%[5]s"
   ingestion_key           = "wltnimmhqt"
-  organization_id         = azurerm_new_relic_monitor.org.organization_id
-  org_creation_source     = azurerm_new_relic_monitor.org.org_creation_source
+  organization_id         = "%[6]s"
+  org_creation_source     = "LIFTR"
   user_id                 = "123456"
 }
-`, template, data.RandomInteger, data.Locations.Primary, effectiveDate, email)
+`, template, data.RandomInteger, effectiveDate, email, accountId, orgId)
 }

--- a/website/docs/r/new_relic_monitor.html.markdown
+++ b/website/docs/r/new_relic_monitor.html.markdown
@@ -54,9 +54,13 @@ The following arguments are supported:
 
 * `account_id` - (Optional) Specifies the account id. Changing this forces a new Azure Native New Relic Monitor to be created.
 
+-> **NOTE:** The value of `account_id` must come from an Azure Native New Relic Monitor instance of another different subscription.
+
 * `ingestion_key` - (Optional) Specifies the ingestion key of account. Changing this forces a new Azure Native New Relic Monitor to be created.
 
 * `organization_id` - (Optional) Specifies the organization id. Changing this forces a new Azure Native New Relic Monitor to be created.
+
+-> **NOTE:** The value of `organization_id` must come from an Azure Native New Relic Monitor instance of another different subscription.
 
 * `org_creation_source` - (Optional) Specifies the source of org creation. Possible values are `LIFTR` and `NEWRELIC`. Defaults to `LIFTR`. Changing this forces a new Azure Native New Relic Monitor to be created.
 


### PR DESCRIPTION
## Description

Azure Service Team added restrictions that `account_id` and `organization_id` must come from monitor instance of a different subscription.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/969e4fde-d367-49ae-8bae-c53fda2f8ae9)


## Test Result

=== RUN   TestAccNewRelicMonitor_complete
=== PAUSE TestAccNewRelicMonitor_complete
=== CONT  TestAccNewRelicMonitor_complete
--- PASS: TestAccNewRelicMonitor_complete (210.86s)
PASS