### PR TITLE
Fix examples/virtual-machines/linux/basic-password/ undefined variables error

### DIFF
--- a/examples/virtual-machines/linux/basic-password/variables.tf
+++ b/examples/virtual-machines/linux/basic-password/variables.tf
@@ -8,3 +8,11 @@ variable "prefix" {
 variable "location" {
   description = "The Azure Region in which all resources in this example should be created."
 }
+
+variable "admin_username" {
+  description = "The admin username for the VM being created."
+}
+
+variable "admin_password" {
+  description = "The password for the VM being created."
+}


### PR DESCRIPTION
In the example found in examples/virtual-machines/linux/basic-password/main.tf references two variables (var.username
& var.password) that are not defined, which causes an error. This patch defines those variables in examples/virtual-machines/linux/basic-password/variables.tf to avoid the error.