### PR TITLE
`azurerm_automation_schedule`:  limit `monthly_occurrence` MaxItems to 1

### DIFF
--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -150,6 +150,7 @@ func resourceAutomationSchedule() *pluginsdk.Resource {
 			"monthly_occurrence": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"day": {

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
 
-* `monthly_occurrence` - (Optional) List of `monthly_occurrence` blocks as defined below to specifies occurrences of days within a month. Only valid when frequency is `Month`. The `monthly_occurrence` block supports fields documented below.
+* `monthly_occurrence` - (Optional) One `monthly_occurrence` blocks as defined below to specifies occurrences of days within a month. Only valid when frequency is `Month`. The `monthly_occurrence` block supports fields documented below.
 
 ---
 


### PR DESCRIPTION
fixes #24587.

We can only set one occurrence of weekdays per month in the Azure Portal, , even though the API supports multiple items.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/6c72bb98-7955-4136-8f1d-ac52b1a21e15)
