### PR TITLE
`azurerm_app_configuration_key` - remove `computed` for `value` property

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -86,7 +86,6 @@ func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
 		"value": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
 		},
 		"locked": {
 			Type:     pluginsdk.TypeBool,

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -111,6 +111,27 @@ func TestAccAppConfigurationKey_KVToVault(t *testing.T) {
 	})
 }
 
+func TestAccAppConfigurationKey_basicNoValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
+	r := AppConfigurationKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicNoValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppConfigurationKey_slash(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
 	r := AppConfigurationKeyResource{}
@@ -253,6 +274,19 @@ resource "azurerm_app_configuration_key" "test" {
 `, t.base(data), data.RandomInteger, data.RandomInteger)
 }
 
+func (t AppConfigurationKeyResource) basicNoValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_configuration_key" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  key                    = "acctest-ackey-%d"
+  content_type           = "test"
+  value                  = ""
+}
+`, t.base(data), data.RandomInteger)
+}
+
 func (t AppConfigurationKeyResource) basicNoLabel(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -351,6 +385,11 @@ resource "azurerm_app_configuration_key" "test" {
   type                   = "vault"
   label                  = "acctest-ackeylabel-%d"
   vault_key_reference    = azurerm_key_vault_secret.example.id
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
 `, t.base(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -112,6 +112,12 @@ resource "azurerm_app_configuration_key" "test" {
   depends_on = [
     azurerm_role_assignment.appconf_dataowner
   ]
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
resolves #24565

To unblock updating value to empty string. As a side effect, we need to add `ignore_changes = [value]` if [vault_key_reference](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key#vault_key_reference) is used.