### PR TITLE
`azurerm_service_plan` - Fix import spec 

### DIFF
--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -91,5 +91,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 AppServices can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_service_plan.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/farm1
+terraform import azurerm_service_plan.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/farm1
 ```


### PR DESCRIPTION
The `serverFarms` is parsed case sensitively after migrating to go-azure-sdk.