### PR TITLE
`azurerm_container_app`: add support for `ip_security_restriction` in data source

### DIFF
--- a/internal/services/containerapps/container_app_data_source_test.go
+++ b/internal/services/containerapps/container_app_data_source_test.go
@@ -24,6 +24,18 @@ func TestAccContainerAppDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app", "test")
+	r := ContainerAppDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
+	})
+}
+
 func (d ContainerAppDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -33,4 +45,15 @@ data "azurerm_container_app" "test" {
   resource_group_name = azurerm_container_app.test.resource_group_name
 }
 `, ContainerAppResource{}.basic(data))
+}
+
+func (d ContainerAppDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_container_app" "test" {
+  name                = azurerm_container_app.test.name
+  resource_group_name = azurerm_container_app.test.resource_group_name
+}
+`, ContainerAppResource{}.complete(data, "rev1"))
 }

--- a/internal/services/containerapps/container_app_data_source_test.go
+++ b/internal/services/containerapps/container_app_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccContainerAppDataSource_complete(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, "rev1"),
 			Check:  acceptance.ComposeTestCheckFunc(),
 		},
 	})
@@ -47,7 +47,7 @@ data "azurerm_container_app" "test" {
 `, ContainerAppResource{}.basic(data))
 }
 
-func (d ContainerAppDataSource) complete(data acceptance.TestData) string {
+func (d ContainerAppDataSource) complete(data acceptance.TestData, revisionSuffix string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -55,5 +55,5 @@ data "azurerm_container_app" "test" {
   name                = azurerm_container_app.test.name
   resource_group_name = azurerm_container_app.test.resource_group_name
 }
-`, ContainerAppResource{}.complete(data, "rev1"))
+`, ContainerAppResource{}.complete(data, revisionSuffix))
 }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -243,6 +243,8 @@ func ContainerAppIngressSchemaComputed() *pluginsdk.Schema {
 					Description: "The FQDN of the ingress.",
 				},
 
+				"ip_security_restriction": ContainerAppIngressIpSecurityRestrictionComputed(),
+
 				"target_port": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -487,6 +489,40 @@ func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "Name for the IP restriction rule.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppIngressIpSecurityRestrictionComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"action": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The action. Allow or Deny.",
+				},
+
+				"description": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "Describe the IP restriction rule that is being sent to the container-app.",
+				},
+
+				"ip_address_range": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "CIDR notation to match incoming IP address.",
+				},
+
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "Name for the IP restriction rule.",
 				},
 			},
 		},

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -265,6 +265,8 @@ An `ingress` block supports the following:
 
 * `external_enabled` - Is this an external Ingress.
 
+* `ip_security_restriction` - One or more `ip_security_restriction` blocks for IP-filtering rules as defined below.
+
 * `target_port` - The target port on the container for the Ingress traffic.
 
 * `traffic_weight` - A `traffic_weight` block as detailed below.
@@ -280,6 +282,18 @@ A `custom_domain` block supports the following:
 * `certificate_id` - The ID of the Container App Environment Certificate.
 
 * `name` - The hostname of the Certificate. Must be the CN or a named SAN in the certificate.
+
+---
+
+A `ip_security_restriction` block supports the following:
+
+* `action` - The IP-filter action. `Allow` or `Deny`.
+
+* `description` - Describe the IP restriction rule that is being sent to the container-app.
+
+* `ip_address_range` - CIDR notation to match incoming IP address.
+
+* `name` - Name for the IP restriction rule.
 
 ---
 

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -285,13 +285,13 @@ A `custom_domain` block supports the following:
 
 ---
 
-A `ip_security_restriction` block supports the following:
+A `ip_security_restriction` block exports the following:
 
-* `action` - The IP-filter action. `Allow` or `Deny`.
+* `action` - The IP-filter action.
 
-* `description` - Describe the IP restriction rule that is being sent to the container-app.
+* `description` - Description of the IP restriction rule that is being sent to the container-app.
 
-* `ip_address_range` - CIDR notation to match incoming IP address.
+* `ip_address_range` - CIDR notation that matches the incoming IP address.
 
 * `name` - Name for the IP restriction rule.
 


### PR DESCRIPTION
* `ip_security_restriction` is supported in the resource but not in data source yet. Add support for this attribute in the data source.

* fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24494