### PR TITLE
`r/application_gateway`: components within the url block is no longer computed

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -3848,6 +3848,7 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 						if actionSet.URLConfiguration != nil {
 							config := *actionSet.URLConfiguration
 							components := ""
+
 							path := ""
 							if config.ModifiedPath != nil {
 								path = *config.ModifiedPath
@@ -3858,12 +3859,17 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 								queryString = *config.ModifiedQueryString
 							}
 
-							if path != queryString {
-								if path != "" && queryString == "" {
-									components = "path_only"
-								} else if queryString != "" && path == "" {
-									components = "query_string_only"
-								}
+							// `components` doesn't exist in the API - it appears to be purely a UI state in the Portal
+							// as such we should consider removing this field in the future.
+							if path == queryString {
+								// used to represent `both`
+								components = ""
+							}
+							if config.ModifiedQueryString != nil && config.ModifiedPath == nil {
+								components = "query_string_only"
+							}
+							if config.ModifiedQueryString == nil && config.ModifiedPath != nil {
+								components = "path_only"
 							}
 
 							reroute := false

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1124,7 +1124,6 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 												"components": {
 													Type:     pluginsdk.TypeString,
 													Optional: true,
-													Computed: true,
 													ValidateFunc: validation.StringInSlice([]string{
 														"path_only",
 														"query_string_only",

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -463,6 +463,18 @@ func TestAccApplicationGateway_rewriteRuleSets_rewriteUrl(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.rewriteRuleSets_rewriteUrlUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+				check.That(data.ResourceName).Key("rewrite_rule_set.#").HasValue("2"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.url.0.components").HasValue(""),
+				check.That(data.ResourceName).Key("rewrite_rule_set.1.rewrite_rule.0.url.0.components").HasValue(""),
+				check.That(data.ResourceName).Key("rewrite_rule_set.1.rewrite_rule.1.url.0.components").HasValue("query_string_only"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -6675,6 +6687,169 @@ resource "azurerm_application_gateway" "test" {
       url {
         path       = "/article.aspx"
         components = "path_only"
+      }
+    }
+
+    rewrite_rule {
+      name          = "${local.rewrite_rule_name}_2"
+      rule_sequence = 2
+
+      condition {
+        variable = "var_uri_path"
+        pattern  = ".*article2/(.*)/(.*)"
+      }
+
+      url {
+        query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
+        components   = "query_string_only"
+      }
+    }
+  }
+
+  redirect_configuration {
+    name                 = local.redirect_configuration_name
+    redirect_type        = "Temporary"
+    target_listener_name = local.target_listener_name
+    include_path         = true
+    include_query_string = false
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) rewriteRuleSets_rewriteUrlUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_port_name2            = "${azurerm_virtual_network.test.name}-feport2"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  target_listener_name           = "${azurerm_virtual_network.test.name}-trgthttplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  redirect_configuration_name    = "${azurerm_virtual_network.test.name}-Port80To8888Redirect"
+  rewrite_rule_set_name          = "${azurerm_virtual_network.test.name}-rwset"
+  rewrite_rule_name              = "${azurerm_virtual_network.test.name}-rwrule"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_port {
+    name = local.frontend_port_name2
+    port = 8888
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  http_listener {
+    name                           = local.target_listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name2
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                        = local.request_routing_rule_name
+    rule_type                   = "Basic"
+    http_listener_name          = local.listener_name
+    redirect_configuration_name = local.redirect_configuration_name
+    rewrite_rule_set_name       = local.rewrite_rule_set_name
+    priority                    = 10
+  }
+
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = local.rewrite_rule_name
+      rule_sequence = 1
+
+      condition {
+        variable    = "var_uri_path"
+        pattern     = ".*article/(.*)/(.*)"
+        ignore_case = false
+        negate      = false
+      }
+      response_header_configuration {
+        header_name  = "X-custom"
+        header_value = "customvalue"
+      }
+
+      url {
+        path         = "/article.aspx"
+        query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
+        reroute      = false
+      }
+    }
+  }
+
+  rewrite_rule_set {
+    name = "${local.rewrite_rule_set_name}_1"
+
+    rewrite_rule {
+      name          = "${local.rewrite_rule_name}_1"
+      rule_sequence = 1
+
+      condition {
+        variable = "var_uri_path"
+        pattern  = ".*article/(.*)/(.*)"
+      }
+
+      url {
+        path = "/article.aspx"
       }
     }
 


### PR DESCRIPTION
This allows this field to be unset in the configuration, which equates to `both`.

This field doesn't actually exist in the API and is used purely to determine which fields should be set/have a value - so marking this as un-computed should be fine.