### PR TITLE
#24317: Support preferred_data_persistence_auth_method for azurerm_redis_cache resource

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -162,6 +162,10 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
+						"data_persistence_authentication_method": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -179,6 +179,16 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Computed: true,
 						},
 
+						"preferred_data_persistence_auth_method": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							Default:  "SAS",
+							ValidateFunc: validation.StringInSlice([]string{
+								"SAS",
+								"ManagedIdentity",
+							}, false),
+						},
+
 						"rdb_backup_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
@@ -830,6 +840,10 @@ func expandRedisConfiguration(d *pluginsdk.ResourceData) (*redis.RedisCommonProp
 		output.MaxmemoryPolicy = utils.String(v)
 	}
 
+	if v := raw["preferred_data_persistence_auth_method"].(string); v != "" {
+		output.PreferredDataPersistenceAuthMethod = utils.String(v)
+	}
+
 	// AAD/Entra support
 	// nolint : staticcheck
 	v, valExists := d.GetOkExists("redis_configuration.0.active_directory_authentication_enabled")
@@ -998,6 +1012,10 @@ func flattenRedisConfiguration(input *redis.RedisCommonPropertiesRedisConfigurat
 	}
 	if input.MaxmemoryPolicy != nil {
 		outputs["maxmemory_policy"] = *input.MaxmemoryPolicy
+	}
+
+	if input.PreferredDataPersistenceAuthMethod != nil {
+		outputs["preferred_data_persistence_auth_method"] = *input.PreferredDataPersistenceAuthMethod
 	}
 
 	if input.MaxfragmentationmemoryReserved != nil {

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -179,7 +179,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Computed: true,
 						},
 
-						"preferred_data_persistence_auth_method": {
+						"data_persistence_authentication_method": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							Default:  "SAS",
@@ -840,7 +840,7 @@ func expandRedisConfiguration(d *pluginsdk.ResourceData) (*redis.RedisCommonProp
 		output.MaxmemoryPolicy = utils.String(v)
 	}
 
-	if v := raw["preferred_data_persistence_auth_method"].(string); v != "" {
+	if v := raw["data_persistence_authentication_method"].(string); v != "" {
 		output.PreferredDataPersistenceAuthMethod = utils.String(v)
 	}
 
@@ -1015,7 +1015,7 @@ func flattenRedisConfiguration(input *redis.RedisCommonPropertiesRedisConfigurat
 	}
 
 	if input.PreferredDataPersistenceAuthMethod != nil {
-		outputs["preferred_data_persistence_auth_method"] = *input.PreferredDataPersistenceAuthMethod
+		outputs["data_persistence_authentication_method"] = *input.PreferredDataPersistenceAuthMethod
 	}
 
 	if input.MaxfragmentationmemoryReserved != nil {

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -30,7 +30,25 @@ func TestAccRedisCache_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("minimum_tls_version").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
-				check.That(data.ResourceName).Key("redis_configuration.0.preferred_data_persistence_auth_method").HasValue("SAS"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRedisCache_managedIdentityAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache", "test")
+	r := RedisCacheResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.managedIdentityAuth(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("minimum_tls_version").Exists(),
+				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("redis_configuration.0.preferred_data_persistence_auth_method").HasValue("ManagedIdentity"),
 			),
 		},
 		data.ImportStep(),
@@ -579,6 +597,34 @@ resource "azurerm_redis_cache" "test" {
   minimum_tls_version = "1.2"
 
   redis_configuration {
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, !requireSSL)
+}
+
+func (RedisCacheResource) managedIdentityAuth(data acceptance.TestData, requireSSL bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 1
+  family              = "C"
+  sku_name            = "Basic"
+  enable_non_ssl_port = %t
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+    preferred_data_persistence_auth_method = "ManagedIdentity"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, !requireSSL)

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -48,7 +48,7 @@ func TestAccRedisCache_managedIdentityAuth(t *testing.T) {
 				check.That(data.ResourceName).Key("minimum_tls_version").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
-				check.That(data.ResourceName).Key("redis_configuration.0.preferred_data_persistence_auth_method").HasValue("ManagedIdentity"),
+				check.That(data.ResourceName).Key("redis_configuration.0.data_persistence_authentication_method").HasValue("ManagedIdentity"),
 			),
 		},
 		data.ImportStep(),
@@ -624,7 +624,7 @@ resource "azurerm_redis_cache" "test" {
   minimum_tls_version = "1.2"
 
   redis_configuration {
-    preferred_data_persistence_auth_method = "ManagedIdentity"
+    data_persistence_authentication_method = "ManagedIdentity"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, !requireSSL)

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -30,6 +30,7 @@ func TestAccRedisCache_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("minimum_tls_version").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("redis_configuration.0.preferred_data_persistence_auth_method").HasValue("SAS"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -146,6 +146,8 @@ redis_configuration {
 * `maxmemory_delta` - (Optional) The max-memory delta for this Redis instance. Defaults are shown below.
 * `maxmemory_policy` - (Optional) How Redis will select what to remove when `maxmemory` is reached. Defaults to `volatile-lru`.
 
+* `preferred_data_persistence_auth_method` - (Optional) Preferred auth method to communicate to storage account used for data persistence. Possible values are `SAS` and `ManagedIdentity`. Defaults to `SAS`.
+
 * `maxfragmentationmemory_reserved` - (Optional) Value in megabytes reserved to accommodate for memory fragmentation. Defaults are shown below.
 
 * `rdb_backup_enabled` - (Optional) Is Backup Enabled? Only supported on Premium SKUs. Defaults to `false`.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -146,7 +146,7 @@ redis_configuration {
 * `maxmemory_delta` - (Optional) The max-memory delta for this Redis instance. Defaults are shown below.
 * `maxmemory_policy` - (Optional) How Redis will select what to remove when `maxmemory` is reached. Defaults to `volatile-lru`.
 
-* `preferred_data_persistence_auth_method` - (Optional) Preferred auth method to communicate to storage account used for data persistence. Possible values are `SAS` and `ManagedIdentity`. Defaults to `SAS`.
+* `data_persistence_authentication_method` - (Optional) Preferred auth method to communicate to storage account used for data persistence. Possible values are `SAS` and `ManagedIdentity`. Defaults to `SAS`.
 
 * `maxfragmentationmemory_reserved` - (Optional) Value in megabytes reserved to accommodate for memory fragmentation. Defaults are shown below.
 


### PR DESCRIPTION
Support `preferred_data_persistence_auth_method` for `azurerm_redis_cache` resource. 

Fixes #24317. 