### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20240130.1054849`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.1
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240126.1105227
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.1
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240130.1054849
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/go-azure-helpers v0.66.1 h1:SokAckK9hvQ9PZO2TmZY/CGru8KWJ4A
 github.com/hashicorp/go-azure-helpers v0.66.1/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227 h1:r5JUEkrm6D6FxXfbJgRhMPfZnA+25J5md6B0/K0VqEQ=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227/go.mod h1:fDIHULaDyn6a7c9uq2MpMcKJMpony6193JYdWf4Jbgs=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240126.1105227 h1:Tk57tCWsQWkfeWuabogTCSQEwDR0d+/9t3ld4tI9/Dw=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240126.1105227/go.mod h1:6jgkzx26qtPndLSW5u7pKIw4m3iiFiLnHlp7yDQ2Crc=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849 h1:2Oue6l5FpoB/7/98SNyfjz0YaPHfuRJuqjqFQiTKo+s=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849/go.mod h1:6jgkzx26qtPndLSW5u7pKIw4m3iiFiLnHlp7yDQ2Crc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.66.1 h1:SokAckK9hvQ9PZO2TmZY/CGru8KWJ4A7hcRUggHMEus=
 github.com/hashicorp/go-azure-helpers v0.66.1/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227 h1:r5JUEkrm6D6FxXfbJgRhMPfZnA+25J5md6B0/K0VqEQ=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227/go.mod h1:fDIHULaDyn6a7c9uq2MpMcKJMpony6193JYdWf4Jbgs=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240130.1054849 h1:9IBUmxryElFOvnPQ7WRU2nWvKuyF2wCpCZL9j6fm7uM=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240130.1054849/go.mod h1:5BV2t0yXagppkFvYPM4eSYqDxAFBHJX8ogZqCAvXxE0=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849 h1:2Oue6l5FpoB/7/98SNyfjz0YaPHfuRJuqjqFQiTKo+s=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849/go.mod h1:6jgkzx26qtPndLSW5u7pKIw4m3iiFiLnHlp7yDQ2Crc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1035,7 +1035,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/managedapis
 github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceplans
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240126.1105227
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240130.1054849
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240126.1105227
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240130.1054849
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20240130.1054849` - further details can be found in a comment.