### PR TITLE
Replace `application_id` with `client_id`

### DIFF
--- a/website/docs/r/redhat_openshift_cluster.html.markdown
+++ b/website/docs/r/redhat_openshift_cluster.html.markdown
@@ -24,7 +24,7 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_service_principal" "example" {
-  application_id = azuread_application.example.application_id
+  client_id = azuread_application.example.client_id
 }
 
 resource "azuread_service_principal_password" "example" {
@@ -33,7 +33,7 @@ resource "azuread_service_principal_password" "example" {
 
 data "azuread_service_principal" "redhatopenshift" {
   // This is the Azure Red Hat OpenShift RP service principal id, do NOT delete it
-  application_id = "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"
+  client_id = "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"
 }
 
 resource "azurerm_role_assignment" "role_network1" {
@@ -111,7 +111,7 @@ resource "azurerm_redhat_openshift_cluster" "example" {
   }
 
   service_principal {
-    client_id     = azuread_application.example.application_id
+    client_id     = azuread_application.example.client_id
     client_secret = azuread_service_principal_password.example.value
   }
 


### PR DESCRIPTION
The `application_id` property has been replaced with the `client_id` property and will be removed in version 3.0 of the AzureAD provider