### PR TITLE
Remove preview Notes from AKS fleet manager (GA)

### DIFF
--- a/website/docs/r/kubernetes_fleet_manager.html.markdown
+++ b/website/docs/r/kubernetes_fleet_manager.html.markdown
@@ -12,9 +12,6 @@ description: |-
 
 Manages a Kubernetes Fleet Manager
 
-~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name FleetResourcePreview` and then `az provider register -n Microsoft.ContainerService`
-.
-
 ## Example Usage
 
 ```hcl
@@ -58,12 +55,12 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `hub_profile` block supports the following arguments:
 
-* `dns_prefix` - (Required) 
+* `dns_prefix` - (Required)
 
 
 In addition to the arguments defined above, the `hub_profile` block exports the following attributes:
 
-* `fqdn` - 
+* `fqdn` -
 * `kubernetes_version` -
 
 ## Timeouts


### PR DESCRIPTION
The feature is GA since November 2023:
https://azure.microsoft.com/en-us/updates/ga-azure-kubernetes-fleet-manager/