### PR TITLE
`azurerm_container_app`: fix support for multiple `custom_scale_rule`

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -382,6 +382,21 @@ func TestAccContainerAppResource_scaleRules(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_multipleScaleRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleScaleRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_scaleRulesUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -1675,6 +1690,70 @@ resource "azurerm_container_app" "test" {
       custom_rule_type = "azure-monitor"
       metadata = {
         foo = "bar"
+      }
+    }
+
+    http_scale_rule {
+      name                = "http-1"
+      concurrent_requests = "100"
+    }
+
+    tcp_scale_rule {
+      name                = "tcp-1"
+      concurrent_requests = "1000"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) multipleScaleRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  secret {
+    name  = "queue-auth-secret"
+    value = "VGhpcyBJcyBOb3QgQSBHb29kIFBhc3N3b3JkCg=="
+  }
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+
+    azure_queue_scale_rule {
+      name         = "azq-1"
+      queue_name   = "foo"
+      queue_length = 10
+
+      authentication {
+        secret_name       = "queue-auth-secret"
+        trigger_parameter = "password"
+      }
+    }
+
+    custom_scale_rule {
+      name             = "csr-1"
+      custom_rule_type = "azure-monitor"
+      metadata = {
+        foo = "bar"
+      }
+    }
+
+    custom_scale_rule {
+      name             = "csr-2"
+      custom_rule_type = "azure-monitor"
+      metadata = {
+        foo = "bar2"
       }
     }
 

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3167,7 +3167,7 @@ func (c *ContainerTemplate) expandContainerAppScaleRules() []containerapps.Scale
 		r := containerapps.ScaleRule{
 			Name: pointer.To(v.Name),
 			Custom: &containerapps.CustomScaleRule{
-				Metadata: &v.Metadata,
+				Metadata: pointer.To(v.Metadata),
 				Type:     pointer.To(v.CustomRuleType),
 			},
 		}


### PR DESCRIPTION
* Customer reported issue on a problem encountered when creating container app with multiple `custom_scale_rule` configured.

resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/24467


```
=== RUN   TestAccContainerAppResource_multipleScaleRules
=== PAUSE TestAccContainerAppResource_multipleScaleRules
=== CONT  TestAccContainerAppResource_multipleScaleRules
--- PASS: TestAccContainerAppResource_multipleScaleRules (719.72s)
PASS
```