### PR TITLE
`azurerm_linux_function_app` `azurerm_function_app_slot` `azurerm_windows_function_app` `azurerm_windows_function_app` - taint resource when resource was partially created.

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -578,6 +578,8 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating Linux %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			stickySettings := helpers.ExpandStickySettings(functionApp.StickySettings)
 
 			if stickySettings != nil {
@@ -642,7 +644,6 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.SetID(id)
 			return nil
 		},
 	}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -545,6 +545,8 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating Linux %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			if !functionAppSlot.PublishingDeployBasicAuthEnabled {
 				sitePolicy := webapps.CsmPublishingCredentialsPoliciesEntity{
 					Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
@@ -619,7 +621,6 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.SetID(id)
 			return nil
 		},
 	}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -578,6 +578,8 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("updating properties of Windows %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			stickySettings := helpers.ExpandStickySettings(functionApp.StickySettings)
 
 			if stickySettings != nil {
@@ -642,7 +644,6 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.SetID(id)
 			return nil
 		},
 	}

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -588,6 +588,8 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("updating properties of Windows %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			backupConfig, err := helpers.ExpandBackupConfig(functionAppSlot.Backup)
 			if err != nil {
 				return fmt.Errorf("expanding backup configuration for Windows %s: %+v", id, err)
@@ -636,7 +638,6 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.SetID(id)
 			return nil
 		},
 	}


### PR DESCRIPTION
This pr should resolve #24517.

#24517 was caused by the [following code](https://github.com/hashicorp/terraform-provider-azurerm/blob/v3.87.0/internal/services/appservice/linux_function_app_resource.go#L637-L643):

```go
                        if functionApp.ZipDeployFile != "" {
				if err = helpers.GetCredentialsAndPublish(ctx, client, id.ResourceGroup, id.SiteName, functionApp.ZipDeployFile); err != nil {
					return err
				}
			}

			metadata.SetID(id)
```

Once an error occurred during `GetCredentialsAndPublish`, the `Create` function would return error without recording resource's state, but on the service side the resource was partially created, when the user run `apply` again, the `Create` function would read a resource with the very same id, then threw an error that required user to import the resource.

This pr pushed `metadata.SetID(id)` right after we've created the resource.

Actually, this behavior is as same as we're doing for [`azurerm_linux_web_app_resource`](https://github.com/hashicorp/terraform-provider-azurerm/blob/v3.87.0/internal/services/appservice/linux_web_app_resource.go#L394-L403) and [`azurerm_linux_web_app_slot`](https://github.com/hashicorp/terraform-provider-azurerm/blob/v3.87.0/internal/services/appservice/linux_web_app_slot_resource.go#L383-L392).

Once the id was set and `Create` function returned an error, the resource was recorded in the state file with `tainted` status, when the user run `apply` again, Terraform would try to delete the partially created resource first, then try to create it again.

@tombuildsstuff @jackofallops WDYT?