### PR TITLE
[TestCase] Fix  TestAccLabServiceLab_*/TestAccLabServiceSchedule_*/TestAccLabServiceUser_*

### DIFF
--- a/internal/services/labservice/lab_service_lab_resource.go
+++ b/internal/services/labservice/lab_service_lab_resource.go
@@ -127,6 +127,33 @@ func (r LabServiceLabResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"location": commonschema.Location(),
 
+		"connection_setting": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"client_rdp_access": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(lab.ConnectionTypePublic),
+						}, false),
+						AtLeastOneOf: []string{"connection_setting.0.client_rdp_access", "connection_setting.0.client_ssh_access"},
+					},
+
+					"client_ssh_access": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(lab.ConnectionTypePublic),
+						}, false),
+						AtLeastOneOf: []string{"connection_setting.0.client_rdp_access", "connection_setting.0.client_ssh_access"},
+					},
+				},
+			},
+		},
+
 		"security": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
@@ -347,31 +374,6 @@ func (r LabServiceLabResource) Arguments() map[string]*pluginsdk.Schema {
 						ValidateFunc: validation.StringInSlice([]string{
 							string(lab.ShutdownOnIdleModeLowUsage),
 							string(lab.ShutdownOnIdleModeUserAbsence),
-						}, false),
-					},
-				},
-			},
-		},
-
-		"connection_setting": {
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"client_rdp_access": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(lab.ConnectionTypePublic),
-						}, false),
-					},
-
-					"client_ssh_access": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(lab.ConnectionTypePublic),
 						}, false),
 					},
 				},

--- a/internal/services/labservice/lab_service_lab_resource_test.go
+++ b/internal/services/labservice/lab_service_lab_resource_test.go
@@ -148,6 +148,10 @@ resource "azurerm_lab_service_lab" "test" {
       capacity = 1
     }
   }
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/labservice/lab_service_lab_resource_test.go
+++ b/internal/services/labservice/lab_service_lab_resource_test.go
@@ -188,6 +188,10 @@ resource "azurerm_lab_service_lab" "import" {
       capacity = 1
     }
   }
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, r.basic(data))
 }

--- a/internal/services/labservice/lab_service_schedule_resource_test.go
+++ b/internal/services/labservice/lab_service_schedule_resource_test.go
@@ -160,6 +160,10 @@ resource "azurerm_lab_service_lab" "test" {
       capacity = 1
     }
   }
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
 }

--- a/internal/services/labservice/lab_service_schedule_resource_test.go
+++ b/internal/services/labservice/lab_service_schedule_resource_test.go
@@ -190,10 +190,6 @@ resource "azurerm_lab_service_schedule" "import" {
   lab_id    = azurerm_lab_service_schedule.test.lab_id
   stop_time = azurerm_lab_service_schedule.test.stop_time
   time_zone = azurerm_lab_service_schedule.test.time_zone
-
-  connection_setting {
-    client_ssh_access = "Public"
-  }
 }
 `, r.basic(data, stopTime))
 }

--- a/internal/services/labservice/lab_service_schedule_resource_test.go
+++ b/internal/services/labservice/lab_service_schedule_resource_test.go
@@ -190,6 +190,10 @@ resource "azurerm_lab_service_schedule" "import" {
   lab_id    = azurerm_lab_service_schedule.test.lab_id
   stop_time = azurerm_lab_service_schedule.test.stop_time
   time_zone = azurerm_lab_service_schedule.test.time_zone
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, r.basic(data, stopTime))
 }

--- a/internal/services/labservice/lab_service_user_resource_test.go
+++ b/internal/services/labservice/lab_service_user_resource_test.go
@@ -142,6 +142,10 @@ resource "azurerm_lab_service_lab" "test" {
       capacity = 1
     }
   }
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
 }

--- a/internal/services/labservice/lab_service_user_resource_test.go
+++ b/internal/services/labservice/lab_service_user_resource_test.go
@@ -170,6 +170,10 @@ resource "azurerm_lab_service_user" "import" {
   name   = azurerm_lab_service_user.test.name
   lab_id = azurerm_lab_service_user.test.lab_id
   email  = azurerm_lab_service_user.test.email
+
+  connection_setting {
+    client_ssh_access = "Public"
+  }
 }
 `, r.basic(data))
 }

--- a/internal/services/labservice/lab_service_user_resource_test.go
+++ b/internal/services/labservice/lab_service_user_resource_test.go
@@ -170,10 +170,6 @@ resource "azurerm_lab_service_user" "import" {
   name   = azurerm_lab_service_user.test.name
   lab_id = azurerm_lab_service_user.test.lab_id
   email  = azurerm_lab_service_user.test.email
-
-  connection_setting {
-    client_ssh_access = "Public"
-  }
 }
 `, r.basic(data))
 }

--- a/website/docs/r/lab_service_lab.html.markdown
+++ b/website/docs/r/lab_service_lab.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Lab Service Lab should exist. Changing this forces a new resource to be created.
 
+* `connection_setting` - (Required) A `connection_setting` block as defined below.
+
 * `security` - (Required) A `security` block as defined below.
 
 * `title` - (Required) The title of the Lab Service Lab.
@@ -66,8 +68,6 @@ The following arguments are supported:
 * `virtual_machine` - (Required) A `virtual_machine` block as defined below.
 
 * `auto_shutdown` - (Optional) An `auto_shutdown` block as defined below.
-
-* `connection_setting` - (Optional) A `connection_setting` block as defined below.
 
 * `description` - (Optional) The description of the Lab Service Lab.
 


### PR DESCRIPTION
Recently, TestAccLabServiceLab_*/TestAccLabServiceSchedule_*/TestAccLabServiceUser_* keep failing in TeamCity Daily Run. After I investigated, I found that recently service team made some improvements on the backend for the lab resource.

The connectionProfile property is a required property and one of clientRDPAccess and clientsshAccess must be set according to the type of image. If it's windows image, clientRDPAccess needs to be 'Public'. If it's linux image, 'clientsshAccess' needs to be 'Public'.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/89ef4c8f-3806-438e-bd2f-37c9263d3b54)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/d82bacf4-bb0d-4019-bf63-d99399122369)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/a8d4cf38-d372-450a-b7a3-a3c37d969df3)
