### PR TITLE
typo: Change in custom domain profile ID should recreate custom domain not front door.

### DIFF
--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Front Door Custom Domain. Possible values must be between 2 and 260 characters in length, must begin with a letter or number, end with a letter or number and contain only letters, numbers and hyphens. Changing this forces a new Front Door Custom Domain to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile. Changing this forces a new Front Door Profile to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile. Changing this forces a new Front Door Custom Domain to be created.
 
 * `host_name` - (Required) The host name of the domain. The `host_name` field must be the FQDN of your domain(e.g. `contoso.fabrikam.com`). Changing this forces a new Front Door Custom Domain to be created.
 


### PR DESCRIPTION
# Summary

Fixes the likely typo as a change in the profile ID will just create another custom domain instead of an entirely new front door profile.