### PR TITLE
doc: Add note about instant_restore_retention_days

### DIFF
--- a/website/docs/r/backup_policy_vm.html.markdown
+++ b/website/docs/r/backup_policy_vm.html.markdown
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 * `instant_restore_retention_days` - (Optional) Specifies the instant restore retention range in days. Possible values are between `1` and `5` when `policy_type` is `V1`, and `1` to `30` when `policy_type` is `V2`.
 
+~> **NOTE:** `instant_restore_retention_days` **must** be set to `5` if the backup frequency is set to `Weekly`.
+
 * `instant_restore_resource_group` - (Optional) Specifies the instant restore resource group name as documented in the `instant_restore_resource_group` block below.
 
 * `retention_daily` - (Optional) Configures the policy daily retention as documented in the `retention_daily` block below. Required when backup frequency is `Daily`.


### PR DESCRIPTION
This is required per the note presented when attempting to create a weekly backup policy in the portal.
See below: 
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/42228088/73653a03-7c57-4aba-9950-b239163197c1)

Otherwise, this ever-present vague error will be presented (taken from activity log):
```
"statusMessage": "{\"error\":{\"code\":\"BMSUserErrorInvalidPolicyInput\",\"message\":\"Input for create or update policy is not in proper format. Please check format of parameters like schedule time, schedule days, retention time and retention days \"}}",
```

This applies to both V1 and V2 policies.