### PR TITLE
`azurerm_storage_account` - Check `access_tier` for unsupported `storage_kind`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -44,7 +44,17 @@ import (
 )
 
 var (
-	storageAccountResourceName = "azurerm_storage_account"
+	storageAccountResourceName  = "azurerm_storage_account"
+	storageKindsSupportsSkuTier = []storage.Kind{
+		storage.KindBlobStorage,
+		storage.KindStorageV2,
+		storage.KindFileStorage,
+	}
+	storageKindsSupportHns = []storage.Kind{
+		storage.KindBlobStorage,
+		storage.KindStorageV2,
+		storage.KindFileStorage,
+	}
 )
 
 type storageAccountServiceSupportLevel struct {
@@ -155,7 +165,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}, false),
 			},
 
-			// Only valid for BlobStorage & StorageV2 accounts, defaults to "Hot" in create function
+			// Only valid for FileStorage, BlobStorage & StorageV2 accounts, defaults to "Hot" in create function
 			"access_tier": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -1249,15 +1259,8 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 
 				if d.Get("access_tier") != "" {
-					if accountKind := d.Get("account_kind").(string); !slices.Contains(
-						[]storage.Kind{
-							storage.KindBlobStorage,
-							storage.KindStorageV2,
-							storage.KindFileStorage,
-						},
-						storage.Kind(accountKind),
-					) {
-						return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
+					if accountKind := d.Get("account_kind").(string); !slices.Contains(storageKindsSupportsSkuTier, storage.Kind(accountKind)) {
+						return fmt.Errorf("`access_tier` is only available for accounts of kind: %v", storageKindsSupportsSkuTier)
 					}
 				}
 
@@ -1399,33 +1402,18 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	accessTier, ok := d.GetOk("access_tier")
-	// AccessTier is only valid for BlobStorage, StorageV2, and FileStorage accounts
-	if slices.Contains(
-		[]storage.Kind{
-			storage.KindBlobStorage,
-			storage.KindStorageV2,
-			storage.KindFileStorage,
-		},
-		storage.Kind(accountKind),
-	) {
+	if slices.Contains(storageKindsSupportsSkuTier, storage.Kind(accountKind)) {
 		if !ok {
 			// default to "Hot"
 			accessTier = string(storage.AccessTierHot)
 		}
 		parameters.AccountPropertiesCreateParameters.AccessTier = storage.AccessTier(accessTier.(string))
 	} else if ok {
-		return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
+		return fmt.Errorf("`access_tier` is only available for accounts of kind: %v", storageKindsSupportsSkuTier)
 	}
 
-	if isHnsEnabled && !slices.Contains(
-		[]storage.Kind{
-			storage.KindStorageV2,
-			storage.KindBlobStorage,
-			storage.KindBlockBlobStorage,
-		},
-		storage.Kind(accountKind),
-	) {
-		return fmt.Errorf("`is_hns_enabled` can only be used with account kinds `StorageV2`, `BlobStorage` and `BlockBlobStorage`")
+	if isHnsEnabled && !slices.Contains(storageKindsSupportHns, storage.Kind(accountKind)) {
+		return fmt.Errorf("`is_hns_enabled` can only be used with account of kinds: %v", storageKindsSupportHns)
 	}
 
 	// NFSv3 is supported for standard general-purpose v2 storage accounts and for premium block blob storage accounts.

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1398,10 +1398,8 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			accessTier = string(storage.AccessTierHot)
 		}
 		parameters.AccountPropertiesCreateParameters.AccessTier = storage.AccessTier(accessTier.(string))
-	} else {
-		if ok {
-			return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
-		}
+	} else if ok {
+		return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
 	}
 
 	if isHnsEnabled && accountKind != string(storage.KindBlockBlobStorage) {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -1248,7 +1249,14 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 
 				if d.Get("access_tier") != "" {
-					if accountKind := d.Get("account_kind").(string); !(accountKind == string(storage.KindBlobStorage) || accountKind == string(storage.KindStorageV2) || accountKind == string(storage.KindFileStorage)) {
+					if accountKind := d.Get("account_kind").(string); !slices.Contains(
+						[]storage.Kind{
+							storage.KindBlobStorage,
+							storage.KindStorageV2,
+							storage.KindFileStorage,
+						},
+						storage.Kind(accountKind),
+					) {
 						return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
 					}
 				}
@@ -1392,7 +1400,14 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	accessTier, ok := d.GetOk("access_tier")
 	// AccessTier is only valid for BlobStorage, StorageV2, and FileStorage accounts
-	if accountKind == string(storage.KindBlobStorage) || accountKind == string(storage.KindStorageV2) || accountKind == string(storage.KindFileStorage) {
+	if slices.Contains(
+		[]storage.Kind{
+			storage.KindBlobStorage,
+			storage.KindStorageV2,
+			storage.KindFileStorage,
+		},
+		storage.Kind(accountKind),
+	) {
 		if !ok {
 			// default to "Hot"
 			accessTier = string(storage.AccessTierHot)
@@ -1402,7 +1417,14 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("`access_tier` is only available for BlobStorage, StorageV2, and FileStorage accounts")
 	}
 
-	if isHnsEnabled && accountKind != string(storage.KindBlockBlobStorage) {
+	if isHnsEnabled && !slices.Contains(
+		[]storage.Kind{
+			storage.KindStorageV2,
+			storage.KindBlobStorage,
+			storage.KindBlockBlobStorage,
+		},
+		storage.Kind(accountKind),
+	) {
 		return fmt.Errorf("`is_hns_enabled` can only be used with account kinds `StorageV2`, `BlobStorage` and `BlockBlobStorage`")
 	}
 


### PR DESCRIPTION
`access_tier` is supported for `account_kind` of BlobStorage, StorageV2, and FileStorage. Previously, the behavior for unsupported `account_kind` is that the provider will silently allow users to set the `access_tier`, which causes the following plan/apply to show a diff (as the access tier is not really set).

This PR changes this behavior to error out for these supported `account_kind` cases.

## Test

```shell
terraform-provider-azurerm on  storage_account_access_tier_check via 🐹 v1.21.4
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run="TestAccStorageAccount_invalidAccountKindForAccessTier"
=== RUN   TestAccStorageAccount_invalidAccountKindForAccessTier
=== PAUSE TestAccStorageAccount_invalidAccountKindForAccessTier
=== CONT  TestAccStorageAccount_invalidAccountKindForAccessTier
--- PASS: TestAccStorageAccount_invalidAccountKindForAccessTier (3.92s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       3.928s
```

Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/24490
Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/15210