### PR TITLE
`azurerm_container_group` - Add support of `priority`

### DIFF
--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -105,6 +105,10 @@ The following arguments are supported:
 
 * `image_registry_credential` - (Optional) An `image_registry_credential` block as documented below. Changing this forces a new resource to be created.
 
+* `priority` - (Optional) The priority of the Container Group. Possible values are `Regular` and `Spot`. Changing this forces a new resource to be created.
+
+~> **NOTE:** When `priority` is set to `Spot`, the `ip_address_type` has to be `None`.
+
 * `restart_policy` - (Optional) Restart policy for the container group. Allowed values are `Always`, `Never`, `OnFailure`. Defaults to `Always`. Changing this forces a new resource to be created.
 
 * `zones` - (Optional) A list of Availability Zones in which this Container Group is located. Changing this forces a new resource to be created.


### PR DESCRIPTION
Azure document of the `priorty` feature: https://learn.microsoft.com/en-us/azure/container-instances/container-instances-spot-containers-overview

## Test

```shell
$ TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run="TestAccContainerGroup_priority"
=== RUN   TestAccContainerGroup_priority
=== PAUSE TestAccContainerGroup_priority
=== CONT  TestAccContainerGroup_priority
--- PASS: TestAccContainerGroup_priority (233.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    233.614s
```