### PR TITLE
`azurerm_orbital_spacecraft`: fix spacecraft acc tests for new validation on backend service

### DIFF
--- a/internal/services/orbital/spacecraft_resource_test.go
+++ b/internal/services/orbital/spacecraft_resource_test.go
@@ -98,8 +98,8 @@ resource "azurerm_orbital_spacecraft" "test" {
   norad_id            = "12345"
 
   links {
-    bandwidth_mhz        = 100
-    center_frequency_mhz = 101
+    bandwidth_mhz        = 30
+    center_frequency_mhz = 2050
     direction            = "Uplink"
     polarization         = "LHCP"
     name                 = "linkname"
@@ -123,8 +123,8 @@ resource "azurerm_orbital_spacecraft" "test" {
   norad_id            = "23456"
 
   links {
-    bandwidth_mhz        = 100
-    center_frequency_mhz = 101
+    bandwidth_mhz        = 20
+    center_frequency_mhz = 2045
     direction            = "Uplink"
     polarization         = "LHCP"
     name                 = "linkname"
@@ -148,8 +148,8 @@ resource "azurerm_orbital_spacecraft" "test" {
   norad_id            = "12345"
 
   links {
-    bandwidth_mhz        = 100
-    center_frequency_mhz = 101
+    bandwidth_mhz        = 30
+    center_frequency_mhz = 2050
     direction            = "Uplink"
     polarization         = "LHCP"
     name                 = "linkname"

--- a/website/docs/r/orbital_spacecraft.html.markdown
+++ b/website/docs/r/orbital_spacecraft.html.markdown
@@ -25,8 +25,8 @@ resource "azurerm_orbital_spacecraft" "example" {
   norad_id            = "12345"
 
   links {
-    bandwidth_mhz        = 100
-    center_frequency_mhz = 101
+    bandwidth_mhz        = 30
+    center_frequency_mhz = 2050
     direction            = "Uplink"
     polarization         = "LHCP"
     name                 = "examplename"
@@ -68,6 +68,8 @@ A `links` block supports the following:
 * `bandwidth_mhz` - (Required) Bandwidth in Mhz.
 
 * `center_frequency_mhz` - (Required) Center frequency in Mhz.
+
+~> **Note:** The value of `center_frequency_mhz +/- bandwidth_mhz / 2` should fall in one of these ranges: `Uplink/LHCP`: [2025, 2120]; `Uplink/Linear`: [399, 403],[435, 438],[449, 451]; `Uplink/RHCP`: [399, 403],[435, 438],[449, 451],[2025, 2120]; `Downlink/LHCP`: [2200, 2300], [7500, 8400]; `Downlink/Linear`: [399, 403], [435, 438], [449, 451]; Downlink/Linear`: [399, 403], [435, 438], [449, 451], [2200, 2300], [7500, 8400]
 
 * `direction` - (Required) Direction if the communication. Possible values are `Uplink` and `Downlink`.
 


### PR DESCRIPTION
* Spacecraft API now validates `center_frequency_mhz` and `bandwidth_mhz` by setting ranges for `center_frequency_mhz +/- bandwidth_mhz`. 

* All acc tests are now passing.

```
--- PASS: TestAccSpacecraft_basic (187.78s)
--- PASS: TestAccSpacecraft_complete (189.61s)
--- PASS: TestAccSpacecraft_update (239.92s)
PASS
```