### PR TITLE
#24358: Support vm_template for azurerm_virtual_desktop_host_pool resource

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -251,7 +251,7 @@ func resourceVirtualDesktopHostPoolCreate(d *pluginsdk.ResourceData, meta interf
 			PersonalDesktopAssignmentType: &personalDesktopAssignmentType,
 			PreferredAppGroupType:         hostpool.PreferredAppGroupType(d.Get("preferred_app_group_type").(string)),
 			AgentUpdate:                   expandAgentUpdateCreate(d.Get("scheduled_agent_updates").([]interface{})),
-			VMTemplate:                    vmTemplate,
+			VMTemplate:                    &vmTemplate,
 		},
 	}
 

--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -196,6 +196,13 @@ func resourceVirtualDesktopHostPool() *pluginsdk.Resource {
 				},
 			},
 
+			"vm_template": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+			},
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -220,6 +227,15 @@ func resourceVirtualDesktopHostPoolCreate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	personalDesktopAssignmentType := hostpool.PersonalDesktopAssignmentType(d.Get("personal_desktop_assignment_type").(string))
+	vmTemplate := utils.String(d.Get("vm_template").(string))
+	if *vmTemplate != "" {
+		// we have no use with the json object as azure accepts string only
+		// merely here for validation
+		_, err := pluginsdk.ExpandJsonFromString(*vmTemplate)
+		if err != nil {
+			return fmt.Errorf("expanding JSON for `vm_template`: %+v", err)
+		}
+	}
 	payload := hostpool.HostPool{
 		Location: utils.String(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -235,6 +251,7 @@ func resourceVirtualDesktopHostPoolCreate(d *pluginsdk.ResourceData, meta interf
 			PersonalDesktopAssignmentType: &personalDesktopAssignmentType,
 			PreferredAppGroupType:         hostpool.PreferredAppGroupType(d.Get("preferred_app_group_type").(string)),
 			AgentUpdate:                   expandAgentUpdateCreate(d.Get("scheduled_agent_updates").([]interface{})),
+			VMTemplate:                    vmTemplate,
 		},
 	}
 
@@ -305,6 +322,10 @@ func resourceVirtualDesktopHostPoolUpdate(d *pluginsdk.ResourceData, meta interf
 		if d.HasChanges("scheduled_agent_updates") {
 			payload.Properties.AgentUpdate = expandAgentUpdatePatch(d.Get("scheduled_agent_updates").([]interface{}))
 		}
+
+		if d.HasChanges("vm_template") {
+			payload.Properties.VMTemplate = utils.String(d.Get("vm_template").(string))
+		}
 	}
 
 	if _, err := client.Update(ctx, *id, payload); err != nil {
@@ -365,6 +386,7 @@ func resourceVirtualDesktopHostPoolRead(d *pluginsdk.ResourceData, meta interfac
 		d.Set("type", string(props.HostPoolType))
 		d.Set("validate_environment", props.ValidationEnvironment)
 		d.Set("scheduled_agent_updates", flattenAgentUpdate(props.AgentUpdate))
+		d.Set("vm_template", props.VMTemplate)
 	}
 
 	return nil

--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -227,11 +227,11 @@ func resourceVirtualDesktopHostPoolCreate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	personalDesktopAssignmentType := hostpool.PersonalDesktopAssignmentType(d.Get("personal_desktop_assignment_type").(string))
-	vmTemplate := utils.String(d.Get("vm_template").(string))
-	if *vmTemplate != "" {
+	vmTemplate := d.Get("vm_template").(string)
+	if vmTemplate != "" {
 		// we have no use with the json object as azure accepts string only
 		// merely here for validation
-		_, err := pluginsdk.ExpandJsonFromString(*vmTemplate)
+		_, err := pluginsdk.ExpandJsonFromString(vmTemplate)
 		if err != nil {
 			return fmt.Errorf("expanding JSON for `vm_template`: %+v", err)
 		}

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 * `scheduled_agent_updates` - (Optional) A `scheduled_agent_updates` block as defined below. This enables control of when Agent Updates will be applied to Session Hosts.
 
+* `vm_template` - (Optional) A VM template for sessionhosts configuration within hostpool. This is a JSON string.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `scheduled_agent_updates` - (Optional) A `scheduled_agent_updates` block as defined below. This enables control of when Agent Updates will be applied to Session Hosts.
 
-* `vm_template` - (Optional) A VM template for sessionhosts configuration within hostpool. This is a JSON string.
+* `vm_template` - (Optional) A VM template for session hosts configuration within hostpool. This is a JSON string.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Support `vm_template` for `azurerm_virtual_desktop_host_pool` resource. 

Fixes #24358. 