### PR TITLE
azurerm_log_analytics_workspace_table support for total_retention_in_days property

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -26,10 +26,11 @@ var _ sdk.ResourceWithUpdate = LogAnalyticsWorkspaceTableResource{}
 var _ sdk.ResourceWithCustomizeDiff = LogAnalyticsWorkspaceTableResource{}
 
 type LogAnalyticsWorkspaceTableResourceModel struct {
-	Name            string `tfschema:"name"`
-	WorkspaceId     string `tfschema:"workspace_id"`
-	Plan            string `tfschema:"plan"`
-	RetentionInDays int64  `tfschema:"retention_in_days"`
+	Name                 string `tfschema:"name"`
+	WorkspaceId          string `tfschema:"workspace_id"`
+	Plan                 string `tfschema:"plan"`
+	RetentionInDays      int64  `tfschema:"retention_in_days"`
+	TotalRetentionInDays int64  `tfschema:"total_retention_in_datys"`
 }
 
 func (r LogAnalyticsWorkspaceTableResource) CustomizeDiff() sdk.ResourceFunc {
@@ -73,6 +74,12 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"retention_in_days": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
+		},
+
+		"total_retention_in_days": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
 			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
@@ -125,6 +132,7 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 
 			if model.Plan == string(tables.TablePlanEnumAnalytics) {
 				updateInput.Properties.RetentionInDays = pointer.To(model.RetentionInDays)
+				updateInput.Properties.TotalRetentionInDays = pointer.To(model.TotalRetentionInDays)
 			}
 			if err := client.CreateOrUpdateThenPoll(ctx, id, updateInput); err != nil {
 				return fmt.Errorf("failed to update table %s in workspace %s in resource group %s: %s", tableName, workspaceId.WorkspaceName, workspaceId.ResourceGroupName, err)
@@ -174,6 +182,10 @@ func (r LogAnalyticsWorkspaceTableResource) Update() sdk.ResourceFunc {
 						if metadata.ResourceData.HasChange("retention_in_days") {
 							updateInput.Properties.RetentionInDays = pointer.To(state.RetentionInDays)
 						}
+
+						if metadata.ResourceData.HasChange("total_retention_in_days") {
+							updateInput.Properties.TotalRetentionInDays = pointer.To(state.TotalRetentionInDays)
+						}
 					}
 
 					if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
@@ -220,6 +232,7 @@ func (r LogAnalyticsWorkspaceTableResource) Read() sdk.ResourceFunc {
 				if props := model.Properties; props != nil {
 					if pointer.From(props.Plan) == tables.TablePlanEnumAnalytics {
 						state.RetentionInDays = pointer.From(props.RetentionInDays)
+						state.TotalRetentionInDays = pointer.From(props.TotalRetentionInDays)
 					}
 					state.Plan = string(pointer.From(props.Plan))
 				}
@@ -247,10 +260,12 @@ func (r LogAnalyticsWorkspaceTableResource) Delete() sdk.ResourceFunc {
 			// We do not delete the resource here, just set the retention to workspace default value, which is
 			// achieved by setting the value to `-1`
 			retentionInDays := utils.Int64(-1)
+			totalRetentionInDays := utils.Int64(-1)
 
 			updateInput := tables.Table{
 				Properties: &tables.TableProperties{
-					RetentionInDays: retentionInDays,
+					RetentionInDays:      retentionInDays,
+					TotalRetentionInDays: totalRetentionInDays,
 				},
 			}
 

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -30,7 +30,7 @@ type LogAnalyticsWorkspaceTableResourceModel struct {
 	WorkspaceId          string `tfschema:"workspace_id"`
 	Plan                 string `tfschema:"plan"`
 	RetentionInDays      int64  `tfschema:"retention_in_days"`
-	TotalRetentionInDays int64  `tfschema:"total_retention_in_datys"`
+	TotalRetentionInDays int64  `tfschema:"total_retention_in_days"`
 }
 
 func (r LogAnalyticsWorkspaceTableResource) CustomizeDiff() sdk.ResourceFunc {

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -30,7 +30,7 @@ func TestAccLogAnalyticsWorkspaceTable_updateTableRetention(t *testing.T) {
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("name").HasValue("AppEvents"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("7"),
-				check.That(data.ResourceName).Key("total_retention_in_days").HasValue("20"),
+				check.That(data.ResourceName).Key("total_retention_in_days").HasValue("32"),
 			),
 		},
 	})

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -83,7 +83,7 @@ resource "azurerm_log_analytics_workspace_table" "test" {
   name                    = "AppEvents"
   workspace_id            = azurerm_log_analytics_workspace.test.id
   retention_in_days       = 7
-  total_retention_in_days = 20
+  total_retention_in_days = 32
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -30,6 +30,7 @@ func TestAccLogAnalyticsWorkspaceTable_updateTableRetention(t *testing.T) {
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("name").HasValue("AppEvents"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("7"),
+				check.That(data.ResourceName).Key("total_retention_in_days").HasValue("20"),
 			),
 		},
 	})
@@ -79,9 +80,10 @@ resource "azurerm_log_analytics_workspace" "test" {
   retention_in_days   = 30
 }
 resource "azurerm_log_analytics_workspace_table" "test" {
-  name              = "AppEvents"
-  workspace_id      = azurerm_log_analytics_workspace.test.id
-  retention_in_days = 7
+  name                    = "AppEvents"
+  workspace_id            = azurerm_log_analytics_workspace.test.id
+  retention_in_days       = 7
+  total_retention_in_days = 20
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/log_analytics_workspace_table.html.markdown
+++ b/website/docs/r/log_analytics_workspace_table.html.markdown
@@ -27,9 +27,10 @@ resource "azurerm_log_analytics_workspace" "example" {
   retention_in_days   = 30
 }
 resource "azurerm_log_analytics_workspace_table" "example" {
-  workspace_id      = azurerm_log_analytics_workspace.example.id
-  name              = "AppMetrics"
-  retention_in_days = 60
+  workspace_id            = azurerm_log_analytics_workspace.example.id
+  name                    = "AppMetrics"
+  retention_in_days       = 60
+  total_retention_in_days = 180
 }
 ```
 
@@ -47,7 +48,9 @@ The following arguments are supported:
 
 * `retention_in_days` - (Optional) The table's retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
--> **Note:** `retention_in_days` will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
+* `total_retention_in_days` - (Optional) The table's total retention in days. Possible values range between 30 and 4383.
+
+-> **Note:** `retention_in_days` and `total_retention_in_days` will revert back to the value of azurerm_log_analytics_workspace retention_in_days when a azurerm_log_analytics_workspace_table is deleted.
 
 -> **Note:** The `retention_in_days` cannot be specified when `plan` is `Basic` because the retention is fixed at eight days.
 
@@ -60,6 +63,8 @@ The following attributes are exported:
 * `workspace_id` - The Workspace (or Customer) ID for the Log Analytics Workspace.
 
 * `retention_in_days` - The table's data retention in days.
+
+* `total_retention_in_days` - The table's total data retention in days.
 
 ## Timeouts
 


### PR DESCRIPTION
As of now, the `azurerm_log_analytics_workspace_table` resource only allows to set the `retention_in_days` field for its tables
```
resource "azurerm_log_analytics_workspace_table" "example" {
  workspace_id      = azurerm_log_analytics_workspace.example.id
  name              = "AppMetrics"
  retention_in_days = 60
}
```

With this PR the goal is to be able to set also a `total_retention_in_days` using the same logic used for `retention_in_days`.