### PR TITLE
Adding ipSecurityRestrictionsDefaultAction and scmIpSecurityRestrictionsDefaultAction to SiteConfig

### DIFF
--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -18,38 +18,40 @@ import (
 )
 
 type SiteConfigLinux struct {
-	AlwaysOn                bool                    `tfschema:"always_on"`
-	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
-	ApiDefinition           string                  `tfschema:"api_definition_url"`
-	AppCommandLine          string                  `tfschema:"app_command_line"`
-	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
-	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
-	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryMSI    string                  `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments        []string                `tfschema:"default_documents"`
-	Http2Enabled            bool                    `tfschema:"http2_enabled"`
-	IpRestriction           []IpRestriction         `tfschema:"ip_restriction"`
-	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
-	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
-	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
-	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
-	ScmType                 string                  `tfschema:"scm_type"`
-	Use32BitWorker          bool                    `tfschema:"use_32_bit_worker"`
-	WebSockets              bool                    `tfschema:"websockets_enabled"`
-	FtpsState               string                  `tfschema:"ftps_state"`
-	HealthCheckPath         string                  `tfschema:"health_check_path"`
-	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers         int                     `tfschema:"worker_count"`
-	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
-	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
-	Cors                    []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
-	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
-	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
+	AlwaysOn                               bool                    `tfschema:"always_on"`
+	ApiManagementConfigId                  string                  `tfschema:"api_management_api_id"`
+	ApiDefinition                          string                  `tfschema:"api_definition_url"`
+	AppCommandLine                         string                  `tfschema:"app_command_line"`
+	AutoHeal                               bool                    `tfschema:"auto_heal_enabled"`
+	AutoHealSettings                       []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
+	UseManagedIdentityACR                  bool                    `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryMSI                   string                  `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments                       []string                `tfschema:"default_documents"`
+	Http2Enabled                           bool                    `tfschema:"http2_enabled"`
+	IpRestriction                          []IpRestriction         `tfschema:"ip_restriction"`
+	IpSecurityRestrictionsDefaultAction    string                  `tfschema:"ip_security_restrictions_default_action"`
+	ScmIpSecurityRestrictionsDefaultAction string                  `tfschema:"scm_ip_security_restrictions_default_action"`
+	ScmUseMainIpRestriction                bool                    `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction                       []IpRestriction         `tfschema:"scm_ip_restriction"`
+	LoadBalancing                          string                  `tfschema:"load_balancing_mode"`
+	LocalMysql                             bool                    `tfschema:"local_mysql_enabled"`
+	ManagedPipelineMode                    string                  `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging                        bool                    `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion                 string                  `tfschema:"remote_debugging_version"`
+	ScmType                                string                  `tfschema:"scm_type"`
+	Use32BitWorker                         bool                    `tfschema:"use_32_bit_worker"`
+	WebSockets                             bool                    `tfschema:"websockets_enabled"`
+	FtpsState                              string                  `tfschema:"ftps_state"`
+	HealthCheckPath                        string                  `tfschema:"health_check_path"`
+	HealthCheckEvictionTime                int                     `tfschema:"health_check_eviction_time_in_min"`
+	NumberOfWorkers                        int                     `tfschema:"worker_count"`
+	ApplicationStack                       []ApplicationStackLinux `tfschema:"application_stack"`
+	MinTlsVersion                          string                  `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion                       string                  `tfschema:"scm_minimum_tls_version"`
+	Cors                                   []CorsSetting           `tfschema:"cors"`
+	DetailedErrorLogging                   bool                    `tfschema:"detailed_error_logging_enabled"`
+	LinuxFxVersion                         string                  `tfschema:"linux_fx_version"`
+	VnetRouteAllEnabled                    bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
 }
 
@@ -124,6 +126,15 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchema(),
 
+				"ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Allow",
+						"Deny",
+					}, false),
+				},
+
 				"scm_use_main_ip_restriction": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
@@ -131,6 +142,15 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				},
 
 				"scm_ip_restriction": IpRestrictionSchema(),
+
+				"scm_ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Allow",
+						"Deny",
+					}, false),
+				},
 
 				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
@@ -332,12 +352,22 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchemaComputed(),
 
+				"ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
 				"scm_use_main_ip_restriction": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
 
 				"scm_ip_restriction": IpRestrictionSchemaComputed(),
+
+				"scm_ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
 
 				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
@@ -833,6 +863,14 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*web.S
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
+	if s.IpSecurityRestrictionsDefaultAction != "" {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	}
+
+	if s.ScmIpSecurityRestrictionsDefaultAction != "" {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	}
+
 	if len(s.ScmIpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
@@ -877,6 +915,8 @@ func (s *SiteConfigLinux) ExpandForUpdate(metadata sdk.ResourceMetaData, existin
 	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
 	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -1033,6 +1073,8 @@ func (s *SiteConfigLinux) Flatten(appSiteConfig *web.SiteConfig) {
 		s.DefaultDocuments = pointer.From(appSiteConfig.DefaultDocuments)
 		s.Http2Enabled = pointer.From(appSiteConfig.HTTP20Enabled)
 		s.IpRestriction = FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions)
+		s.IpSecurityRestrictionsDefaultAction = string(appSiteConfig.IPSecurityRestrictionsDefaultAction)
+		s.ScmIpSecurityRestrictionsDefaultAction = string(appSiteConfig.ScmIPSecurityRestrictionsDefaultAction)
 		s.ManagedPipelineMode = string(appSiteConfig.ManagedPipelineMode)
 		s.ScmType = string(appSiteConfig.ScmType)
 		s.FtpsState = string(appSiteConfig.FtpsState)

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -18,40 +18,40 @@ import (
 )
 
 type SiteConfigLinux struct {
-	AlwaysOn                               bool                    `tfschema:"always_on"`
-	ApiManagementConfigId                  string                  `tfschema:"api_management_api_id"`
-	ApiDefinition                          string                  `tfschema:"api_definition_url"`
-	AppCommandLine                         string                  `tfschema:"app_command_line"`
-	AutoHeal                               bool                    `tfschema:"auto_heal_enabled"`
-	AutoHealSettings                       []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
-	UseManagedIdentityACR                  bool                    `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryMSI                   string                  `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments                       []string                `tfschema:"default_documents"`
-	Http2Enabled                           bool                    `tfschema:"http2_enabled"`
-	IpRestriction                          []IpRestriction         `tfschema:"ip_restriction"`
-	IpSecurityRestrictionsDefaultAction    string                  `tfschema:"ip_security_restrictions_default_action"`
-	ScmIpSecurityRestrictionsDefaultAction string                  `tfschema:"scm_ip_security_restrictions_default_action"`
-	ScmUseMainIpRestriction                bool                    `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction                       []IpRestriction         `tfschema:"scm_ip_restriction"`
-	LoadBalancing                          string                  `tfschema:"load_balancing_mode"`
-	LocalMysql                             bool                    `tfschema:"local_mysql_enabled"`
-	ManagedPipelineMode                    string                  `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging                        bool                    `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion                 string                  `tfschema:"remote_debugging_version"`
-	ScmType                                string                  `tfschema:"scm_type"`
-	Use32BitWorker                         bool                    `tfschema:"use_32_bit_worker"`
-	WebSockets                             bool                    `tfschema:"websockets_enabled"`
-	FtpsState                              string                  `tfschema:"ftps_state"`
-	HealthCheckPath                        string                  `tfschema:"health_check_path"`
-	HealthCheckEvictionTime                int                     `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers                        int                     `tfschema:"worker_count"`
-	ApplicationStack                       []ApplicationStackLinux `tfschema:"application_stack"`
-	MinTlsVersion                          string                  `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion                       string                  `tfschema:"scm_minimum_tls_version"`
-	Cors                                   []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging                   bool                    `tfschema:"detailed_error_logging_enabled"`
-	LinuxFxVersion                         string                  `tfschema:"linux_fx_version"`
-	VnetRouteAllEnabled                    bool                    `tfschema:"vnet_route_all_enabled"`
+	AlwaysOn                bool                    `tfschema:"always_on"`
+	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
+	ApiDefinition           string                  `tfschema:"api_definition_url"`
+	AppCommandLine          string                  `tfschema:"app_command_line"`
+	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
+	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
+	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryMSI    string                  `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments        []string                `tfschema:"default_documents"`
+	Http2Enabled            bool                    `tfschema:"http2_enabled"`
+	IpRestriction           []IpRestriction         `tfschema:"ip_restriction"`
+	IpAccessEnabled         bool                    `tfschema:"ip_access_enabled"`
+	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
+	ScmIpAccessEnabled      bool                    `tfschema:"scm_ip_access_enabled"`
+	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
+	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
+	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
+	ScmType                 string                  `tfschema:"scm_type"`
+	Use32BitWorker          bool                    `tfschema:"use_32_bit_worker"`
+	WebSockets              bool                    `tfschema:"websockets_enabled"`
+	FtpsState               string                  `tfschema:"ftps_state"`
+	HealthCheckPath         string                  `tfschema:"health_check_path"`
+	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
+	NumberOfWorkers         int                     `tfschema:"worker_count"`
+	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
+	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
+	Cors                    []CorsSetting           `tfschema:"cors"`
+	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
+	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
+	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
 }
 
@@ -126,13 +126,10 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchema(),
 
-				"ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
+				"ip_access_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
+					Default:  true,
 				},
 
 				"scm_use_main_ip_restriction": {
@@ -143,13 +140,10 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchema(),
 
-				"scm_ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
+				"scm_ip_access_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
+					Default:  true,
 				},
 
 				"local_mysql_enabled": {
@@ -352,22 +346,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchemaComputed(),
 
-				"ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
-				},
-
-				"scm_use_main_ip_restriction": {
-					Type:     pluginsdk.TypeBool,
-					Computed: true,
-				},
-
 				"scm_ip_restriction": IpRestrictionSchemaComputed(),
-
-				"scm_ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
-				},
 
 				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
@@ -776,6 +755,8 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*web.S
 	expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
 	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
 
 	if s.ApiManagementConfigId != "" {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -863,12 +844,12 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*web.S
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
-	if s.IpSecurityRestrictionsDefaultAction != "" {
-		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	if !s.IpAccessEnabled {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
 	}
 
-	if s.ScmIpSecurityRestrictionsDefaultAction != "" {
-		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	if !s.ScmIpAccessEnabled {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
 	}
 
 	if len(s.ScmIpRestriction) != 0 {
@@ -915,8 +896,16 @@ func (s *SiteConfigLinux) ExpandForUpdate(metadata sdk.ResourceMetaData, existin
 	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
 	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
-	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
-	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+
+	if !s.IpAccessEnabled {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
+	}
+
+	if !s.ScmIpAccessEnabled {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -1073,8 +1062,8 @@ func (s *SiteConfigLinux) Flatten(appSiteConfig *web.SiteConfig) {
 		s.DefaultDocuments = pointer.From(appSiteConfig.DefaultDocuments)
 		s.Http2Enabled = pointer.From(appSiteConfig.HTTP20Enabled)
 		s.IpRestriction = FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions)
-		s.IpSecurityRestrictionsDefaultAction = string(appSiteConfig.IPSecurityRestrictionsDefaultAction)
-		s.ScmIpSecurityRestrictionsDefaultAction = string(appSiteConfig.ScmIPSecurityRestrictionsDefaultAction)
+		s.IpAccessEnabled = true
+		s.ScmIpAccessEnabled = true
 		s.ManagedPipelineMode = string(appSiteConfig.ManagedPipelineMode)
 		s.ScmType = string(appSiteConfig.ScmType)
 		s.FtpsState = string(appSiteConfig.FtpsState)
@@ -1093,6 +1082,14 @@ func (s *SiteConfigLinux) Flatten(appSiteConfig *web.SiteConfig) {
 		s.WebSockets = pointer.From(appSiteConfig.WebSocketsEnabled)
 		s.VnetRouteAllEnabled = pointer.From(appSiteConfig.VnetRouteAllEnabled)
 		s.Cors = FlattenCorsSettings(appSiteConfig.Cors)
+
+		if strings.EqualFold(string(appSiteConfig.IPSecurityRestrictionsDefaultAction), string(web.DefaultActionDeny)) {
+			s.IpAccessEnabled = false
+		}
+
+		if strings.EqualFold(string(appSiteConfig.ScmIPSecurityRestrictionsDefaultAction), string(web.DefaultActionDeny)) {
+			s.ScmIpAccessEnabled = false
+		}
 
 		if appSiteConfig.APIManagementConfig != nil {
 			s.ApiManagementConfigId = pointer.From(appSiteConfig.APIManagementConfig.ID)

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -18,39 +18,41 @@ import (
 )
 
 type SiteConfigLinuxWebAppSlot struct {
-	AlwaysOn                bool                    `tfschema:"always_on"`
-	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
-	ApiDefinition           string                  `tfschema:"api_definition_url"`
-	AppCommandLine          string                  `tfschema:"app_command_line"`
-	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
-	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
-	AutoSwapSlotName        string                  `tfschema:"auto_swap_slot_name"`
-	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryMSI    string                  `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments        []string                `tfschema:"default_documents"`
-	Http2Enabled            bool                    `tfschema:"http2_enabled"`
-	IpRestriction           []IpRestriction         `tfschema:"ip_restriction"`
-	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
-	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
-	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
-	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
-	ScmType                 string                  `tfschema:"scm_type"`
-	Use32BitWorker          bool                    `tfschema:"use_32_bit_worker"`
-	WebSockets              bool                    `tfschema:"websockets_enabled"`
-	FtpsState               string                  `tfschema:"ftps_state"`
-	HealthCheckPath         string                  `tfschema:"health_check_path"`
-	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
-	WorkerCount             int                     `tfschema:"worker_count"`
-	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
-	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
-	Cors                    []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
-	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
-	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
+	AlwaysOn                               bool                    `tfschema:"always_on"`
+	ApiManagementConfigId                  string                  `tfschema:"api_management_api_id"`
+	ApiDefinition                          string                  `tfschema:"api_definition_url"`
+	AppCommandLine                         string                  `tfschema:"app_command_line"`
+	AutoHeal                               bool                    `tfschema:"auto_heal_enabled"`
+	AutoHealSettings                       []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
+	AutoSwapSlotName                       string                  `tfschema:"auto_swap_slot_name"`
+	UseManagedIdentityACR                  bool                    `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryMSI                   string                  `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments                       []string                `tfschema:"default_documents"`
+	Http2Enabled                           bool                    `tfschema:"http2_enabled"`
+	IpRestriction                          []IpRestriction         `tfschema:"ip_restriction"`
+	IpSecurityRestrictionsDefaultAction    string                  `tfschema:"ip_security_restrictions_default_action"`
+	ScmIpSecurityRestrictionsDefaultAction string                  `tfschema:"scm_ip_security_restrictions_default_action"`
+	ScmUseMainIpRestriction                bool                    `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction                       []IpRestriction         `tfschema:"scm_ip_restriction"`
+	LoadBalancing                          string                  `tfschema:"load_balancing_mode"`
+	LocalMysql                             bool                    `tfschema:"local_mysql_enabled"`
+	ManagedPipelineMode                    string                  `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging                        bool                    `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion                 string                  `tfschema:"remote_debugging_version"`
+	ScmType                                string                  `tfschema:"scm_type"`
+	Use32BitWorker                         bool                    `tfschema:"use_32_bit_worker"`
+	WebSockets                             bool                    `tfschema:"websockets_enabled"`
+	FtpsState                              string                  `tfschema:"ftps_state"`
+	HealthCheckPath                        string                  `tfschema:"health_check_path"`
+	HealthCheckEvictionTime                int                     `tfschema:"health_check_eviction_time_in_min"`
+	WorkerCount                            int                     `tfschema:"worker_count"`
+	ApplicationStack                       []ApplicationStackLinux `tfschema:"application_stack"`
+	MinTlsVersion                          string                  `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion                       string                  `tfschema:"scm_minimum_tls_version"`
+	Cors                                   []CorsSetting           `tfschema:"cors"`
+	DetailedErrorLogging                   bool                    `tfschema:"detailed_error_logging_enabled"`
+	LinuxFxVersion                         string                  `tfschema:"linux_fx_version"`
+	VnetRouteAllEnabled                    bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
 }
 
@@ -126,10 +128,28 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchema(),
 
+				"ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Allow",
+						"Deny",
+					}, false),
+				},
+
 				"scm_use_main_ip_restriction": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
+				},
+
+				"scm_ip_security_restrictions_default_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Allow",
+						"Deny",
+					}, false),
 				},
 
 				"scm_ip_restriction": IpRestrictionSchema(),
@@ -653,6 +673,14 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
+	if s.IpSecurityRestrictionsDefaultAction != "" {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	}
+
+	if s.ScmIpSecurityRestrictionsDefaultAction != "" {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	}
+
 	if len(s.ScmIpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
@@ -693,6 +721,8 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
 	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -851,6 +881,8 @@ func (s *SiteConfigLinuxWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig) {
 	s.DetailedErrorLogging = pointer.From(appSiteSlotConfig.DetailedErrorLoggingEnabled)
 	s.Http2Enabled = pointer.From(appSiteSlotConfig.HTTP20Enabled)
 	s.IpRestriction = FlattenIpRestrictions(appSiteSlotConfig.IPSecurityRestrictions)
+	s.IpSecurityRestrictionsDefaultAction = string(appSiteSlotConfig.IPSecurityRestrictionsDefaultAction)
+	s.ScmIpSecurityRestrictionsDefaultAction = string(appSiteSlotConfig.ScmIPSecurityRestrictionsDefaultAction)
 	s.ManagedPipelineMode = string(appSiteSlotConfig.ManagedPipelineMode)
 	s.ScmType = string(appSiteSlotConfig.ScmType)
 	s.FtpsState = string(appSiteSlotConfig.FtpsState)

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -18,41 +18,41 @@ import (
 )
 
 type SiteConfigLinuxWebAppSlot struct {
-	AlwaysOn                               bool                    `tfschema:"always_on"`
-	ApiManagementConfigId                  string                  `tfschema:"api_management_api_id"`
-	ApiDefinition                          string                  `tfschema:"api_definition_url"`
-	AppCommandLine                         string                  `tfschema:"app_command_line"`
-	AutoHeal                               bool                    `tfschema:"auto_heal_enabled"`
-	AutoHealSettings                       []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
-	AutoSwapSlotName                       string                  `tfschema:"auto_swap_slot_name"`
-	UseManagedIdentityACR                  bool                    `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryMSI                   string                  `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments                       []string                `tfschema:"default_documents"`
-	Http2Enabled                           bool                    `tfschema:"http2_enabled"`
-	IpRestriction                          []IpRestriction         `tfschema:"ip_restriction"`
-	IpSecurityRestrictionsDefaultAction    string                  `tfschema:"ip_security_restrictions_default_action"`
-	ScmIpSecurityRestrictionsDefaultAction string                  `tfschema:"scm_ip_security_restrictions_default_action"`
-	ScmUseMainIpRestriction                bool                    `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction                       []IpRestriction         `tfschema:"scm_ip_restriction"`
-	LoadBalancing                          string                  `tfschema:"load_balancing_mode"`
-	LocalMysql                             bool                    `tfschema:"local_mysql_enabled"`
-	ManagedPipelineMode                    string                  `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging                        bool                    `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion                 string                  `tfschema:"remote_debugging_version"`
-	ScmType                                string                  `tfschema:"scm_type"`
-	Use32BitWorker                         bool                    `tfschema:"use_32_bit_worker"`
-	WebSockets                             bool                    `tfschema:"websockets_enabled"`
-	FtpsState                              string                  `tfschema:"ftps_state"`
-	HealthCheckPath                        string                  `tfschema:"health_check_path"`
-	HealthCheckEvictionTime                int                     `tfschema:"health_check_eviction_time_in_min"`
-	WorkerCount                            int                     `tfschema:"worker_count"`
-	ApplicationStack                       []ApplicationStackLinux `tfschema:"application_stack"`
-	MinTlsVersion                          string                  `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion                       string                  `tfschema:"scm_minimum_tls_version"`
-	Cors                                   []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging                   bool                    `tfschema:"detailed_error_logging_enabled"`
-	LinuxFxVersion                         string                  `tfschema:"linux_fx_version"`
-	VnetRouteAllEnabled                    bool                    `tfschema:"vnet_route_all_enabled"`
+	AlwaysOn                bool                    `tfschema:"always_on"`
+	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
+	ApiDefinition           string                  `tfschema:"api_definition_url"`
+	AppCommandLine          string                  `tfschema:"app_command_line"`
+	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
+	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
+	AutoSwapSlotName        string                  `tfschema:"auto_swap_slot_name"`
+	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryMSI    string                  `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments        []string                `tfschema:"default_documents"`
+	Http2Enabled            bool                    `tfschema:"http2_enabled"`
+	IpRestriction           []IpRestriction         `tfschema:"ip_restriction"`
+	IpAccessEnabled         bool                    `tfschema:"ip_access_enabled"`
+	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
+	ScmIpAccessEnabled      bool                    `tfschema:"scm_ip_access_enabled"`
+	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
+	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
+	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
+	ScmType                 string                  `tfschema:"scm_type"`
+	Use32BitWorker          bool                    `tfschema:"use_32_bit_worker"`
+	WebSockets              bool                    `tfschema:"websockets_enabled"`
+	FtpsState               string                  `tfschema:"ftps_state"`
+	HealthCheckPath         string                  `tfschema:"health_check_path"`
+	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
+	WorkerCount             int                     `tfschema:"worker_count"`
+	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
+	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
+	Cors                    []CorsSetting           `tfschema:"cors"`
+	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
+	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
+	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
 }
 
@@ -128,13 +128,10 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 
 				"ip_restriction": IpRestrictionSchema(),
 
-				"ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
+				"ip_access_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
+					Default:  true,
 				},
 
 				"scm_use_main_ip_restriction": {
@@ -143,13 +140,10 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 					Default:  false,
 				},
 
-				"scm_ip_security_restrictions_default_action": {
-					Type:     pluginsdk.TypeString,
+				"scm_ip_access_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
+					Default:  true,
 				},
 
 				"scm_ip_restriction": IpRestrictionSchema(),
@@ -580,6 +574,8 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 	expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
 	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
 
 	if s.ApiManagementConfigId != "" {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -673,12 +669,12 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
-	if s.IpSecurityRestrictionsDefaultAction != "" {
-		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
+	if !s.IpAccessEnabled {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
 	}
 
-	if s.ScmIpSecurityRestrictionsDefaultAction != "" {
-		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	if !s.ScmIpAccessEnabled {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
 	}
 
 	if len(s.ScmIpRestriction) != 0 {
@@ -721,8 +717,16 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
 	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
 	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
-	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultAction(s.IpSecurityRestrictionsDefaultAction)
-	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultAction(s.ScmIpSecurityRestrictionsDefaultAction)
+	expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+	expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionAllow
+
+	if !s.IpAccessEnabled {
+		expanded.IPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
+	}
+
+	if !s.ScmIpAccessEnabled {
+		expanded.ScmIPSecurityRestrictionsDefaultAction = web.DefaultActionDeny
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -881,8 +885,8 @@ func (s *SiteConfigLinuxWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig) {
 	s.DetailedErrorLogging = pointer.From(appSiteSlotConfig.DetailedErrorLoggingEnabled)
 	s.Http2Enabled = pointer.From(appSiteSlotConfig.HTTP20Enabled)
 	s.IpRestriction = FlattenIpRestrictions(appSiteSlotConfig.IPSecurityRestrictions)
-	s.IpSecurityRestrictionsDefaultAction = string(appSiteSlotConfig.IPSecurityRestrictionsDefaultAction)
-	s.ScmIpSecurityRestrictionsDefaultAction = string(appSiteSlotConfig.ScmIPSecurityRestrictionsDefaultAction)
+	s.IpAccessEnabled = true
+	s.ScmIpAccessEnabled = true
 	s.ManagedPipelineMode = string(appSiteSlotConfig.ManagedPipelineMode)
 	s.ScmType = string(appSiteSlotConfig.ScmType)
 	s.FtpsState = string(appSiteSlotConfig.FtpsState)
@@ -900,6 +904,14 @@ func (s *SiteConfigLinuxWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig) {
 	s.UseManagedIdentityACR = pointer.From(appSiteSlotConfig.AcrUseManagedIdentityCreds)
 	s.WebSockets = pointer.From(appSiteSlotConfig.WebSocketsEnabled)
 	s.VnetRouteAllEnabled = pointer.From(appSiteSlotConfig.VnetRouteAllEnabled)
+
+	if strings.EqualFold(string(appSiteSlotConfig.IPSecurityRestrictionsDefaultAction), string(web.DefaultActionDeny)) {
+		s.IpAccessEnabled = false
+	}
+
+	if strings.EqualFold(string(appSiteSlotConfig.ScmIPSecurityRestrictionsDefaultAction), string(web.DefaultActionDeny)) {
+		s.ScmIpAccessEnabled = false
+	}
 
 	if appSiteSlotConfig.APIManagementConfig != nil && appSiteSlotConfig.APIManagementConfig.ID != nil {
 		s.ApiManagementConfigId = *appSiteSlotConfig.APIManagementConfig.ID

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -403,6 +403,57 @@ func TestAccLinuxWebApp_withIPRestrictionsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebApp_withIPRestrictionsDefaultAction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIPRestrictionsDefaultAction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_withIPRestrictionsDefaultActionUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withIPRestrictionsDefaultAction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withIPRestrictionsDefaultActionUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxWebApp_withAuthSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
 	r := LinuxWebAppResource{}
@@ -1754,19 +1805,21 @@ resource "azurerm_linux_web_app" "test" {
       "third.aspx",
       "hostingstart.html",
     ]
-    http2_enabled               = true
-    scm_use_main_ip_restriction = true
-    local_mysql_enabled         = true
-    managed_pipeline_mode       = "Integrated"
-    remote_debugging_enabled    = true
-    remote_debugging_version    = "VS2022"
-    use_32_bit_worker           = false
-    websockets_enabled          = true
-    ftps_state                  = "FtpsOnly"
-    health_check_path           = "/health"
-    worker_count                = 1
-    minimum_tls_version         = "1.1"
-    scm_minimum_tls_version     = "1.1"
+    http2_enabled                               = true
+    scm_use_main_ip_restriction                 = true
+    local_mysql_enabled                         = true
+    managed_pipeline_mode                       = "Integrated"
+    remote_debugging_enabled                    = true
+    remote_debugging_version                    = "VS2022"
+    use_32_bit_worker                           = false
+    websockets_enabled                          = true
+    ftps_state                                  = "FtpsOnly"
+    health_check_path                           = "/health"
+    worker_count                                = 1
+    minimum_tls_version                         = "1.1"
+    scm_minimum_tls_version                     = "1.1"
+    ip_security_restrictions_default_action     = "Allow"
+    scm_ip_security_restrictions_default_action = "Allow"
 
     cors {
       allowed_origins = [
@@ -1927,19 +1980,21 @@ resource "azurerm_linux_web_app" "test" {
       "third.aspx",
       "hostingstart.html",
     ]
-    http2_enabled                     = false
-    scm_use_main_ip_restriction       = false
-    local_mysql_enabled               = false
-    managed_pipeline_mode             = "Integrated"
-    remote_debugging_enabled          = true
-    remote_debugging_version          = "VS2017"
-    websockets_enabled                = true
-    ftps_state                        = "FtpsOnly"
-    health_check_path                 = "/health2"
-    health_check_eviction_time_in_min = 7
-    worker_count                      = 2
-    minimum_tls_version               = "1.2"
-    scm_minimum_tls_version           = "1.2"
+    http2_enabled                               = false
+    scm_use_main_ip_restriction                 = false
+    local_mysql_enabled                         = false
+    managed_pipeline_mode                       = "Integrated"
+    remote_debugging_enabled                    = true
+    remote_debugging_version                    = "VS2017"
+    websockets_enabled                          = true
+    ftps_state                                  = "FtpsOnly"
+    health_check_path                           = "/health2"
+    health_check_eviction_time_in_min           = 7
+    worker_count                                = 2
+    minimum_tls_version                         = "1.2"
+    scm_minimum_tls_version                     = "1.2"
+    ip_security_restrictions_default_action     = "Deny"
+    scm_ip_security_restrictions_default_action = "Deny"
 
     cors {
       allowed_origins = [
@@ -2503,6 +2558,50 @@ resource "azurerm_linux_web_app" "test" {
         x_forwarded_host  = ["example.com", "anotherexample.com"]
       }
     }
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r LinuxWebAppResource) withIPRestrictionsDefaultAction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    ip_security_restrictions_default_action     = "Deny"
+    scm_ip_security_restrictions_default_action = "Deny"
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r LinuxWebAppResource) withIPRestrictionsDefaultActionUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    ip_security_restrictions_default_action     = "Allow"
+    scm_ip_security_restrictions_default_action = "Deny"
   }
 }
 `, r.baseTemplate(data), data.RandomInteger)

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -370,6 +370,50 @@ func TestAccLinuxWebAppSlot_withIPRestrictionsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebAppSlot_withIPRestrictionsDefaultAction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIPRestrictionsDefaultAction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withIPRestrictionsDefaultActionUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIPRestrictionsDefaultAction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withIPRestrictionsDefaultActionUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withIPRestrictionsDefaultAction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxWebAppSlot_withAuthSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
 	r := LinuxWebAppSlotResource{}
@@ -1631,19 +1675,21 @@ resource "azurerm_linux_web_app_slot" "test" {
       "third.aspx",
       "hostingstart.html",
     ]
-    http2_enabled               = true
-    scm_use_main_ip_restriction = true
-    local_mysql_enabled         = true
-    managed_pipeline_mode       = "Integrated"
-    remote_debugging_enabled    = true
-    remote_debugging_version    = "VS2019"
-    use_32_bit_worker           = true
-    websockets_enabled          = true
-    ftps_state                  = "FtpsOnly"
-    health_check_path           = "/health"
-    worker_count                = 1
-    minimum_tls_version         = "1.1"
-    scm_minimum_tls_version     = "1.1"
+    http2_enabled                               = true
+    scm_use_main_ip_restriction                 = true
+    local_mysql_enabled                         = true
+    managed_pipeline_mode                       = "Integrated"
+    remote_debugging_enabled                    = true
+    remote_debugging_version                    = "VS2019"
+    use_32_bit_worker                           = true
+    websockets_enabled                          = true
+    ftps_state                                  = "FtpsOnly"
+    health_check_path                           = "/health"
+    worker_count                                = 1
+    minimum_tls_version                         = "1.1"
+    scm_minimum_tls_version                     = "1.1"
+    ip_security_restrictions_default_action     = "Allow"
+    scm_ip_security_restrictions_default_action = "Allow"
     cors {
       allowed_origins = [
         "http://www.contoso.com",
@@ -2071,6 +2117,46 @@ resource "azurerm_linux_web_app_slot" "test" {
         x_forwarded_host  = ["example.com", "anotherexample.com"]
       }
     }
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r LinuxWebAppSlotResource) withIPRestrictionsDefaultAction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {
+    ip_security_restrictions_default_action     = "Deny"
+    scm_ip_security_restrictions_default_action = "Deny"
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r LinuxWebAppSlotResource) withIPRestrictionsDefaultActionUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {
+    ip_security_restrictions_default_action     = "Allow"
+    scm_ip_security_restrictions_default_action = "Allow"
   }
 }
 `, r.baseTemplate(data), data.RandomInteger)


### PR DESCRIPTION
Both ipSecurityRestrictionsDefaultAction and scmIpSecurityRestrictionsDefaultAction were not configurable and had to be updated via azapi. 
To overcome this workaround this PR adds ipSecurityRestrictionsDefaultAction and scmIpSecurityRestrictionsDefaultAction to the SiteConfig and fixes #22593 

**UPDATE**: Adjusted property naming, adopting from #24519 

Partially duplicate of PR #24519 as they are sending the attributes differently during updates and this PR (#24464) doesn't cover windows yet and misses documentation updates