### PR TITLE
`azurerm_maintenance_configuration` - set reboot `AlwaysReboot` to `Always`

### DIFF
--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -446,7 +446,13 @@ func flattenMaintenanceConfigurationInstallPatches(input *maintenanceconfigurati
 		output := make(map[string]interface{})
 
 		if rebootSetting := v.RebootSetting; rebootSetting != nil {
-			output["reboot"] = *rebootSetting
+			// https://github.com/Azure/azure-rest-api-specs/issues/27222
+			if *rebootSetting == "AlwaysReboot" {
+				output["reboot"] = "Always"
+
+			} else {
+				output["reboot"] = *rebootSetting
+			}
 		}
 
 		if windowsParameters := v.WindowsParameters; windowsParameters != nil {

--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -448,7 +448,7 @@ func flattenMaintenanceConfigurationInstallPatches(input *maintenanceconfigurati
 
 		if rebootSetting := v.RebootSetting; rebootSetting != nil {
 			// https://github.com/Azure/azure-rest-api-specs/issues/27222
-			if strings.EqualFold(*rebootSetting, "AlwaysReboot") {
+			if strings.EqualFold(string(*rebootSetting), "AlwaysReboot") {
 				output["reboot"] = "Always"
 			} else {
 				output["reboot"] = *rebootSetting

--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -447,9 +448,8 @@ func flattenMaintenanceConfigurationInstallPatches(input *maintenanceconfigurati
 
 		if rebootSetting := v.RebootSetting; rebootSetting != nil {
 			// https://github.com/Azure/azure-rest-api-specs/issues/27222
-			if *rebootSetting == "AlwaysReboot" {
+			if strings.EqualFold(*rebootSetting, "AlwaysReboot") {
 				output["reboot"] = "Always"
-
 			} else {
 				output["reboot"] = *rebootSetting
 			}

--- a/internal/services/maintenance/maintenance_configuration_resource_test.go
+++ b/internal/services/maintenance/maintenance_configuration_resource_test.go
@@ -219,9 +219,9 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_maintenance_configuration" "test" {
-  name                = "acctest-MC%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+  name                     = "acctest-MC%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
   scope                    = "InGuestPatch"
   in_guest_user_patch_mode = "User"
   install_patches {

--- a/internal/services/maintenance/maintenance_configuration_resource_test.go
+++ b/internal/services/maintenance/maintenance_configuration_resource_test.go
@@ -35,6 +35,21 @@ func TestAccMaintenanceConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccMaintenanceConfiguration_basicWithAlwaysReboot(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_configuration", "test")
+	r := MaintenanceConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic_withAlwaysReboot(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMaintenanceConfiguration_basicWithInGuestPatch(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_maintenance_configuration", "test")
 	r := MaintenanceConfigurationResource{}
@@ -188,6 +203,57 @@ resource "azurerm_maintenance_configuration" "test" {
   location            = azurerm_resource_group.test.location
   scope               = "SQLDB"
   visibility          = "Custom"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (MaintenanceConfigurationResource) basic_withAlwaysReboot(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-maint-%d"
+  location = "%s"
+}
+
+resource "azurerm_maintenance_configuration" "test" {
+  name                = "acctest-MC%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope                    = "InGuestPatch"
+  in_guest_user_patch_mode = "User"
+  install_patches {
+    reboot = "Always"
+    linux {
+      classifications_to_include = [
+        "Critical",
+        "Security",
+      ]
+      package_names_mask_to_exclude = []
+      package_names_mask_to_include = []
+    }
+
+    windows {
+      classifications_to_include = [
+        "Critical",
+        "Security",
+        "UpdateRollup",
+        "Definition",
+        "Updates",
+      ]
+      kb_numbers_to_exclude = []
+      kb_numbers_to_include = []
+    }
+  }
+
+  window {
+    duration        = "02:00"
+    recur_every     = "Day"
+    start_date_time = "2025-02-01 11:00"
+    time_zone       = "Central Standard Time"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Fix #24357 
Upstream API returns `AlwaysReboot` if pass `Always` for `reboot` field, but only `Always` is allowed in [REST API](https://github.com/Azure/azure-rest-api-specs/blob/2299e0ee52b170edc9c7b50e1a864501d514692f/specification/maintenance/resource-manager/Microsoft.Maintenance/stable/2023-04-01/Maintenance.json#L2543), API issue https://github.com/Azure/azure-rest-api-specs/issues/27222

```
TF_ACC=1 go test -v ./internal/services/maintenance -parallel 5 -run TestAccMaintenanceConfiguration_basicWithAlwaysReboot -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMaintenanceConfiguration_basicWithAlwaysReboot
=== PAUSE TestAccMaintenanceConfiguration_basicWithAlwaysReboot
=== CONT  TestAccMaintenanceConfiguration_basicWithAlwaysReboot
--- PASS: TestAccMaintenanceConfiguration_basicWithAlwaysReboot (106.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/maintenance   106.271s
```