### PR TITLE
`azurerm_app_service_plan` - fix casing in `serverFarms`

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -548,7 +548,11 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if props := resp.SiteProperties; props != nil {
-		d.Set("app_service_plan_id", props.ServerFarmID)
+		servicePlanId, err := commonids.ParseAppServicePlanIDInsensitively(*props.ServerFarmID)
+		if err != nil {
+			return err
+		}
+		d.Set("app_service_plan_id", servicePlanId.ID())
 		d.Set("enabled", props.Enabled)
 		d.Set("default_hostname", props.DefaultHostName)
 		d.Set("https_only", props.HTTPSOnly)

--- a/internal/services/web/app_service_plan_data_source.go
+++ b/internal/services/web/app_service_plan_data_source.go
@@ -111,7 +111,7 @@ func AppServicePlanDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	id := parse.NewAppServicePlanID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		return fmt.Errorf("making Read request on %s: %+v", id, err)
 	}
@@ -122,7 +122,7 @@ func AppServicePlanDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	d.SetId(id.ID())
 
-	d.Set("name", id.ServerfarmName)
+	d.Set("name", id.ServerFarmName)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("kind", resp.Kind)
 

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -5,7 +5,6 @@ package web
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/migration"
 	"log"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -5,6 +5,7 @@ package web
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/migration"
 	"log"
 	"strings"
 	"time"
@@ -43,6 +44,12 @@ func resourceAppServicePlan() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
+
+		SchemaVersion: 1,
+
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.AppServicePlanV0toV1{},
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -155,7 +162,7 @@ func resourceAppServicePlanCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	id := parse.NewAppServicePlanID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+		existing, err := client.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
@@ -220,7 +227,7 @@ func resourceAppServicePlanCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		appServicePlan.AppServicePlanProperties.Reserved = utils.Bool(reserved)
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServerfarmName, appServicePlan)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServerFarmName, appServicePlan)
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
@@ -244,26 +251,26 @@ func resourceAppServicePlanRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] App Service Plan %q was not found in Resource Group %q - removnig from state!", id.ServerfarmName, id.ResourceGroup)
+			log.Printf("[DEBUG] App Service Plan %q was not found in Resource Group %q - removnig from state!", id.ServerFarmName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("making Read request on App Service Plan %q (Resource Group %q): %+v", id.ServerfarmName, id.ResourceGroup, err)
+		return fmt.Errorf("making Read request on App Service Plan %q (Resource Group %q): %+v", id.ServerFarmName, id.ResourceGroup, err)
 	}
 
 	// A 404 doesn't error from the app service plan sdk so we'll add this check here to catch resource not found responses
 	// TODO This block can be removed if https://github.com/Azure/azure-sdk-for-go/issues/5407 gets addressed.
 	if utils.ResponseWasNotFound(resp.Response) {
-		log.Printf("[DEBUG] App Service Plan %q was not found in Resource Group %q - removing from state!", id.ServerfarmName, id.ResourceGroup)
+		log.Printf("[DEBUG] App Service Plan %q was not found in Resource Group %q - removing from state!", id.ServerFarmName, id.ResourceGroup)
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("name", id.ServerfarmName)
+	d.Set("name", id.ServerFarmName)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -312,12 +319,12 @@ func resourceAppServicePlanDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting App Service Plan %q (Resource Group %q)", id.ServerfarmName, id.ResourceGroup)
+	log.Printf("[DEBUG] Deleting App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.ServerfarmName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp) {
-			return fmt.Errorf("deleting App Service Plan %q (Resource Group %q): %+v", id.ServerfarmName, id.ResourceGroup, err)
+			return fmt.Errorf("deleting App Service Plan %q (Resource Group %q): %+v", id.ServerFarmName, id.ResourceGroup, err)
 		}
 	}
 

--- a/internal/services/web/app_service_plan_resource_test.go
+++ b/internal/services/web/app_service_plan_resource_test.go
@@ -243,12 +243,12 @@ func (r AppServicePlanResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+	resp, err := clients.Web.AppServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retrieving App Service Plan %q (Resource Group %q): %+v", id.ServerfarmName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving App Service Plan %q (Resource Group %q): %+v", id.ServerFarmName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -259,10 +259,10 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 	// Check if App Service Plan is part of ASE
 	// If so, the name needs updating to <app name>.<ASE name>.appserviceenvironment.net and FQDN setting true for name availability check
-	aspDetails, err := aspClient.Get(ctx, aspID.ResourceGroup, aspID.ServerfarmName)
+	aspDetails, err := aspClient.Get(ctx, aspID.ResourceGroup, aspID.ServerFarmName)
 	// 404 is incorrectly being considered an acceptable response, issue tracked at https://github.com/Azure/azure-sdk-for-go/issues/15002
 	if err != nil || utils.ResponseWasNotFound(aspDetails.Response) {
-		return fmt.Errorf("App Service Environment %q or Resource Group %q does not exist", aspID.ServerfarmName, aspID.ResourceGroup)
+		return fmt.Errorf("App Service Environment %q or Resource Group %q does not exist", aspID.ServerFarmName, aspID.ResourceGroup)
 	}
 	if aspDetails.HostingEnvironmentProfile != nil {
 		availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s.appserviceenvironment.net", id.SiteName, *aspDetails.HostingEnvironmentProfile.Name))

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -367,10 +367,10 @@ func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, met
 		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", appServicePlanId, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerfarmName, id.ResourceGroup)
+	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
 
 	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClient
-	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanId, err)
 	}

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -68,10 +68,9 @@ func resourceFunctionAppSlot() *pluginsdk.Resource {
 			},
 
 			"app_service_plan_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: webValidate.AppServicePlanID,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"version": {

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -689,10 +689,10 @@ func getFunctionAppSlotServiceTier(ctx context.Context, appServicePlanID string,
 		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", appServicePlanID, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerfarmName, id.ResourceGroup)
+	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
 
 	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClient
-	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerfarmName)
+	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanID, err)
 	}

--- a/internal/services/web/migration/app_service_plan.go
+++ b/internal/services/web/migration/app_service_plan.go
@@ -1,0 +1,125 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type AppServicePlanV0toV1 struct{}
+
+var _ pluginsdk.StateUpgrade = AppServicePlanV0toV1{}
+
+func (a AppServicePlanV0toV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"kind": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "Windows",
+			ForceNew: true,
+		},
+
+		"sku": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"tier": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"size": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"capacity": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		// / AppServicePlanProperties
+		"app_service_environment_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"per_site_scaling": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"reserved": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"maximum_elastic_worker_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+
+		"maximum_number_of_workers": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"is_xenon": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"zone_redundant": {
+			Type:     pluginsdk.TypeBool,
+			ForceNew: true,
+			Optional: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (a AppServicePlanV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := commonids.ParseAppServicePlanIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/web/parse/app_service_plan.go
+++ b/internal/services/web/parse/app_service_plan.go
@@ -15,20 +15,20 @@ import (
 type AppServicePlanId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	ServerfarmName string
+	ServerFarmName string
 }
 
-func NewAppServicePlanID(subscriptionId, resourceGroup, serverfarmName string) AppServicePlanId {
+func NewAppServicePlanID(subscriptionId, resourceGroup, serverFarmName string) AppServicePlanId {
 	return AppServicePlanId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		ServerfarmName: serverfarmName,
+		ServerFarmName: serverFarmName,
 	}
 }
 
 func (id AppServicePlanId) String() string {
 	segments := []string{
-		fmt.Sprintf("Serverfarm Name %q", id.ServerfarmName),
+		fmt.Sprintf("Server Farm Name %q", id.ServerFarmName),
 		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
 	segmentsStr := strings.Join(segments, " / ")
@@ -36,8 +36,8 @@ func (id AppServicePlanId) String() string {
 }
 
 func (id AppServicePlanId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/serverfarms/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ServerfarmName)
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/serverFarms/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ServerFarmName)
 }
 
 // AppServicePlanID parses a AppServicePlan ID into an AppServicePlanId struct
@@ -60,7 +60,7 @@ func AppServicePlanID(input string) (*AppServicePlanId, error) {
 		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
 	}
 
-	if resourceId.ServerfarmName, err = id.PopSegment("serverfarms"); err != nil {
+	if resourceId.ServerFarmName, err = id.PopSegment("serverFarms"); err != nil {
 		return nil, err
 	}
 

--- a/internal/services/web/parse/app_service_plan_test.go
+++ b/internal/services/web/parse/app_service_plan_test.go
@@ -15,7 +15,7 @@ var _ resourceids.Id = AppServicePlanId{}
 
 func TestAppServicePlanIDFormatter(t *testing.T) {
 	actual := NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "resGroup1", "farm1").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/farm1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/farm1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -59,24 +59,24 @@ func TestAppServicePlanID(t *testing.T) {
 		},
 
 		{
-			// missing ServerfarmName
+			// missing ServerFarmName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/",
 			Error: true,
 		},
 
 		{
-			// missing value for ServerfarmName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/",
+			// missing value for ServerFarmName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/farm1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/farm1",
 			Expected: &AppServicePlanId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
-				ServerfarmName: "farm1",
+				ServerFarmName: "farm1",
 			},
 		},
 
@@ -108,8 +108,8 @@ func TestAppServicePlanID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.ServerfarmName != v.Expected.ServerfarmName {
-			t.Fatalf("Expected %q but got %q for ServerfarmName", v.Expected.ServerfarmName, actual.ServerfarmName)
+		if actual.ServerFarmName != v.Expected.ServerFarmName {
+			t.Fatalf("Expected %q but got %q for ServerFarmName", v.Expected.ServerFarmName, actual.ServerFarmName)
 		}
 	}
 }

--- a/internal/services/web/resourceids.go
+++ b/internal/services/web/resourceids.go
@@ -21,4 +21,4 @@ package web
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkSwiftConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/config/virtualNetwork
 
 // @tombuildsstuff: this is going to require a State Migration to account for `serverfarms` -> `serverFarms` prior to migrating to `hashicorp/go-azure-sdk`
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppServicePlan -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/farm1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppServicePlan -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/farm1

--- a/internal/services/web/validate/app_service_plan_id_test.go
+++ b/internal/services/web/validate/app_service_plan_id_test.go
@@ -44,20 +44,20 @@ func TestAppServicePlanID(t *testing.T) {
 		},
 
 		{
-			// missing ServerfarmName
+			// missing ServerFarmName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/",
 			Valid: false,
 		},
 
 		{
-			// missing value for ServerfarmName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/",
+			// missing value for ServerFarmName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverfarms/farm1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/serverFarms/farm1",
 			Valid: true,
 		},
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -162,5 +162,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 App Service Plan instances can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_service_plan.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverfarms/instance1
+terraform import azurerm_app_service_plan.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverFarms/instance1
 ```


### PR DESCRIPTION
* `azurerm_logic_app_standard` - fix read function to parse app service ID insensitively
* `azurerm_app_service_plan` - fix casing in `serverFarms` due to ID update

closes #24560 