### PR TITLE
New data source `azurerm_ip_groups`

### DIFF
--- a/internal/services/network/ip_group_resource_test.go
+++ b/internal/services/network/ip_group_resource_test.go
@@ -208,6 +208,32 @@ resource "azurerm_ip_group" "test" {
     cost_center = "MSFT"
   }
 }
+
+resource "azurerm_ip_group" "test2" {
+  name                = "acceptanceTestIpGroup2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["192.168.0.1", "172.16.240.0/20", "10.48.0.0/12"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+resource "azurerm_ip_group" "test3" {
+  name                = "acceptanceTestIpGroup3"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["192.168.0.1", "172.16.240.0/20", "10.48.0.0/12"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
 `, data.RandomInteger, data.Locations.Primary)
 }
 
@@ -311,7 +337,6 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
     }
   }
 }
-
 
 resource "azurerm_virtual_network" "test" {
   name                = "testvnet"

--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func dataSourceIpGroups() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceIpGroupsRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"location": commonschema.LocationComputed(),
+
+			"ids": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:      pluginsdk.HashString,
+			},
+
+			"names": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:      pluginsdk.HashString,
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+// Find IDs and names of multiple IP Groups, filtered by name substring
+func dataSourceIpGroupsRead(d *pluginsdk.ResourceData, meta interface{}) error {
+
+	// Establish a client to handle i/o operations against the API
+	client := meta.(*clients.Client).Network.IPGroupsClient
+
+	// Create a context for the request and defer cancellation
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	// Make the request to the API to download all IP groups in the resource group
+	allGroups, err := client.ListByResourceGroup(ctx, d.Get("resource_group_name").(string))
+	if err != nil {
+		return fmt.Errorf("error listing IP groups: %+v", err)
+	}
+
+	// Establish lists of strings to append to, set equal to empty set to start
+	// If no IP groups are found, an empty set will be returned
+	names := []string{}
+	ids := []string{}
+
+	// Filter IDs list by substring
+	for _, ipGroup := range allGroups.Values() {
+		if ipGroup.Name != nil && strings.Contains(*ipGroup.Name, d.Get("name").(string)) {
+			names = append(names, *ipGroup.Name)
+			ids = append(ids, *ipGroup.ID)
+		}
+	}
+
+	// Sort lists of strings alphabetically
+	slices.Sort(names)
+	slices.Sort(ids)
+
+	// Set names
+	err = d.Set("names", names)
+	if err != nil {
+		return fmt.Errorf("error setting names: %+v", err)
+	}
+	//fmt.Println("Names set as: ", d.Get("names").(*schema.Set).List())
+
+	// Set IDs
+	err = d.Set("ids", ids)
+	if err != nil {
+		return fmt.Errorf("error setting ids: %+v", err)
+	}
+	//fmt.Println("IDs set as: ", d.Get("ids").(*schema.Set).List())
+
+	// Return nil error
+	return nil
+
+}

--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -92,7 +92,7 @@ func dataSourceIpGroupsRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	// Set resource ID, required for Terraform state
 	// Since this is a multi-resource data source, we need to create a unique ID
-	// Using the internal ID of the resource
+	// Using the ID of the resource group
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	id := commonids.NewResourceGroupID(subscriptionId, resourceGroupName)
 	d.SetId(id.ID())

--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -91,14 +91,12 @@ func dataSourceIpGroupsRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error setting names: %+v", err)
 	}
-	//fmt.Println("Names set as: ", d.Get("names").(*schema.Set).List())
 
 	// Set IDs
 	err = d.Set("ids", ids)
 	if err != nil {
 		return fmt.Errorf("error setting ids: %+v", err)
 	}
-	//fmt.Println("IDs set as: ", d.Get("ids").(*schema.Set).List())
 
 	// Return nil error
 	return nil

--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -36,17 +36,15 @@ func dataSourceIpGroups() *pluginsdk.Resource {
 			"location": commonschema.LocationComputed(),
 
 			"ids": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:      pluginsdk.HashString,
 			},
 
 			"names": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:      pluginsdk.HashString,
 			},
 
 			"tags": tags.SchemaDataSource(),

--- a/internal/services/network/ip_groups_data_source_test.go
+++ b/internal/services/network/ip_groups_data_source_test.go
@@ -13,14 +13,13 @@ import (
 
 type IPGroupsDataSource struct{}
 
-// Basic == No results, returns empty list
-func TestAccDataSourceIPGroups_basic(t *testing.T) {
+func TestAccDataSourceIPGroups_noResults(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
 	r := IPGroupsDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.noResults(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("ids.#").HasValue("0"),
 				check.That(data.ResourceName).Key("names.#").HasValue("0"),
@@ -60,13 +59,16 @@ func TestAccDataSourceIPGroups_multiple(t *testing.T) {
 }
 
 // Find IP group which doesn't exist
-func (IPGroupsDataSource) basic(data acceptance.TestData) string {
+func (IPGroupsDataSource) noResults(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_ip_groups" "test" {
   name                = "doesNotExist"
   resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_ip_group.test,
+  ]
 }
 `, IPGroupResource{}.basic(data))
 }
@@ -79,6 +81,9 @@ func (IPGroupsDataSource) single(data acceptance.TestData) string {
 data "azurerm_ip_groups" "test" {
   name                = "acceptanceTestIpGroup1"
   resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_ip_group.test,
+  ]
 }
 `, IPGroupResource{}.basic(data))
 }
@@ -91,6 +96,11 @@ func (IPGroupsDataSource) multiple(data acceptance.TestData) string {
 data "azurerm_ip_groups" "test" {
   name                = "acceptanceTestIpGroup"
   resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_ip_group.test,
+    azurerm_ip_group.test2,
+    azurerm_ip_group.test3,
+  ]
 }
 `, IPGroupResource{}.complete(data))
 }

--- a/internal/services/network/ip_groups_data_source_test.go
+++ b/internal/services/network/ip_groups_data_source_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type IPGroupsDataSource struct{}
+
+func TestAccDataSourceIPGroups_noResults(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
+	r := IPGroupsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.noResults(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("ids.#").HasValue("0"),
+				check.That(data.ResourceName).Key("names.#").HasValue("0"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceIPGroups_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
+	r := IPGroupsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("names.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceIPGroups_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
+	r := IPGroupsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("ids.#").HasValue("2"),
+				check.That(data.ResourceName).Key("names.#").HasValue("2"),
+			),
+		},
+	})
+}
+
+// Find IP group which doesn't exist
+func (IPGroupsDataSource) noResults(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_ip_groups" "test" {
+  name                = "doesNotExist"
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, IPGroupResource{}.basic(data))
+}
+
+// Find single IP group
+func (IPGroupsDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_ip_groups" "test" {
+  name                = "acceptanceTestIpGroup1"
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, IPGroupResource{}.basic(data))
+}
+
+// Find multiple IP Groups, filtered by name substring
+func (IPGroupsDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_ip_groups" "test" {
+  name                = "acceptanceTestIpGroup"
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, IPGroupResource{}.complete(data))
+}

--- a/internal/services/network/ip_groups_data_source_test.go
+++ b/internal/services/network/ip_groups_data_source_test.go
@@ -28,13 +28,13 @@ func TestAccDataSourceIPGroups_noResults(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceIPGroups_basic(t *testing.T) {
+func TestAccDataSourceIPGroups_single(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
 	r := IPGroupsDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.single(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("ids.#").HasValue("1"),
 				check.That(data.ResourceName).Key("names.#").HasValue("1"),
@@ -43,13 +43,13 @@ func TestAccDataSourceIPGroups_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceIPGroups_complete(t *testing.T) {
+func TestAccDataSourceIPGroups_multiple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
 	r := IPGroupsDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.multiple(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("ids.#").HasValue("2"),
 				check.That(data.ResourceName).Key("names.#").HasValue("2"),
@@ -71,7 +71,7 @@ data "azurerm_ip_groups" "test" {
 }
 
 // Find single IP group
-func (IPGroupsDataSource) basic(data acceptance.TestData) string {
+func (IPGroupsDataSource) single(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -83,7 +83,7 @@ data "azurerm_ip_groups" "test" {
 }
 
 // Find multiple IP Groups, filtered by name substring
-func (IPGroupsDataSource) complete(data acceptance.TestData) string {
+func (IPGroupsDataSource) multiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/network/ip_groups_data_source_test.go
+++ b/internal/services/network/ip_groups_data_source_test.go
@@ -13,13 +13,14 @@ import (
 
 type IPGroupsDataSource struct{}
 
-func TestAccDataSourceIPGroups_noResults(t *testing.T) {
+// Basic == No results, returns empty list
+func TestAccDataSourceIPGroups_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
 	r := IPGroupsDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.noResults(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("ids.#").HasValue("0"),
 				check.That(data.ResourceName).Key("names.#").HasValue("0"),
@@ -51,15 +52,15 @@ func TestAccDataSourceIPGroups_multiple(t *testing.T) {
 		{
 			Config: r.multiple(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("ids.#").HasValue("2"),
-				check.That(data.ResourceName).Key("names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("ids.#").HasValue("3"),
+				check.That(data.ResourceName).Key("names.#").HasValue("3"),
 			),
 		},
 	})
 }
 
 // Find IP group which doesn't exist
-func (IPGroupsDataSource) noResults(data acceptance.TestData) string {
+func (IPGroupsDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -66,6 +66,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_bastion_host":                              dataSourceBastionHost(),
 		"azurerm_express_route_circuit":                     dataSourceExpressRouteCircuit(),
 		"azurerm_ip_group":                                  dataSourceIpGroup(),
+		"azurerm_ip_groups":                                 dataSourceIpGroups(),
 		"azurerm_nat_gateway":                               dataSourceNatGateway(),
 		"azurerm_network_ddos_protection_plan":              dataSourceNetworkDDoSProtectionPlan(),
 		"azurerm_network_interface":                         dataSourceNetworkInterface(),

--- a/website/docs/d/ip_groups.html.markdown
+++ b/website/docs/d/ip_groups.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about existing IP Groups.
 
 ```hcl
 data "azurerm_ip_groups" "example" {
-  name = "existing"
+  name                = "existing"
   resource_group_name = "existing"
 }
 

--- a/website/docs/d/ip_groups.html.markdown
+++ b/website/docs/d/ip_groups.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_ip_groups"
+description: |-
+  Gets information about existing IP Groups.
+---
+
+# Data Source: azurerm_ip_groups
+
+Use this data source to access information about existing IP Groups.
+
+## Example Usage
+
+```hcl
+data "azurerm_ip_groups" "example" {
+  name = "existing" # Can be a substring to match multiple IP Groups
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_ip_groups.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A substring to match some number of IP Groups.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the IP Groups exist.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `ids` - A list of IP Group IDs.
+
+* `names` - A list of IP Group Names.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 10 minutes) Used when retrieving the IP Groups.

--- a/website/docs/d/ip_groups.html.markdown
+++ b/website/docs/d/ip_groups.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about existing IP Groups.
 
 ```hcl
 data "azurerm_ip_groups" "example" {
-  name = "existing" # Can be a substring to match multiple IP Groups
+  name = "existing"
   resource_group_name = "existing"
 }
 


### PR DESCRIPTION
`azurerm_ip_group` data source only permits fetching the info of one data source. This data intends to fetch the data from multiple IP Groups within a resource group by using the `name` attribute as a substring match. 

Tests passing:
```
❯ make acctests SERVICE='network' TESTARGS='-run=TestAccDataSourceIPGroups_' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccDataSourceIPGroups_ -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceIPGroups_noResults
=== PAUSE TestAccDataSourceIPGroups_noResults
=== RUN   TestAccDataSourceIPGroups_single
=== PAUSE TestAccDataSourceIPGroups_single
=== RUN   TestAccDataSourceIPGroups_multiple
=== PAUSE TestAccDataSourceIPGroups_multiple
=== CONT  TestAccDataSourceIPGroups_noResults
=== CONT  TestAccDataSourceIPGroups_multiple
=== CONT  TestAccDataSourceIPGroups_single
--- PASS: TestAccDataSourceIPGroups_multiple (49.75s)
--- PASS: TestAccDataSourceIPGroups_noResults (112.59s)
--- PASS: TestAccDataSourceIPGroups_single (112.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/network	116.525s
```