### PR TITLE
`azurerm_linux_virtual_machine_scale_set` - Fix testcases for VMSS Security Group Update

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
@@ -638,6 +638,10 @@ resource "azurerm_application_security_group" "test" {
   name                = "acctestasg-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -686,12 +690,20 @@ resource "azurerm_application_security_group" "test" {
   name                = "acctestasg-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_application_security_group" "other" {
   name                = "acctestasg2-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
@@ -639,6 +639,10 @@ resource "azurerm_application_security_group" "test" {
   name                = "acctestasg-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
@@ -685,12 +689,20 @@ resource "azurerm_application_security_group" "test" {
   name                = "acctestasg-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_application_security_group" "other" {
   name                = "acctestasg2-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {


### PR DESCRIPTION
## Test Result

=== RUN   TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate (659.57s)


=== RUN   TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate (616.58s)