### PR TITLE
#24408: Support updates of workload_profile part of azurerm_container_app_environment

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -351,6 +351,10 @@ func (r ContainerAppEnvironmentResource) Update() sdk.ResourceFunc {
 				existing.Model.Tags = tags.Expand(state.Tags)
 			}
 
+			if metadata.ResourceData.HasChange("workload_profile") {
+				existing.Model.Properties.WorkloadProfiles = helpers.ExpandWorkloadProfiles(state.WorkloadProfiles)
+			}
+
 			// (@jackofallops) This is not updatable and needs to be removed since the read does not return the sensitive Key field.
 			// Whilst not ideal, this means we don't need to try and retrieve it again just to send a no-op.
 			existing.Model.Properties.AppLogsConfiguration = nil

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -102,6 +102,7 @@ func TestAccContainerAppEnvironment_updateWorkloadProfile(t *testing.T) {
 			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("workload_profile.0.maximum_count").HasValue("3"),
 			),
 		},
 		data.ImportStep("log_analytics_workspace_id"),
@@ -303,6 +304,13 @@ resource "azurerm_container_app_environment" "test" {
   infrastructure_subnet_id = azurerm_subnet.control.id
 
   internal_load_balancer_enabled = true
+
+  workload_profile {
+    maximum_count         = 3
+    minimum_count         = 0
+    name                  = "My-GP-01"
+    workload_profile_type = "D4"
+  }
 
   tags = {
     Foo = "test"


### PR DESCRIPTION
Support updates of  `workload_profile` part of `azurerm_container_app_environment`. 

Fixes #24408. 