### PR TITLE
Add to public_cert_data documentation

### DIFF
--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -264,7 +264,7 @@ The `root_certificate` block supports:
 
 * `name` - (Required) A user-defined name of the root certificate.
 
-* `public_cert_data` - (Required) The public certificate of the root certificate authority. The certificate must be provided in Base-64 encoded X.509 format (PEM). In particular, this argument *must not* include the `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` markers.
+* `public_cert_data` - (Required) The public certificate of the root certificate authority. The certificate must be provided in Base-64 encoded X.509 format (PEM). In particular, this argument *must not* include the `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` markers, nor any newlines.
 
 ---
 


### PR DESCRIPTION
I lost a lot of hours due to this.

It was not enough for me to transform the certificate PEM data by just removing the `--- BEGIN/END CERTIFICATE ----`, I had to also remove all newlines around _and_ between the base64 encoded data rows.

Hopefully this will save others time in the future.

Also any input on a way to phrase this in an even more obvious way would be appreciated.