### PR TITLE
`azurerm_linux_web_app_slot` - fix ignored `worker_count` argument in `site_config` block

### DIFF
--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -666,6 +666,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 		expanded.RemoteDebuggingVersion = pointer.To(s.RemoteDebuggingVersion)
 	}
 
+	if s.WorkerCount != 0 {
+		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
+	}
+
 	if s.HealthCheckPath != "" {
 		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
 	}
@@ -813,6 +817,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 
 	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
 		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
+	}
+
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
+		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -667,7 +667,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 	}
 
 	if s.WorkerCount != 0 {
-		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
+		expanded.NumberOfWorkers = pointer.To(s.WorkerCount)
 	}
 
 	if s.HealthCheckPath != "" {
@@ -820,7 +820,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
-		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
+		expanded.NumberOfWorkers = pointer.To(s.WorkerCount)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {


### PR DESCRIPTION
Currently the [`worker_count`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app_slot#worker_count) argument in the `site_config` block on `azurerm_linux_web_app_slot` seems to get ignored when the resource is created:

```
resource "azurerm_linux_web_app_slot" "example" {
  name           = "example-slot"
  app_service_id = azurerm_linux_web_app.example.id

  site_config {
    worker_count = 2
  }
}
```
Running `terraform apply` on this code will show no issues and finish successfully. The resulting slot will have a `worker_count` of `1` however, which you can check via the JSON View of the slot in the Azure Portal.

Re-running a `terraform plan` directly after the `terraform apply` will show differences:

```
      ~ site_config {
          ~ worker_count                            = 1 -> 2
```

While debugging I discovered the `NumberOfWorkers` argument is simply missing from the AzureRM API call to Azure when the `azurerm_linux_web_app_slot` resource gets created. 

I think this is because it is never added to the expanded arguments. 

The goal of this PR is to remedy this, by adding the `NumberOfWorkers` to the expanded arguments. This causes the resulting slot to have the correct number of workers.

Unit tests:

```
=== RUN   TestAccLinuxWebAppSlot_complete
=== PAUSE TestAccLinuxWebAppSlot_complete
=== RUN   TestAccLinuxWebAppSlot_completeUpdate
=== PAUSE TestAccLinuxWebAppSlot_completeUpdate
=== CONT  TestAccLinuxWebAppSlot_complete
=== CONT  TestAccLinuxWebAppSlot_completeUpdate
--- PASS: TestAccLinuxWebAppSlot_complete (152.51s)
--- PASS: TestAccLinuxWebAppSlot_completeUpdate (221.91s)
PASS
```
fixes #24678 