### PR TITLE
[documentation] fix redundant new resource change text

### DIFF
--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -33,10 +33,8 @@ resource "azurerm_image" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the image. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create. Changing this forces a new resource to be created.
-    the image. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the image. Changing this forces a new resource to be created.
 * `location` - (Required) Specified the supported Azure location where the resource exists. Changing this forces a new resource to be created.
-    Changing this forces a new resource to be created.
 * `source_virtual_machine_id` - (Optional) The Virtual Machine ID from which to create the image.
 * `os_disk` - (Optional) One or more `os_disk` blocks as defined below. Changing this forces a new resource to be created.
 * `data_disk` - (Optional) One or more `data_disk` blocks as defined below.

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -107,7 +107,7 @@ resource "azurerm_orbital_contact" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Contact. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Contact. Changing this forces a new resource to be created.
 
 * `spacecraft_id` - (Required) The ID of the spacecraft which the contact will be made to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -45,8 +45,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Topic resource. Changing this forces a new resource to be created.
 
-* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create Changing this forces a new resource to be created.
-    this topic in. Changing this forces a new resource to be created.
+* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create this topic in. Changing this forces a new resource to be created.
 
 * `status` - (Optional) The Status of the Service Bus Topic. Acceptable values are `Active` or `Disabled`. Defaults to `Active`.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -48,7 +48,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the storage blob. Must be unique within the storage container the blob is located. Changing this forces a new resource to be created.
 
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage container. Changing this forces a new resource to be created.
- Changing this forces a new resource to be created.
 
 * `storage_container_name` - (Required) The name of the storage container in which this blob should be created. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
I was looking at documentation and noticed some errors which appear to have been introduced in https://github.com/hashicorp/terraform-provider-azurerm/pull/19514.

It looks like some of these were added without acknowledging that some points were continued on multiple lines. Something like 300 or more files were touched, so here is some of the regex I used to try to find as much as possible:
* `egrep -Hnor '^[^*].*Changing this forces a new resource to be created\.'`
* `egrep -Hnor '.*Changing this forces a new resource to be created\.(.*\n[^*])?.*Changing this forces a new resource to be created\.'`

If there is a better way to contribute to documentation, I would be happy to correct or open a new pr.