### PR TITLE
doc: update role_assignment to reflect how condition and condition_version operate

### DIFF
--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -145,6 +145,8 @@ The following arguments are supported:
 
 * `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created.
 
+~> **NOTE:** If one of `condition` or `condition_version` is set both fields must be present.
+
 * `condition` - (Optional) The condition that limits the resources that the role can be assigned to. Changing this forces a new resource to be created.
 
 * `condition_version` - (Optional) The version of the condition. Possible values are `1.0` or `2.0`. Changing this forces a new resource to be created.


### PR DESCRIPTION
I have updated the documentation to be more clear on the use of `condition` and `condition_version`. Both hinted at as being optional but if you specify `condition` with no `condition_version` you are returned the following error. 

```
"condition": all of `condition,condition_version` must be specified
```

This change makes it clear to developers before they begin using the resource how these two fields interact. 