### PR TITLE
`azurerm_cognitive_deployment` - includes `version` to `Update` function

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -311,6 +311,10 @@ func (r CognitiveDeploymentResource) Update() sdk.ResourceFunc {
 				properties.Properties.RaiPolicyName = pointer.To(model.RaiPolicyName)
 			}
 
+			if metadata.ResourceData.HasChange("model.0.version") {
+				properties.Properties.Model.Version = pointer.To(model.Model[0].Version)
+			}
+
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -99,6 +99,14 @@ func TestAccCognitiveDeployment_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.updateVersion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("model.0.version").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -207,10 +215,6 @@ resource "azurerm_cognitive_deployment" "test" {
 func (r CognitiveDeploymentTestResource) update(data acceptance.TestData) string {
 	template := r.template(data, "OpenAI")
 	return fmt.Sprintf(`
-
-
-
-
 %s
 
 resource "azurerm_cognitive_deployment" "test" {
@@ -221,6 +225,28 @@ resource "azurerm_cognitive_deployment" "test" {
     format  = "OpenAI"
     name    = "text-embedding-ada-002"
     version = "2"
+  }
+  scale {
+    type     = "Standard"
+    capacity = 2
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CognitiveDeploymentTestResource) updateVersion(data acceptance.TestData) string {
+	template := r.template(data, "OpenAI")
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_deployment" "test" {
+  name                 = "acctest-cd-%d"
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  rai_policy_name      = "Microsoft.Default"
+  model {
+    format  = "OpenAI"
+    name    = "text-embedding-ada-002"
+    version = "1"
   }
   scale {
     type     = "Standard"

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -127,7 +127,7 @@ func (r CognitiveDeploymentTestResource) Exists(ctx context.Context, clients *cl
 	return utils.Bool(resp.Model != nil), nil
 }
 
-func (r CognitiveDeploymentTestResource) template(data acceptance.TestData, kind string) string {
+func (r CognitiveDeploymentTestResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -141,14 +141,14 @@ resource "azurerm_cognitive_account" "test" {
   name                = "acctest-ca-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  kind                = "%s"
+  kind                = "OpenAI"
   sku_name            = "S0"
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, kind)
+`, data.RandomInteger, data.Locations.Secondary, data.RandomInteger)
 }
 
 func (r CognitiveDeploymentTestResource) basic(data acceptance.TestData) string {
-	template := r.template(data, "OpenAI")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -190,7 +190,7 @@ resource "azurerm_cognitive_deployment" "import" {
 }
 
 func (r CognitiveDeploymentTestResource) complete(data acceptance.TestData) string {
-	template := r.template(data, "OpenAI")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -213,7 +213,7 @@ resource "azurerm_cognitive_deployment" "test" {
 }
 
 func (r CognitiveDeploymentTestResource) update(data acceptance.TestData) string {
-	template := r.template(data, "OpenAI")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -235,7 +235,7 @@ resource "azurerm_cognitive_deployment" "test" {
 }
 
 func (r CognitiveDeploymentTestResource) updateVersion(data acceptance.TestData) string {
-	template := r.template(data, "OpenAI")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
Changes:
- add `version` to Update function
- include this feature in the update test
- fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24516
- change template function to use OpenAI in default because golint error

Test Evidence:
```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccCognitiveDeployment_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccCognitiveDeployment_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccCognitiveDeployment_update\E$ #gosetup
=== RUN   TestAccCognitiveDeployment_update
--- PASS: TestAccCognitiveDeployment_update (257.09s)
PASS


Process finished with the exit code 0
```