### PR TITLE
Update postgresql_flexible_server.html.markdown

### DIFF
--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -55,7 +55,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   private_dns_zone_name = azurerm_private_dns_zone.example.name
   virtual_network_id    = azurerm_virtual_network.example.id
   resource_group_name   = azurerm_resource_group.example.name
-  depends_on = [azurerm_subnet.example]
+  depends_on            = [azurerm_subnet.example]
 }
 
 resource "azurerm_postgresql_flexible_server" "example" {

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -55,6 +55,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   private_dns_zone_name = azurerm_private_dns_zone.example.name
   virtual_network_id    = azurerm_virtual_network.example.id
   resource_group_name   = azurerm_resource_group.example.name
+  depends_on = [azurerm_subnet.example]
 }
 
 resource "azurerm_postgresql_flexible_server" "example" {


### PR DESCRIPTION
Using the example code from this document on terraform destroy operations the azurerm_subnet will have its DELETE request sent before the azurerm_private_dns_zone_virtual_network_link resource has completed its deletion. 

This results in the error "InUseSubnetCannotBeDeleted" and the azurerm_virtual_network with the azurerm_subnet not being deleted by the terraform destroy command. 

Adding the depends_on forces Terraform to wait until the azurerm_private_dns_zone_virtual_network_link is fully deleted before attempting to delete the azurerm_subnet resource allowing the destroy to complete without error.