### PR TITLE
`azurerm_kubernetes_*`: add `drain_timeout_in_minutes` to `upgrade_settings`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -1465,20 +1465,17 @@ func flattenKubernetesClusterDataSourceMicrosoftDefender(input *managedclusters.
 }
 
 func flattenKubernetesClusterDataSourceUpgradeSettings(input *managedclusters.AgentPoolUpgradeSettings) []interface{} {
-	maxSurge := ""
+	values := make(map[string]interface{})
+
 	if input != nil && input.MaxSurge != nil {
-		maxSurge = *input.MaxSurge
+		values["max_surge"] = *input.MaxSurge
 	}
 
-	if maxSurge == "" {
-		return []interface{}{}
+	if input != nil && input.DrainTimeoutInMinutes != nil {
+		values["drain_timeout_in_minutes"] = *input.DrainTimeoutInMinutes
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"max_surge": maxSurge,
-		},
-	}
+	return []interface{}{values}
 }
 
 func flattenCustomCaTrustCerts(input *managedclusters.ManagedClusterSecurityProfile) []interface{} {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1084,6 +1084,10 @@ func upgradeSettingsSchema() *pluginsdk.Schema {
 						Type:     pluginsdk.TypeString,
 						Required: true,
 					},
+					"drain_timeout_in_minutes": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
 				},
 			},
 		}
@@ -1174,8 +1178,8 @@ func expandAgentPoolUpgradeSettings(input []interface{}) *agentpools.AgentPoolUp
 	if maxSurgeRaw := v["max_surge"].(string); maxSurgeRaw != "" {
 		setting.MaxSurge = utils.String(maxSurgeRaw)
 	}
-	if drainTimeoutInMinutesRaw := int64(v["drain_timeout_in_minutes"].(int)); drainTimeoutInMinutesRaw != int64(0) {
-		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
+	if drainTimeoutInMinutesRaw := v["drain_timeout_in_minutes"].(int); drainTimeoutInMinutesRaw != 0 {
+		setting.DrainTimeoutInMinutes = utils.Int64(int64(drainTimeoutInMinutesRaw))
 	}
 	return setting
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1174,6 +1174,9 @@ func expandAgentPoolUpgradeSettings(input []interface{}) *agentpools.AgentPoolUp
 	if maxSurgeRaw := v["max_surge"].(string); maxSurgeRaw != "" {
 		setting.MaxSurge = utils.String(maxSurgeRaw)
 	}
+	if drainTimeoutInMinutesRaw := int64(v["drain_timeout_in_minutes"].(int)); drainTimeoutInMinutesRaw != int64(0) {
+		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
+	}
 	return setting
 }
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1099,6 +1099,10 @@ func upgradeSettingsSchema() *pluginsdk.Schema {
 					Optional: true,
 					Default:  "10%",
 				},
+				"drain_timeout_in_minutes": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
 			},
 		},
 	}
@@ -1174,20 +1178,17 @@ func expandAgentPoolUpgradeSettings(input []interface{}) *agentpools.AgentPoolUp
 }
 
 func flattenAgentPoolUpgradeSettings(input *agentpools.AgentPoolUpgradeSettings) []interface{} {
-	maxSurge := ""
-	if input != nil && input.MaxSurge != nil {
-		maxSurge = *input.MaxSurge
+	values := make(map[string]interface{})
+
+	if input != nil && input.MaxSurge != nil && *input.MaxSurge != "" {
+		values["max_surge"] = *input.MaxSurge
 	}
 
-	if maxSurge == "" {
-		return []interface{}{}
+	if input != nil && input.DrainTimeoutInMinutes != nil && *input.DrainTimeoutInMinutes != 0 {
+		values["drain_timeout_in_minutes"] = *input.DrainTimeoutInMinutes
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"max_surge": maxSurge,
-		},
-	}
+	return []interface{}{values}
 }
 
 func expandNodeLabels(input map[string]interface{}) *map[string]string {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -568,7 +568,7 @@ func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 			Config: r.upgradeSettingsConfig(data, "2", 35),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("2"),
+				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.max_surge").HasValue("2"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.drain_timeout_in_minutes").HasValue("35"),
 			),
@@ -578,7 +578,7 @@ func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 			Config: r.upgradeSettingsConfig(data, "4", 40),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("2"),
+				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.max_surge").HasValue("4"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.drain_timeout_in_minutes").HasValue("40"),
 			),

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -565,25 +565,27 @@ func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeSettingsConfig(data, "2"),
+			Config: r.upgradeSettingsConfig(data, "2", 35),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("2"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.max_surge").HasValue("2"),
+				check.That(data.ResourceName).Key("upgrade_settings.0.drain_timeout_in_minutes").HasValue("35"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "4"),
+			Config: r.upgradeSettingsConfig(data, "4", 40),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("2"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.max_surge").HasValue("4"),
+				check.That(data.ResourceName).Key("upgrade_settings.0.drain_timeout_in_minutes").HasValue("40"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "10%"),
+			Config: r.upgradeSettingsConfig(data, "", 0),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -585,11 +585,12 @@ func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "", 0),
+			Config: r.upgradeSettingsConfig(data, "10%", 35),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("upgrade_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("upgrade_settings.0.max_surge").HasValue("10%"),
+				check.That(data.ResourceName).Key("upgrade_settings.0.drain_timeout_in_minutes").HasValue("35"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2010,12 +2010,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
 `, r.templateConfig(data))
 }
 
-func (r KubernetesClusterNodePoolResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string) string {
+func (r KubernetesClusterNodePoolResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string, drainTimeoutInMinutes int) string {
 	template := r.templateConfig(data)
 	if maxSurge != "" {
 		maxSurge = fmt.Sprintf(`upgrade_settings {
     max_surge = %q
-  }`, maxSurge)
+	drain_timeout_in_minutes = %d
+
+  }`, maxSurge, drainTimeoutInMinutes)
 	}
 
 	return fmt.Sprintf(`

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -707,11 +707,12 @@ resource "azurerm_kubernetes_cluster" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, enabled)
 }
 
-func (r KubernetesClusterResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string) string {
+func (r KubernetesClusterResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string, drainTimeoutInMinutes int) string {
 	if maxSurge != "" {
 		maxSurge = fmt.Sprintf(`upgrade_settings {
-    max_surge = %q
-  }`, maxSurge)
+    max_surge                = %q
+    drain_timeout_in_minutes = %d
+  }`, maxSurge, drainTimeoutInMinutes)
 	}
 
 	return fmt.Sprintf(`

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -282,7 +282,7 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 			Config: r.upgradeSettingsConfig(data, "2", 40),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("2"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("2"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("40"),
 			),
@@ -302,7 +302,7 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 			Config: r.upgradeSettingsConfig(data, "2", 30),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("2"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("2"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("30"),
 			),

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -289,12 +289,12 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "", 0),
+			Config: r.upgradeSettingsConfig(data, "10%", 35),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
-				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("30"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("10%"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("35"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -292,6 +292,7 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("30"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("10%"),
 			),
 		},

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -279,16 +279,17 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeSettingsConfig(data, "2"),
+			Config: r.upgradeSettingsConfig(data, "2", 40),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("2"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("2"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("40"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "10%"),
+			Config: r.upgradeSettingsConfig(data, "", 0),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
@@ -298,11 +299,12 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettingsConfig(data, "2"),
+			Config: r.upgradeSettingsConfig(data, "2", 30),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.#").HasValue("2"),
 				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.max_surge").HasValue("2"),
+				check.That(data.ResourceName).Key("default_node_pool.0.upgrade_settings.0.drain_timeout_in_minutes").HasValue("30"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -2214,7 +2214,7 @@ func expandClusterNodePoolUpgradeSettings(input []interface{}) *managedclusters.
 		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
 		fmt.Println("Setting drain timeout in minutes to", drainTimeoutInMinutesRaw)
 	}
-	if drainTimeoutInMinutesRaw := v["drain_timeout_in_minutes"].(int64); drainTimeoutInMinutesRaw != int64(0) {
+	if drainTimeoutInMinutesRaw := int64(v["drain_timeout_in_minutes"].(int)); drainTimeoutInMinutesRaw != int64(0) {
 		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
 	}
 	return setting

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -2208,14 +2208,9 @@ func expandClusterNodePoolUpgradeSettings(input []interface{}) *managedclusters.
 	v := input[0].(map[string]interface{})
 	if maxSurgeRaw := v["max_surge"].(string); maxSurgeRaw != "" {
 		setting.MaxSurge = utils.String(maxSurgeRaw)
-		fmt.Println("Setting max surge to", maxSurgeRaw)
 	}
-	if drainTimeoutInMinutesRaw := int64(v["drain_timeout_in_minutes"].(int)); drainTimeoutInMinutesRaw != int64(0) {
-		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
-		fmt.Println("Setting drain timeout in minutes to", drainTimeoutInMinutesRaw)
-	}
-	if drainTimeoutInMinutesRaw := int64(v["drain_timeout_in_minutes"].(int)); drainTimeoutInMinutesRaw != int64(0) {
-		setting.DrainTimeoutInMinutes = utils.Int64(drainTimeoutInMinutesRaw)
+	if drainTimeoutInMinutesRaw := v["drain_timeout_in_minutes"].(int); drainTimeoutInMinutesRaw != 0 {
+		setting.DrainTimeoutInMinutes = utils.Int64(int64(drainTimeoutInMinutesRaw))
 	}
 	return setting
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -2201,7 +2201,6 @@ func findDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProfile
 func expandClusterNodePoolUpgradeSettings(input []interface{}) *managedclusters.AgentPoolUpgradeSettings {
 	setting := &managedclusters.AgentPoolUpgradeSettings{}
 	if len(input) == 0 || input[0] == nil {
-		fmt.Println("No upgrade settings found")
 		return setting
 	}
 

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool.go
@@ -455,6 +455,10 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 						Type:     pluginsdk.TypeString,
 						Required: true,
 					},
+					"drain_timeout_in_minutes": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
 				},
 			},
 		},

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -182,6 +182,9 @@ An `azure_active_directory_role_based_access_control` block exports the followin
 
 A `upgrade_settings` block exports the following:
 
+
+* `drain_timeout_in_minutes` - The amount of time in minutes to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails.
+
 * `max_surge` - The maximum number or percentage of nodes that will be added to the Node Pool size during an upgrade.
 
 ---

--- a/website/docs/d/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/d/kubernetes_cluster_node_pool.html.markdown
@@ -94,6 +94,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 A `upgrade_settings` block exports the following:
 
+* `drain_timeout_in_minutes` - The amount of time in minutes to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails.
+
 * `max_surge` - The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
 ## Timeouts

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -945,6 +945,8 @@ A `http_proxy_config` block supports the following:
 
 A `upgrade_settings` block supports the following:
 
+* `drain_timeout_in_minutes` - (Optional) The amount of time in minutes to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails.
+
 * `max_surge` - (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
 -> **Note:** If a percentage is provided, the number of surge nodes is calculated from the `node_count` value on the current cluster. Node surge can allow a cluster to have more nodes than `max_count` during an upgrade. Ensure that your cluster has enough [IP space](https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade) during an upgrade.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -308,6 +308,8 @@ A `sysctl_config` block supports the following:
 
 A `upgrade_settings` block supports the following:
 
+* `drain_timeout_in_minutes` - (Optional) The amount of time in minutes to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails.
+
 * `max_surge` - (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
 ---


### PR DESCRIPTION
Fixes #13066
Depends on #24481 and #24473

## TODO
- [x] Run tests
- [x] It is not possible to remove (part of) the upgrade settings after setting them, filed an issue for that
- [x] Docs
- [x] Dependencies merged

## Tests
```bash
$ TF_ACC=1 go test -v ./internal/services/containers -run=_upgradeSettings -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesClusterNodePool_upgradeSettings
=== PAUSE TestAccKubernetesClusterNodePool_upgradeSettings
=== RUN   TestAccKubernetesCluster_upgradeSettings
=== PAUSE TestAccKubernetesCluster_upgradeSettings
=== CONT  TestAccKubernetesClusterNodePool_upgradeSettings
=== CONT  TestAccKubernetesCluster_upgradeSettings
--- PASS: TestAccKubernetesCluster_upgradeSettings (543.27s)
--- PASS: TestAccKubernetesClusterNodePool_upgradeSettings (648.68s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    651.123s
```