### PR TITLE
`azurerm_linux_virtual_machine`,`azurerm_windows_virtual_machine` - Support update `virtual_machine_scale_set_id`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -330,7 +330,6 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			"virtual_machine_scale_set_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
 				ConflictsWith: []string{
 					"availability_set_id",
 				},
@@ -1191,6 +1190,18 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 
 		update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
 			OsDisk: osDisk,
+		}
+	}
+
+	if d.HasChange("virtual_machine_scale_set_id") {
+		shouldUpdate = true
+
+		if vmssIDRaw, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
+			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{
+				ID: utils.String(vmssIDRaw.(string)),
+			}
+		} else {
+			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{}
 		}
 	}
 

--- a/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
@@ -101,7 +101,155 @@ func TestAccLinuxVirtualMachine_orchestratedMultipleNonZonal(t *testing.T) {
 	})
 }
 
+func TestAccLinuxVirtualMachine_orchestratedIdUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.orchestratedIdUnAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.orchestratedIdAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.orchestratedIdUnAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func (r LinuxVirtualMachineResource) orchestratedZonal(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestVMO-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  platform_fault_domain_count = 1
+
+  zones = ["1"]
+
+  tags = {
+    ENV = "Test"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@ssw0rd1234!"
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  virtual_machine_scale_set_id = azurerm_orchestrated_virtual_machine_scale_set.test.id
+  zone                         = tolist(azurerm_orchestrated_virtual_machine_scale_set.test.zones)[0]
+}
+`, r.templateBaseForOchestratedVMSS(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) orchestratedIdUnAttached(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestVMO-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  platform_fault_domain_count = 1
+
+  zones = ["1"]
+
+  tags = {
+    ENV = "Test"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@ssw0rd1234!"
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  zone = tolist(azurerm_orchestrated_virtual_machine_scale_set.test.zones)[0]
+}
+`, r.templateBaseForOchestratedVMSS(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) orchestratedIdAttached(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -359,7 +359,6 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			"virtual_machine_scale_set_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
 				ConflictsWith: []string{
 					"availability_set_id",
 				},
@@ -1352,6 +1351,18 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 		update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
 			OsDisk: osDisk,
+		}
+	}
+
+	if d.HasChange("virtual_machine_scale_set_id") {
+		shouldUpdate = true
+
+		if vmssIDRaw, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
+			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{
+				ID: utils.String(vmssIDRaw.(string)),
+			}
+		} else {
+			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{}
 		}
 	}
 

--- a/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
@@ -101,7 +101,153 @@ func TestAccWindowsVirtualMachine_orchestratedMultipleNoneZonal(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_orchestratedIdUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.orchestratedIdUnAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.orchestratedIdAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.orchestratedIdUnAttached(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func (r WindowsVirtualMachineResource) orchestratedZonal(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestVMO-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  platform_fault_domain_count = 1
+
+  zones = ["1"]
+
+  tags = {
+    ENV = "Test"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  virtual_machine_scale_set_id = azurerm_orchestrated_virtual_machine_scale_set.test.id
+  zone                         = tolist(azurerm_orchestrated_virtual_machine_scale_set.test.zones)[0]
+}
+`, r.templateBaseForOchestratedVMSS(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) orchestratedIdUnAttached(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestVMO-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  platform_fault_domain_count = 1
+
+  zones = ["1"]
+
+  tags = {
+    ENV = "Test"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  zone = tolist(azurerm_orchestrated_virtual_machine_scale_set.test.zones)[0]
+}
+`, r.templateBaseForOchestratedVMSS(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) orchestratedIdAttached(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -210,7 +210,7 @@ The following arguments are supported:
 
 * `vtpm_enabled` - (Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created.
 
-* `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within. Changing this forces a new resource to be created.
+* `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within.
 
 ~> **NOTE:** Orchestrated Virtual Machine Scale Sets can be provisioned using [the `azurerm_orchestrated_virtual_machine_scale_set` resource](/docs/providers/azurerm/r/orchestrated_virtual_machine_scale_set.html).
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -212,6 +212,8 @@ The following arguments are supported:
 
 * `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within.
 
+-> **NOTE:** To update `virtual_machine_scale_set_id` the Preview Feature `Microsoft.Compute/SingleFDAttachDetachVMToVmss` needs to be enabled, see [the documentation](https://review.learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm#enroll-in-the-preview) for more information.
+
 ~> **NOTE:** Orchestrated Virtual Machine Scale Sets can be provisioned using [the `azurerm_orchestrated_virtual_machine_scale_set` resource](/docs/providers/azurerm/r/orchestrated_virtual_machine_scale_set.html).
 
 * `zone` - (Optional) Specifies the Availability Zones in which this Linux Virtual Machine should be located. Changing this forces a new Linux Virtual Machine to be created.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -205,7 +205,7 @@ The following arguments are supported:
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine.
 
-* `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within. Changing this forces a new resource to be created.
+* `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within.
 
 ~> **NOTE:** Orchestrated Virtual Machine Scale Sets can be provisioned using [the `azurerm_orchestrated_virtual_machine_scale_set` resource](/docs/providers/azurerm/r/orchestrated_virtual_machine_scale_set.html).
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -207,6 +207,8 @@ The following arguments are supported:
 
 * `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within.
 
+-> **NOTE:** To update `virtual_machine_scale_set_id` the Preview Feature `Microsoft.Compute/SingleFDAttachDetachVMToVmss` needs to be enabled, see [the documentation](https://review.learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm#enroll-in-the-preview) for more information.
+
 ~> **NOTE:** Orchestrated Virtual Machine Scale Sets can be provisioned using [the `azurerm_orchestrated_virtual_machine_scale_set` resource](/docs/providers/azurerm/r/orchestrated_virtual_machine_scale_set.html).
 
 * `vtpm_enabled` - (Optional) Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine. Changing this forces a new resource to be created.


### PR DESCRIPTION
## Prerequisites

Run `az feature register` command to [enroll in this feature](https://review.learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&branchFallbackFrom=pr-en-us-250984&tabs=cli-1%2Cportal-2%2Cportal-3#enroll-in-the-preview):

`az feature register --namespace "Microsoft.Compute" --name "SingleFDAttachDetachVMToVmss"`

## Related Document

[Swagger](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/virtualMachine.json#L3065)
[MS-Doc](https://review.learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&branchFallbackFrom=pr-en-us-250984&tabs=cli-1%2Cportal-2%2Cportal-3#attach-an-existing-vm-to-a-virtual-machine-scale-set-preview)


## Test Result

=== RUN   TestAccLinuxVirtualMachine_orchestratedIdUpdate
=== PAUSE TestAccLinuxVirtualMachine_orchestratedIdUpdate
=== CONT  TestAccLinuxVirtualMachine_orchestratedIdUpdate
--- PASS: TestAccLinuxVirtualMachine_orchestratedIdUpdate (598.52s)
PASS


=== RUN   TestAccWindowsVirtualMachine_orchestratedIdUpdate
=== PAUSE TestAccWindowsVirtualMachine_orchestratedIdUpdate
=== CONT  TestAccWindowsVirtualMachine_orchestratedIdUpdate
--- PASS: TestAccWindowsVirtualMachine_orchestratedIdUpdate (801.96s)
PASS