### PR TITLE
`azurerm_cognitive_account` - allows empty `tier` value for sku 'DC0'

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -659,7 +659,9 @@ func expandAccountSkuName(skuName string) (*cognitiveservicesaccounts.Sku, error
 	case "E":
 		tier = cognitiveservicesaccounts.SkuTierEnterprise
 	default:
-		return nil, fmt.Errorf("sku_name %s has unknown sku tier %s", skuName, skuName[0:1])
+		return &cognitiveservicesaccounts.Sku{
+			Name: skuName,
+		}, nil
 	}
 
 	return &cognitiveservicesaccounts.Sku{

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -338,9 +338,8 @@ func resourceCognitiveAccountCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	sku, err := expandAccountSkuName(d.Get("sku_name").(string))
-	if err != nil {
-		return fmt.Errorf("expanding sku_name for %s: %v", id, err)
+	sku := cognitiveservicesaccounts.Sku{
+		Name: d.Get("sku_name").(string),
 	}
 
 	networkAcls, subnetIds := expandCognitiveAccountNetworkAcls(d)
@@ -373,7 +372,7 @@ func resourceCognitiveAccountCreate(d *pluginsdk.ResourceData, meta interface{})
 	props := cognitiveservicesaccounts.Account{
 		Kind:     utils.String(kind),
 		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
-		Sku:      sku,
+		Sku:      &sku,
 		Properties: &cognitiveservicesaccounts.AccountProperties{
 			ApiProperties:                 apiProps,
 			NetworkAcls:                   networkAcls,
@@ -425,9 +424,8 @@ func resourceCognitiveAccountUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	sku, err := expandAccountSkuName(d.Get("sku_name").(string))
-	if err != nil {
-		return fmt.Errorf("expanding sku_name for %s: %+v", *id, err)
+	sku := cognitiveservicesaccounts.Sku{
+		Name: d.Get("sku_name").(string),
 	}
 
 	networkAcls, subnetIds := expandCognitiveAccountNetworkAcls(d)
@@ -458,7 +456,7 @@ func resourceCognitiveAccountUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	props := cognitiveservicesaccounts.Account{
-		Sku: sku,
+		Sku: &sku,
 		Properties: &cognitiveservicesaccounts.AccountProperties{
 			ApiProperties:                 apiProps,
 			NetworkAcls:                   networkAcls,
@@ -645,29 +643,6 @@ func resourceCognitiveAccountDelete(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	return nil
-}
-
-func expandAccountSkuName(skuName string) (*cognitiveservicesaccounts.Sku, error) {
-	var tier cognitiveservicesaccounts.SkuTier
-	switch skuName[0:1] {
-	case "F":
-		tier = cognitiveservicesaccounts.SkuTierFree
-	case "S":
-		tier = cognitiveservicesaccounts.SkuTierStandard
-	case "P":
-		tier = cognitiveservicesaccounts.SkuTierPremium
-	case "E":
-		tier = cognitiveservicesaccounts.SkuTierEnterprise
-	default:
-		return &cognitiveservicesaccounts.Sku{
-			Name: skuName,
-		}, nil
-	}
-
-	return &cognitiveservicesaccounts.Sku{
-		Name: skuName,
-		Tier: &tier,
-	}, nil
 }
 
 func cognitiveAccountStateRefreshFunc(ctx context.Context, client *cognitiveservicesaccounts.CognitiveServicesAccountsClient, id cognitiveservicesaccounts.AccountId) pluginsdk.StateRefreshFunc {


### PR DESCRIPTION
We received a important customer complaint regarding not able to deploy cognitive account with sku `DC0`.

This sku is introduced from https://github.com/hashicorp/terraform-provider-azurerm/pull/20426, but never parsed in expandAccountSkuName. After comfirming with the cognitive service team, the `tier` value should not be set for any `sku_name`. In fact, to avoid customer mistakenly passing tier value, service team will remove all other properties in block `sku` and only keep the `sku_name`.

I think the simplest way to address this issue is to just remove `tier` value from provider. 

Testing evidience:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/17947406/cda5a105-b2ca-4b78-a921-10f8ac53ee0a)
