### PR TITLE
Update vendors with latest go-sdk

### DIFF
--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/id_provideropenshiftcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/id_provideropenshiftcluster.go
@@ -10,7 +10,7 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-var _ resourceids.ResourceId = ProviderOpenShiftClusterId{}
+var _ resourceids.ResourceId = &ProviderOpenShiftClusterId{}
 
 // ProviderOpenShiftClusterId is a struct representing the Resource ID for a Provider Open Shift Cluster
 type ProviderOpenShiftClusterId struct {
@@ -30,7 +30,7 @@ func NewProviderOpenShiftClusterID(subscriptionId string, resourceGroupName stri
 
 // ParseProviderOpenShiftClusterID parses 'input' into a ProviderOpenShiftClusterId
 func ParseProviderOpenShiftClusterID(input string) (*ProviderOpenShiftClusterId, error) {
-	parser := resourceids.NewParserFromResourceIdType(ProviderOpenShiftClusterId{})
+	parser := resourceids.NewParserFromResourceIdType(&ProviderOpenShiftClusterId{})
 	parsed, err := parser.Parse(input, false)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)
@@ -47,7 +47,7 @@ func ParseProviderOpenShiftClusterID(input string) (*ProviderOpenShiftClusterId,
 // ParseProviderOpenShiftClusterIDInsensitively parses 'input' case-insensitively into a ProviderOpenShiftClusterId
 // note: this method should only be used for API response data and not user input
 func ParseProviderOpenShiftClusterIDInsensitively(input string) (*ProviderOpenShiftClusterId, error) {
-	parser := resourceids.NewParserFromResourceIdType(ProviderOpenShiftClusterId{})
+	parser := resourceids.NewParserFromResourceIdType(&ProviderOpenShiftClusterId{})
 	parsed, err := parser.Parse(input, true)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/method_list.go
@@ -20,7 +20,8 @@ type ListOperationResponse struct {
 }
 
 type ListCompleteResult struct {
-	Items []OpenShiftCluster
+	LatestHttpResponse *http.Response
+	Items              []OpenShiftCluster
 }
 
 // List ...
@@ -84,7 +85,8 @@ func (c OpenShiftClustersClient) ListCompleteMatchingPredicate(ctx context.Conte
 	}
 
 	result = ListCompleteResult{
-		Items: items,
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
 	}
 	return
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/method_listbyresourcegroup.go
@@ -20,7 +20,8 @@ type ListByResourceGroupOperationResponse struct {
 }
 
 type ListByResourceGroupCompleteResult struct {
-	Items []OpenShiftCluster
+	LatestHttpResponse *http.Response
+	Items              []OpenShiftCluster
 }
 
 // ListByResourceGroup ...
@@ -84,7 +85,8 @@ func (c OpenShiftClustersClient) ListByResourceGroupCompleteMatchingPredicate(ct
 	}
 
 	result = ListByResourceGroupCompleteResult{
-		Items: items,
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
 	}
 	return
 }


### PR DESCRIPTION
It looks like the SDK was updated on Jan 18th 2024 (3 days ago), and Openshift changes with vendor landed on Jan 19th. It was very likely the case that the openshift vendor changes were not regenerated when the SDK changed and the new resource was merged here https://github.com/hashicorp/terraform-provider-azurerm/pull/24375.

This commit updates the vendors directory with latest changes (**changes generated by running** `make depscheck`).


**Current build error on main**
```shell
terraform-provider-azurerm $ make build
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
go generate ./internal/services/...
go generate ./internal/provider/
# github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters
../../vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/id_provideropenshiftcluster.go:13:32: cannot use ProviderOpenShiftClusterId{} (value of type ProviderOpenShiftClusterId) as resourceids.ResourceId value in variable declaration: ProviderOpenShiftClusterId does not implement resourceids.ResourceId (method FromParseResult has pointer receiver)
../../vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/id_provideropenshiftcluster.go:33:52: cannot use ProviderOpenShiftClusterId{} (value of type ProviderOpenShiftClusterId) as resourceids.ResourceId value in argument to resourceids.NewParserFromResourceIdType: ProviderOpenShiftClusterId does not implement resourceids.ResourceId (method FromParseResult has pointer receiver)
../../vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/id_provideropenshiftcluster.go:50:52: cannot use ProviderOpenShiftClusterId{} (value of type ProviderOpenShiftClusterId) as resourceids.ResourceId value in argument to resourceids.NewParserFromResourceIdType: ProviderOpenShiftClusterId does not implement resourceids.ResourceId (method FromParseResult has pointer receiver)
internal/provider/services.go:135: running "go": exit status 1
make: *** [generate] Error 1
```

**`make build` after updating vendors**
```shell
terraform-provider-azurerm $ make build
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
go generate ./internal/services/...
go generate ./internal/provider/
go install
```