### PR TITLE
`azurerm_dedicated_host` - fix `TestAccMaintenanceAssignmentDedicatedHost_basic`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2391,7 +2391,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%[1]d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 0
 }
 

--- a/internal/services/maintenance/maintenance_assignment_dedicated_host_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dedicated_host_resource_test.go
@@ -115,7 +115,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%[1]d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/dedicated_host.html.markdown
+++ b/website/docs/r/dedicated_host.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_dedicated_host" "example" {
   name                    = "example-host"
   location                = azurerm_resource_group.example.location
   dedicated_host_group_id = azurerm_dedicated_host_group.example.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 ```

--- a/website/docs/r/maintenance_assignment_dedicated_host.html.markdown
+++ b/website/docs/r/maintenance_assignment_dedicated_host.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_dedicated_host" "example" {
   name                    = "example-host"
   location                = azurerm_resource_group.example.location
   dedicated_host_group_id = azurerm_dedicated_host_group.example.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/virtual-machines/dedicated-host-retirement#migrations-required-by-30-june-2023-updated
`DSv3-Type1` is retired and need to migrate.