### PR TITLE
`azurerm_elastic_cloud_elasticsearch`: fixed the issue where the `ess-monthly-conspiration_Monthly`  of  `sku_name` is defined as stop sell

### DIFF
--- a/internal/services/elastic/elasticsearch_resource_test.go
+++ b/internal/services/elastic/elasticsearch_resource_test.go
@@ -207,7 +207,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-estc%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
 
   tags = {
@@ -232,7 +232,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-estc%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
   monitoring_enabled          = false
 
@@ -258,7 +258,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-estc%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
 
   logs {
@@ -292,7 +292,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-estc%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
 
   logs {

--- a/internal/services/elastic/elasticsearch_resource_test.go
+++ b/internal/services/elastic/elasticsearch_resource_test.go
@@ -172,7 +172,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-estc%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -660,7 +660,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   name                        = "acctest-elastic%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  sku_name                    = "ess-monthly-consumption_Monthly"
+  sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "user@example.com"
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-03-01/virtualmachineruncommands/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-03-01/virtualmachineruncommands/method_list.go
@@ -19,7 +19,8 @@ type ListOperationResponse struct {
 }
 
 type ListCompleteResult struct {
-	Items []RunCommandDocumentBase
+	LatestHttpResponse *http.Response
+	Items              []RunCommandDocumentBase
 }
 
 // List ...
@@ -83,7 +84,8 @@ func (c VirtualMachineRunCommandsClient) ListCompleteMatchingPredicate(ctx conte
 	}
 
 	result = ListCompleteResult{
-		Items: items,
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
 	}
 	return
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-03-01/virtualmachineruncommands/method_listbyvirtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-03-01/virtualmachineruncommands/method_listbyvirtualmachine.go
@@ -19,7 +19,8 @@ type ListByVirtualMachineOperationResponse struct {
 }
 
 type ListByVirtualMachineCompleteResult struct {
-	Items []VirtualMachineRunCommand
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineRunCommand
 }
 
 type ListByVirtualMachineOperationOptions struct {
@@ -111,7 +112,8 @@ func (c VirtualMachineRunCommandsClient) ListByVirtualMachineCompleteMatchingPre
 	}
 
 	result = ListByVirtualMachineCompleteResult{
-		Items: items,
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
 	}
 	return
 }


### PR DESCRIPTION
All [test cases](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_ELASTIC/87898?buildTab=tests) in teamcity for Elastic RP are failing due to the sku name `ess-monthly-consumption_Monthly` is defined as stop sell issue. Submit this PR to update the `sku_name` for test cases to fix this error. Also, fix the same error for test case [TestAccMonitorDiagnosticSetting_partnerSolution](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MONITOR/87978?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true&expandBuildDeploymentsSection=false).

Test results:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/0dc5dde1-94d1-4bec-8be3-5dbeed323edd)


