### PR TITLE
New Data Source: azurerm_databricks_access_connector

### DIFF
--- a/internal/services/databricks/databricks_access_connector_data_source.go
+++ b/internal/services/databricks/databricks_access_connector_data_source.go
@@ -1,0 +1,91 @@
+package databricks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databricks/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ sdk.DataSource = DatabricksAccessConnectorDataSource{}
+
+type DatabricksAccessConnectorDataSource struct{}
+
+type DatabricksAccessConnectorDataSourceModel struct {
+	Name          string `tfschema:"name"`
+	ResourceGroup string `tfschema:"resource_group_name"`
+}
+
+func (DatabricksAccessConnectorDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.AccessConnectorName,
+		},
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (DatabricksAccessConnectorDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+		"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
+		"tags":     commonschema.TagsDataSource(),
+	}
+}
+
+func (DatabricksAccessConnectorDataSource) ModelObject() interface{} {
+	return &DatabricksAccessConnectorDataSourceModel{}
+}
+
+func (DatabricksAccessConnectorDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model DatabricksAccessConnectorDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			client := metadata.Client.DataBricks.AccessConnectorClient
+
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := accessconnector.NewAccessConnectorID(subscriptionId, model.ResourceGroup, model.Name)
+
+			resp, err := client.Get(ctx, id)
+			resourceData := metadata.ResourceData
+			// Handle fetch errors
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+			// Set the attributes
+			metadata.SetID(id)
+			resourceData.Set("location", location.NormalizeNilable(&resp.Model.Location))
+			identity, err := identity.FlattenLegacySystemAndUserAssignedMap(resp.Model.Identity)
+			if err != nil {
+				return fmt.Errorf("flattening `identity`: %+v", err)
+			}
+			if err := resourceData.Set("identity", identity); err != nil {
+				return fmt.Errorf("setting `identity`: %+v", err)
+			}
+			return tags.FlattenAndSet(resourceData, resp.Model.Tags)
+		},
+	}
+}
+
+func (DatabricksAccessConnectorDataSource) ResourceType() string {
+	return "azurerm_databricks_access_connector"
+}

--- a/internal/services/databricks/databricks_access_connector_data_source_test.go
+++ b/internal/services/databricks/databricks_access_connector_data_source_test.go
@@ -1,0 +1,94 @@
+package databricks_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DatabricksAccessConnectorDataSource struct{}
+
+func TestAccDatabricksAccessConnectorDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databricks_access_connector", "test")
+	r := DatabricksAccessConnectorDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
+	})
+}
+
+func TestAccDatabricksAccessConnectorDataSource_systemIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_databricks_access_connector", "test")
+	r := DatabricksAccessConnectorDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.systemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("identity.#").Exists(),
+				check.That(data.ResourceName).Key("identity.0.type").Exists(),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDatabricksAccessConnectorDataSource_userIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_databricks_access_connector", "test")
+	r := DatabricksAccessConnectorDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.userIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("identity.#").Exists(),
+				check.That(data.ResourceName).Key("identity.0.type").Exists(),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").Exists(),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.0").Exists(),
+			),
+		},
+	})
+}
+
+func (DatabricksAccessConnectorDataSource) basic(data acceptance.TestData) string {
+	template := DatabricksAccessConnectorResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+data "azurerm_databricks_access_connector" "test" {
+  name                = azurerm_databricks_access_connector.test.name
+  resource_group_name = azurerm_databricks_access_connector.test.resource_group_name
+}
+`, template)
+}
+
+func (DatabricksAccessConnectorDataSource) systemIdentity(data acceptance.TestData) string {
+	template := DatabricksAccessConnectorResource{}.complete(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_databricks_access_connector" "test" {
+  name                = azurerm_databricks_access_connector.test.name
+  resource_group_name = azurerm_databricks_access_connector.test.resource_group_name
+}
+`, template)
+}
+
+func (DatabricksAccessConnectorDataSource) userIdentity(data acceptance.TestData) string {
+	template := DatabricksAccessConnectorResource{}.identityUserAssigned(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_databricks_access_connector" "test" {
+  name                = azurerm_databricks_access_connector.test.name
+  resource_group_name = azurerm_databricks_access_connector.test.resource_group_name
+}
+`, template)
+}

--- a/internal/services/databricks/registration.go
+++ b/internal/services/databricks/registration.go
@@ -51,7 +51,9 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 // DataSources returns the typed DataSources supported by this service
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		DatabricksAccessConnectorDataSource{},
+	}
 }
 
 // Resources returns the typed Resources supported by this service

--- a/website/docs/d/databricks_access_connector.html.markdown
+++ b/website/docs/d/databricks_access_connector.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Databricks"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_databricks_access_connector"
+description: |-
+  Gets information about an existing Databricks Access Connector.
+---
+
+# Data Source: azurerm_databricks_access_connector
+
+Use this data source to access information about an existing Databricks Access Connector.
+
+## Example Usage
+
+```hcl
+data "azurerm_databricks_access_connector" "example" {
+  name = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_databricks_access_connector.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Databricks Access Connector.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Databricks Access Connector exists. Changing this forces a new Databricks Access Connector to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Databricks Access Connector.
+
+* `identity` - A `identity` block as defined below.
+
+* `location` - The Azure Region where the Databricks Access Connector exists.
+
+* `tags` - A mapping of tags assigned to the Databricks Access Connector.
+
+---
+
+A `identity` block exports the following:
+
+* `identity_ids` - A `identity_ids` block as defined below.
+
+* `principal_id` - The ID of the TODO.
+
+* `tenant_id` - The ID of the TODO.
+
+* `type` - TODO.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Databricks Access Connector.


### PR DESCRIPTION
Adds a data source for `azurerm_databricks_access_connector`.

Output from acceptance tests:
```
--- PASS: TestAccDatabricksAccessConnectorDataSource_systemIdentity (142.23s)
--- PASS: TestAccDatabricksAccessConnectorDataSource_basic (144.97s)
--- PASS: TestAccDatabricksAccessConnectorDataSource_userIdentity (162.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/databricks	166.252s
```

Resolves: #23947 