### PR TITLE
`azurerm_spring_cloud_api_portal` - support for the `api_try_out_enabled` property

### DIFF
--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -25,6 +25,7 @@ type SpringCloudAPIPortalModel struct {
 	HttpsOnlyEnabled           bool                `tfschema:"https_only_enabled"`
 	InstanceCount              int                 `tfschema:"instance_count"`
 	PublicNetworkAccessEnabled bool                `tfschema:"public_network_access_enabled"`
+	ApiTryOutEnabled           bool                `tfschema:"api_try_out_enabled"`
 	Sso                        []ApiPortalSsoModel `tfschema:"sso"`
 	Url                        string              `tfschema:"url"`
 }
@@ -69,6 +70,11 @@ func (s SpringCloudAPIPortalResource) Arguments() map[string]*pluginsdk.Schema {
 			Required:     true,
 			ForceNew:     true,
 			ValidateFunc: commonids.ValidateSpringCloudServiceID,
+		},
+
+		"api_try_out_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
 		},
 
 		"gateway_ids": {
@@ -184,12 +190,18 @@ func (s SpringCloudAPIPortalResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("invalid `sku` for %s", springId)
 			}
 
+			apiTryOutEnabledState := appplatform.ApiPortalApiTryOutEnabledStateDisabled
+			if model.ApiTryOutEnabled {
+				apiTryOutEnabledState = appplatform.ApiPortalApiTryOutEnabledStateEnabled
+			}
+
 			apiPortalResource := appplatform.ApiPortalResource{
 				Properties: &appplatform.ApiPortalProperties{
-					GatewayIds:    pointer.To(model.GatewayIds),
-					HTTPSOnly:     pointer.To(model.HttpsOnlyEnabled),
-					Public:        pointer.To(model.PublicNetworkAccessEnabled),
-					SsoProperties: expandAPIPortalSsoProperties(model.Sso),
+					GatewayIds:            pointer.To(model.GatewayIds),
+					HTTPSOnly:             pointer.To(model.HttpsOnlyEnabled),
+					Public:                pointer.To(model.PublicNetworkAccessEnabled),
+					SsoProperties:         expandAPIPortalSsoProperties(model.Sso),
+					ApiTryOutEnabledState: pointer.To(apiTryOutEnabledState),
 				},
 				Sku: &appplatform.Sku{
 					Name:     service.Model.Sku.Name,
@@ -262,6 +274,14 @@ func (s SpringCloudAPIPortalResource) Update() sdk.ResourceFunc {
 				sku.Capacity = pointer.To(int64(model.InstanceCount))
 			}
 
+			if metadata.ResourceData.HasChange("api_try_out_enabled") {
+				apiTryOutEnabledState := appplatform.ApiPortalApiTryOutEnabledStateDisabled
+				if model.ApiTryOutEnabled {
+					apiTryOutEnabledState = appplatform.ApiPortalApiTryOutEnabledStateEnabled
+				}
+				properties.ApiTryOutEnabledState = pointer.To(apiTryOutEnabledState)
+			}
+
 			apiPortalResource := appplatform.ApiPortalResource{
 				Properties: properties,
 				Sku:        sku,
@@ -312,6 +332,7 @@ func (s SpringCloudAPIPortalResource) Read() sdk.ResourceFunc {
 					state.HttpsOnlyEnabled = pointer.From(props.HTTPSOnly)
 					state.PublicNetworkAccessEnabled = pointer.From(props.Public)
 					state.Sso = flattenAPIPortalSsoProperties(props.SsoProperties, model.Sso)
+					state.ApiTryOutEnabled = props.ApiTryOutEnabledState != nil && *props.ApiTryOutEnabledState == appplatform.ApiPortalApiTryOutEnabledStateEnabled
 				}
 
 				if sku := resp.Model.Sku; sku != nil {

--- a/internal/services/springcloud/spring_cloud_api_portal_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource_test.go
@@ -172,6 +172,7 @@ resource "azurerm_spring_cloud_api_portal" "test" {
   https_only_enabled            = false
   public_network_access_enabled = false
   instance_count                = 1
+  api_try_out_enabled           = true
 
   sso {
     client_id     = "%s"

--- a/website/docs/r/spring_cloud_api_portal.html.markdown
+++ b/website/docs/r/spring_cloud_api_portal.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 ---
 
-* `api_try_out_enabled` - (Optional) Specifies whether the API try-out feature is enabled or disabled. When enabled, users can try out the API by sending requests and viewing responses in API portal.
+* `api_try_out_enabled` - (Optional) Specifies whether the API try-out feature is enabled. When enabled, users can try out the API by sending requests and viewing responses in API portal.
 
 * `gateway_ids` - (Optional) Specifies a list of Spring Cloud Gateway.
 

--- a/website/docs/r/spring_cloud_api_portal.html.markdown
+++ b/website/docs/r/spring_cloud_api_portal.html.markdown
@@ -43,6 +43,7 @@ resource "azurerm_spring_cloud_api_portal" "example" {
   https_only_enabled            = false
   public_network_access_enabled = true
   instance_count                = 1
+  api_try_out_enabled           = true
   sso {
     client_id     = "test"
     client_secret = "secret"
@@ -61,6 +62,8 @@ The following arguments are supported:
 * `spring_cloud_service_id` - (Required) The ID of the Spring Cloud Service. Changing this forces a new Spring Cloud API Portal to be created.
 
 ---
+
+* `api_try_out_enabled` - (Optional) Specifies whether the API try-out feature is enabled or disabled. When enabled, users can try out the API by sending requests and viewing responses in API portal.
 
 * `gateway_ids` - (Optional) Specifies a list of Spring Cloud Gateway.
 


### PR DESCRIPTION
```
=== RUN   TestAccSpringCloudAPIPortal_basic
=== PAUSE TestAccSpringCloudAPIPortal_basic
=== CONT  TestAccSpringCloudAPIPortal_basic
--- PASS: TestAccSpringCloudAPIPortal_basic (578.05s)
=== RUN   TestAccSpringCloudAPIPortal_requiresImport
=== PAUSE TestAccSpringCloudAPIPortal_requiresImport
=== CONT  TestAccSpringCloudAPIPortal_requiresImport
--- PASS: TestAccSpringCloudAPIPortal_requiresImport (688.49s)
=== RUN   TestAccSpringCloudAPIPortal_complete
=== PAUSE TestAccSpringCloudAPIPortal_complete
=== CONT  TestAccSpringCloudAPIPortal_complete
--- PASS: TestAccSpringCloudAPIPortal_complete (776.44s)
=== RUN   TestAccSpringCloudAPIPortal_update
=== PAUSE TestAccSpringCloudAPIPortal_update
=== CONT  TestAccSpringCloudAPIPortal_update
--- PASS: TestAccSpringCloudAPIPortal_update (913.30s)
PASS


```