### PR TITLE
`azurerm_linux_virtual_machine_scale_set` - Fix testcases for VMSS Network Security Group Update

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
@@ -1320,6 +1320,10 @@ resource "azurerm_network_security_group" "test" {
   name                = "acctestnsg-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -1368,12 +1372,20 @@ resource "azurerm_network_security_group" "test" {
   name                = "acctestnsg-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_network_security_group" "other" {
   name                = "acctestnsg2-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
@@ -1295,6 +1295,10 @@ resource "azurerm_network_security_group" "test" {
   name                = "acctestnsg-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
@@ -1341,12 +1345,20 @@ resource "azurerm_network_security_group" "test" {
   name                = "acctestnsg-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_network_security_group" "other" {
   name                = "acctestnsg2-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {


### PR DESCRIPTION
## Test Result

=== RUN   TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate (544.80s)
PASS


=== RUN   TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate (585.00s)
PASS