### PR TITLE
`azurerm_mssql_managed_instance` : support read-only property `dns_zone` 

### DIFF
--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
@@ -26,6 +26,7 @@ type MsSqlManagedInstanceDataSourceModel struct {
 	AdministratorLogin        string                              `tfschema:"administrator_login"`
 	Collation                 string                              `tfschema:"collation"`
 	CustomerManagedKeyId      string                              `tfschema:"customer_managed_key_id"`
+	DnsZone                   string                              `tfschema:"dns_zone"`
 	DnsZonePartnerId          string                              `tfschema:"dns_zone_partner_id"`
 	Fqdn                      string                              `tfschema:"fqdn"`
 	Identity                  []identity.SystemOrUserAssignedList `tfschema:"identity"`
@@ -83,6 +84,11 @@ func (d MsSqlManagedInstanceDataSource) Attributes() map[string]*pluginsdk.Schem
 
 		"customer_managed_key_id": {
 			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"dns_zone": {
+			Type:     schema.TypeString,
 			Computed: true,
 		},
 
@@ -197,6 +203,9 @@ func (d MsSqlManagedInstanceDataSource) Read() sdk.ResourceFunc {
 				}
 				if props.Collation != nil {
 					model.Collation = *props.Collation
+				}
+				if props.DNSZone != nil {
+					model.DnsZone = *props.DNSZone
 				}
 				if props.KeyID != nil {
 					model.CustomerManagedKeyId = *props.KeyID

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source_test.go
@@ -24,6 +24,7 @@ func TestAccDataSourceSqlManagedInstance_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
 				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+				check.That(data.ResourceName).Key("dns_zone").Exists(),
 			),
 		},
 	})

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -32,6 +32,7 @@ type MsSqlManagedInstanceModel struct {
 	AdministratorLoginPassword   string                              `tfschema:"administrator_login_password"`
 	Collation                    string                              `tfschema:"collation"`
 	DnsZonePartnerId             string                              `tfschema:"dns_zone_partner_id"`
+	DnsZone                      string                              `tfschema:"dns_zone"`
 	Fqdn                         string                              `tfschema:"fqdn"`
 	Identity                     []identity.SystemOrUserAssignedList `tfschema:"identity"`
 	LicenseType                  string                              `tfschema:"license_type"`
@@ -238,6 +239,10 @@ func (r MsSqlManagedInstanceResource) Arguments() map[string]*pluginsdk.Schema {
 
 func (r MsSqlManagedInstanceResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
+		"dns_zone": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"fqdn": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -476,6 +481,9 @@ func (r MsSqlManagedInstanceResource) Read() sdk.ResourceFunc {
 				}
 				if props.Collation != nil {
 					model.Collation = *props.Collation
+				}
+				if props.DNSZone != nil {
+					model.DnsZone = *props.DNSZone
 				}
 				if props.FullyQualifiedDomainName != nil {
 					model.Fqdn = *props.FullyQualifiedDomainName

--- a/website/docs/d/mssql_managed_instance.html.markdown
+++ b/website/docs/d/mssql_managed_instance.html.markdown
@@ -37,6 +37,8 @@ The following attributes are exported:
 
 * `customer_managed_key` - Specifies KeyVault key, used by SQL Managed Instance for Transparent Data Encryption.
 
+* `dns_zone` - The Dns Zone where the SQL Managed Instance is located.
+
 * `dns_zone_partner_id` - The ID of the SQL Managed Instance which shares the DNS zone.
 
 * `fqdn` - The fully qualified domain name of the Azure Managed SQL Instance.

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -263,6 +263,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The SQL Managed Instance ID.
 
+* `dns_zone` - The Dns Zone where the SQL Managed Instance is located.
+
 * `fqdn` - The fully qualified domain name of the Azure Managed SQL Instance
 
 ---


### PR DESCRIPTION
Swagger: https://github.com/Azure/azure-rest-api-specs/blob/d736c01be58a43b9297ed4f602c5018cd4fb8a5d/specification/sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/ManagedInstances.json#L674

Fix #24415.
