### PR TITLE
New resource `azurerm_virtual_desktop_scaling_plan_host_pool_association`

### DIFF
--- a/internal/services/desktopvirtualization/parse/scaling_plan_host_pool_association.go
+++ b/internal/services/desktopvirtualization/parse/scaling_plan_host_pool_association.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan"
+)
+
+var _ resourceids.Id = ScalingPlanHostPoolAssociationId{}
+
+type ScalingPlanHostPoolAssociationId struct {
+	ScalingPlan scalingplan.ScalingPlanId
+	HostPool    scalingplan.HostPoolId
+}
+
+func (id ScalingPlanHostPoolAssociationId) String() string {
+	components := []string{
+		fmt.Sprintf("Scaling Plan %s", id.ScalingPlan.String()),
+		fmt.Sprintf("Host Pool %s", id.HostPool.String()),
+	}
+	return fmt.Sprintf("Scaling Plan Host Pool Association %s", strings.Join(components, " / "))
+}
+
+func (id ScalingPlanHostPoolAssociationId) ID() string {
+	scalingplanId := id.ScalingPlan.ID()
+	hostPoolId := id.HostPool.ID()
+	return fmt.Sprintf("%s|%s", scalingplanId, hostPoolId)
+}
+
+func NewScalingPlanHostPoolAssociationId(scalingplan scalingplan.ScalingPlanId, hostPool scalingplan.HostPoolId) ScalingPlanHostPoolAssociationId {
+	return ScalingPlanHostPoolAssociationId{
+		ScalingPlan: scalingplan,
+		HostPool:    hostPool,
+	}
+}
+
+func ScalingPlanHostPoolAssociationID(input string) (*ScalingPlanHostPoolAssociationId, error) {
+	segments := strings.Split(input, "|")
+	if len(segments) != 2 {
+		return nil, fmt.Errorf("expected an ID in the format {scalingplanID}|{hostPoolID} but got %q", input)
+	}
+
+	scalingplanId, err := scalingplan.ParseScalingPlanID(segments[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing Scaling Plan ID for Scaling Plan/Host Pool Association %q: %+v", segments[0], err)
+	}
+
+	hostPoolId, err := scalingplan.ParseHostPoolID(segments[1])
+	if err != nil {
+		return nil, fmt.Errorf("parsing Host Pool ID for Scaling Plan/Host Pool Association %q: %+v", segments[1], err)
+	}
+
+	return &ScalingPlanHostPoolAssociationId{
+		ScalingPlan: *scalingplanId,
+		HostPool:    *hostPoolId,
+	}, nil
+}

--- a/internal/services/desktopvirtualization/registration.go
+++ b/internal/services/desktopvirtualization/registration.go
@@ -57,6 +57,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_virtual_desktop_application_group":                       resourceVirtualDesktopApplicationGroup(),
 		"azurerm_virtual_desktop_application":                             resourceVirtualDesktopApplication(),
 		"azurerm_virtual_desktop_workspace_application_group_association": resourceVirtualDesktopWorkspaceApplicationGroupAssociation(),
+		"azurerm_virtual_desktop_scaling_plan_host_pool_association":      resourceVirtualDesktopScalingPlanHostPoolAssociation(),
 		"azurerm_virtual_desktop_host_pool_registration_info":             resourceVirtualDesktopHostPoolRegistrationInfo(),
 	}
 }

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource.go
@@ -1,0 +1,307 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package desktopvirtualization
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceVirtualDesktopScalingPlanHostPoolAssociation() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceVirtualDesktopScalingPlanHostPoolAssociationCreate,
+		Read:   resourceVirtualDesktopScalingPlanHostPoolAssociationRead,
+		Update: resourceVirtualDesktopScalingPlanHostPoolAssociationUpdate,
+		Delete: resourceVirtualDesktopScalingPlanHostPoolAssociationDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ScalingPlanHostPoolAssociationID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"scaling_plan_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: scalingplan.ValidateScalingPlanID,
+			},
+
+			"host_pool_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: scalingplan.ValidateHostPoolID,
+			},
+
+			"enabled": {
+				Type:     pluginsdk.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceVirtualDesktopScalingPlanHostPoolAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DesktopVirtualization.ScalingPlansClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for Virtual Desktop Scaling Plan <-> Host Pool Association creation.")
+	scalingPlanId, err := scalingplan.ParseScalingPlanID(d.Get("scaling_plan_id").(string))
+	if err != nil {
+		return err
+	}
+	hostPoolId, err := scalingplan.ParseHostPoolID(d.Get("host_pool_id").(string))
+	if err != nil {
+		return err
+	}
+	associationId := parse.NewScalingPlanHostPoolAssociationId(*scalingPlanId, *hostPoolId).ID()
+
+	locks.ByName(scalingPlanId.ScalingPlanName, scalingPlanResourceType)
+	defer locks.UnlockByName(scalingPlanId.ScalingPlanName, scalingPlanResourceType)
+
+	locks.ByName(hostPoolId.HostPoolName, hostPoolResourceType)
+	defer locks.UnlockByName(hostPoolId.HostPoolName, hostPoolResourceType)
+
+	existing, err := client.Get(ctx, *scalingPlanId)
+	if err != nil {
+		if response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("%s was not found", *scalingPlanId)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", *scalingPlanId, err)
+	}
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: model was nil", *scalingPlanId)
+	}
+	model := *existing.Model
+
+	hostPoolAssociations := []scalingplan.ScalingHostPoolReference{}
+	if props := model.Properties; props != nil && props.HostPoolReferences != nil {
+		hostPoolAssociations = *props.HostPoolReferences
+	}
+
+	hostPoolStr := hostPoolId.ID()
+	if scalingPlanHostPoolAssociationExists(model.Properties, hostPoolStr) {
+		return tf.ImportAsExistsError("azurerm_virtual_desktop_scaling_plan_host_pool_association", associationId)
+	}
+	hostPoolAssociations = append(hostPoolAssociations, scalingplan.ScalingHostPoolReference{
+		HostPoolArmPath:    &hostPoolStr,
+		ScalingPlanEnabled: utils.Bool(d.Get("enabled").(bool)),
+	})
+
+	payload := scalingplan.ScalingPlanPatch{
+		Properties: &scalingplan.ScalingPlanPatchProperties{
+			HostPoolReferences: &hostPoolAssociations,
+			Schedules:          model.Properties.Schedules,
+		},
+		Tags: model.Tags,
+	}
+	if _, err = client.Update(ctx, *scalingPlanId, payload); err != nil {
+		return fmt.Errorf("creating association between %s and %s: %+v", *scalingPlanId, *hostPoolId, err)
+	}
+
+	d.SetId(associationId)
+	return resourceVirtualDesktopScalingPlanHostPoolAssociationRead(d, meta)
+}
+
+func resourceVirtualDesktopScalingPlanHostPoolAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DesktopVirtualization.ScalingPlansClient
+
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ScalingPlanHostPoolAssociationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	scalingPlan, err := client.Get(ctx, id.ScalingPlan)
+	if err != nil {
+		if response.WasNotFound(scalingPlan.HttpResponse) {
+			log.Printf("[DEBUG] %s was not found - removing from state!", id.ScalingPlan)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id.ScalingPlan, err)
+	}
+	if model := scalingPlan.Model; model != nil {
+		hostPoolId := id.HostPool.ID()
+		exists := scalingPlanHostPoolAssociationExists(model.Properties, hostPoolId)
+		if !exists {
+			log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.ScalingPlan, id.HostPool)
+			d.SetId("")
+			return nil
+		}
+		if props := model.Properties; props != nil && props.HostPoolReferences != nil {
+			for _, referenceId := range *props.HostPoolReferences {
+				if referenceId.HostPoolArmPath != nil {
+					if strings.EqualFold(*referenceId.HostPoolArmPath, hostPoolId) {
+						d.Set("enabled", referenceId.ScalingPlanEnabled)
+					}
+				}
+			}
+		}
+
+		d.Set("scaling_plan_id", id.ScalingPlan.ID())
+		d.Set("host_pool_id", hostPoolId)
+	}
+
+	return nil
+}
+
+func resourceVirtualDesktopScalingPlanHostPoolAssociationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DesktopVirtualization.ScalingPlansClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ScalingPlanHostPoolAssociationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.ScalingPlan.ScalingPlanName, scalingPlanResourceType)
+	defer locks.UnlockByName(id.ScalingPlan.ScalingPlanName, scalingPlanResourceType)
+
+	locks.ByName(id.HostPool.HostPoolName, hostPoolResourceType)
+	defer locks.UnlockByName(id.HostPool.HostPoolName, hostPoolResourceType)
+
+	existing, err := client.Get(ctx, id.ScalingPlan)
+	if err != nil {
+		if response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("%s was not found", id.ScalingPlan)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id.ScalingPlan, err)
+	}
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: model was nil", id.ScalingPlan)
+	}
+	model := *existing.Model
+	if !scalingPlanHostPoolAssociationExists(model.Properties, id.HostPool.ID()) {
+		log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.ScalingPlan, id.HostPool)
+		d.SetId("")
+		return nil
+	}
+
+	hostPoolReferences := []scalingplan.ScalingHostPoolReference{}
+	hostPoolId := id.HostPool.ID()
+	if props := model.Properties; props != nil && props.HostPoolReferences != nil {
+		for _, referenceId := range *props.HostPoolReferences {
+			if referenceId.HostPoolArmPath != nil {
+				if strings.EqualFold(*referenceId.HostPoolArmPath, hostPoolId) {
+					referenceId.ScalingPlanEnabled = utils.Bool(d.Get("enabled").(bool))
+				}
+			}
+			hostPoolReferences = append(hostPoolReferences, referenceId)
+		}
+	}
+
+	payload := scalingplan.ScalingPlanPatch{
+		Properties: &scalingplan.ScalingPlanPatchProperties{
+			HostPoolReferences: &hostPoolReferences,
+			Schedules:          model.Properties.Schedules,
+		},
+		Tags: model.Tags,
+	}
+	if _, err = client.Update(ctx, id.ScalingPlan, payload); err != nil {
+		return fmt.Errorf("updating association between %s and %s: %+v", id.ScalingPlan, id.HostPool, err)
+	}
+
+	return nil
+}
+
+func resourceVirtualDesktopScalingPlanHostPoolAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DesktopVirtualization.ScalingPlansClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ScalingPlanHostPoolAssociationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.ScalingPlan.ScalingPlanName, scalingPlanResourceType)
+	defer locks.UnlockByName(id.ScalingPlan.ScalingPlanName, scalingPlanResourceType)
+
+	locks.ByName(id.HostPool.HostPoolName, hostPoolResourceType)
+	defer locks.UnlockByName(id.HostPool.HostPoolName, hostPoolResourceType)
+
+	existing, err := client.Get(ctx, id.ScalingPlan)
+	if err != nil {
+		if response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("%s was not found", id.ScalingPlan)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id.ScalingPlan, err)
+	}
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: model was nil", id.ScalingPlan)
+	}
+	model := *existing.Model
+
+	hostPoolReferences := []scalingplan.ScalingHostPoolReference{}
+	hostPoolId := id.HostPool.ID()
+	if props := model.Properties; props != nil && props.HostPoolReferences != nil {
+		for _, referenceId := range *props.HostPoolReferences {
+			if referenceId.HostPoolArmPath != nil {
+				if strings.EqualFold(*referenceId.HostPoolArmPath, hostPoolId) {
+					continue
+				}
+			}
+
+			hostPoolReferences = append(hostPoolReferences, referenceId)
+		}
+	}
+
+	payload := scalingplan.ScalingPlanPatch{
+		Properties: &scalingplan.ScalingPlanPatchProperties{
+			HostPoolReferences: &hostPoolReferences,
+			Schedules:          model.Properties.Schedules,
+		},
+		Tags: model.Tags,
+	}
+	if _, err = client.Update(ctx, id.ScalingPlan, payload); err != nil {
+		return fmt.Errorf("removing association between %s and %s: %+v", id.ScalingPlan, id.HostPool, err)
+	}
+
+	return nil
+}
+
+func scalingPlanHostPoolAssociationExists(props *scalingplan.ScalingPlanProperties, applicationGroupId string) bool {
+	if props == nil || props.HostPoolReferences == nil {
+		return false
+	}
+
+	for _, id := range *props.HostPoolReferences {
+		if id.HostPoolArmPath != nil {
+			if strings.EqualFold(*id.HostPoolArmPath, applicationGroupId) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package desktopvirtualization_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type VirtualDesktopScalingPlanAssociationResource struct{}
+
+func TestAccVirtualDesktopScalingPlanAssociation_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_scaling_plan_host_pool_association", "test")
+	r := VirtualDesktopScalingPlanAssociationResource{}
+	roleAssignmentId := uuid.New().String()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, roleAssignmentId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+			),
+		},
+	})
+}
+
+func TestAccVirtualDesktopScalingPlanAssociation_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_scaling_plan_host_pool_association", "test")
+	r := VirtualDesktopScalingPlanAssociationResource{}
+	roleAssignmentId := uuid.New().String()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, roleAssignmentId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(data, roleAssignmentId),
+			ExpectError: acceptance.RequiresImportError("azurerm_virtual_desktop_scaling_plan_host_pool_association"),
+		},
+	})
+}
+
+func (VirtualDesktopScalingPlanAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.ScalingPlanHostPoolAssociationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.DesktopVirtualization.ScalingPlansClient.Get(ctx, id.ScalingPlan)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	found := false
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil && props.HostPoolReferences != nil {
+			for _, hostpool := range *props.HostPoolReferences {
+				if strings.EqualFold(*hostpool.HostPoolArmPath, id.HostPool.ID()) {
+					found = true
+				}
+			}
+		}
+	}
+
+	return utils.Bool(found), nil
+}
+
+func (VirtualDesktopScalingPlanAssociationResource) basic(data acceptance.TestData, roleAssignmentId string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_desktop_scaling_plan_host_pool_association" "test" {
+  host_pool_id    = azurerm_virtual_desktop_host_pool.test.id
+  scaling_plan_id = azurerm_virtual_desktop_scaling_plan.test.id
+  enabled         = true
+  depends_on      = [azurerm_role_assignment.test]
+}
+
+
+`, VirtualDesktopScalingPlanResource{}.basic(data, roleAssignmentId))
+}
+
+func (r VirtualDesktopScalingPlanAssociationResource) requiresImport(data acceptance.TestData, roleAssignmentId string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_desktop_scaling_plan_host_pool_association" "import" {
+  host_pool_id    = azurerm_virtual_desktop_host_pool.test.id
+  scaling_plan_id = azurerm_virtual_desktop_scaling_plan.test.id
+  enabled         = true
+  depends_on      = [azurerm_role_assignment.test]
+}
+
+
+`, r.basic(data, roleAssignmentId))
+}

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var scalingPlanResourceType = "azurerm_virtual_desktop_scaling_plan"
+
 func resourceVirtualDesktopScalingPlan() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceVirtualDesktopScalingPlanCreate,
@@ -221,6 +223,7 @@ func resourceVirtualDesktopScalingPlan() *pluginsdk.Resource {
 			"host_pool": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"hostpool_id": {

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource_test.go
@@ -125,40 +125,9 @@ provider "azuread" {}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-vdesktop-%d"
-  location = "westeurope"
+  location = "%s"
 }
 
-resource "azurerm_role_definition" "test" {
-  name        = "AVD-AutoScale%s"
-  scope       = azurerm_resource_group.test.id
-  description = "AVD AutoScale Role"
-
-  permissions {
-    actions = [
-      "Microsoft.Insights/eventtypes/values/read",
-      "Microsoft.Compute/virtualMachines/deallocate/action",
-      "Microsoft.Compute/virtualMachines/restart/action",
-      "Microsoft.Compute/virtualMachines/powerOff/action",
-      "Microsoft.Compute/virtualMachines/start/action",
-      "Microsoft.Compute/virtualMachines/read",
-      "Microsoft.DesktopVirtualization/hostpools/read",
-      "Microsoft.DesktopVirtualization/hostpools/write",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/read",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/write",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/delete",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/sendMessage/action",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read"
-    ]
-    not_actions = []
-  }
-
-  assignable_scopes = [
-    azurerm_resource_group.test.id, # /subscriptions/00000000-0000-0000-0000-000000000000
-  ]
-
-  depends_on = [azurerm_resource_group.test]
-}
 
 data "azuread_service_principal" "test" {
   display_name = "Windows Virtual Desktop"
@@ -167,11 +136,9 @@ data "azuread_service_principal" "test" {
 resource "azurerm_role_assignment" "test" {
   name                             = "%s"
   scope                            = azurerm_resource_group.test.id
-  role_definition_id               = azurerm_role_definition.test.role_definition_resource_id
-  principal_id                     = data.azuread_service_principal.test.application_id
+  role_definition_name             = "Desktop Virtualization Power On Off Contributor"
+  principal_id                     = data.azuread_service_principal.test.object_id
   skip_service_principal_aad_check = true
-
-  depends_on = [azurerm_role_definition.test]
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {
@@ -185,7 +152,7 @@ resource "azurerm_virtual_desktop_host_pool" "test" {
 
 resource "azurerm_virtual_desktop_scaling_plan" "test" {
   name                = "scalingPlan%x"
-  location            = "westeurope"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   friendly_name       = "Scaling Plan Test"
   description         = "Test Scaling Plan"
@@ -200,7 +167,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     peak_start_time                      = "09:00"
     peak_load_balancing_algorithm        = "BreadthFirst"
     ramp_down_start_time                 = "18:00"
-    ramp_down_load_balancing_algorithm   = "DepthFirst"
+    ramp_down_load_balancing_algorithm   = "BreadthFirst"
     ramp_down_minimum_hosts_percent      = 10
     ramp_down_force_logoff_users         = false
     ramp_down_wait_time_minutes          = 45
@@ -208,14 +175,14 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     ramp_down_capacity_threshold_percent = 5
     ramp_down_stop_hosts_when            = "ZeroSessions"
     off_peak_start_time                  = "22:00"
-    off_peak_load_balancing_algorithm    = "DepthFirst"
+    off_peak_load_balancing_algorithm    = "BreadthFirst"
   }
 
   depends_on = [azurerm_role_assignment.test]
 
 
 }
-`, data.RandomInteger, data.RandomString, roleAssignmentId, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, roleAssignmentId, data.RandomString, data.RandomString)
 }
 
 func (VirtualDesktopScalingPlanResource) complete(data acceptance.TestData, roleAssignmentId string) string {
@@ -228,39 +195,7 @@ provider "azuread" {}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-vdesktop-%d"
-  location = "westeurope"
-}
-
-resource "azurerm_role_definition" "test" {
-  name        = "AVD-AutoScale%s"
-  scope       = azurerm_resource_group.test.id
-  description = "AVD AutoScale Role"
-
-  permissions {
-    actions = [
-      "Microsoft.Insights/eventtypes/values/read",
-      "Microsoft.Compute/virtualMachines/deallocate/action",
-      "Microsoft.Compute/virtualMachines/restart/action",
-      "Microsoft.Compute/virtualMachines/powerOff/action",
-      "Microsoft.Compute/virtualMachines/start/action",
-      "Microsoft.Compute/virtualMachines/read",
-      "Microsoft.DesktopVirtualization/hostpools/read",
-      "Microsoft.DesktopVirtualization/hostpools/write",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/read",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/write",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/delete",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/sendMessage/action",
-      "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read"
-    ]
-    not_actions = []
-  }
-
-  assignable_scopes = [
-    azurerm_resource_group.test.id, # /subscriptions/00000000-0000-0000-0000-000000000000
-  ]
-
-  depends_on = [azurerm_resource_group.test]
+  location = "%s"
 }
 
 data "azuread_service_principal" "test" {
@@ -270,11 +205,9 @@ data "azuread_service_principal" "test" {
 resource "azurerm_role_assignment" "test" {
   name                             = "%s"
   scope                            = azurerm_resource_group.test.id
-  role_definition_id               = azurerm_role_definition.test.role_definition_resource_id
-  principal_id                     = data.azuread_service_principal.test.application_id
+  role_definition_name             = "Desktop Virtualization Power On Off Contributor"
+  principal_id                     = data.azuread_service_principal.test.object_id
   skip_service_principal_aad_check = true
-
-  depends_on = [azurerm_role_definition.test]
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {
@@ -288,7 +221,7 @@ resource "azurerm_virtual_desktop_host_pool" "test" {
 
 resource "azurerm_virtual_desktop_scaling_plan" "test" {
   name                = "scalingPlan%x"
-  location            = "westeurope"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   friendly_name       = "Scaling Plan Test"
   description         = "Test Scaling Plan"
@@ -304,7 +237,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     peak_start_time                      = "09:00"
     peak_load_balancing_algorithm        = "BreadthFirst"
     ramp_down_start_time                 = "19:00"
-    ramp_down_load_balancing_algorithm   = "DepthFirst"
+    ramp_down_load_balancing_algorithm   = "BreadthFirst"
     ramp_down_minimum_hosts_percent      = 10
     ramp_down_force_logoff_users         = false
     ramp_down_wait_time_minutes          = 45
@@ -312,7 +245,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     ramp_down_capacity_threshold_percent = 5
     ramp_down_stop_hosts_when            = "ZeroSessions"
     off_peak_start_time                  = "22:00"
-    off_peak_load_balancing_algorithm    = "DepthFirst"
+    off_peak_load_balancing_algorithm    = "BreadthFirst"
   }
 
   schedule {
@@ -325,7 +258,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     peak_start_time                      = "10:00"
     peak_load_balancing_algorithm        = "BreadthFirst"
     ramp_down_start_time                 = "16:00"
-    ramp_down_load_balancing_algorithm   = "DepthFirst"
+    ramp_down_load_balancing_algorithm   = "BreadthFirst"
     ramp_down_minimum_hosts_percent      = 10
     ramp_down_force_logoff_users         = false
     ramp_down_wait_time_minutes          = 45
@@ -333,7 +266,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
     ramp_down_capacity_threshold_percent = 5
     ramp_down_stop_hosts_when            = "ZeroSessions"
     off_peak_start_time                  = "20:00"
-    off_peak_load_balancing_algorithm    = "DepthFirst"
+    off_peak_load_balancing_algorithm    = "BreadthFirst"
   }
 
 
@@ -344,7 +277,7 @@ resource "azurerm_virtual_desktop_scaling_plan" "test" {
   depends_on = [azurerm_role_assignment.test]
 }
 
-`, data.RandomInteger, data.RandomString, roleAssignmentId, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, roleAssignmentId, data.RandomString, data.RandomString)
 }
 
 func (r VirtualDesktopScalingPlanResource) requiresImport(data acceptance.TestData, roleAssignmentId string) string {

--- a/website/docs/r/virtual_desktop_scaling_plan_host_pool_association.html.markdown
+++ b/website/docs/r/virtual_desktop_scaling_plan_host_pool_association.html.markdown
@@ -1,0 +1,122 @@
+---
+subcategory: "Desktop Virtualization"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_desktop_scaling_plan_host_pool_association"
+description: |-
+  Manages a Virtual Desktop Scaling Plan Host Pool Association.
+---
+
+# azurerm_virtual_desktop_scaling_plan_host_pool_association
+
+Manages a Virtual Desktop Scaling Plan Host Pool Association.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+provider "azuread" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example-virtualdesktop"
+  location = "West Europe"
+}
+
+
+data "azuread_service_principal" "example" {
+  # In some environments this will be "Azure Virtual Desktop"
+  display_name = "Windows Virtual Desktop"
+}
+
+resource "azurerm_role_assignment" "example" {
+  scope                = azurerm_resource_group.example.id
+  role_definition_name = "Desktop Virtualization Power On Off Contributor"
+  principal_id         = data.azuread_service_principal.example.object_id
+}
+
+resource "azurerm_virtual_desktop_host_pool" "example" {
+  name                 = "example-hostpool"
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
+  type                 = "Pooled"
+  validate_environment = true
+  load_balancer_type   = "BreadthFirst"
+}
+
+resource "azurerm_virtual_desktop_scaling_plan" "example" {
+  name                = "example-scaling-plan"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  friendly_name       = "Scaling Plan Test"
+  description         = "Test Scaling Plan"
+  time_zone           = "GMT Standard Time"
+  schedule {
+    name                                 = "Weekdays"
+    days_of_week                         = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+    ramp_up_start_time                   = "06:00"
+    ramp_up_load_balancing_algorithm     = "BreadthFirst"
+    ramp_up_minimum_hosts_percent        = 20
+    ramp_up_capacity_threshold_percent   = 10
+    peak_start_time                      = "09:00"
+    peak_load_balancing_algorithm        = "BreadthFirst"
+    ramp_down_start_time                 = "18:00"
+    ramp_down_load_balancing_algorithm   = "BreadthFirst"
+    ramp_down_minimum_hosts_percent      = 10
+    ramp_down_force_logoff_users         = false
+    ramp_down_wait_time_minutes          = 45
+    ramp_down_notification_message       = "Please log of in the next 45 minutes..."
+    ramp_down_capacity_threshold_percent = 5
+    ramp_down_stop_hosts_when            = "ZeroSessions"
+    off_peak_start_time                  = "22:00"
+    off_peak_load_balancing_algorithm    = "BreadthFirst"
+  }
+
+  depends_on = [azurerm_role_assignment.example]
+}
+
+
+resource "azurerm_virtual_desktop_scaling_plan_host_pool_association" "example" {
+  host_pool_id    = azurerm_virtual_desktop_host_pool.example.id
+  scaling_plan_id = azurerm_virtual_desktop_scaling_plan.example.id
+  enabled         = true
+  depends_on      = [azurerm_role_assignment.example]
+}
+
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `host_pool_id` - (Required) The resource ID for the Virtual Desktop Host Pool. Changing this forces a new resource to be created.
+
+- `scaling_plan_id` - (Required) The resource ID for the Virtual Desktop Scaling Plan. Changing this forces a new resource to be created.
+
+- `enabled` - (Required) Should the Scaling Plan be enabled on this Host Pool.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+- `id` - The ID of the Virtual Desktop Scaling Plan Host Pool association.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+- `create` - (Defaults to 60 minutes) Used when creating the Virtual Desktop Scaling Plan Host Pool association.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Desktop Scaling Plan Host Pool association.
+- `update` - (Defaults to 60 minutes) Used when updating the Virtual Desktop Scaling Plan Host Pool association.
+- `delete` - (Defaults to 60 minutes) Used when deleting the Virtual Desktop Scaling Plan Host Pool association.
+
+## Import
+
+Associations between Virtual Desktop Scaling Plans and Virtual Desktop Host Pools can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_desktop_scaling_plan_host_pool_association.example "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/scalingPlans/plan1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/hostPools/myhostpool"
+```
+
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{virtualDesktopScalingPlanID}|{virtualDesktopHostPoolID}`.


### PR DESCRIPTION
PR for the creation of a new resource `azurerm_virtual_desktop_scaling_plan_host_pool_association`

### Why
In my AVD deployments I have a normal worktime scaling plan and a holiday period scaling plan. I'd like to have a variable to easily switch from one SP to another. Using the `host_pool` block within the current `azurerm_virtual_desktop_scaling_plan` you would need to do something with dynamic blocks and there doesn't seem to be a clean solution. 
Having a dedicated resource would make this much easier.

It would also be more inline with the existing resource `azurerm_virtual_desktop_workspace_application_group_association` (which this PR is mostly copied from)

### Help
When using this resource alongside `azurerm_virtual_desktop_scaling_plan` there will be conflicts where an association has been created in the new resource but not declared in a `host_pool` block. Is there a way to prevent the `host_pool` block being checked if it hasn't been declared in the users configuration? Rather than the user having to add an `ignore_changes` to their code.

### Documentation and Tests
If you're happy with this resource in principle I'll get the docs and tests written up
Thanks in advance!