### PR TITLE
`azurerm_storage_share` - Add error message for `NFS` protocol specified for storage account whose `account_kind` is not `FileStorage`

### DIFF
--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -22,6 +22,8 @@ var (
 
 type accountDetails struct {
 	ID            string
+	Kind          storage.Kind
+	Sku           *storage.Sku
 	ResourceGroup string
 	Properties    *storage.AccountProperties
 
@@ -132,6 +134,8 @@ func populateAccountDetails(accountName string, props storage.Account) (*account
 	return &accountDetails{
 		name:          accountName,
 		ID:            accountId,
+		Kind:          props.Kind,
+		Sku:           props.Sku,
 		ResourceGroup: id.ResourceGroupName,
 		Properties:    props.AccountProperties,
 	}, nil

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
@@ -163,6 +164,15 @@ func resourceStorageShareCreate(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 	}
 
+	protocol := shares.ShareProtocol(d.Get("enabled_protocol").(string))
+	if protocol == shares.NFS {
+		// Only FileStorage (whose sku tier is Premium only) storage account is able to have NFS file shares.
+		// See: https://learn.microsoft.com/en-us/azure/storage/files/storage-files-quick-create-use-linux#applies-to
+		if account.Kind != storage.KindFileStorage {
+			return fmt.Errorf("NFS File Share is only supported for Storage Account with kind `FileStorage`, got `%s`", account.Kind)
+		}
+	}
+
 	client, err := storageClient.FileSharesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("building File Share Client: %s", err)
@@ -182,7 +192,7 @@ func resourceStorageShareCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	input := shares.CreateInput{
 		QuotaInGB:       quota,
 		MetaData:        metaData,
-		EnabledProtocol: shares.ShareProtocol(d.Get("enabled_protocol").(string)),
+		EnabledProtocol: protocol,
 	}
 
 	if accessTier := d.Get("access_tier").(string); accessTier != "" {

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. The `SMB` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. The `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `SMB`. Changing this forces a new resource to be created.
 
-~>**NOTE:** The `Premium` SKU of the `azurerm_storage_account` is required for the `NFS` protocol.
+~>**NOTE:** The `FileStorage` `account_kind` of the `azurerm_storage_account` is required for the `NFS` protocol.
 
 * `quota` - (Required) The maximum size of the share, in gigabytes.
 


### PR DESCRIPTION
`azurerm_storage_share` - Add error message for `NFS` protocol specified for storage account whose `account_kind` is not `FileStorage`

Fix #24269