### PR TITLE
Provider RP registration: register AppConfiguration, DataFactory, SignalRService

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -13,6 +13,7 @@ package resourceproviders
 func Required() map[string]struct{} {
 	// NOTE: Resource Providers in this list are case sensitive
 	return map[string]struct{}{
+		"Microsoft.AppConfiguration":        {},
 		"Microsoft.ApiManagement":           {},
 		"Microsoft.AppPlatform":             {},
 		"Microsoft.Authorization":           {},
@@ -30,6 +31,7 @@ func Required() map[string]struct{} {
 		"Microsoft.CostManagement":          {},
 		"Microsoft.CustomProviders":         {},
 		"Microsoft.Databricks":              {},
+		"Microsoft.DataFactory":             {},
 		"Microsoft.DataLakeAnalytics":       {},
 		"Microsoft.DataLakeStore":           {},
 		"Microsoft.DataMigration":           {},
@@ -68,6 +70,7 @@ func Required() map[string]struct{} {
 		"Microsoft.Relay":                   {},
 		"Microsoft.RecoveryServices":        {},
 		"Microsoft.Resources":               {},
+		"Microsoft.SignalRService":          {},
 		"Microsoft.Search":                  {},
 		"Microsoft.Security":                {},
 		"Microsoft.SecurityInsights":        {},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -195,6 +195,8 @@ For some advanced scenarios, such as where more granular permissions are necessa
 
 -> By default, Terraform will attempt to register any Resource Providers that it supports, even if they're not used in your configurations to be able to display more helpful error messages. If you're running in an environment with restricted permissions, or wish to manage Resource Provider Registration outside of Terraform you may wish to disable this flag; however, please note that the error messages returned from Azure may be confusing as a result (example: `API version 2019-01-01 was not found for Microsoft.Foo`).
 
+~> **Note:** If you are using terraform with a User/Service Principal that has limited permissions you will likely need to set `skip_provider_registration` to `true` otherwise RP registration will fail due to permissions errors.
+
 * `storage_use_azuread` - (Optional) Should the AzureRM Provider use AzureAD to connect to the Storage Blob & Queue API's, rather than the SharedKey from the Storage Account? This can also be sourced from the `ARM_STORAGE_USE_AZUREAD` Environment Variable. Defaults to `false`.
 
 ~> **Note:** This requires that the User/Service Principal being used has the associated `Storage` roles - which are added to new Contributor/Owner role-assignments, but **have not** been backported by Azure to existing role-assignments.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -195,7 +195,7 @@ For some advanced scenarios, such as where more granular permissions are necessa
 
 -> By default, Terraform will attempt to register any Resource Providers that it supports, even if they're not used in your configurations to be able to display more helpful error messages. If you're running in an environment with restricted permissions, or wish to manage Resource Provider Registration outside of Terraform you may wish to disable this flag; however, please note that the error messages returned from Azure may be confusing as a result (example: `API version 2019-01-01 was not found for Microsoft.Foo`).
 
-~> **Note:** If you are using terraform with a User/Service Principal that has limited permissions you will likely need to set `skip_provider_registration` to `true` otherwise RP registration will fail due to permissions errors.
+-> **Note:** When Terraform is configured to use credentials with limited permissions you *must* set `skip_provider_registration` to true (or the environment variable `ARM_SKIP_PROVIDER_REGISTRATION=true`) in order to account for this - otherwise Terraform will, as described above, try to register any Resource Providers.
 
 * `storage_use_azuread` - (Optional) Should the AzureRM Provider use AzureAD to connect to the Storage Blob & Queue API's, rather than the SharedKey from the Storage Account? This can also be sourced from the `ARM_STORAGE_USE_AZUREAD` Environment Variable. Defaults to `false`.
 


### PR DESCRIPTION
there have been reports that these RPs were not required to be registered before using the provider resources, but seem to be now. Digging into it the old auto-rest transport layer was automatically registering these RPs when the APIs where used and the new transport layer was not. 

As such we are going to auto register them for the remainder of 3.x while we figure out a better solution to RP registration for 4.0.