### PR TITLE
`azurerm_storage_table_entity`: fix entity data type logic

### DIFF
--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -239,10 +239,9 @@ func flattenEntity(entity map[string]interface{}) map[string]interface{} {
 				result[k] = fmt.Sprint(v)
 			case "Edm.Double":
 				result[k] = fmt.Sprintf("%f", v)
-			case "Edm.Int32":
-				fallthrough
-			case "Edm.Int64":
-				result[k] = fmt.Sprintf("%d", int64(v.(float64)))
+			case "Edm.Int32", "Edm.Int64":
+				// `v` returned as string for int 64
+				result[k] = fmt.Sprint(v)
 			case "Edm.String":
 				result[k] = v
 			default:
@@ -264,7 +263,8 @@ func flattenEntity(entity map[string]interface{}) map[string]interface{} {
 					result[k] = fmt.Sprintf("%d", int64(f64))
 					result[k+"@odata.type"] = "Edm.Int32"
 				} else {
-					result[k] = fmt.Sprintf("%f", v)
+					// fmt.Sprintf("%f", v) will return `123.123000` for `123.123`, have to use fmt.Sprint
+					result[k] = fmt.Sprint(v)
 					result[k+"@odata.type"] = "Edm.Double"
 				}
 			case string:

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -280,7 +280,7 @@ resource "azurerm_storage_table_entity" "test" {
     Test             = "Updated"
   }
   lifecycle {
-	ignore_changes = [entity]
+    ignore_changes = [entity]
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -73,7 +73,6 @@ func TestAccTableEntity_update(t *testing.T) {
 func TestAccTableEntity_update_typed(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_table_entity", "test")
 	r := StorageTableEntityResource{}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -89,6 +88,30 @@ func TestAccTableEntity_update_typed(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.updated_typedInt64(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updated_typedDouble(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updated_typedString(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updated_typedBoolean(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 	})
 }
 
@@ -194,6 +217,89 @@ resource "azurerm_storage_table_entity" "test" {
   entity = {
     Foo              = 123
     "Foo@odata.type" = "Edm.Int32"
+    Test             = "Updated"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StorageTableEntityResource) updated_typedInt64(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_account_name = azurerm_storage_account.test.name
+  table_name           = azurerm_storage_table.test.name
+
+  partition_key = "test_partition%d"
+  row_key       = "test_row%d"
+  entity = {
+    Foo              = 123
+    "Foo@odata.type" = "Edm.Int64"
+    Test             = "Updated"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StorageTableEntityResource) updated_typedDouble(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_account_name = azurerm_storage_account.test.name
+  table_name           = azurerm_storage_table.test.name
+
+  partition_key = "test_partition%d"
+  row_key       = "test_row%d"
+  entity = {
+    Foo              = 123.123
+    "Foo@odata.type" = "Edm.Double"
+    Test             = "Updated"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StorageTableEntityResource) updated_typedString(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_account_name = azurerm_storage_account.test.name
+  table_name           = azurerm_storage_table.test.name
+
+  partition_key = "test_partition%d"
+  row_key       = "test_row%d"
+  entity = {
+    Foo              = "123.123"
+    "Foo@odata.type" = "Edm.String"
+    Test             = "Updated"
+  }
+  lifecycle {
+	ignore_changes = [entity]
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StorageTableEntityResource) updated_typedBoolean(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_account_name = azurerm_storage_account.test.name
+  table_name           = azurerm_storage_table.test.name
+
+  partition_key = "test_partition%d"
+  row_key       = "test_row%d"
+  entity = {
+    Foo              = "true"
+    "Foo@odata.type" = "Edm.Boolean"
     Test             = "Updated"
   }
 }


### PR DESCRIPTION
fix #24538.

The data type field may not be returned by the API, and the returned actual data type can vary.

```
--- PASS: TestAccTableEntity_update_typed (254.71s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       254.719s
```
