### PR TITLE
Docs: update document linter tool for partial force new and circular reference

### DIFF
--- a/internal/tools/document-lint/check/check_circular_ref.go
+++ b/internal/tools/document-lint/check/check_circular_ref.go
@@ -1,0 +1,41 @@
+package check
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/document-lint/model"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/document-lint/util"
+)
+
+type circularRef struct {
+	checkBase
+	fieldName string
+	md        *model.ResourceDoc
+}
+
+func newCircularRef(name string, md *model.ResourceDoc) *circularRef {
+	base := newCheckBase(0, "", nil)
+	return &circularRef{
+		checkBase: base,
+		fieldName: name,
+		md:        md,
+	}
+}
+
+// Fix implements Checker.
+func (*circularRef) Fix(line string) (result string, err error) {
+	return line, nil
+}
+
+// Key implements Checker.
+// ShouldSkip implements Checker.
+func (*circularRef) ShouldSkip() bool {
+	return false
+}
+
+// String implements Checker.
+func (c *circularRef) String() string {
+	return fmt.Sprintf("0 document has circular reference in block name: %s", util.Bold(c.fieldName))
+}
+
+var _ Checker = (*circularRef)(nil)

--- a/internal/tools/document-lint/check/check_resource.go
+++ b/internal/tools/document-lint/check/check_resource.go
@@ -77,8 +77,13 @@ func (r *ResourceDiff) DiffAll() {
 	if r.md == nil {
 		mark := md.MustNewMarkFromFile(r.MDFile)
 		r.md = mark.BuildResourceDoc()
-
 	}
+
+	if name := r.md.HasCircularRef(); name != "" {
+		r.Diff = append(r.Diff, newCircularRef(name, r.md))
+		return
+	}
+
 	r.Diff = checkPossibleValues(r.tf, r.md)
 
 	missDiff := crossCheckProperty(r.tf, r.md)

--- a/internal/tools/document-lint/md/resource_doc.go
+++ b/internal/tools/document-lint/md/resource_doc.go
@@ -52,8 +52,15 @@ func getDefaultValue(line string) string {
 // ForceNewReg have to stop at dot or end of line to remove this part from the document when needed
 var ForceNewReg = regexp.MustCompile(` ?Changing.*forces? a [^.]*(\.|$)`)
 
+// customized forceNew like: Changing this forces a new resource to be created when types `LRS`, `GRS` and `RAGRS` are changed to `ZRS`, `GZRS` or `RAGZRS` and vice versa.
+var partForceNewReg = regexp.MustCompile(` ?Changing.*forces? a [^.]* created when [^.]*(\.|$)`)
+
 func isForceNew(line string) bool {
-	return ForceNewReg.MatchString(line)
+	if ForceNewReg.MatchString(line) && !partForceNewReg.MatchString(line) {
+		return true
+	}
+
+	return false
 }
 
 func extractFieldFromLine(line string) (field *model.Field) {

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -502,7 +502,7 @@ A `stream_declaration` block supports the following:
 
 A `syslog` block supports the following:
 
-* `facility_names` - (Required) Specifies a list of facility names. Use a wildcard `*` to collect logs for all facility names. Possible values are `auth`, `authpriv`, `cron`, `daemon`, `kern`, `lpr`, `mail`, `mark`, `news`, `syslog`, `user`, `uucp`, `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`,and `*`.
+* `facility_names` - (Required) Specifies a list of facility names. Use a wildcard `*` to collect logs for all facility names. Possible values are `alert`, `*`, `audit`, `auth`, `authpriv`, `clock`, `cron`, `daemon`, `ftp`, `kern`, `local5`, `local4`, `local1`, `local7`, `local6`, `local3`, `local2`, `local0`, `lpr`, `mail`, `mark`, `news`, `nopri`, `ntp`, `syslog`, `user` and `uucp`.
 
 * `log_levels` - (Required) Specifies a list of log levels. Use a wildcard `*` to collect logs for all log levels. Possible values are `Debug`, `Info`, `Notice`, `Warning`, `Error`, `Critical`, `Alert`, `Emergency`,and `*`.
 


### PR DESCRIPTION
This PR addresses circular references in document blocks, which can lead to an infinite loop when checking for missing properties in the tool. This issue occurs in certain commits that reference an incorrect block name, as shown below:

```
An `foo` block supports the following:

* `bar` - (Required) The xxxx.

* `foo2` - (Optional) One or more `foo` blocks as defined below.
```

Also some customized Force New logic should be ignored just like https://github.com/hashicorp/terraform-provider-azurerm/blob/624a9b03a0bc7512a52405298749debd385a48fc/website/docs/r/storage_account.html.markdown#L95