### PR TITLE
AzureML workspace, changing high_business_impact property should force a redeployment of AML workspace

### DIFF
--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -163,6 +163,7 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 			"high_business_impact": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"sku_name": {

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -376,7 +376,7 @@ The following arguments are supported:
 
 * `friendly_name` - (Optional) Display name for this Machine Learning Workspace.
 
-* `high_business_impact` - (Optional) Flag to signal High Business Impact (HBI) data in the workspace and reduce diagnostic data collected by the service
+* `high_business_impact` - (Optional) Flag to signal High Business Impact (HBI) data in the workspace and reduce diagnostic data collected by the service. Changing this forces a new resource to be created.
 
 * `primary_user_assigned_identity` - (Optional) The user assigned identity id that represents the workspace identity.
 


### PR DESCRIPTION
A simple PR to move the resource inline with the MSFT docs;

"Selecting high business impact can only be done when creating a workspace. You cannot change this setting after workspace creation."

https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace?view=azureml-api-2&tabs=python#create-a-workspace