### PR TITLE
`r/subscription`: refactoring the Tags client use `hashicorp/go-azure-sdk`

### DIFF
--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/README.md
@@ -1,0 +1,163 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags` Documentation
+
+The `tags` SDK allows for interaction with the Azure Resource Manager Service `resources` (API Version `2023-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags"
+```
+
+
+### Client Initialization
+
+```go
+client := tags.NewTagsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `TagsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := tags.NewTagNameID("12345678-1234-9876-4563-123456789012", "tagValue")
+
+read, err := client.CreateOrUpdate(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagsClient.CreateOrUpdateAtScope`
+
+```go
+ctx := context.TODO()
+id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+payload := tags.TagsResource{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateAtScopeThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TagsClient.CreateOrUpdateValue`
+
+```go
+ctx := context.TODO()
+id := tags.NewTagValueID("12345678-1234-9876-4563-123456789012", "tagValue", "tagValueValue")
+
+read, err := client.CreateOrUpdateValue(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := tags.NewTagNameID("12345678-1234-9876-4563-123456789012", "tagValue")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagsClient.DeleteAtScope`
+
+```go
+ctx := context.TODO()
+id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+if err := client.DeleteAtScopeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TagsClient.DeleteValue`
+
+```go
+ctx := context.TODO()
+id := tags.NewTagValueID("12345678-1234-9876-4563-123456789012", "tagValue", "tagValueValue")
+
+read, err := client.DeleteValue(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagsClient.GetAtScope`
+
+```go
+ctx := context.TODO()
+id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+read, err := client.GetAtScope(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagsClient.List`
+
+```go
+ctx := context.TODO()
+id := tags.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `TagsClient.UpdateAtScope`
+
+```go
+ctx := context.TODO()
+id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+payload := tags.TagsPatchResource{
+	// ...
+}
+
+
+if err := client.UpdateAtScopeThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/client.go
@@ -1,0 +1,26 @@
+package tags
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewTagsClientWithBaseURI(sdkApi sdkEnv.Api) (*TagsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "tags", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating TagsClient: %+v", err)
+	}
+
+	return &TagsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/constants.go
@@ -1,0 +1,54 @@
+package tags
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsPatchOperation string
+
+const (
+	TagsPatchOperationDelete  TagsPatchOperation = "Delete"
+	TagsPatchOperationMerge   TagsPatchOperation = "Merge"
+	TagsPatchOperationReplace TagsPatchOperation = "Replace"
+)
+
+func PossibleValuesForTagsPatchOperation() []string {
+	return []string{
+		string(TagsPatchOperationDelete),
+		string(TagsPatchOperationMerge),
+		string(TagsPatchOperationReplace),
+	}
+}
+
+func (s *TagsPatchOperation) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTagsPatchOperation(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTagsPatchOperation(input string) (*TagsPatchOperation, error) {
+	vals := map[string]TagsPatchOperation{
+		"delete":  TagsPatchOperationDelete,
+		"merge":   TagsPatchOperationMerge,
+		"replace": TagsPatchOperationReplace,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TagsPatchOperation(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/id_tagname.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/id_tagname.go
@@ -1,0 +1,114 @@
+package tags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &TagNameId{}
+
+// TagNameId is a struct representing the Resource ID for a Tag Name
+type TagNameId struct {
+	SubscriptionId string
+	TagName        string
+}
+
+// NewTagNameID returns a new TagNameId struct
+func NewTagNameID(subscriptionId string, tagName string) TagNameId {
+	return TagNameId{
+		SubscriptionId: subscriptionId,
+		TagName:        tagName,
+	}
+}
+
+// ParseTagNameID parses 'input' into a TagNameId
+func ParseTagNameID(input string) (*TagNameId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TagNameId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TagNameId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseTagNameIDInsensitively parses 'input' case-insensitively into a TagNameId
+// note: this method should only be used for API response data and not user input
+func ParseTagNameIDInsensitively(input string) (*TagNameId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TagNameId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TagNameId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *TagNameId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.TagName, ok = input.Parsed["tagName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "tagName", input)
+	}
+
+	return nil
+}
+
+// ValidateTagNameID checks that 'input' can be parsed as a Tag Name ID
+func ValidateTagNameID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTagNameID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Tag Name ID
+func (id TagNameId) ID() string {
+	fmtString := "/subscriptions/%s/tagNames/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.TagName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Tag Name ID
+func (id TagNameId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticTagNames", "tagNames", "tagNames"),
+		resourceids.UserSpecifiedSegment("tagName", "tagValue"),
+	}
+}
+
+// String returns a human-readable description of this Tag Name ID
+func (id TagNameId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Tag Name: %q", id.TagName),
+	}
+	return fmt.Sprintf("Tag Name (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/id_tagvalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/id_tagvalue.go
@@ -1,0 +1,123 @@
+package tags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &TagValueId{}
+
+// TagValueId is a struct representing the Resource ID for a Tag Value
+type TagValueId struct {
+	SubscriptionId string
+	TagName        string
+	TagValueName   string
+}
+
+// NewTagValueID returns a new TagValueId struct
+func NewTagValueID(subscriptionId string, tagName string, tagValueName string) TagValueId {
+	return TagValueId{
+		SubscriptionId: subscriptionId,
+		TagName:        tagName,
+		TagValueName:   tagValueName,
+	}
+}
+
+// ParseTagValueID parses 'input' into a TagValueId
+func ParseTagValueID(input string) (*TagValueId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TagValueId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TagValueId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseTagValueIDInsensitively parses 'input' case-insensitively into a TagValueId
+// note: this method should only be used for API response data and not user input
+func ParseTagValueIDInsensitively(input string) (*TagValueId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TagValueId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TagValueId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *TagValueId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.TagName, ok = input.Parsed["tagName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "tagName", input)
+	}
+
+	if id.TagValueName, ok = input.Parsed["tagValueName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "tagValueName", input)
+	}
+
+	return nil
+}
+
+// ValidateTagValueID checks that 'input' can be parsed as a Tag Value ID
+func ValidateTagValueID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTagValueID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Tag Value ID
+func (id TagValueId) ID() string {
+	fmtString := "/subscriptions/%s/tagNames/%s/tagValues/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.TagName, id.TagValueName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Tag Value ID
+func (id TagValueId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticTagNames", "tagNames", "tagNames"),
+		resourceids.UserSpecifiedSegment("tagName", "tagValue"),
+		resourceids.StaticSegment("staticTagValues", "tagValues", "tagValues"),
+		resourceids.UserSpecifiedSegment("tagValueName", "tagValueValue"),
+	}
+}
+
+// String returns a human-readable description of this Tag Value ID
+func (id TagValueId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Tag Name: %q", id.TagName),
+		fmt.Sprintf("Tag Value Name: %q", id.TagValueName),
+	}
+	return fmt.Sprintf("Tag Value (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdate.go
@@ -1,0 +1,52 @@
+package tags
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TagDetails
+}
+
+// CreateOrUpdate ...
+func (c TagsClient) CreateOrUpdate(ctx context.Context, id TagNameId) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdateatscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdateatscope.go
@@ -1,0 +1,76 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateAtScopeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TagsResource
+}
+
+// CreateOrUpdateAtScope ...
+func (c TagsClient) CreateOrUpdateAtScope(ctx context.Context, id commonids.ScopeId, input TagsResource) (result CreateOrUpdateAtScopeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateAtScopeThenPoll performs CreateOrUpdateAtScope then polls until it's completed
+func (c TagsClient) CreateOrUpdateAtScopeThenPoll(ctx context.Context, id commonids.ScopeId, input TagsResource) error {
+	result, err := c.CreateOrUpdateAtScope(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdateAtScope: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdateAtScope: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdatevalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_createorupdatevalue.go
@@ -1,0 +1,52 @@
+package tags
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateValueOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TagValue
+}
+
+// CreateOrUpdateValue ...
+func (c TagsClient) CreateOrUpdateValue(ctx context.Context, id TagValueId) (result CreateOrUpdateValueOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_delete.go
@@ -1,0 +1,47 @@
+package tags
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c TagsClient) Delete(ctx context.Context, id TagNameId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_deleteatscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_deleteatscope.go
@@ -1,0 +1,71 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteAtScopeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// DeleteAtScope ...
+func (c TagsClient) DeleteAtScope(ctx context.Context, id commonids.ScopeId) (result DeleteAtScopeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteAtScopeThenPoll performs DeleteAtScope then polls until it's completed
+func (c TagsClient) DeleteAtScopeThenPoll(ctx context.Context, id commonids.ScopeId) error {
+	result, err := c.DeleteAtScope(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing DeleteAtScope: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after DeleteAtScope: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_deletevalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_deletevalue.go
@@ -1,0 +1,47 @@
+package tags
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteValueOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// DeleteValue ...
+func (c TagsClient) DeleteValue(ctx context.Context, id TagValueId) (result DeleteValueOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_getatscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_getatscope.go
@@ -1,0 +1,53 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetAtScopeOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TagsResource
+}
+
+// GetAtScope ...
+func (c TagsClient) GetAtScope(ctx context.Context, id commonids.ScopeId) (result GetAtScopeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_list.go
@@ -1,0 +1,92 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]TagDetails
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []TagDetails
+}
+
+// List ...
+func (c TagsClient) List(ctx context.Context, id commonids.SubscriptionId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/tagNames", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]TagDetails `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c TagsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, TagDetailsOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c TagsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate TagDetailsOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]TagDetails, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_updateatscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/method_updateatscope.go
@@ -1,0 +1,76 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateAtScopeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TagsResource
+}
+
+// UpdateAtScope ...
+func (c TagsClient) UpdateAtScope(ctx context.Context, id commonids.ScopeId, input TagsPatchResource) (result UpdateAtScopeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateAtScopeThenPoll performs UpdateAtScope then polls until it's completed
+func (c TagsClient) UpdateAtScopeThenPoll(ctx context.Context, id commonids.ScopeId, input TagsPatchResource) error {
+	result, err := c.UpdateAtScope(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UpdateAtScope: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after UpdateAtScope: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagcount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagcount.go
@@ -1,0 +1,9 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagCount struct {
+	Type  *string `json:"type,omitempty"`
+	Value *int64  `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagdetails.go
@@ -1,0 +1,11 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagDetails struct {
+	Count   *TagCount   `json:"count,omitempty"`
+	Id      *string     `json:"id,omitempty"`
+	TagName *string     `json:"tagName,omitempty"`
+	Values  *[]TagValue `json:"values,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tags.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tags.go
@@ -1,0 +1,8 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Tags struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagspatchresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagspatchresource.go
@@ -1,0 +1,9 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsPatchResource struct {
+	Operation  *TagsPatchOperation `json:"operation,omitempty"`
+	Properties *Tags               `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagsresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagsresource.go
@@ -1,0 +1,11 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsResource struct {
+	Id         *string `json:"id,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	Properties Tags    `json:"properties"`
+	Type       *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagvalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/model_tagvalue.go
@@ -1,0 +1,10 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagValue struct {
+	Count    *TagCount `json:"count,omitempty"`
+	Id       *string   `json:"id,omitempty"`
+	TagValue *string   `json:"tagValue,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/predicates.go
@@ -1,0 +1,22 @@
+package tags
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagDetailsOperationPredicate struct {
+	Id      *string
+	TagName *string
+}
+
+func (p TagDetailsOperationPredicate) Matches(input TagDetails) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.TagName != nil && (input.TagName == nil || *p.TagName != *input.TagName) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/version.go
@@ -1,0 +1,12 @@
+package tags
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-07-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/tags/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -913,6 +913,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyas
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-12-01/subscriptions
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups
+github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/adminkeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/querykeys


### PR DESCRIPTION
This removes another usage of the old Azure SDK, since this is now available in `hashicorp/go-azure-sdk`