### PR TITLE
#24401: Support request_body_check part of azurerm_cdn_frontdoor_firewall_policy

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -83,6 +83,12 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 				ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
 			},
 
+			"request_body_check": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"custom_block_response_status_code": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
@@ -475,6 +481,12 @@ func resourceCdnFrontDoorFirewallPolicyCreate(d *pluginsdk.ResourceData, meta in
 		enabled = frontdoor.PolicyEnabledStateEnabled
 	}
 
+	requestBodyCheck := frontdoor.PolicyRequestBodyCheckDisabled
+
+	if d.Get("request_body_check").(bool) {
+		requestBodyCheck = frontdoor.PolicyRequestBodyCheckEnabled
+	}
+
 	sku := d.Get("sku_name").(string)
 	mode := frontdoor.PolicyMode(d.Get("mode").(string))
 	redirectUrl := d.Get("redirect_url").(string)
@@ -499,8 +511,9 @@ func resourceCdnFrontDoorFirewallPolicyCreate(d *pluginsdk.ResourceData, meta in
 		},
 		WebApplicationFirewallPolicyProperties: &frontdoor.WebApplicationFirewallPolicyProperties{
 			PolicySettings: &frontdoor.PolicySettings{
-				EnabledState: enabled,
-				Mode:         mode,
+				EnabledState:     enabled,
+				Mode:             mode,
+				RequestBodyCheck: requestBodyCheck,
 			},
 			CustomRules: expandCdnFrontDoorFirewallCustomRules(customRules),
 		},
@@ -561,14 +574,19 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 
 	props := *existing.WebApplicationFirewallPolicyProperties
 
-	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url") {
+	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url", "request_body_check") {
 		enabled := frontdoor.PolicyEnabledStateDisabled
 		if d.Get("enabled").(bool) {
 			enabled = frontdoor.PolicyEnabledStateEnabled
 		}
+		requestBodyCheck := frontdoor.PolicyRequestBodyCheckDisabled
+		if d.Get("request_body_check").(bool) {
+			requestBodyCheck = frontdoor.PolicyRequestBodyCheckEnabled
+		}
 		props.PolicySettings = &frontdoor.PolicySettings{
-			EnabledState: enabled,
-			Mode:         frontdoor.PolicyMode(d.Get("mode").(string)),
+			EnabledState:     enabled,
+			Mode:             frontdoor.PolicyMode(d.Get("mode").(string)),
+			RequestBodyCheck: requestBodyCheck,
 		}
 
 		if redirectUrl := d.Get("redirect_url").(string); redirectUrl != "" {
@@ -653,6 +671,7 @@ func resourceCdnFrontDoorFirewallPolicyRead(d *pluginsdk.ResourceData, meta inte
 		if policy := properties.PolicySettings; policy != nil {
 			d.Set("enabled", policy.EnabledState == frontdoor.PolicyEnabledStateEnabled)
 			d.Set("mode", string(policy.Mode))
+			d.Set("request_body_check", policy.RequestBodyCheck == frontdoor.PolicyRequestBodyCheckEnabled)
 			d.Set("redirect_url", policy.RedirectURL)
 			d.Set("custom_block_response_status_code", policy.CustomBlockResponseStatusCode)
 			d.Set("custom_block_response_body", policy.CustomBlockResponseBody)

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -83,7 +83,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 				ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
 			},
 
-			"request_body_check": {
+			"request_body_check_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -483,7 +483,7 @@ func resourceCdnFrontDoorFirewallPolicyCreate(d *pluginsdk.ResourceData, meta in
 
 	requestBodyCheck := frontdoor.PolicyRequestBodyCheckDisabled
 
-	if d.Get("request_body_check").(bool) {
+	if d.Get("request_body_check_enabled").(bool) {
 		requestBodyCheck = frontdoor.PolicyRequestBodyCheckEnabled
 	}
 
@@ -574,13 +574,13 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 
 	props := *existing.WebApplicationFirewallPolicyProperties
 
-	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url", "request_body_check") {
+	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url", "request_body_check_enabled") {
 		enabled := frontdoor.PolicyEnabledStateDisabled
 		if d.Get("enabled").(bool) {
 			enabled = frontdoor.PolicyEnabledStateEnabled
 		}
 		requestBodyCheck := frontdoor.PolicyRequestBodyCheckDisabled
-		if d.Get("request_body_check").(bool) {
+		if d.Get("request_body_check_enabled").(bool) {
 			requestBodyCheck = frontdoor.PolicyRequestBodyCheckEnabled
 		}
 		props.PolicySettings = &frontdoor.PolicySettings{
@@ -671,7 +671,7 @@ func resourceCdnFrontDoorFirewallPolicyRead(d *pluginsdk.ResourceData, meta inte
 		if policy := properties.PolicySettings; policy != nil {
 			d.Set("enabled", policy.EnabledState == frontdoor.PolicyEnabledStateEnabled)
 			d.Set("mode", string(policy.Mode))
-			d.Set("request_body_check", policy.RequestBodyCheck == frontdoor.PolicyRequestBodyCheckEnabled)
+			d.Set("request_body_check_enabled", policy.RequestBodyCheck == frontdoor.PolicyRequestBodyCheckEnabled)
 			d.Set("redirect_url", policy.RedirectURL)
 			d.Set("custom_block_response_status_code", policy.CustomBlockResponseStatusCode)
 			d.Set("custom_block_response_body", policy.CustomBlockResponseBody)

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -330,11 +330,11 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
   redirect_url                      = "https://www.contoso.com"
   custom_block_response_status_code = 403
   custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+  request_body_check_enabled        = false
 
   custom_rule {
     name                           = "Rule1"
-    enabled                        = true
-    request_body_check_enabled     = false
+    enabled                        = true    
     priority                       = 1
     rate_limit_duration_in_minutes = 1
     rate_limit_threshold           = 10

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -56,6 +56,7 @@ func TestAccCdnFrontDoorFirewallPolicy_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("request_body_check").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -333,6 +334,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
   custom_rule {
     name                           = "Rule1"
     enabled                        = true
+    request_body_check             = false
     priority                       = 1
     rate_limit_duration_in_minutes = 1
     rate_limit_threshold           = 10

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -56,7 +56,7 @@ func TestAccCdnFrontDoorFirewallPolicy_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("request_body_check").HasValue("false"),
+				check.That(data.ResourceName).Key("request_body_check_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -334,7 +334,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
   custom_rule {
     name                           = "Rule1"
     enabled                        = true
-    request_body_check             = false
+    request_body_check_enabled     = false
     priority                       = 1
     rate_limit_duration_in_minutes = 1
     rate_limit_threshold           = 10

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -334,7 +334,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 
   custom_rule {
     name                           = "Rule1"
-    enabled                        = true    
+    enabled                        = true
     priority                       = 1
     rate_limit_duration_in_minutes = 1
     rate_limit_threshold           = 10

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 * `mode` - (Required) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`.
 
-* `request_body_check` - (Optional) Should policy managed rules inspect the request body content? Defaults to `true`.
+* `request_body_check_enabled` - (Optional) Should policy managed rules inspect the request body content? Defaults to `true`.
 
 -> **NOTE:** When run in `Detection` mode, the Front Door Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched Front Door Rule to the Web Application Firewall logs.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -143,6 +143,8 @@ The following arguments are supported:
 
 * `mode` - (Required) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`.
 
+* `request_body_check` - (Optional) Should policy managed rules inspect the request body content? Defaults to `true`.
+
 -> **NOTE:** When run in `Detection` mode, the Front Door Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched Front Door Rule to the Web Application Firewall logs.
 
 * `redirect_url` - (Optional) If action type is redirect, this field represents redirect URL for the client.


### PR DESCRIPTION
Support `request_body_check` part of `azurerm_cdn_frontdoor_firewall_policy`. 

Fixes #24401.