### PR TITLE
Fixup colons in 'Note' section

### DIFF
--- a/website/docs/d/aadb2c_directory.html.markdown
+++ b/website/docs/d/aadb2c_directory.html.markdown
@@ -49,7 +49,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `tenant_id` - The Tenant ID for the AAD B2C tenant.
 
-~> **Note**: The `country_code` and `display_name` are not returned by this data source due to API limitations.
+~> **Note:** The `country_code` and `display_name` are not returned by this data source due to API limitations.
 
 ## Timeouts
 

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -31,7 +31,7 @@ We recommend using either a Service Principal or Managed Service Identity when r
 
 ## Logging into the Azure CLI
 
-~> **Note**: If you're using the **China** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
+~> **Note:** If you're using the **China** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
 
 ```shell
 az cloud set --name AzureChinaCloud|AzureUSGovernment

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -29,7 +29,7 @@ It's possible to complete this task in either the [Azure CLI](#creating-a-servic
 
 ### Creating a Service Principal using the Azure CLI
 
-~> **Note**: If you're using the **China** or **US Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
+~> **Note:** If you're using the **China** or **US Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
 
 ```shell
 az cloud set --name AzureChinaCloud|AzureUSGovernment
@@ -112,7 +112,7 @@ Once logged in as the Service Principal - we should be able to list the VM sizes
 az vm list-sizes --location westus
 ```
 
-~> **Note**: If you're using the **China** or **Government** Azure Clouds - you will need to switch `westus` out for another region. You can find which regions are available by running:
+~> **Note:** If you're using the **China** or **Government** Azure Clouds - you will need to switch `westus` out for another region. You can find which regions are available by running:
 
 ```shell
 az account list-locations

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Application Gateway.
 
-~> **NOTE**: The `backend_address_pool`, `backend_http_settings`, `http_listener`, `private_link_configuration`, `request_routing_rule`, `redirect_configuration`, `probe`, `ssl_certificate`, 
+~> **NOTE:** The `backend_address_pool`, `backend_http_settings`, `http_listener`, `private_link_configuration`, `request_routing_rule`, `redirect_configuration`, `probe`, `ssl_certificate`,
 and `frontend_port` properties are Sets as the service API returns these lists of objects in a different order from how the provider sends them. As Sets are stored using a hash, if one 
 value is added or removed from the Set, Terraform considers the entire list of objects changed and the plan shows that it is removing every value in the list and re-adding it with the 
 new information. Though Terraform is showing all the values being removed and re-added, we are not actually removing anything unless the user specifies a removal in the configfile.

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -406,7 +406,7 @@ An `encryption` block supports the following:
 
 * `user_assigned_identity_id` - (Optional) The Key Vault URI to access the encryption key.
 
-~> **Note**: `user_assigned_identity_id` must set when`identity.type` is `UserAssigned` or service won't be able to find the assigned permissions.
+~> **Note:** `user_assigned_identity_id` must set when`identity.type` is `UserAssigned` or service won't be able to find the assigned permissions.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -284,7 +284,7 @@ An `identity` block supports the following:
 
 An `immutability_policy` block supports the following:
 
-~> **NOTE**: This argument specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
+~> **NOTE:** This argument specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
 
 * `allow_protected_append_writes` - (Required) When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted.
 

--- a/website/docs/r/storage_blob_inventory_policy.html.markdown
+++ b/website/docs/r/storage_blob_inventory_policy.html.markdown
@@ -71,11 +71,11 @@ A `filter` block supports the following:
 
 * `blob_types` - (Required) A set of blob types. Possible values are `blockBlob`, `appendBlob`, and `pageBlob`. The storage account with `is_hns_enabled` is `true` doesn't support `pageBlob`.
 
-~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `BlobType` so that you can specify the `blob_types`.
+~> **NOTE:** The `rules.*.schema_fields` for this rule has to include `BlobType` so that you can specify the `blob_types`.
 
 * `include_blob_versions` - (Optional) Includes blob versions in blob inventory or not? Defaults to `false`.
 
-~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `IsCurrentVersion` and `VersionId` so that you can specify the `include_blob_versions`.
+~> **NOTE:** The `rules.*.schema_fields` for this rule has to include `IsCurrentVersion` and `VersionId` so that you can specify the `include_blob_versions`.
 
 * `include_deleted` - (Optional) Includes deleted blobs in blob inventory or not? Defaults to `false`.
 
@@ -83,7 +83,7 @@ A `filter` block supports the following:
 
 * `include_snapshots` - (Optional) Includes blob snapshots in blob inventory or not? Defaults to `false`.
 
-~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `Snapshot` so that you can specify the `include_snapshots`.
+~> **NOTE:** The `rules.*.schema_fields` for this rule has to include `Snapshot` so that you can specify the `include_snapshots`.
 
 * `prefix_match` - (Optional) A set of strings for blob prefixes to be matched. Maximum of 10 blob prefixes.
 


### PR DESCRIPTION
The current version of documentation has colons on the Note section on the line after the header making the sentences look off.