### PR TITLE
`azurerm_key_vault_managed_hardware_security_module`: fix poll issue in update

### DIFF
--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -272,7 +273,10 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleUpdate(d *pluginsdk.Resourc
 	}
 	if hasUpdate {
 		if err := hsmClient.CreateOrUpdateThenPoll(ctx, *id, *model); err != nil {
-			return fmt.Errorf("updating %s tags: %+v", id, err)
+			// remove the condition when use a new base layer SDK: https://github.com/hashicorp/pandora/issues/3229
+			if !strings.Contains(err.Error(), "the response did not contain a body") {
+				return fmt.Errorf("updating %s tags: %+v", id, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is a workaround of https://github.com/hashicorp/pandora/issues/3229, to fix the issue when polling a PUT operation like: `        Error: updating Managed H S M (Subscription: "*******"
        Resource Group Name: "acctestRG-KV-240109003333503848"
        Managed H S M Name: "kvHsm240109003333503848") tags: polling after CreateOrUpdate: pollingTrackerPut#checkForErrors: the response did not contain a body: StatusCode=0
`


```
--- PASS: TestAccKeyVaultManagedHardwareSecurityModule (2731.24s)
    --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource (2731.24s)
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/update (2731.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      2731.253s
```

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/8ce27c0f-3eba-412e-87a0-a746704e3cd9)
