### PR TITLE
Validate 'Display Name' for API Management's named values

### DIFF
--- a/internal/services/apimanagement/api_management_named_value_resource.go
+++ b/internal/services/apimanagement/api_management_named_value_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -50,7 +51,7 @@ func resourceApiManagementNamedValue() *pluginsdk.Resource {
 			"display_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validate.ApiManagementNamedValueDisplayName,
 			},
 
 			"value_from_key_vault": {

--- a/internal/services/apimanagement/validate/api_management.go
+++ b/internal/services/apimanagement/validate/api_management.go
@@ -85,9 +85,20 @@ func ApiManagementApiPath(v interface{}, k string) (ws []string, es []error) {
 func ApiManagementBackendName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	// From https://docs.microsoft.com/en-us/rest/api/apimanagement/2018-01-01/backend/createorupdate#uri-parameters
+	// From https://learn.microsoft.com/en-us/rest/api/apimanagement/backend/create-or-update#uri-parameters
 	if matched := regexp.MustCompile(`(^[\w]+$)|(^[\w][\w\-]+[\w]$)`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes up to 50 characters in length", k))
+	}
+
+	return warnings, errors
+}
+
+func ApiManagementNamedValueDisplayName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	// From the portal: `Name may contain only letters, digits, periods, dash, and underscore.`
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z_.-]$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, periods, underscores and dashes", k))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
When creating a new Named Value through APIM in the Azure portal, an apparently undocumented naming restriction is noted regarding its display name:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/17701655/749c6d10-0d7d-4f51-921d-0b3832e4248b)

When applying a plan containing a named value with a non-compliant display name, this would previously plan as valid, then fail with an ambiguous `performing CreateOrUpdate: unexpected status 400 with error: ValidationError: One or more fields contain incorrect values`.
