### PR TITLE
[Bug:] `azurerm_cdn_frontdoor_route` - `cdn_frontdoor_origin_path` gets removed on `update` if unchanged.

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -455,11 +455,12 @@ func resourceCdnFrontDoorRouteUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	// NOTE: You need to always pass these two on update else you will
-	// disable your cache and disassociate your custom domains...
+	// NOTE: You need to always pass these three on update else you will
+	// disable your cache, disassociate your custom domains or remove your origin path...
 	updateProps := azuresdkhacks.RouteUpdatePropertiesParameters{
 		CustomDomains:      existing.RouteProperties.CustomDomains,
 		CacheConfiguration: existing.RouteProperties.CacheConfiguration,
+		OriginPath:         existing.RouteProperties.OriginPath,
 	}
 
 	if d.HasChange("cache") {

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -492,6 +492,8 @@ func resourceCdnFrontDoorRouteUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("cdn_frontdoor_origin_path") {
+		updateProps.OriginPath = nil
+
 		originPath := d.Get("cdn_frontdoor_origin_path").(string)
 		if originPath != "" {
 			updateProps.OriginPath = utils.String(originPath)


### PR DESCRIPTION
(fixes #24466)