### PR TITLE
add `azurerm_nginx_certificate` data source

### DIFF
--- a/internal/services/nginx/nginx_certificate_data_source.go
+++ b/internal/services/nginx/nginx_certificate_data_source.go
@@ -1,0 +1,118 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package nginx
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2023-04-01/nginxcertificate"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2023-04-01/nginxdeployment"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type CertificateDataSourceModel struct {
+	Name                   string `tfschema:"name"`
+	NginxDeploymentId      string `tfschema:"nginx_deployment_id"`
+	KeyVirtualPath         string `tfschema:"key_virtual_path"`
+	CertificateVirtualPath string `tfschema:"certificate_virtual_path"`
+	KeyVaultSecretId       string `tfschema:"key_vault_secret_id"`
+}
+
+type CertificateDataSource struct{}
+
+var _ sdk.DataSource = CertificateDataSource{}
+
+func (m CertificateDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"nginx_deployment_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: nginxdeployment.ValidateNginxDeploymentID,
+		},
+	}
+}
+
+func (m CertificateDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"key_virtual_path": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"certificate_virtual_path": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"key_vault_secret_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (m CertificateDataSource) ModelObject() interface{} {
+	return &CertificateDataSourceModel{}
+}
+
+func (m CertificateDataSource) ResourceType() string {
+	return "azurerm_nginx_certificate"
+}
+
+func (m CertificateDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Nginx.NginxCertificate
+			var model CertificateDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+			deploymentId, err := nginxdeployment.ParseNginxDeploymentID(model.NginxDeploymentId)
+			if err != nil {
+				return err
+			}
+			id := nginxcertificate.NewCertificateID(
+				deploymentId.SubscriptionId,
+				deploymentId.ResourceGroupName,
+				deploymentId.NginxDeploymentName,
+				model.Name,
+			)
+			result, err := client.CertificatesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			output := CertificateDataSourceModel{
+				Name:              id.CertificateName,
+				NginxDeploymentId: deploymentId.ID(),
+			}
+
+			if model := result.Model; model != nil {
+				prop := result.Model.Properties
+				output.KeyVirtualPath = pointer.From(prop.KeyVirtualPath)
+				output.KeyVaultSecretId = pointer.From(prop.KeyVaultSecretId)
+				output.CertificateVirtualPath = pointer.From(prop.CertificateVirtualPath)
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&output)
+		},
+	}
+}

--- a/internal/services/nginx/nginx_certificate_data_source_test.go
+++ b/internal/services/nginx/nginx_certificate_data_source_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package nginx_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type NginxCertificateDataSource struct{}
+
+func TestAccNginxCertificateDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_nginx_certificate", "test")
+	r := NginxCertificateDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_virtual_path").Exists(),
+				check.That(data.ResourceName).Key("key_vault_secret_id").Exists(),
+				check.That(data.ResourceName).Key("key_virtual_path").Exists(),
+			),
+		},
+	})
+}
+
+func (d NginxCertificateDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_nginx_certificate" "test" {
+  name                = azurerm_nginx_certificate.test.name
+  nginx_deployment_id = azurerm_nginx_deployment.test.id
+}
+`, CertificateResource{}.basic(data))
+}

--- a/internal/services/nginx/registration.go
+++ b/internal/services/nginx/registration.go
@@ -31,6 +31,7 @@ func (r Registration) WebsiteCategories() []string {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		DeploymentDataSource{},
+		CertificateDataSource{},
 	}
 }
 

--- a/website/docs/d/nginx_certificate.html.markdown
+++ b/website/docs/d/nginx_certificate.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Nginx"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_nginx_certificate"
+description: |-
+  Gets information about an existing Nginx Certificate.
+---
+
+# Data Source: azurerm_nginx_certificate
+
+Use this data source to access information about an existing Nginx Certificate.
+
+## Example Usage
+
+```hcl
+data "azurerm_nginx_certificate" "example" {
+  name                = "existing"
+  nginx_deployment_id = azurerm_nginx_deployment.example.id
+}
+
+output "id" {
+  value = data.azurerm_nginx_certificate.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Nginx Certificate.
+
+* `nginx_deployment_id` - (Required) The ID of the Nginx Deployment that this certificate is associated with.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Nginx Certificate.
+
+* `certificate_virtual_path` - The path to the certificate file of this certificate.
+
+* `key_virtual_path` - The path to the key file of this certificate.
+
+* `key_vault_secret_id` - The ID of the Key Vault Secret for this certificate.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Certificate.

--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Nginx"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nginx_certificate"
 description: |-
-  Manages a Certificate for an NGinx Deployment.
+  Manages a Certificate for an Nginx Deployment.
 ---
 
 # azurerm_nginx_certificate
@@ -127,7 +127,7 @@ The following arguments are supported:
 
 * `nginx_deployment_id` - (Required) The ID of the Nginx Deployment that this Certificate should be associated with. Changing this forces a new Nginx Certificate to be created.
 
-* `certificate_virtual_path` - (Required) Specify the path to the cert file of this certificate.
+* `certificate_virtual_path` - (Required) Specify the path to the certificate file of this certificate.
 
 * `key_virtual_path` - (Required) Specify the path to the key file of this certificate.
 


### PR DESCRIPTION
```shell
terraform-provider-azurerm $ make acctests SERVICE="nginx" TESTARGS="-run=TestAccNginxCertificateDataSource_basic"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxCertificateDataSource_basic -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxCertificateDataSource_basic
=== PAUSE TestAccNginxCertificateDataSource_basic
=== CONT  TestAccNginxCertificateDataSource_basic
--- PASS: TestAccNginxCertificateDataSource_basic (626.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx	629.577s
```