### PR TITLE
azurerm_virtual_desktop_workspace - name validation function

### DIFF
--- a/internal/services/desktopvirtualization/validate/worksapce_name_test.go
+++ b/internal/services/desktopvirtualization/validate/worksapce_name_test.go
@@ -70,7 +70,7 @@ func TestWorkspaceName(t *testing.T) {
 			Valid: false,
 		},
 		{
-			// start with a number
+			// can start with a number
 			Input: "0abc",
 			Valid: true,
 		},

--- a/internal/services/desktopvirtualization/validate/worksapce_name_test.go
+++ b/internal/services/desktopvirtualization/validate/worksapce_name_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/desktopvirtualization/validate"
+)
+
+func TestWorkspaceName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+		{
+			// basic example
+			Input: "hello",
+			Valid: true,
+		},
+		{
+			// 63 chars
+			Input: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk",
+			Valid: true,
+		},
+		{
+			// 64 chars
+			Input: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl",
+			Valid: true,
+		},
+		{
+			// 65 chars
+			Input: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm",
+			Valid: false,
+		},
+		{
+			// may contain alphanumerics, dots, dashes and underscores
+			Input: "hello_world7.goodbye-world4",
+			Valid: true,
+		},
+		{
+			// must begin with an alphanumeric
+			Input: "_hello",
+			Valid: false,
+		},
+		{
+			// can't end with a period
+			Input: "hello.",
+			Valid: false,
+		},
+		{
+			// can't end with a dash
+			Input: "hello-",
+			Valid: false,
+		},
+		{
+			// can end with an underscore
+			Input: "hello_",
+			Valid: true,
+		},
+		{
+			// can't contain an exclamation mark
+			Input: "hello!",
+			Valid: false,
+		},
+		{
+			// start with a number
+			Input: "0abc",
+			Valid: true,
+		},
+		{
+			// can contain only numbers
+			Input: "12345",
+			Valid: true,
+		},
+		{
+			// can start with upper case letter
+			Input: "Test",
+			Valid: true,
+		},
+		{
+			// can end with upper case letter
+			Input: "TEST",
+			Valid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errs := validate.WorkspaceName(tc.Input, "name")
+		valid := len(errs) == 0
+
+		if valid != tc.Valid {
+			t.Fatalf("expected %s to be %t, got %t", tc.Input, tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/desktopvirtualization/validate/workspace_name.go
+++ b/internal/services/desktopvirtualization/validate/workspace_name.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func WorkspaceName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	// The value must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	const minLength = 3
+	const maxLength = 64
+
+	// Workspace name can be 3-64 characters in length
+	if len(v) > maxLength || len(v) < minLength {
+		errors = append(errors, fmt.Errorf("%q must be between %d-%d characters, got %d", k, minLength, maxLength, len(v)))
+	}
+
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dots, dashes and underscores", k))
+	}
+
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9]`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q must begin with an alphanumeric character", k))
+	}
+
+	if matched := regexp.MustCompile(`\w$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q must end with an alphanumeric character or underscore", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/desktopvirtualization/migration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/desktopvirtualization/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -56,7 +57,7 @@ func resourceArmDesktopVirtualizationWorkspace() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty, // TODO: determine more accurate requirements in time
+				ValidateFunc: validate.WorkspaceName,
 			},
 
 			"location": commonschema.Location(),


### PR DESCRIPTION
The original schema validation for the `azurerm_virtual_desktop_workspace` resource is currently only checking if the name argument is an empty string. 

A previous contributor left a comment to come back to add some more extensive validation; I will also be creating a data source for this resource in the future.

Utilising the [Resource Naming Rules and Restrictions Doc](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftdesktopvirtualization), I've added validation for the `azurerm_virtual_desktop_workspace` name argument with the relevant tests.

Acceptance Testing:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/72310905/feb7bb95-ff0c-4856-af86-9a9f80c36ff7)

