### PR TITLE
`data.azurerm_storage_account_blob_container_sas` - doc add notes for `sas`

### DIFF
--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -115,7 +115,7 @@ for additional details on the fields above.
 
 ## Attributes Reference
 
-* `sas` - The computed Blob Container Shared Access Signature (SAS).
+* `sas` - The computed Blob Container Shared Access Signature (SAS). The delimiter character ('?') for the query string is the prefix of `sas`.
 
 ## Timeouts
 


### PR DESCRIPTION
From https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token, the delimiter character ('?') is not part of SAS token, so may need to add notes for this.