### PR TITLE
`tools` - update `internal/tools/document-lint` dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/autorest/validation v0.3.1
 	github.com/Azure/go-autorest/tracing v0.6.0
-	github.com/agiledragon/gomonkey/v2 v2.10.1
+	github.com/agiledragon/gomonkey/v2 v2.11.0
 	github.com/btubbs/datetime v0.1.1
 	github.com/dave/jennifer v1.6.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/agiledragon/gomonkey/v2 v2.10.1 h1:FPJJNykD1957cZlGhr9X0zjr291/lbazoZ/dmc4mS4c=
-github.com/agiledragon/gomonkey/v2 v2.10.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
+github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
+github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=

--- a/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_darwin.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_darwin.go
@@ -1,27 +1,24 @@
 package gomonkey
 
-import "syscall"
+import (
+	"fmt"
+	"reflect"
+	"syscall"
+	"unsafe"
+)
+
+func PtrOf(val []byte) uintptr {
+	return (*reflect.SliceHeader)(unsafe.Pointer(&val)).Data
+}
 
 func modifyBinary(target uintptr, bytes []byte) {
-	function := entryAddress(target, len(bytes))
-	err := mprotectCrossPage(target, len(bytes), syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC)
-	if err != nil {
-		panic(err)
-	}
-	copy(function, bytes)
-	err = mprotectCrossPage(target, len(bytes), syscall.PROT_READ|syscall.PROT_EXEC)
-	if err != nil {
-		panic(err)
+	targetPage := pageStart(target)
+	res := write(target, PtrOf(bytes), len(bytes), targetPage, syscall.Getpagesize(), syscall.PROT_READ|syscall.PROT_EXEC)
+	if res != 0 {
+		panic(fmt.Errorf("failed to write memory, code %v", res))
 	}
 }
 
-func mprotectCrossPage(addr uintptr, length int, prot int) error {
-	pageSize := syscall.Getpagesize()
-	for p := pageStart(addr); p < addr+uintptr(length); p += uintptr(pageSize) {
-		page := entryAddress(p, pageSize)
-		if err := syscall.Mprotect(page, prot); err != nil {
-			return err
-		}
-	}
-	return nil
-}
+//go:cgo_import_dynamic mach_task_self mach_task_self "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic mach_vm_protect mach_vm_protect "/usr/lib/libSystem.B.dylib"
+func write(target, data uintptr, len int, page uintptr, pageSize, oriProt int) int

--- a/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_amd64.s
+++ b/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_amd64.s
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+#define NOP8 BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90;
+#define NOP64 NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8;
+#define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
+#define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
+
+#define protRW $(0x1|0x2|0x10)
+#define mProtect $(0x2000000+74)
+
+TEXT ·write(SB),NOSPLIT,$24
+    JMP START
+    NOP4096
+START:
+    MOVQ    mProtect, AX
+    MOVQ    page+24(FP), DI
+    MOVQ    pageSize+32(FP), SI
+    MOVQ    protRW, DX
+    SYSCALL
+    CMPQ    AX, $0
+    JZ      PROTECT_OK
+    CALL    mach_task_self(SB)
+    MOVQ    AX, DI
+    MOVQ    target+0(FP), SI
+    MOVQ    len+16(FP), DX
+    MOVQ    $0, CX
+    MOVQ    protRW, R8
+    CALL    mach_vm_protect(SB)
+    CMPQ    AX, $0
+    JNZ     RETURN
+PROTECT_OK:
+    MOVQ    target+0(FP), DI
+    MOVQ    data+8(FP), SI
+    MOVQ    len+16(FP), CX
+    MOVQ    DI, to-24(SP)
+    MOVQ    SI, from-16(SP)
+    MOVQ    CX, n-8(SP)
+    CALL    runtime·memmove(SB)
+    MOVQ    mProtect, AX
+    MOVQ    page+24(FP), DI
+    MOVQ    pageSize+32(FP), SI
+    MOVQ    oriProt+40(FP), DX
+    SYSCALL
+    JMP     RETURN
+    NOP4096
+RETURN:
+    MOVQ AX, ret+48(FP)
+    RET

--- a/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_arm64.s
+++ b/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_arm64.s
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+#define NOP64 WORD $0x1f2003d5; WORD $0x1f2003d5;
+#define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
+#define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
+#define NOP16384 NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096;
+
+#define protRW $(0x1|0x2|0x10)
+#define mProtect $(0x2000000+74)
+
+TEXT ·write(SB),NOSPLIT,$24
+    B START
+    NOP16384
+START:
+    MOVD    mProtect, R16
+    MOVD    page+24(FP), R0
+    MOVD    pageSize+32(FP), R1
+    MOVD    protRW, R2
+    SVC     $0x80
+    CMP     $0, R0
+    BEQ     PROTECT_OK
+    CALL    mach_task_self(SB)
+    MOVD    target+0(FP), R1
+    MOVD    len+16(FP), R2
+    MOVD    $0, R3
+    MOVD    protRW, R4
+    CALL    mach_vm_protect(SB)
+    CMP     $0, R0
+    BNE     RETURN
+PROTECT_OK:
+    MOVD    target+0(FP), R0
+    MOVD    data+8(FP), R1
+    MOVD    len+16(FP), R2
+    MOVD    R0, to-24(SP)
+    MOVD    R1, from-16(SP)
+    MOVD    R2, n-8(SP)
+    CALL    runtime·memmove(SB)
+    MOVD    mProtect, R16
+    MOVD    page+24(FP), R0
+    MOVD    pageSize+32(FP), R1
+    MOVD    oriProt+40(FP), R2
+    SVC     $0x80
+    B       RETURN
+    NOP16384
+RETURN:
+    MOVD R0, ret+48(FP)
+    RET

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ github.com/ProtonMail/go-crypto/openpgp/s2k
 # github.com/agext/levenshtein v1.2.3
 ## explicit
 github.com/agext/levenshtein
-# github.com/agiledragon/gomonkey/v2 v2.10.1
+# github.com/agiledragon/gomonkey/v2 v2.11.0
 ## explicit; go 1.14
 github.com/agiledragon/gomonkey/v2
 github.com/agiledragon/gomonkey/v2/creflect


### PR DESCRIPTION
Updated gomonkey to latest to fix `panic: permission denied`

Fixes of `internal/tools/document-lint` are 99% already fixed with #24100