### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20240206.1080438`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.2
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240206.1080438
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.2
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240201.1064937
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.66.2 h1:+Pzuo7pdKl0hBXXr5ymmhs4Q40tHAo2nAvHq4WgSjx8=
 github.com/hashicorp/go-azure-helpers v0.66.2/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937 h1:0Qsxoi+3HFoZfWfcXFUKlWbbk2SiYdbb+FyRrMcrY1c=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937/go.mod h1:tWvx1elhgqkBLrnieHoGYzw253uFkybKTbXLfSMeJy8=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240206.1080438 h1:1TX0auCiI2JoPc9xZNVuFZp2UqSXifbqUVaRdMnbVZ0=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240206.1080438/go.mod h1:FDOLG1MTj+n6GA5ZiBh94eVbmsj0Hx+0CbQvPH8jbe4=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438 h1:g6BVcMdt2HPyhPEjux82HxG6hbkO/J49+lXUC/EPJ0Y=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438/go.mod h1:IKIPyL+hfFWBHABKT0NOWlIEzlusiUBG0SxIfaiv278=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/go-azure-helpers v0.66.2 h1:+Pzuo7pdKl0hBXXr5ymmhs4Q40tHAo2
 github.com/hashicorp/go-azure-helpers v0.66.2/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937 h1:0Qsxoi+3HFoZfWfcXFUKlWbbk2SiYdbb+FyRrMcrY1c=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937/go.mod h1:tWvx1elhgqkBLrnieHoGYzw253uFkybKTbXLfSMeJy8=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240201.1064937 h1:lb3ePovn8wlLdemYrT4MJFrWuzXKHiwDXvdcpeWlqPw=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240201.1064937/go.mod h1:6jgkzx26qtPndLSW5u7pKIw4m3iiFiLnHlp7yDQ2Crc=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438 h1:g6BVcMdt2HPyhPEjux82HxG6hbkO/J49+lXUC/EPJ0Y=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438/go.mod h1:IKIPyL+hfFWBHABKT0NOWlIEzlusiUBG0SxIfaiv278=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := domainservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := domainservices.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := tenants.NewSubscriptionID()
+id := commonids.NewSubscriptionID()
 
 payload := tenants.CheckNameAvailabilityRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tenants.NewResourceGroupID()
+id := commonids.NewResourceGroupID()
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -107,7 +108,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := tenants.NewSubscriptionID()
+id := commonids.NewSubscriptionID()
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/advisor/2020-01-01/getrecommendations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/advisor/2020-01-01/getrecommendations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/advisor/2020-01-01/getrecommendations"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := getrecommendations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.RecommendationsList(ctx, id, getrecommendations.DefaultRecommendationsListOperationOptions())` can be used to do batched pagination
 items, err := client.RecommendationsListComplete(ctx, id, getrecommendations.DefaultRecommendationsListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := alertprocessingrules.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := alertprocessingrules.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2023-03-01/prometheusrulegroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2023-03-01/prometheusrulegroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2023-03-01/prometheusrulegroups"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := prometheusrulegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := prometheusrulegroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/analysisservices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/analysisservices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/analysisservices"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := analysisservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ServersListSkusForNew(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers"
 ```
 
@@ -106,7 +107,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -122,7 +123,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/apimanagementservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/apimanagementservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/apimanagementservice"
 ```
 
@@ -58,7 +59,7 @@ if err := client.BackupThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := apimanagementservice.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := apimanagementservice.ApiManagementServiceCheckNameAvailabilityParameters{
 	// ...
@@ -124,7 +125,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := apimanagementservice.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.GetDomainOwnershipIdentifier(ctx, id)
 if err != nil {
@@ -156,7 +157,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := apimanagementservice.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -173,7 +174,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := apimanagementservice.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/deletedservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/deletedservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/deletedservice"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := deletedservice.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := configurationstores.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := configurationstores.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/deletedconfigurationstores/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/deletedconfigurationstores/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/deletedconfigurationstores"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := deletedconfigurationstores.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ConfigurationStoresListDeleted(ctx, id)` can be used to do batched pagination
 items, err := client.ConfigurationStoresListDeletedComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/operations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/operations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/operations"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := operations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := operations.CheckNameAvailabilityParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workbooktemplatesapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.WorkbookTemplatesListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workbooksapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.WorkbooksListByResourceGroup(ctx, id, workbooksapis.DefaultWorkbooksListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.WorkbooksListByResourceGroupComplete(ctx, id, workbooksapis.DefaultWorkbooksListByResourceGroupOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workbooksapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.WorkbooksListBySubscription(ctx, id, workbooksapis.DefaultWorkbooksListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.WorkbooksListBySubscriptionComplete(ctx, id, workbooksapis.DefaultWorkbooksListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webtestsapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.WebTestsList(ctx, id)` can be used to do batched pagination
 items, err := client.WebTestsListComplete(ctx, id)
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webtestsapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.WebTestsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.WebTestsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2023-11-01-preview/appplatform/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2023-11-01-preview/appplatform/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2023-11-01-preview/appplatform"
 ```
 
@@ -131,7 +132,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ApiPortalsList(ctx, id)` can be used to do batched pagination
 items, err := client.ApiPortalsListComplete(ctx, id)
@@ -214,7 +215,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ApmsList(ctx, id)` can be used to do batched pagination
 items, err := client.ApmsListComplete(ctx, id)
@@ -292,7 +293,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ApplicationAcceleratorsList(ctx, id)` can be used to do batched pagination
 items, err := client.ApplicationAcceleratorsListComplete(ctx, id)
@@ -354,7 +355,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ApplicationLiveViewsList(ctx, id)` can be used to do batched pagination
 items, err := client.ApplicationLiveViewsListComplete(ctx, id)
@@ -432,7 +433,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.AppsList(ctx, id)` can be used to do batched pagination
 items, err := client.AppsListComplete(ctx, id)
@@ -890,7 +891,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.BuildServiceListBuildServices(ctx, id)` can be used to do batched pagination
 items, err := client.BuildServiceListBuildServicesComplete(ctx, id)
@@ -1018,7 +1019,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.BuildpackBindingListForCluster(ctx, id)` can be used to do batched pagination
 items, err := client.BuildpackBindingListForClusterComplete(ctx, id)
@@ -1080,7 +1081,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.CertificatesList(ctx, id)` can be used to do batched pagination
 items, err := client.CertificatesListComplete(ctx, id)
@@ -1097,7 +1098,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ConfigServersGet(ctx, id)
 if err != nil {
@@ -1113,7 +1114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ConfigServerResource{
 	// ...
@@ -1130,7 +1131,7 @@ if err := client.ConfigServersUpdatePatchThenPoll(ctx, id, payload); err != nil 
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ConfigServerResource{
 	// ...
@@ -1147,7 +1148,7 @@ if err := client.ConfigServersUpdatePutThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ConfigServerSettings{
 	// ...
@@ -1209,7 +1210,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ConfigurationServicesList(ctx, id)` can be used to do batched pagination
 items, err := client.ConfigurationServicesListComplete(ctx, id)
@@ -1305,7 +1306,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ContainerRegistriesList(ctx, id)` can be used to do batched pagination
 items, err := client.ContainerRegistriesListComplete(ctx, id)
@@ -1658,7 +1659,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.DeploymentsListForCluster(ctx, id, appplatform.DefaultDeploymentsListForClusterOperationOptions())` can be used to do batched pagination
 items, err := client.DeploymentsListForClusterComplete(ctx, id, appplatform.DefaultDeploymentsListForClusterOperationOptions())
@@ -1790,7 +1791,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.DevToolPortalsList(ctx, id)` can be used to do batched pagination
 items, err := client.DevToolPortalsListComplete(ctx, id)
@@ -1807,7 +1808,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.EurekaServersGet(ctx, id)
 if err != nil {
@@ -1823,7 +1824,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.EurekaServersList(ctx, id)
 if err != nil {
@@ -1839,7 +1840,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.EurekaServerResource{
 	// ...
@@ -1856,7 +1857,7 @@ if err := client.EurekaServersUpdatePatchThenPoll(ctx, id, payload); err != nil 
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.EurekaServerResource{
 	// ...
@@ -2042,7 +2043,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.GatewaysList(ctx, id)` can be used to do batched pagination
 items, err := client.GatewaysListComplete(ctx, id)
@@ -2125,7 +2126,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.MonitoringSettingsGet(ctx, id)
 if err != nil {
@@ -2141,7 +2142,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.MonitoringSettingResource{
 	// ...
@@ -2158,7 +2159,7 @@ if err := client.MonitoringSettingsUpdatePatchThenPoll(ctx, id, payload); err !=
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.MonitoringSettingResource{
 	// ...
@@ -2288,7 +2289,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ServiceRegistriesList(ctx, id)` can be used to do batched pagination
 items, err := client.ServiceRegistriesListComplete(ctx, id)
@@ -2326,7 +2327,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ServiceResource{
 	// ...
@@ -2343,7 +2344,7 @@ if err := client.ServicesCreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 if err := client.ServicesDeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -2355,7 +2356,7 @@ if err := client.ServicesDeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ApmReference{
 	// ...
@@ -2372,7 +2373,7 @@ if err := client.ServicesDisableApmGloballyThenPoll(ctx, id, payload); err != ni
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ServicesDisableTestEndpoint(ctx, id)
 if err != nil {
@@ -2388,7 +2389,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ApmReference{
 	// ...
@@ -2405,7 +2406,7 @@ if err := client.ServicesEnableApmGloballyThenPoll(ctx, id, payload); err != nil
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ServicesEnableTestEndpoint(ctx, id)
 if err != nil {
@@ -2421,7 +2422,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 if err := client.ServicesFlushVnetDnsSettingThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -2433,7 +2434,7 @@ if err := client.ServicesFlushVnetDnsSettingThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ServicesGet(ctx, id)
 if err != nil {
@@ -2449,7 +2450,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ServicesList(ctx, id)` can be used to do batched pagination
 items, err := client.ServicesListComplete(ctx, id)
@@ -2466,7 +2467,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ServicesListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ServicesListBySubscriptionComplete(ctx, id)
@@ -2483,7 +2484,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ServicesListGloballyEnabledApms(ctx, id)
 if err != nil {
@@ -2499,7 +2500,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ServicesListSupportedApmTypes(ctx, id)` can be used to do batched pagination
 items, err := client.ServicesListSupportedApmTypesComplete(ctx, id)
@@ -2516,7 +2517,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.ServicesListSupportedServerVersions(ctx, id)` can be used to do batched pagination
 items, err := client.ServicesListSupportedServerVersionsComplete(ctx, id)
@@ -2533,7 +2534,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 read, err := client.ServicesListTestKeys(ctx, id)
 if err != nil {
@@ -2549,7 +2550,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.RegenerateTestKeyRequestPayload{
 	// ...
@@ -2570,7 +2571,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 if err := client.ServicesStartThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -2582,7 +2583,7 @@ if err := client.ServicesStartThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 if err := client.ServicesStopThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -2594,7 +2595,7 @@ if err := client.ServicesStopThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 payload := appplatform.ServiceResource{
 	// ...
@@ -2611,7 +2612,7 @@ if err := client.ServicesUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.SkusList(ctx, id)` can be used to do batched pagination
 items, err := client.SkusListComplete(ctx, id)
@@ -2673,7 +2674,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appplatform.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
+id := commonids.NewSpringCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "springValue")
 
 // alternatively `client.StoragesList(ctx, id)` can be used to do batched pagination
 items, err := client.StoragesListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := attestationproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -109,7 +110,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := attestationproviders.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -125,7 +126,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := attestationproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListDefault(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2018-01-01-preview/roledefinitions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2018-01-01-preview/roledefinitions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2018-01-01-preview/roledefinitions"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roledefinitions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id, roledefinitions.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, roledefinitions.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentscheduleinstances/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentscheduleinstances/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentscheduleinstances"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignmentscheduleinstances.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForScope(ctx, id, roleassignmentscheduleinstances.DefaultListForScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListForScopeComplete(ctx, id, roleassignmentscheduleinstances.DefaultListForScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentschedulerequests/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentschedulerequests/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleassignmentschedulerequests"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignmentschedulerequests.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForScope(ctx, id, roleassignmentschedulerequests.DefaultListForScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListForScopeComplete(ctx, id, roleassignmentschedulerequests.DefaultListForScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityscheduleinstances/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityscheduleinstances/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityscheduleinstances"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleeligibilityscheduleinstances.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForScope(ctx, id, roleeligibilityscheduleinstances.DefaultListForScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListForScopeComplete(ctx, id, roleeligibilityscheduleinstances.DefaultListForScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityschedulerequests/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityschedulerequests/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityschedulerequests"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleeligibilityschedulerequests.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForScope(ctx, id, roleeligibilityschedulerequests.DefaultListForScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListForScopeComplete(ctx, id, roleeligibilityschedulerequests.DefaultListForScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roleassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roleassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roleassignments"
 ```
 
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := roleassignments.RoleAssignmentCreateParameters{
 	// ...
@@ -82,7 +83,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.DeleteById(ctx, id, roleassignments.DefaultDeleteByIdOperationOptions())
 if err != nil {
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.GetById(ctx, id, roleassignments.DefaultGetByIdOperationOptions())
 if err != nil {
@@ -130,7 +131,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForResource(ctx, id, roleassignments.DefaultListForResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceComplete(ctx, id, roleassignments.DefaultListForResourceOperationOptions())
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListForResourceGroup(ctx, id, roleassignments.DefaultListForResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceGroupComplete(ctx, id, roleassignments.DefaultListForResourceGroupOperationOptions())
@@ -164,7 +165,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForScope(ctx, id, roleassignments.DefaultListForScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListForScopeComplete(ctx, id, roleassignments.DefaultListForScopeOperationOptions())
@@ -181,7 +182,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := roleassignments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListForSubscription(ctx, id, roleassignments.DefaultListForSubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListForSubscriptionComplete(ctx, id, roleassignments.DefaultListForSubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roledefinitions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roledefinitions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roledefinitions"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := roledefinitions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id, roledefinitions.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, roledefinitions.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/automationaccount/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/automationaccount/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/automationaccount"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := automationaccount.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := automationaccount.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2023-11-01/automationaccount/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2023-11-01/automationaccount/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/automation/2023-11-01/automationaccount"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := automationaccount.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := automationaccount.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2023-08-01/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2023-08-01/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2023-08-01/clusters"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2023-05-01/batchaccount/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2023-05-01/batchaccount/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/batch/2023-05-01/batchaccount"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := batchaccount.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := batchaccount.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/assignment/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/assignment/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/assignment"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := assignment.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/blueprint/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/blueprint/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview/blueprint"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blueprint.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/botservice/2022-09-15/channel/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/botservice/2022-09-15/channel/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/botservice/2022-09-15/channel"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 payload := channel.BotChannel{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 payload := channel.SiteInfo{
 	// ...
@@ -82,7 +83,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue")
+id := commonids.NewBotServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue")
 
 read, err := client.EmailCreateSignInUrl(ctx, id)
 if err != nil {
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue")
+id := commonids.NewBotServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -131,7 +132,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 read, err := client.ListWithKeys(ctx, id)
 if err != nil {
@@ -147,7 +148,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := channel.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
+id := commonids.NewBotServiceChannelID("12345678-1234-9876-4563-123456789012", "example-resource-group", "botServiceValue", "AcsChatChannel")
 
 payload := channel.BotChannel{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/capabilities/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/capabilities/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/capabilities"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capabilities.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
+id := commonids.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
 
 payload := capabilities.Capability{
 	// ...
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capabilities.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
+id := commonids.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capabilities.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
+id := commonids.NewChaosStudioCapabilityID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue", "capabilityValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capabilities.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
+id := commonids.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
 
 // alternatively `client.List(ctx, id, capabilities.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, capabilities.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/experiments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/experiments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/experiments"
 ```
 
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := experiments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id, experiments.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, experiments.DefaultListOperationOptions())
@@ -130,7 +131,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := experiments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id, experiments.DefaultListAllOperationOptions())` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id, experiments.DefaultListAllOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/targets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/targets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/targets"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := targets.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
+id := commonids.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
 
 payload := targets.Target{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := targets.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
+id := commonids.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := targets.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
+id := commonids.NewChaosStudioTargetID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "targetValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := targets.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id, targets.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, targets.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/cognitiveservicesaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/cognitiveservicesaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/cognitiveservicesaccounts"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cognitiveservicesaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.AccountsList(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := cognitiveservicesaccounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.AccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListByResourceGroupComplete(ctx, id)
@@ -206,7 +207,7 @@ if err := client.AccountsUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := cognitiveservicesaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := cognitiveservicesaccounts.CheckDomainAvailabilityParameter{
 	// ...
@@ -264,7 +265,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cognitiveservicesaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.DeletedAccountsList(ctx, id)` can be used to do batched pagination
 items, err := client.DeletedAccountsListComplete(ctx, id)
@@ -293,7 +294,7 @@ if err := client.DeletedAccountsPurgeThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := cognitiveservicesaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ResourceSkusList(ctx, id)` can be used to do batched pagination
 items, err := client.ResourceSkusListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := communicationservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := communicationservices.CheckNameAvailabilityRequest{
 	// ...
@@ -111,7 +112,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := communicationservices.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -128,7 +129,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := communicationservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := emailservices.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := emailservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := emailservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListVerifiedExchangeOnlineDomains(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/skus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/skus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/skus"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := skus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ResourceSkusList(ctx, id, skus.DefaultResourceSkusListOperationOptions())` can be used to do batched pagination
 items, err := client.ResourceSkusListComplete(ctx, id, skus.DefaultResourceSkusListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
+id := commonids.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
 
 payload := availabilitysets.AvailabilitySet{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
+id := commonids.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
+id := commonids.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
+id := commonids.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
 
 read, err := client.ListAvailableSizes(ctx, id)
 if err != nil {
@@ -110,7 +111,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, availabilitysets.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, availabilitysets.DefaultListBySubscriptionOperationOptions())
@@ -127,7 +128,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := availabilitysets.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
+id := commonids.NewAvailabilitySetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "availabilitySetValue")
 
 payload := availabilitysets.AvailabilitySetUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
+id := commonids.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
 
 payload := dedicatedhostgroups.DedicatedHostGroup{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
+id := commonids.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
+id := commonids.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
 
 read, err := client.Get(ctx, id, dedicatedhostgroups.DefaultGetOperationOptions())
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhostgroups.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
+id := commonids.NewDedicatedHostGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue")
 
 payload := dedicatedhostgroups.DedicatedHostGroupUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := dedicatedhosts.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
+id := commonids.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
 
 payload := dedicatedhosts.DedicatedHost{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhosts.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
+id := commonids.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhosts.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
+id := commonids.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
 
 read, err := client.Get(ctx, id, dedicatedhosts.DefaultGetOperationOptions())
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhosts.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
+id := commonids.NewDedicatedHostID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostGroupValue", "hostValue")
 
 payload := dedicatedhosts.DedicatedHostUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := sshpublickeys.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -110,7 +111,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := sshpublickeys.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines"
 ```
 
@@ -171,7 +172,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualmachines.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id, virtualmachines.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, virtualmachines.DefaultListOperationOptions())
@@ -188,7 +189,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualmachines.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id, virtualmachines.DefaultListAllOperationOptions())` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id, virtualmachines.DefaultListAllOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capacityreservationgroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, capacityreservationgroups.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, capacityreservationgroups.DefaultListByResourceGroupOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := capacityreservationgroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, capacityreservationgroups.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, capacityreservationgroups.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := images.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := images.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := proximityplacementgroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := proximityplacementgroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses"
 ```
 
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := diskaccesses.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -130,7 +131,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := diskaccesses.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
+id := commonids.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
 
 payload := diskencryptionsets.DiskEncryptionSet{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
+id := commonids.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
+id := commonids.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
+id := commonids.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
 
 // alternatively `client.ListAssociatedResources(ctx, id)` can be used to do batched pagination
 items, err := client.ListAssociatedResourcesComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -120,7 +121,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := diskencryptionsets.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
+id := commonids.NewDiskEncryptionSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskEncryptionSetValue")
 
 payload := diskencryptionsets.DiskEncryptionSetUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
 ```
 
@@ -86,7 +87,7 @@ if err := client.GrantAccessThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := galleries.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 payload := galleries.Gallery{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := galleries.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := galleries.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 read, err := client.Get(ctx, id, galleries.DefaultGetOperationOptions())
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := galleries.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := galleries.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := galleries.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 payload := galleries.GalleryUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := galleryapplications.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 // alternatively `client.ListByGallery(ctx, id)` can be used to do batched pagination
 items, err := client.ListByGalleryComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := gallerysharingupdate.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+id := commonids.NewSharedImageGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
 
 payload := gallerysharingupdate.SharingUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 payload := disks.Disk{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 payload := disks.GrantAccessData{
 	// ...
@@ -86,7 +87,7 @@ if err := client.GrantAccessThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := disks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := disks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -120,7 +121,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 if err := client.RevokeAccessThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -132,7 +133,7 @@ if err := client.RevokeAccessThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := disks.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
+id := commonids.NewManagedDiskID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskValue")
 
 payload := disks.DiskUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := confidentialledger.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.LedgerListByResourceGroup(ctx, id, confidentialledger.DefaultLedgerListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.LedgerListByResourceGroupComplete(ctx, id, confidentialledger.DefaultLedgerListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := confidentialledger.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.LedgerListBySubscription(ctx, id, confidentialledger.DefaultLedgerListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.LedgerListBySubscriptionComplete(ctx, id, confidentialledger.DefaultLedgerListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := budgets.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/containerapps/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/containerapps/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/containerapps"
 ```
 
@@ -167,7 +168,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := containerapps.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -184,7 +185,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := containerapps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
 ```
 
@@ -192,7 +193,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedenvironments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -209,7 +210,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedenvironments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2023-05-01/containerinstance/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2023-05-01/containerinstance/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2023-05-01/containerinstance"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := containerinstance.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ContainerGroupsList(ctx, id)` can be used to do batched pagination
 items, err := client.ContainerGroupsListComplete(ctx, id)
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := containerinstance.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ContainerGroupsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ContainerGroupsListByResourceGroupComplete(ctx, id)
@@ -283,7 +284,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := containerinstance.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 if err := client.SubnetServiceAssociationLinkDeleteThenPoll(ctx, id); err != nil {
 	// handle the error

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/operation/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/operation/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/operation"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := operation.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := operation.RegistryNameCheckRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries"
 ```
 
@@ -103,7 +104,7 @@ if err := client.ImportImageThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := registries.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -120,7 +121,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := registries.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetAvailableAgentPoolVersions(ctx, id)
 if err != nil {
@@ -117,7 +118,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleets"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fleets.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := fleets.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := maintenanceconfigurations.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListByManagedCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByManagedClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.AbortLatestOperation(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedCluster{
 	// ...
@@ -57,7 +58,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationOptions()); err != nil {
 	// handle the error
@@ -69,7 +70,7 @@ if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationO
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -133,7 +134,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetUpgradeProfile(ctx, id)
 if err != nil {
@@ -149,7 +150,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -166,7 +167,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -183,7 +184,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterAdminCredentials(ctx, id, managedclusters.DefaultListClusterAdminCredentialsOperationOptions())
 if err != nil {
@@ -199,7 +200,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterMonitoringUserCredentials(ctx, id, managedclusters.DefaultListClusterMonitoringUserCredentialsOperationOptions())
 if err != nil {
@@ -215,7 +216,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterUserCredentials(ctx, id, managedclusters.DefaultListClusterUserCredentialsOperationOptions())
 if err != nil {
@@ -231,7 +232,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListOutboundNetworkDependenciesEndpoints(ctx, id)` can be used to do batched pagination
 items, err := client.ListOutboundNetworkDependenciesEndpointsComplete(ctx, id)
@@ -248,7 +249,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterAADProfile{
 	// ...
@@ -265,7 +266,7 @@ if err := client.ResetAADProfileThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterServicePrincipalProfile{
 	// ...
@@ -282,7 +283,7 @@ if err := client.ResetServicePrincipalProfileThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -294,7 +295,7 @@ if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -306,7 +307,7 @@ if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.RunCommandRequest{
 	// ...
@@ -323,7 +324,7 @@ if err := client.RunCommandThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StartThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -335,7 +336,7 @@ if err := client.StartThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StopThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -347,7 +348,7 @@ if err := client.StopThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclustersnapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclustersnapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclustersnapshots"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclustersnapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclustersnapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections"
 ```
 
@@ -52,7 +53,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpointconnections.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privatelinkresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privatelinkresources/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privatelinkresources"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := privatelinkresources.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/resolveprivatelinkserviceid/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/resolveprivatelinkserviceid/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/resolveprivatelinkserviceid"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := resolveprivatelinkserviceid.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := resolveprivatelinkserviceid.PrivateLinkResource{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/snapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/snapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/snapshots"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := trustedaccess.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.RoleBindingsList(ctx, id)` can be used to do batched pagination
 items, err := client.RoleBindingsListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/agentpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/agentpools/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/agentpools"
 ```
 
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetAvailableAgentPoolVersions(ctx, id)
 if err != nil {
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/maintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/maintenanceconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/maintenanceconfigurations"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := maintenanceconfigurations.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListByManagedCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByManagedClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.AbortLatestOperationThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -36,7 +37,7 @@ if err := client.AbortLatestOperationThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedCluster{
 	// ...
@@ -53,7 +54,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationOptions()); err != nil {
 	// handle the error
@@ -65,7 +66,7 @@ if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationO
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -129,7 +130,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetUpgradeProfile(ctx, id)
 if err != nil {
@@ -145,7 +146,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -162,7 +163,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -179,7 +180,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterAdminCredentials(ctx, id, managedclusters.DefaultListClusterAdminCredentialsOperationOptions())
 if err != nil {
@@ -195,7 +196,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterMonitoringUserCredentials(ctx, id, managedclusters.DefaultListClusterMonitoringUserCredentialsOperationOptions())
 if err != nil {
@@ -211,7 +212,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterUserCredentials(ctx, id, managedclusters.DefaultListClusterUserCredentialsOperationOptions())
 if err != nil {
@@ -243,7 +244,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListOutboundNetworkDependenciesEndpoints(ctx, id)` can be used to do batched pagination
 items, err := client.ListOutboundNetworkDependenciesEndpointsComplete(ctx, id)
@@ -260,7 +261,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterAADProfile{
 	// ...
@@ -277,7 +278,7 @@ if err := client.ResetAADProfileThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterServicePrincipalProfile{
 	// ...
@@ -294,7 +295,7 @@ if err := client.ResetServicePrincipalProfileThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -306,7 +307,7 @@ if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -318,7 +319,7 @@ if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.RunCommandRequest{
 	// ...
@@ -335,7 +336,7 @@ if err := client.RunCommandThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StartThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -347,7 +348,7 @@ if err := client.StartThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StopThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -359,7 +360,7 @@ if err := client.StopThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclustersnapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclustersnapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/managedclustersnapshots"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclustersnapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclustersnapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privateendpointconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privateendpointconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privateendpointconnections"
 ```
 
@@ -52,7 +53,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpointconnections.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privatelinkresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privatelinkresources/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/privatelinkresources"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := privatelinkresources.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/resolveprivatelinkserviceid/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/resolveprivatelinkserviceid/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/resolveprivatelinkserviceid"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := resolveprivatelinkserviceid.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := resolveprivatelinkserviceid.PrivateLinkResource{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/snapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/snapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/snapshots"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/trustedaccess/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/trustedaccess/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-03-02-preview/trustedaccess"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := trustedaccess.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.RoleBindingsList(ctx, id)` can be used to do batched pagination
 items, err := client.RoleBindingsListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
 ```
 
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetAvailableAgentPoolVersions(ctx, id)
 if err != nil {
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agentpools.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/maintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/maintenanceconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/maintenanceconfigurations"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := maintenanceconfigurations.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListByManagedCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByManagedClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/managedclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/managedclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/managedclusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.AbortLatestOperationThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -36,7 +37,7 @@ if err := client.AbortLatestOperationThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedCluster{
 	// ...
@@ -53,7 +54,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationOptions()); err != nil {
 	// handle the error
@@ -65,7 +66,7 @@ if err := client.DeleteThenPoll(ctx, id, managedclusters.DefaultDeleteOperationO
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -161,7 +162,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.GetUpgradeProfile(ctx, id)
 if err != nil {
@@ -177,7 +178,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -194,7 +195,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -211,7 +212,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterAdminCredentials(ctx, id, managedclusters.DefaultListClusterAdminCredentialsOperationOptions())
 if err != nil {
@@ -227,7 +228,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterMonitoringUserCredentials(ctx, id, managedclusters.DefaultListClusterMonitoringUserCredentialsOperationOptions())
 if err != nil {
@@ -243,7 +244,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 read, err := client.ListClusterUserCredentials(ctx, id, managedclusters.DefaultListClusterUserCredentialsOperationOptions())
 if err != nil {
@@ -292,7 +293,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListMeshUpgradeProfiles(ctx, id)` can be used to do batched pagination
 items, err := client.ListMeshUpgradeProfilesComplete(ctx, id)
@@ -309,7 +310,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 // alternatively `client.ListOutboundNetworkDependenciesEndpoints(ctx, id)` can be used to do batched pagination
 items, err := client.ListOutboundNetworkDependenciesEndpointsComplete(ctx, id)
@@ -326,7 +327,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterAADProfile{
 	// ...
@@ -343,7 +344,7 @@ if err := client.ResetAADProfileThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.ManagedClusterServicePrincipalProfile{
 	// ...
@@ -360,7 +361,7 @@ if err := client.ResetServicePrincipalProfileThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -372,7 +373,7 @@ if err := client.RotateClusterCertificatesThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -384,7 +385,7 @@ if err := client.RotateServiceAccountSigningKeysThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.RunCommandRequest{
 	// ...
@@ -401,7 +402,7 @@ if err := client.RunCommandThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StartThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -413,7 +414,7 @@ if err := client.StartThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 if err := client.StopThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -425,7 +426,7 @@ if err := client.StopThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := managedclusters.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
+id := commonids.NewKubernetesClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterValue")
 
 payload := managedclusters.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/snapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/snapshots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/snapshots"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := snapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-10-15/fleets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-10-15/fleets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-10-15/fleets"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fleets.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := fleets.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb"
 ```
 
@@ -482,7 +483,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.DatabaseAccountsList(ctx, id)
 if err != nil {
@@ -498,7 +499,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.DatabaseAccountsListByResourceGroup(ctx, id)
 if err != nil {
@@ -978,7 +979,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.LocationsList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb"
 ```
 
@@ -482,7 +483,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.DatabaseAccountsList(ctx, id)
 if err != nil {
@@ -498,7 +499,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.DatabaseAccountsListByResourceGroup(ctx, id)
 if err != nil {
@@ -978,7 +979,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cosmosdb.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.LocationsList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras"
 ```
 
@@ -98,7 +99,7 @@ if err := client.CassandraClustersInvokeCommandThenPoll(ctx, id, payload); err !
 
 ```go
 ctx := context.TODO()
-id := managedcassandras.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.CassandraClustersListByResourceGroup(ctx, id)
 if err != nil {
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedcassandras.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.CassandraClustersListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports"
 ```
 
@@ -109,7 +110,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := exports.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.List(ctx, id, exports.DefaultListOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions"
 ```
 
@@ -44,7 +45,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scheduledactions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := scheduledactions.CheckNameAvailabilityRequest{
 	// ...
@@ -220,7 +221,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := scheduledactions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByScope(ctx, id, scheduledactions.DefaultListByScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListByScopeComplete(ctx, id, scheduledactions.DefaultListByScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions"
 ```
 
@@ -44,7 +45,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scheduledactions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := scheduledactions.CheckNameAvailabilityRequest{
 	// ...
@@ -188,7 +189,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := scheduledactions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByScope(ctx, id, scheduledactions.DefaultListByScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListByScopeComplete(ctx, id, scheduledactions.DefaultListByScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views"
 ```
 
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := views.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByScope(ctx, id)` can be used to do batched pagination
 items, err := client.ListByScopeComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := customresourceprovider.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := customresourceprovider.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dashboard/2023-09-01/grafanaresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dashboard/2023-09-01/grafanaresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dashboard/2023-09-01/grafanaresource"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := grafanaresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.GrafanaList(ctx, id)` can be used to do batched pagination
 items, err := client.GrafanaListComplete(ctx, id)
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := grafanaresource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.GrafanaListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.GrafanaListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices"
 ```
 
@@ -178,7 +179,7 @@ if err := client.InstallUpdatesThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := devices.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, devices.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, devices.DefaultListByResourceGroupOperationOptions())
@@ -195,7 +196,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := devices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, devices.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, devices.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-04-01-preview/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-04-01-preview/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-04-01-preview/workspaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := accessconnector.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := accessconnector.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/agreements/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/agreements/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/agreements"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := agreements.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := agreements.DatadogAgreementResource{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agreements.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.MarketplaceAgreementsList(ctx, id)` can be used to do batched pagination
 items, err := client.MarketplaceAgreementsListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := monitorsresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.MonitorsList(ctx, id)` can be used to do batched pagination
 items, err := client.MonitorsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := monitorsresource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.MonitorsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.MonitorsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
 ```
 
@@ -140,7 +141,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := factories.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -157,7 +158,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := factories.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serviceresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ServicesList(ctx, id)` can be used to do batched pagination
 items, err := client.ServicesListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backupvaults/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backupvaults/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backupvaults"
 ```
 
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := backupvaults.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.GetInResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.GetInResourceGroupComplete(ctx, id)
@@ -107,7 +108,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := backupvaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.GetInSubscription(ctx, id)` can be used to do batched pagination
 items, err := client.GetInSubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/resourceguards/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/resourceguards/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/resourceguards"
 ```
 
@@ -220,7 +221,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceguards.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.GetResourcesInResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.GetResourcesInResourceGroupComplete(ctx, id)
@@ -237,7 +238,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceguards.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.GetResourcesInSubscription(ctx, id)` can be used to do batched pagination
 items, err := client.GetResourcesInSubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := account.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := account.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/applicationgroup/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/applicationgroup/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/applicationgroup"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgroup.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, applicationgroup.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, applicationgroup.DefaultListByResourceGroupOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationgroup.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, applicationgroup.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, applicationgroup.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/hostpool/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/hostpool/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/hostpool"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := hostpool.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := hostpool.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/workspace/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/workspace/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/workspace"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspace.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspace.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgroup.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, applicationgroup.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, applicationgroup.DefaultListByResourceGroupOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationgroup.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, applicationgroup.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, applicationgroup.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := hostpool.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := hostpool.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan"
 ```
 
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := scalingplan.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := scalingplan.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspace.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspace.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/checknameavailability/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/checknameavailability/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/checknameavailability"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := checknameavailability.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := checknameavailability.CheckNameAvailabilityRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/devcenters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/devcenters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/devcenters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := devcenters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, devcenters.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, devcenters.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := devcenters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, devcenters.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, devcenters.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/networkconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/networkconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/networkconnections"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkconnections.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkconnections.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/projects/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/projects/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/projects"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := projects.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, projects.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, projects.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := projects.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, projects.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, projects.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/skus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/skus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2023-04-01/skus"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := skus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dpscertificate.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := iotdpsresource.OperationInputs{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 payload := iotdpsresource.ProvisioningServiceDescription{
 	// ...
@@ -79,7 +80,7 @@ if err := client.CreateOrUpdatePrivateEndpointConnectionThenPoll(ctx, id, payloa
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -103,7 +104,7 @@ if err := client.DeletePrivateEndpointConnectionThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -151,7 +152,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -168,7 +169,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)
@@ -185,7 +186,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 // alternatively `client.ListKeys(ctx, id)` can be used to do batched pagination
 items, err := client.ListKeysComplete(ctx, id)
@@ -218,7 +219,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 read, err := client.ListPrivateEndpointConnections(ctx, id)
 if err != nil {
@@ -234,7 +235,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 read, err := client.ListPrivateLinkResources(ctx, id)
 if err != nil {
@@ -250,7 +251,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 // alternatively `client.ListValidSkus(ctx, id)` can be used to do batched pagination
 items, err := client.ListValidSkusComplete(ctx, id)
@@ -267,7 +268,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := iotdpsresource.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
+id := commonids.NewProvisioningServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "provisioningServiceValue")
 
 payload := iotdpsresource.TagsResource{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
 ```
 
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := deviceupdates.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.AccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListByResourceGroupComplete(ctx, id)
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := deviceupdates.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.AccountsListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListBySubscriptionComplete(ctx, id)
@@ -136,7 +137,7 @@ if err := client.AccountsUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := deviceupdates.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := deviceupdates.CheckNameAvailabilityRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/globalschedules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/globalschedules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/globalschedules"
 ```
 
@@ -89,7 +90,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := globalschedules.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, globalschedules.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, globalschedules.DefaultListByResourceGroupOperationOptions())
@@ -106,7 +107,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := globalschedules.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, globalschedules.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, globalschedules.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs"
 ```
 
@@ -153,7 +154,7 @@ if err := client.ImportVirtualMachineThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := labs.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, labs.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, labs.DefaultListByResourceGroupOperationOptions())
@@ -170,7 +171,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := labs.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, labs.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, labs.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/digitaltwinsinstance/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/digitaltwinsinstance/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/digitaltwinsinstance"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := digitaltwinsinstance.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.DigitalTwinsList(ctx, id)` can be used to do batched pagination
 items, err := client.DigitalTwinsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := digitaltwinsinstance.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.DigitalTwinsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.DigitalTwinsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/dns/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/dns/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/dns"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := dns.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := dns.DnsResourceReferenceRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := zones.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, zones.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, zones.DefaultListOperationOptions())
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := zones.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, zones.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, zones.DefaultListByResourceGroupOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dnsforwardingrulesets.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, dnsforwardingrulesets.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, dnsforwardingrulesets.DefaultListOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dnsforwardingrulesets.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, dnsforwardingrulesets.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, dnsforwardingrulesets.DefaultListByResourceGroupOperationOptions())
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dnsforwardingrulesets.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.ListByVirtualNetwork(ctx, id, dnsforwardingrulesets.DefaultListByVirtualNetworkOperationOptions())` can be used to do batched pagination
 items, err := client.ListByVirtualNetworkComplete(ctx, id, dnsforwardingrulesets.DefaultListByVirtualNetworkOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dnsresolvers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, dnsresolvers.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, dnsresolvers.DefaultListOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dnsresolvers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, dnsresolvers.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, dnsresolvers.DefaultListByResourceGroupOperationOptions())
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dnsresolvers.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.ListByVirtualNetwork(ctx, id, dnsresolvers.DefaultListByVirtualNetworkOperationOptions())` can be used to do batched pagination
 items, err := client.ListByVirtualNetworkComplete(ctx, id, dnsresolvers.DefaultListByVirtualNetworkOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2023-06-01/monitorsresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2023-06-01/monitorsresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2023-06-01/monitorsresource"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := monitorsresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.MonitorsList(ctx, id)` can be used to do batched pagination
 items, err := client.MonitorsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := monitorsresource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.MonitorsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.MonitorsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsan/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsan/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsan"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := elasticsan.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsans/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsans/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsans"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := elasticsans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsanskus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsanskus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsanskus"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := elasticsanskus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.SkusList(ctx, id, elasticsanskus.DefaultSkusListOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/domains/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/domains/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/domains"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := domains.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, domains.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, domains.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := domains.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, domains.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, domains.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions"
 ```
 
@@ -340,7 +341,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := eventsubscriptions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByResource(ctx, id, eventsubscriptions.DefaultListByResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceComplete(ctx, id, eventsubscriptions.DefaultListByResourceOperationOptions())
@@ -357,7 +358,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := eventsubscriptions.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListGlobalByResourceGroup(ctx, id, eventsubscriptions.DefaultListGlobalByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListGlobalByResourceGroupComplete(ctx, id, eventsubscriptions.DefaultListGlobalByResourceGroupOperationOptions())
@@ -391,7 +392,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := eventsubscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListGlobalBySubscription(ctx, id, eventsubscriptions.DefaultListGlobalBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListGlobalBySubscriptionComplete(ctx, id, eventsubscriptions.DefaultListGlobalBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerconfigurations"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := partnerconfigurations.Partner{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := partnerconfigurations.PartnerConfiguration{
 	// ...
@@ -62,7 +63,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -74,7 +75,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -106,7 +107,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, partnerconfigurations.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, partnerconfigurations.DefaultListBySubscriptionOperationOptions())
@@ -123,7 +124,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := partnerconfigurations.Partner{
 	// ...
@@ -144,7 +145,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := partnerconfigurations.PartnerConfigurationUpdateParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnernamespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnernamespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnernamespaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnernamespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, partnernamespaces.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, partnernamespaces.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := partnernamespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, partnernamespaces.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, partnernamespaces.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerregistrations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerregistrations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnerregistrations"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnerregistrations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, partnerregistrations.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, partnerregistrations.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := partnerregistrations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, partnerregistrations.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, partnerregistrations.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnertopics/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnertopics/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/partnertopics"
 ```
 
@@ -105,7 +106,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := partnertopics.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, partnertopics.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, partnertopics.DefaultListByResourceGroupOperationOptions())
@@ -122,7 +123,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := partnertopics.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, partnertopics.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, partnertopics.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privateendpointconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privateendpointconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privateendpointconnections"
 ```
 
@@ -52,7 +53,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpointconnections.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByResource(ctx, id, privateendpointconnections.DefaultListByResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceComplete(ctx, id, privateendpointconnections.DefaultListByResourceOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privatelinkresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privatelinkresources/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/privatelinkresources"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkresources.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByResource(ctx, id, privatelinkresources.DefaultListByResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceComplete(ctx, id, privatelinkresources.DefaultListByResourceOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/systemtopics/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/systemtopics/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/systemtopics"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := systemtopics.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, systemtopics.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, systemtopics.DefaultListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := systemtopics.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, systemtopics.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, systemtopics.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics"
 ```
 
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := topics.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.ExtensionTopicsGet(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := topics.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, topics.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, topics.DefaultListByResourceGroupOperationOptions())
@@ -102,7 +103,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := topics.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, topics.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, topics.DefaultListBySubscriptionOperationOptions())
@@ -119,7 +120,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := topics.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.ListEventTypes(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubsclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubsclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubsclusters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := eventhubsclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ClustersListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ClustersListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := eventhubsclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ClustersListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ClustersListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fluidrelayservers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -110,7 +111,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := fluidrelayservers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapplicationfirewallpolicies.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.PoliciesList(ctx, id)` can be used to do batched pagination
 items, err := client.PoliciesListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
 ```
 
@@ -148,7 +149,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := frontdoors.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -165,7 +166,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := frontdoors.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13/graphservicesprods/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13/graphservicesprods/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13/graphservicesprods"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := graphservicesprods.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.AccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListByResourceGroupComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := graphservicesprods.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.AccountsListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/guestconfiguration/2020-06-25/guestconfigurationassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/guestconfiguration/2020-06-25/guestconfigurationassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/guestconfiguration/2020-06-25/guestconfigurationassignments"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := guestconfigurationassignments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.RGList(ctx, id)
 if err != nil {
@@ -109,7 +110,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := guestconfigurationassignments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.SubscriptionList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhsms.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.DedicatedHsmListByResourceGroup(ctx, id, dedicatedhsms.DefaultDedicatedHsmListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.DedicatedHsmListByResourceGroupComplete(ctx, id, dedicatedhsms.DefaultDedicatedHsmListByResourceGroupOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dedicatedhsms.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.DedicatedHsmListBySubscription(ctx, id, dedicatedhsms.DefaultDedicatedHsmListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.DedicatedHsmListBySubscriptionComplete(ctx, id, dedicatedhsms.DefaultDedicatedHsmListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/applications/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/applications/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/applications"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applications.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 // alternatively `client.ListByCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterCreateParametersExtended{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ExecuteScriptActionParameters{
 	// ...
@@ -70,7 +71,7 @@ if err := client.ExecuteScriptActionsThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -86,7 +87,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.GetGatewaySettings(ctx, id)
 if err != nil {
@@ -102,7 +103,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -119,7 +120,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -136,7 +137,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterResizeParameters{
 	// ...
@@ -153,7 +154,7 @@ if err := client.ResizeThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterDiskEncryptionParameters{
 	// ...
@@ -170,7 +171,7 @@ if err := client.RotateDiskEncryptionKeyThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterPatchParameters{
 	// ...
@@ -191,7 +192,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.AutoscaleConfigurationUpdateParameter{
 	// ...
@@ -208,7 +209,7 @@ if err := client.UpdateAutoScaleConfigurationThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.UpdateGatewaySettingsParameters{
 	// ...
@@ -225,7 +226,7 @@ if err := client.UpdateGatewaySettingsThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.UpdateClusterIdentityCertificateParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/configurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/configurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/configurations"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := configurations.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/extensions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/extensions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/extensions"
 ```
 
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.DisableAzureMonitorThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -65,7 +66,7 @@ if err := client.DisableAzureMonitorThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.DisableMonitoringThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -77,7 +78,7 @@ if err := client.DisableMonitoringThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := extensions.AzureMonitorRequest{
 	// ...
@@ -94,7 +95,7 @@ if err := client.EnableAzureMonitorThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := extensions.ClusterMonitoringRequest{
 	// ...
@@ -127,7 +128,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.GetAzureMonitorStatus(ctx, id)
 if err != nil {
@@ -143,7 +144,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.GetMonitoringStatus(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privateendpointconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privateendpointconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privateendpointconnections"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpointconnections.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 // alternatively `client.ListByCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privatelinkresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privatelinkresources/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/privatelinkresources"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkresources.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListByCluster(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptactions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptactions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptactions"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scriptactions.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 // alternatively `client.ListByCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptexecutionhistory/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptexecutionhistory/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/scriptexecutionhistory"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := scriptexecutionhistory.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 // alternatively `client.ListByCluster(ctx, id)` can be used to do batched pagination
 items, err := client.ListByClusterComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/virtualmachines/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/virtualmachines/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/virtualmachines"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := virtualmachines.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListHosts(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualmachines.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewHDInsightClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 var payload []string
 
 if err := client.RestartHostsThenPoll(ctx, id, payload); err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := healthbots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.BotsList(ctx, id)` can be used to do batched pagination
 items, err := client.BotsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := healthbots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.BotsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.BotsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/workspaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := machines.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := machines.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
 ```
 
@@ -105,7 +106,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkscopes.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -122,7 +123,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := privatelinkscopes.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := connectedclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ConnectedClusterListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ConnectedClusterListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := connectedclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ConnectedClusterListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ConnectedClusterListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/activitylogs/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/activitylogs/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/activitylogs"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := activitylogs.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, activitylogs.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, activitylogs.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := logprofiles.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := metricalerts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := metricalerts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scheduledqueryrules.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id, scheduledqueryrules.DefaultListByResourceGroupOperationOptions())
 if err != nil {
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scheduledqueryrules.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id, scheduledqueryrules.DefaultListBySubscriptionOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopesapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopesapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopesapis"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkscopesapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.PrivateLinkScopesList(ctx, id)` can be used to do batched pagination
 items, err := client.PrivateLinkScopesListComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := privatelinkscopesapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.PrivateLinkScopesListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.PrivateLinkScopesListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2020-10-01/activitylogalertsapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2020-10-01/activitylogalertsapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2020-10-01/activitylogalertsapis"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := activitylogalertsapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ActivityLogAlertsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ActivityLogAlertsListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := activitylogalertsapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ActivityLogAlertsListBySubscriptionId(ctx, id)` can be used to do batched pagination
 items, err := client.ActivityLogAlertsListBySubscriptionIdComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettings"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := diagnosticsettings.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettingscategories/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettingscategories/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettingscategories"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := diagnosticsettingscategories.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.DiagnosticSettingsCategoryList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scheduledqueryrules.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := scheduledqueryrules.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionendpoints/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionendpoints/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionendpoints"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := datacollectionendpoints.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := datacollectionendpoints.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations"
 ```
 
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := datacollectionruleassociations.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByResource(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := datacollectionrules.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := datacollectionrules.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-10-01/autoscalesettings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-10-01/autoscalesettings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-10-01/autoscalesettings"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := autoscalesettings.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := autoscalesettings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-01-01/actiongroupsapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-01-01/actiongroupsapis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-01-01/actiongroupsapis"
 ```
 
@@ -131,7 +132,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := actiongroupsapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ActionGroupsListByResourceGroup(ctx, id)
 if err != nil {
@@ -147,7 +148,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := actiongroupsapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ActionGroupsListBySubscriptionId(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := azuremonitorworkspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := azuremonitorworkspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := apps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := apps.OperationInputs{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := apps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := apps.OperationInputs{
 	// ...
@@ -111,7 +112,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := apps.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -128,7 +129,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := apps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)
@@ -145,7 +146,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := apps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListTemplates(ctx, id)` can be used to do batched pagination
 items, err := client.ListTemplatesComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/managedhsms/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/managedhsms/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/managedhsms"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managedhsms.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := managedhsms.CheckMhsmNameAvailabilityParameters{
 	// ...
@@ -106,7 +107,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedhsms.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, managedhsms.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, managedhsms.DefaultListByResourceGroupOperationOptions())
@@ -123,7 +124,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedhsms.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, managedhsms.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, managedhsms.DefaultListBySubscriptionOperationOptions())
@@ -140,7 +141,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedhsms.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListDeleted(ctx, id)` can be used to do batched pagination
 items, err := client.ListDeletedComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := vaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := vaults.VaultCheckNameAvailabilityParameters{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
 
 payload := vaults.VaultCreateOrUpdateParameters{
 	// ...
@@ -62,7 +63,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -78,7 +79,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -110,7 +111,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, vaults.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, vaults.DefaultListOperationOptions())
@@ -127,7 +128,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, vaults.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, vaults.DefaultListByResourceGroupOperationOptions())
@@ -144,7 +145,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, vaults.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, vaults.DefaultListBySubscriptionOperationOptions())
@@ -161,7 +162,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListDeleted(ctx, id)` can be used to do batched pagination
 items, err := client.ListDeletedComplete(ctx, id)
@@ -190,7 +191,7 @@ if err := client.PurgeDeletedThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
 
 payload := vaults.VaultPatchParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := extensions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/fluxconfiguration/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/fluxconfiguration/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/fluxconfiguration"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fluxconfiguration.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/attacheddatabaseconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/attacheddatabaseconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/attacheddatabaseconfigurations"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := attacheddatabaseconfigurations.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := attacheddatabaseconfigurations.AttachedDatabaseConfigurationsCheckNameRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := attacheddatabaseconfigurations.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListByCluster(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusterprincipalassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusterprincipalassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusterprincipalassignments"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := clusterprincipalassignments.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusterprincipalassignments.ClusterPrincipalAssignmentCheckNameRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusterprincipalassignments.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/clusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.LanguageExtensionsList{
 	// ...
@@ -62,7 +63,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.Cluster{
 	// ...
@@ -79,7 +80,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload, clusters.DefaultCreate
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -91,7 +92,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.FollowerDatabaseDefinition{
 	// ...
@@ -108,7 +109,7 @@ if err := client.DetachFollowerDatabasesThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.DiagnoseVirtualNetworkThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -120,7 +121,7 @@ if err := client.DiagnoseVirtualNetworkThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -136,7 +137,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -152,7 +153,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -168,7 +169,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListFollowerDatabases(ctx, id)
 if err != nil {
@@ -184,7 +185,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListLanguageExtensions(ctx, id)
 if err != nil {
@@ -200,7 +201,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.ListSkusByResource(ctx, id)
 if err != nil {
@@ -216,7 +217,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterMigrateRequest{
 	// ...
@@ -233,7 +234,7 @@ if err := client.MigrateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.LanguageExtensionsList{
 	// ...
@@ -250,7 +251,7 @@ if err := client.RemoveLanguageExtensionsThenPoll(ctx, id, payload); err != nil 
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.StartThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -262,7 +263,7 @@ if err := client.StartThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 if err := client.StopThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -274,7 +275,7 @@ if err := client.StopThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := clusters.ClusterUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databaseprincipalassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databaseprincipalassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databaseprincipalassignments"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := databaseprincipalassignments.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databaseprincipalassignments.DatabasePrincipalAssignmentCheckNameRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databaseprincipalassignments.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databases/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databases/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/databases"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databases.DatabasePrincipalListRequest{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := databases.CheckNameRequest{
 	// ...
@@ -66,7 +67,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databases.Database{
 	// ...
@@ -83,7 +84,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload, databases.DefaultCreat
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databases.DatabaseInviteFollowerRequest{
 	// ...
@@ -104,7 +105,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -116,7 +117,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -132,7 +133,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 // alternatively `client.ListByCluster(ctx, id, databases.DefaultListByClusterOperationOptions())` can be used to do batched pagination
 items, err := client.ListByClusterComplete(ctx, id, databases.DefaultListByClusterOperationOptions())
@@ -149,7 +150,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 read, err := client.ListPrincipals(ctx, id)
 if err != nil {
@@ -165,7 +166,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databases.DatabasePrincipalListRequest{
 	// ...
@@ -186,7 +187,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := databases.Database{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/dataconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/dataconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/dataconnections"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := dataconnections.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := dataconnections.DataConnectionCheckNameRequest{
 	// ...
@@ -62,7 +63,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := dataconnections.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := dataconnections.DataConnectionValidation{
 	// ...
@@ -107,7 +108,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dataconnections.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 read, err := client.ListByDatabase(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/managedprivateendpoints/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/managedprivateendpoints/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/managedprivateendpoints"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managedprivateendpoints.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 payload := managedprivateendpoints.ManagedPrivateEndpointsCheckNameRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedprivateendpoints.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+id := commonids.NewKustoClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/scripts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/scripts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/scripts"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := scripts.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 payload := scripts.ScriptCheckNameRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := scripts.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
+id := commonids.NewKustoDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue", "databaseValue")
 
 read, err := client.ListByDatabase(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/lab/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/lab/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/lab"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := lab.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := lab.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/labplan/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/labplan/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/labplan"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := labplan.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := labplan.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2022-12-01/loadtests/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2022-12-01/loadtests/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2022-12-01/loadtests"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := loadtests.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := loadtests.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := integrationaccounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, integrationaccounts.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, integrationaccounts.DefaultListByResourceGroupOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := integrationaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, integrationaccounts.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, integrationaccounts.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := integrationserviceenvironments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, integrationserviceenvironments.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, integrationserviceenvironments.DefaultListByResourceGroupOperationOptions())
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := integrationserviceenvironments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, integrationserviceenvironments.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, integrationserviceenvironments.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows"
 ```
 
@@ -130,7 +131,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workflows.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, workflows.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, workflows.DefaultListByResourceGroupOperationOptions())
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workflows.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, workflows.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, workflows.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/monitors/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/monitors/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/monitors"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := monitors.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := monitors.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-10-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-10-01/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-10-01/workspaces"
 ```
 
@@ -86,7 +87,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, workspaces.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, workspaces.DefaultListByResourceGroupOperationOptions())
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, workspaces.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, workspaces.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments"
 ```
 
@@ -130,7 +131,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := configurationassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -146,7 +147,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := configurationassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.ListParent(ctx, id)
 if err != nil {
@@ -162,7 +163,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := configurationassignments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.WithinSubscriptionList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations"
 ```
 
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := maintenanceconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ForResourceGroupList(ctx, id)
 if err != nil {
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := maintenanceconfigurations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/publicmaintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/publicmaintenanceconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/publicmaintenanceconfigurations"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := publicmaintenanceconfigurations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applicationdefinitions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applicationdefinitions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applicationdefinitions"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationdefinitions.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationdefinitions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applications/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applications/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/managedapplications/2021-07-01/applications"
 ```
 
@@ -130,7 +131,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applications.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applications.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2023-01-31/managedidentities/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2023-01-31/managedidentities/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2023-01-31/managedidentities"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
+id := commonids.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
 
 // alternatively `client.FederatedIdentityCredentialsList(ctx, id, managedidentities.DefaultFederatedIdentityCredentialsListOperationOptions())` can be used to do batched pagination
 items, err := client.FederatedIdentityCredentialsListComplete(ctx, id, managedidentities.DefaultFederatedIdentityCredentialsListOperationOptions())
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.SystemAssignedIdentitiesGetByScope(ctx, id)
 if err != nil {
@@ -110,7 +111,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
+id := commonids.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
 
 payload := managedidentities.Identity{
 	// ...
@@ -131,7 +132,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
+id := commonids.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
 
 read, err := client.UserAssignedIdentitiesDelete(ctx, id)
 if err != nil {
@@ -147,7 +148,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
+id := commonids.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
 
 read, err := client.UserAssignedIdentitiesGet(ctx, id)
 if err != nil {
@@ -163,7 +164,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.UserAssignedIdentitiesListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.UserAssignedIdentitiesListByResourceGroupComplete(ctx, id)
@@ -180,7 +181,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.UserAssignedIdentitiesListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.UserAssignedIdentitiesListBySubscriptionComplete(ctx, id)
@@ -197,7 +198,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedidentities.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
+id := commonids.NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityValue")
 
 payload := managedidentities.IdentityUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2019-06-01/registrationassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2019-06-01/registrationassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2019-06-01/registrationassignments"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := registrationassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id, registrationassignments.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, registrationassignments.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := registrationdefinitions.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.List(ctx, id, registrationdefinitions.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, registrationdefinitions.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/accounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/accounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/accounts"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := accounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := accounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := agreements.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.MarketplaceAgreementsList(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts"
 ```
 
@@ -94,7 +95,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := accounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.MediaservicesList(ctx, id)` can be used to do batched pagination
 items, err := client.MediaservicesListComplete(ctx, id)
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := accounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.MediaservicesListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.MediaservicesListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/machines/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/machines/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/machines"
 ```
 
@@ -41,7 +42,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := machines.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
+id := commonids.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
 
 read, err := client.GetMachine(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := machines.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
+id := commonids.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
 
 read, err := client.StartMachine(ctx, id)
 if err != nil {
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := machines.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
+id := commonids.NewVMwareSiteMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "machineValue")
 
 read, err := client.StopMachine(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/runasaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/runasaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/migrate/2020-01-01/runasaccounts"
 ```
 
@@ -41,7 +42,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := runasaccounts.NewVMwareSiteRunAsAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "runAsAccountValue")
+id := commonids.NewVMwareSiteRunAsAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vmwareSiteValue", "runAsAccountValue")
 
 read, err := client.GetRunAsAccount(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.RemoteRenderingAccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.RemoteRenderingAccountsListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.RemoteRenderingAccountsListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.RemoteRenderingAccountsListBySubscriptionComplete(ctx, id)
@@ -185,7 +186,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.SpatialAnchorsAccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.SpatialAnchorsAccountsListByResourceGroupComplete(ctx, id)
@@ -202,7 +203,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.SpatialAnchorsAccountsListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.SpatialAnchorsAccountsListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/checknameavailability/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/checknameavailability/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/checknameavailability"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := checknameavailability.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := checknameavailability.NameAvailabilityRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/checknameavailability/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/checknameavailability/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/checknameavailability"
 ```
 
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := checknameavailability.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := checknameavailability.NameAvailabilityRequest{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2022-01-01/servers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2023-05-01/netappaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2023-05-01/netappaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2023-05-01/netappaccounts"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := netappaccounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.AccountsList(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := netappaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.AccountsListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.AccountsListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationgateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationgateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationgateways"
 ```
 
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -131,7 +132,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)
@@ -148,7 +149,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAvailableRequestHeaders(ctx, id)
 if err != nil {
@@ -164,7 +165,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAvailableResponseHeaders(ctx, id)
 if err != nil {
@@ -180,7 +181,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAvailableServerVariables(ctx, id)
 if err != nil {
@@ -196,7 +197,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAvailableSslOptions(ctx, id)
 if err != nil {
@@ -212,7 +213,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAvailableSslPredefinedPolicies(ctx, id)` can be used to do batched pagination
 items, err := client.ListAvailableSslPredefinedPoliciesComplete(ctx, id)
@@ -229,7 +230,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAvailableWafRuleSets(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationsecuritygroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationsecuritygroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/applicationsecuritygroups"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationsecuritygroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationsecuritygroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/azurefirewalls/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/azurefirewalls/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/azurefirewalls"
 ```
 
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := azurefirewalls.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -98,7 +99,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := azurefirewalls.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bastionhosts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bastionhosts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bastionhosts"
 ```
 
@@ -164,7 +165,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := bastionhosts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -181,7 +182,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := bastionhosts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bgpservicecommunities/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bgpservicecommunities/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/bgpservicecommunities"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := bgpservicecommunities.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/cloudservicepublicipaddresses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/cloudservicepublicipaddresses/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/cloudservicepublicipaddresses"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := cloudservicepublicipaddresses.NewCloudServicesPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue", "networkInterfaceValue", "ipConfigurationValue", "publicIPAddressValue")
+id := commonids.NewCloudServicesPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue", "networkInterfaceValue", "ipConfigurationValue", "publicIPAddressValue")
 
 read, err := client.PublicIPAddressesGetCloudServicePublicIPAddress(ctx, id, cloudservicepublicipaddresses.DefaultPublicIPAddressesGetCloudServicePublicIPAddressOperationOptions())
 if err != nil {
@@ -57,7 +58,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := cloudservicepublicipaddresses.NewCloudServicesIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue", "networkInterfaceValue", "ipConfigurationValue")
+id := commonids.NewCloudServicesIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue", "networkInterfaceValue", "ipConfigurationValue")
 
 // alternatively `client.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses(ctx, id)` can be used to do batched pagination
 items, err := client.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/customipprefixes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/customipprefixes/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/customipprefixes"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := customipprefixes.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := customipprefixes.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ddosprotectionplans/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ddosprotectionplans/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ddosprotectionplans"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := ddosprotectionplans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := ddosprotectionplans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/dscpconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/dscpconfigurations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/dscpconfigurations"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := dscpconfigurations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.DscpConfigurationList(ctx, id)` can be used to do batched pagination
 items, err := client.DscpConfigurationListComplete(ctx, id)
@@ -41,7 +42,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dscpconfigurations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.DscpConfigurationListAll(ctx, id)` can be used to do batched pagination
 items, err := client.DscpConfigurationListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitconnections"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuitconnections.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitpeerings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitpeerings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitpeerings"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuitpeerings.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 payload := expressroutecircuitpeerings.ExpressRouteCircuitPeering{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuitpeerings.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuitpeerings.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuits/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuits/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuits"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuits.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuits.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitstats/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitstats/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecircuitstats"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := expressroutecircuitstats.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 read, err := client.ExpressRouteCircuitsGetPeeringStats(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecrossconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecrossconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutecrossconnections"
 ```
 
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutecrossconnections.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -74,7 +75,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := expressroutecrossconnections.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutegateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutegateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressroutegateways"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutegateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressroutegateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteports/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteports/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteports"
 ```
 
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressrouteports.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -107,7 +108,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := expressrouteports.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteportslocations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteportslocations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteportslocations"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressrouteportslocations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteproviderports/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteproviderports/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteproviderports"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := expressrouteproviderports.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.LocationList(ctx, id, expressrouteproviderports.DefaultLocationListOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteserviceproviders/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteserviceproviders/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/expressrouteserviceproviders"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := expressrouteserviceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/firewallpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/firewallpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/firewallpolicies"
 ```
 
@@ -185,7 +186,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := firewallpolicies.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -202,7 +203,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := firewallpolicies.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipallocations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipallocations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipallocations"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := ipallocations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := ipallocations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipgroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipgroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/ipgroups"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := ipgroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := ipgroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/loadbalancers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/loadbalancers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/loadbalancers"
 ```
 
@@ -131,7 +132,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := loadbalancers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -148,7 +149,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := loadbalancers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/localnetworkgateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/localnetworkgateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/localnetworkgateways"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := localnetworkgateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/natgateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/natgateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/natgateways"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := natgateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := natgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkinterfaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkinterfaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkinterfaces"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 payload := networkinterfaces.NetworkInterface{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 read, err := client.Get(ctx, id, networkinterfaces.DefaultGetOperationOptions())
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 if err := client.GetEffectiveRouteTableThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -97,7 +98,7 @@ if err := client.GetEffectiveRouteTableThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewVirtualMachineScaleSetIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue")
+id := commonids.NewVirtualMachineScaleSetIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue")
 
 read, err := client.GetVirtualMachineScaleSetIPConfiguration(ctx, id, networkinterfaces.DefaultGetVirtualMachineScaleSetIPConfigurationOperationOptions())
 if err != nil {
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
+id := commonids.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
 
 read, err := client.GetVirtualMachineScaleSetNetworkInterface(ctx, id, networkinterfaces.DefaultGetVirtualMachineScaleSetNetworkInterfaceOperationOptions())
 if err != nil {
@@ -129,7 +130,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -146,7 +147,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)
@@ -197,7 +198,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 if err := client.ListEffectiveNetworkSecurityGroupsThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -209,7 +210,7 @@ if err := client.ListEffectiveNetworkSecurityGroupsThenPoll(ctx, id); err != nil
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
+id := commonids.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
 
 // alternatively `client.ListVirtualMachineScaleSetIPConfigurations(ctx, id, networkinterfaces.DefaultListVirtualMachineScaleSetIPConfigurationsOperationOptions())` can be used to do batched pagination
 items, err := client.ListVirtualMachineScaleSetIPConfigurationsComplete(ctx, id, networkinterfaces.DefaultListVirtualMachineScaleSetIPConfigurationsOperationOptions())
@@ -260,7 +261,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue", "ipConfigurationValue")
+id := commonids.NewNetworkInterfaceIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue", "ipConfigurationValue")
 
 read, err := client.NetworkInterfaceIPConfigurationsGet(ctx, id)
 if err != nil {
@@ -276,7 +277,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 // alternatively `client.NetworkInterfaceIPConfigurationsList(ctx, id)` can be used to do batched pagination
 items, err := client.NetworkInterfaceIPConfigurationsListComplete(ctx, id)
@@ -293,7 +294,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 // alternatively `client.NetworkInterfaceLoadBalancersList(ctx, id)` can be used to do batched pagination
 items, err := client.NetworkInterfaceLoadBalancersListComplete(ctx, id)
@@ -326,7 +327,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 // alternatively `client.NetworkInterfaceTapConfigurationsList(ctx, id)` can be used to do batched pagination
 items, err := client.NetworkInterfaceTapConfigurationsListComplete(ctx, id)
@@ -343,7 +344,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+id := commonids.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
 
 payload := networkinterfaces.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagerconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagerconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagerconnections"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkmanagerconnections.NewManagementGroupID("groupIdValue")
+id := commonids.NewManagementGroupID("groupIdValue")
 
 // alternatively `client.ManagementGroupNetworkManagerConnectionsList(ctx, id, networkmanagerconnections.DefaultManagementGroupNetworkManagerConnectionsListOperationOptions())` can be used to do batched pagination
 items, err := client.ManagementGroupNetworkManagerConnectionsListComplete(ctx, id, networkmanagerconnections.DefaultManagementGroupNetworkManagerConnectionsListOperationOptions())
@@ -147,7 +148,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkmanagerconnections.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.SubscriptionNetworkManagerConnectionsList(ctx, id, networkmanagerconnections.DefaultSubscriptionNetworkManagerConnectionsListOperationOptions())` can be used to do batched pagination
 items, err := client.SubscriptionNetworkManagerConnectionsListComplete(ctx, id, networkmanagerconnections.DefaultSubscriptionNetworkManagerConnectionsListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectiveconnectivityconfiguration/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectiveconnectivityconfiguration/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectiveconnectivityconfiguration"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := networkmanagereffectiveconnectivityconfiguration.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 payload := networkmanagereffectiveconnectivityconfiguration.QueryRequestOptions{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectivesecurityadminrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectivesecurityadminrules/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagereffectivesecurityadminrules"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := networkmanagereffectivesecurityadminrules.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 payload := networkmanagereffectivesecurityadminrules.QueryRequestOptions{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkmanagers"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkmanagers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id, networkmanagers.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, networkmanagers.DefaultListOperationOptions())
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkmanagers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, networkmanagers.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, networkmanagers.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkprofiles/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkprofiles/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkprofiles"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkprofiles.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkprofiles.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networksecuritygroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networksecuritygroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networksecuritygroups"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networksecuritygroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networksecuritygroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkvirtualappliances/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkvirtualappliances/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkvirtualappliances"
 ```
 
@@ -86,7 +87,7 @@ if err := client.InboundSecurityRuleCreateOrUpdateThenPoll(ctx, id, payload); er
 
 ```go
 ctx := context.TODO()
-id := networkvirtualappliances.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := networkvirtualappliances.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkwatchers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkwatchers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/networkwatchers"
 ```
 
@@ -230,7 +231,7 @@ if err := client.GetVMSecurityRulesThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := networkwatchers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -246,7 +247,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := networkwatchers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListAll(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/p2svpngateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/p2svpngateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/p2svpngateways"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 payload := p2svpngateways.P2SVpnConnectionRequest{
 	// ...
@@ -41,7 +42,7 @@ if err := client.DisconnectP2sVpnConnectionsThenPoll(ctx, id, payload); err != n
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 payload := p2svpngateways.P2SVpnProfileParameters{
 	// ...
@@ -58,7 +59,7 @@ if err := client.GenerateVpnProfileThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 if err := client.GetP2sVpnConnectionHealthThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -70,7 +71,7 @@ if err := client.GetP2sVpnConnectionHealthThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 payload := p2svpngateways.P2SVpnConnectionHealthRequest{
 	// ...
@@ -87,7 +88,7 @@ if err := client.GetP2sVpnConnectionHealthDetailedThenPoll(ctx, id, payload); er
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 if err := client.ResetThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -99,7 +100,7 @@ if err := client.ResetThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := p2svpngateways.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 payload := p2svpngateways.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/peerexpressroutecircuitconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/peerexpressroutecircuitconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/peerexpressroutecircuitconnections"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := peerexpressroutecircuitconnections.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
+id := commonids.NewExpressRouteCircuitPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "expressRouteCircuitValue", "peeringValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privateendpoints/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privateendpoints/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privateendpoints"
 ```
 
@@ -103,7 +104,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpoints.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -120,7 +121,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := privateendpoints.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privatelinkservices/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privatelinkservices/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/privatelinkservices"
 ```
 
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkservices.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -165,7 +166,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := privatelinkservices.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipaddresses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipaddresses/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipaddresses"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
+id := commonids.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
 
 payload := publicipaddresses.PublicIPAddress{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
+id := commonids.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
 
 if err := client.DdosProtectionStatusThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DdosProtectionStatusThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
+id := commonids.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -65,7 +66,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
+id := commonids.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
 
 read, err := client.Get(ctx, id, publicipaddresses.DefaultGetOperationOptions())
 if err != nil {
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -98,7 +99,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)
@@ -115,7 +116,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := publicipaddresses.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
+id := commonids.NewPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "publicIPAddressValue")
 
 payload := publicipaddresses.TagsObject{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipprefixes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipprefixes/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/publicipprefixes"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := publicipprefixes.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := publicipprefixes.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routefilters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routefilters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routefilters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := routefilters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := routefilters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routetables/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routetables/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/routetables"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := routetables.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := routetables.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/securitypartnerproviders/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/securitypartnerproviders/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/securitypartnerproviders"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := securitypartnerproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := securitypartnerproviders.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/serviceendpointpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/serviceendpointpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/serviceendpointpolicies"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serviceendpointpolicies.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := serviceendpointpolicies.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/subnets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/subnets/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/subnets"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := subnets.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 payload := subnets.Subnet{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := subnets.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := subnets.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 read, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := subnets.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualapplianceskus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualapplianceskus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualapplianceskus"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualapplianceskus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgatewayconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgatewayconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgatewayconnections"
 ```
 
@@ -97,7 +98,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworkgatewayconnections.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkgateways"
 ```
 
@@ -192,7 +193,7 @@ if err := client.GetVpnclientIPsecParametersThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworkgateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkpeerings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkpeerings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworkpeerings"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworkpeerings.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworks"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 payload := virtualnetworks.VirtualNetwork{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 read, err := client.Get(ctx, id, virtualnetworks.DefaultGetOperationOptions())
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)
@@ -103,7 +104,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 read, err := client.ResourceNavigationLinksList(ctx, id)
 if err != nil {
@@ -119,7 +120,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 read, err := client.ServiceAssociationLinksList(ctx, id)
 if err != nil {
@@ -135,7 +136,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 payload := virtualnetworks.PrepareNetworkPoliciesRequest{
 	// ...
@@ -152,7 +153,7 @@ if err := client.SubnetsPrepareNetworkPoliciesThenPoll(ctx, id, payload); err !=
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
 
 payload := virtualnetworks.UnprepareNetworkPoliciesRequest{
 	// ...
@@ -169,7 +170,7 @@ if err := client.SubnetsUnprepareNetworkPoliciesThenPoll(ctx, id, payload); err 
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 payload := virtualnetworks.TagsObject{
 	// ...
@@ -190,7 +191,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 read, err := client.VirtualNetworksCheckIPAddressAvailability(ctx, id, virtualnetworks.DefaultVirtualNetworksCheckIPAddressAvailabilityOperationOptions())
 if err != nil {
@@ -206,7 +207,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.VirtualNetworksListDdosProtectionStatus(ctx, id, virtualnetworks.DefaultVirtualNetworksListDdosProtectionStatusOperationOptions())` can be used to do batched pagination
 items, err := client.VirtualNetworksListDdosProtectionStatusComplete(ctx, id, virtualnetworks.DefaultVirtualNetworksListDdosProtectionStatusOperationOptions())
@@ -223,7 +224,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworks.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
 
 // alternatively `client.VirtualNetworksListUsage(ctx, id)` can be used to do batched pagination
 items, err := client.VirtualNetworksListUsageComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworktaps/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworktaps/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualnetworktaps"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := virtualnetworktaps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)
@@ -41,7 +42,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualnetworktaps.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouterpeerings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouterpeerings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouterpeerings"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := virtualrouterpeerings.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
+id := commonids.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
 
 payload := virtualrouterpeerings.VirtualRouterPeering{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualrouterpeerings.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
+id := commonids.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualrouterpeerings.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
+id := commonids.NewVirtualRouterPeeringID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualRouterValue", "peeringValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualrouters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualrouters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualrouters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualwans/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualwans/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/virtualwans"
 ```
 
@@ -351,7 +352,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 payload := virtualwans.P2SVpnGateway{
 	// ...
@@ -368,7 +369,7 @@ if err := client.P2sVpnGatewaysCreateOrUpdateThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 if err := client.P2sVpnGatewaysDeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -380,7 +381,7 @@ if err := client.P2sVpnGatewaysDeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
+id := commonids.NewVirtualWANP2SVPNGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "p2sVpnGatewayValue")
 
 read, err := client.P2sVpnGatewaysGet(ctx, id)
 if err != nil {
@@ -396,7 +397,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.P2sVpnGatewaysList(ctx, id)` can be used to do batched pagination
 items, err := client.P2sVpnGatewaysListComplete(ctx, id)
@@ -413,7 +414,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.P2sVpnGatewaysListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.P2sVpnGatewaysListByResourceGroupComplete(ctx, id)
@@ -591,7 +592,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
+id := commonids.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
 
 payload := virtualwans.BgpConnection{
 	// ...
@@ -608,7 +609,7 @@ if err := client.VirtualHubBgpConnectionCreateOrUpdateThenPoll(ctx, id, payload)
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
+id := commonids.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
 
 if err := client.VirtualHubBgpConnectionDeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -620,7 +621,7 @@ if err := client.VirtualHubBgpConnectionDeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
+id := commonids.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
 
 read, err := client.VirtualHubBgpConnectionGet(ctx, id)
 if err != nil {
@@ -653,7 +654,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
+id := commonids.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
 
 if err := client.VirtualHubBgpConnectionsListAdvertisedRoutesThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -665,7 +666,7 @@ if err := client.VirtualHubBgpConnectionsListAdvertisedRoutesThenPoll(ctx, id); 
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
+id := commonids.NewVirtualHubBGPConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "bgpConnectionValue")
 
 if err := client.VirtualHubBgpConnectionsListLearnedRoutesThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -677,7 +678,7 @@ if err := client.VirtualHubBgpConnectionsListLearnedRoutesThenPoll(ctx, id); err
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
+id := commonids.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
 
 payload := virtualwans.HubIPConfiguration{
 	// ...
@@ -694,7 +695,7 @@ if err := client.VirtualHubIPConfigurationCreateOrUpdateThenPoll(ctx, id, payloa
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
+id := commonids.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
 
 if err := client.VirtualHubIPConfigurationDeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -706,7 +707,7 @@ if err := client.VirtualHubIPConfigurationDeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
+id := commonids.NewVirtualHubIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualHubValue", "ipConfigurationValue")
 
 read, err := client.VirtualHubIPConfigurationGet(ctx, id)
 if err != nil {
@@ -897,7 +898,7 @@ if err := client.VirtualHubsGetOutboundRoutesThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.VirtualHubsList(ctx, id)` can be used to do batched pagination
 items, err := client.VirtualHubsListComplete(ctx, id)
@@ -914,7 +915,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.VirtualHubsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.VirtualHubsListByResourceGroupComplete(ctx, id)
@@ -997,7 +998,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.VirtualWansList(ctx, id)` can be used to do batched pagination
 items, err := client.VirtualWansListComplete(ctx, id)
@@ -1014,7 +1015,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.VirtualWansListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.VirtualWansListByResourceGroupComplete(ctx, id)
@@ -1031,7 +1032,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 payload := virtualwans.VpnConnection{
 	// ...
@@ -1048,7 +1049,7 @@ if err := client.VpnConnectionsCreateOrUpdateThenPoll(ctx, id, payload); err != 
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 if err := client.VpnConnectionsDeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -1060,7 +1061,7 @@ if err := client.VpnConnectionsDeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 read, err := client.VpnConnectionsGet(ctx, id)
 if err != nil {
@@ -1093,7 +1094,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 payload := virtualwans.VpnConnectionPacketCaptureStartParameters{
 	// ...
@@ -1110,7 +1111,7 @@ if err := client.VpnConnectionsStartPacketCaptureThenPoll(ctx, id, payload); err
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 payload := virtualwans.VpnConnectionPacketCaptureStopParameters{
 	// ...
@@ -1172,7 +1173,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.VpnGatewaysList(ctx, id)` can be used to do batched pagination
 items, err := client.VpnGatewaysListComplete(ctx, id)
@@ -1189,7 +1190,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.VpnGatewaysListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.VpnGatewaysListByResourceGroupComplete(ctx, id)
@@ -1218,7 +1219,7 @@ if err := client.VpnLinkConnectionsGetIkeSasThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
+id := commonids.NewVPNConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vpnGatewayValue", "vpnConnectionValue")
 
 // alternatively `client.VpnLinkConnectionsListByVpnConnection(ctx, id)` can be used to do batched pagination
 items, err := client.VpnLinkConnectionsListByVpnConnectionComplete(ctx, id)
@@ -1292,7 +1293,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.VpnServerConfigurationsList(ctx, id)` can be used to do batched pagination
 items, err := client.VpnServerConfigurationsListComplete(ctx, id)
@@ -1309,7 +1310,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.VpnServerConfigurationsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.VpnServerConfigurationsListByResourceGroupComplete(ctx, id)
@@ -1437,7 +1438,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.VpnSitesList(ctx, id)` can be used to do batched pagination
 items, err := client.VpnSitesListComplete(ctx, id)
@@ -1454,7 +1455,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := virtualwans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.VpnSitesListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.VpnSitesListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/vmsspublicipaddresses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/vmsspublicipaddresses/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/vmsspublicipaddresses"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := vmsspublicipaddresses.NewVirtualMachineScaleSetPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue", "publicIPAddressValue")
+id := commonids.NewVirtualMachineScaleSetPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue", "publicIPAddressValue")
 
 read, err := client.PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddress(ctx, id, vmsspublicipaddresses.DefaultPublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOperationOptions())
 if err != nil {
@@ -57,7 +58,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := vmsspublicipaddresses.NewVirtualMachineScaleSetIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue")
+id := commonids.NewVirtualMachineScaleSetIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue")
 
 // alternatively `client.PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddresses(ctx, id)` can be used to do batched pagination
 items, err := client.PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddressesComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webapplicationfirewallpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webapplicationfirewallpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webapplicationfirewallpolicies"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapplicationfirewallpolicies.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapplicationfirewallpolicies.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webcategories/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webcategories/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webcategories"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webcategories.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := azuretrafficcollectors.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ByResourceGroupList(ctx, id)` can be used to do batched pagination
 items, err := client.ByResourceGroupListComplete(ctx, id)
@@ -41,7 +42,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := azuretrafficcollectors.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.BySubscriptionList(ctx, id)` can be used to do batched pagination
 items, err := client.BySubscriptionListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2022-07-01/monitors/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2022-07-01/monitors/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2022-07-01/monitors"
 ```
 
@@ -133,7 +134,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := monitors.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -150,7 +151,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := monitors.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2023-09-01/nginxdeployment/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2023-09-01/nginxdeployment/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2023-09-01/nginxdeployment"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := nginxdeployment.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.DeploymentsList(ctx, id)` can be used to do batched pagination
 items, err := client.DeploymentsListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := nginxdeployment.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.DeploymentsListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.DeploymentsListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := namespaces.CheckAvailabilityParameters{
 	// ...
@@ -147,7 +148,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -164,7 +165,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks"
 ```
 
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := querypacks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := querypacks.LogAnalyticsQueryPack{
 	// ...
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := querypacks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -115,7 +116,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := querypacks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 ```
 
@@ -133,7 +134,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -149,7 +150,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := solution.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := solution.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := contactprofile.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := contactprofile.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/groundstation/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/groundstation/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/groundstation"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := groundstation.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.AvailableGroundStationsListByCapability(ctx, id, groundstation.DefaultAvailableGroundStationsListByCapabilityOperationOptions())` can be used to do batched pagination
 items, err := client.AvailableGroundStationsListByCapabilityComplete(ctx, id, groundstation.DefaultAvailableGroundStationsListByCapabilityOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := spacecraft.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := spacecraft.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/firewalls/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/firewalls/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/firewalls"
 ```
 
@@ -138,7 +139,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := firewalls.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -155,7 +156,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := firewalls.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/localrulestacks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/localrulestacks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/localrulestacks"
 ```
 
@@ -145,7 +146,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := localrulestacks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -162,7 +163,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := localrulestacks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/firewalls/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/firewalls/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/firewalls"
 ```
 
@@ -138,7 +139,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := firewalls.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -155,7 +156,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := firewalls.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/localrulestacks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/localrulestacks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/localrulestacks"
 ```
 
@@ -146,7 +147,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := localrulestacks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -163,7 +164,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := localrulestacks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations"
 ```
 
@@ -385,7 +386,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := remediations.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForResource(ctx, id, remediations.DefaultListForResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceComplete(ctx, id, remediations.DefaultListForResourceOperationOptions())
@@ -402,7 +403,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := remediations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListForResourceGroup(ctx, id, remediations.DefaultListForResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceGroupComplete(ctx, id, remediations.DefaultListForResourceGroupOperationOptions())
@@ -419,7 +420,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := remediations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListForSubscription(ctx, id, remediations.DefaultListForSubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListForSubscriptionComplete(ctx, id, remediations.DefaultListForSubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := dashboard.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := dashboard.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/servers"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := clusters.NameAvailabilityRequest{
 	// ...
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -107,7 +108,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities"
 ```
 
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capacities.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -106,7 +107,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := capacities.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2020-06-01/privatezones/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2020-06-01/privatezones/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2020-06-01/privatezones"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatezones.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, privatezones.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, privatezones.DefaultListOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := privatezones.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, privatezones.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, privatezones.DefaultListByResourceGroupOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account"
 ```
 
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := account.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -107,7 +108,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := account.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := vaults.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscriptionId(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionIdComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := openshiftclusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -102,7 +103,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := openshiftclusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
 ```
 
@@ -148,7 +149,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := redis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := redis.CheckNameAvailabilityParameters{
 	// ...
@@ -413,7 +414,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := redis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -430,7 +431,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := redis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2023-10-01-preview/redisenterprise/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2023-10-01-preview/redisenterprise/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2023-10-01-preview/redisenterprise"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := redisenterprise.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := redisenterprise.CheckNameAvailabilityParameters{
 	// ...
@@ -270,7 +271,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := redisenterprise.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -287,7 +288,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := redisenterprise.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := namespaces.CheckNameAvailability{
 	// ...
@@ -180,7 +181,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -214,7 +215,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourceconnector/2022-10-27/appliances/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourceconnector/2022-10-27/appliances/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resourceconnector/2022-10-27/appliances"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appliances.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.GetTelemetryConfig(ctx, id)
 if err != nil {
@@ -101,7 +102,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appliances.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -118,7 +119,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appliances.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks"
 ```
 
@@ -236,7 +237,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managementlocks.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListAtResourceGroupLevel(ctx, id, managementlocks.DefaultListAtResourceGroupLevelOperationOptions())` can be used to do batched pagination
 items, err := client.ListAtResourceGroupLevelComplete(ctx, id, managementlocks.DefaultListAtResourceGroupLevelOperationOptions())
@@ -253,7 +254,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managementlocks.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListAtResourceLevel(ctx, id, managementlocks.DefaultListAtResourceLevelOperationOptions())` can be used to do batched pagination
 items, err := client.ListAtResourceLevelComplete(ctx, id, managementlocks.DefaultListAtResourceLevelOperationOptions())
@@ -270,7 +271,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managementlocks.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAtSubscriptionLevel(ctx, id, managementlocks.DefaultListAtSubscriptionLevelOperationOptions())` can be used to do batched pagination
 items, err := client.ListAtSubscriptionLevelComplete(ctx, id, managementlocks.DefaultListAtSubscriptionLevelOperationOptions())
@@ -287,7 +288,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managementlocks.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListByScope(ctx, id, managementlocks.DefaultListByScopeOperationOptions())` can be used to do batched pagination
 items, err := client.ListByScopeComplete(ctx, id, managementlocks.DefaultListByScopeOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/privatelinkassociation/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/privatelinkassociation/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/privatelinkassociation"
 ```
 
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privatelinkassociation.NewManagementGroupID("groupIdValue")
+id := commonids.NewManagementGroupID("groupIdValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink"
 ```
 
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcemanagementprivatelink.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -72,7 +73,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcemanagementprivatelink.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts"
 ```
 
@@ -105,7 +106,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := deploymentscripts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -122,7 +123,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := deploymentscripts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2021-07-01/features/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2021-07-01/features/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2021-07-01/features"
 ```
 
@@ -57,7 +58,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := features.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
 items, err := client.ListAllComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 ```
 
@@ -130,7 +131,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := policyassignments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, policyassignments.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, policyassignments.DefaultListOperationOptions())
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := policyassignments.NewManagementGroupID("groupIdValue")
+id := commonids.NewManagementGroupID("groupIdValue")
 
 // alternatively `client.ListForManagementGroup(ctx, id, policyassignments.DefaultListForManagementGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListForManagementGroupComplete(ctx, id, policyassignments.DefaultListForManagementGroupOperationOptions())
@@ -164,7 +165,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := policyassignments.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.ListForResource(ctx, id, policyassignments.DefaultListForResourceOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceComplete(ctx, id, policyassignments.DefaultListForResourceOperationOptions())
@@ -181,7 +182,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := policyassignments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListForResourceGroup(ctx, id, policyassignments.DefaultListForResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListForResourceGroupComplete(ctx, id, policyassignments.DefaultListForResourceGroupOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers"
 ```
 
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := providers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, providers.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, providers.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-12-01/subscriptions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-12-01/subscriptions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-12-01/subscriptions"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := subscriptions.CheckZonePeersRequest{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -78,7 +79,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListLocations(ctx, id, subscriptions.DefaultListLocationsOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.CheckExistence(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourcegroups.ResourceGroup{
 	// ...
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 if err := client.DeleteThenPoll(ctx, id, resourcegroups.DefaultDeleteOperationOptions()); err != nil {
 	// handle the error
@@ -73,7 +74,7 @@ if err := client.DeleteThenPoll(ctx, id, resourcegroups.DefaultDeleteOperationOp
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourcegroups.ExportTemplateRequest{
 	// ...
@@ -90,7 +91,7 @@ if err := client.ExportTemplateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -106,7 +107,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, resourcegroups.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, resourcegroups.DefaultListOperationOptions())
@@ -123,7 +124,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ResourcesListByResourceGroup(ctx, id, resourcegroups.DefaultResourcesListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ResourcesListByResourceGroupComplete(ctx, id, resourcegroups.DefaultResourcesListByResourceGroupOperationOptions())
@@ -140,7 +141,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourcegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourcegroups.ResourceGroupPatchable{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := tags.TagsResource{
 	// ...
@@ -89,7 +90,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 if err := client.DeleteAtScopeThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -117,7 +118,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.GetAtScope(ctx, id)
 if err != nil {
@@ -133,7 +134,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tags.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -150,7 +151,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := tags.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := tags.TagsPatchResource{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := services.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := services.CheckNameAvailabilityInput{
 	// ...
@@ -94,7 +95,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := services.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, services.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, services.DefaultListByResourceGroupOperationOptions())
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := services.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, services.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, services.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/services/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/services/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/search/2023-11-01/services"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := services.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := services.CheckNameAvailabilityInput{
 	// ...
@@ -94,7 +95,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := services.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, services.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, services.DefaultListByResourceGroupOperationOptions())
@@ -111,7 +112,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := services.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id, services.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id, services.DefaultListBySubscriptionOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2019-01-01-preview/automations"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := automations.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -94,7 +95,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := automations.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 ```
 
@@ -110,7 +111,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := assessmentsmetadata.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := settings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-12-01-preview/defenderforstorage"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := defenderforstorage.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 payload := defenderforstorage.DefenderForStorageSetting{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := defenderforstorage.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 read, err := client.Get(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := pricings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-05-01/servervulnerabilityassessmentssettings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-05-01/servervulnerabilityassessmentssettings/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-05-01/servervulnerabilityassessmentssettings"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := servervulnerabilityassessmentssettings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := servervulnerabilityassessmentssettings.ServerVulnerabilityAssessmentsSetting{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servervulnerabilityassessmentssettings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servervulnerabilityassessmentssettings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servervulnerabilityassessmentssettings.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-10-01-preview/namespaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-10-01-preview/namespaces/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-10-01-preview/namespaces"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := namespaces.CheckNameAvailability{
 	// ...
@@ -127,7 +128,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -144,7 +145,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := namespaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := cluster.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := cluster.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managedcluster.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := managedcluster.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker"
 ```
 
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servicelinker.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
 
 // alternatively `client.LinkerList(ctx, id)` can be used to do batched pagination
 items, err := client.LinkerListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicenetworking/2023-05-01-preview/trafficcontrollerinterface/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicenetworking/2023-05-01-preview/trafficcontrollerinterface/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/servicenetworking/2023-05-01-preview/trafficcontrollerinterface"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := trafficcontrollerinterface.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := trafficcontrollerinterface.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr"
 ```
 
@@ -218,7 +219,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := signalr.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -235,7 +236,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := signalr.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/backupshorttermretentionpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/backupshorttermretentionpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/backupshorttermretentionpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := backupshorttermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := backupshorttermretentionpolicies.BackupShortTermRetentionPolicy{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := backupshorttermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := backupshorttermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.ListByDatabase(ctx, id)` can be used to do batched pagination
 items, err := client.ListByDatabaseComplete(ctx, id)
@@ -74,7 +75,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := backupshorttermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := backupshorttermretentionpolicies.BackupShortTermRetentionPolicy{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databases/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databases/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databases"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databases.Database{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databases.ExportDatabaseDefinition{
 	// ...
@@ -70,7 +71,7 @@ if err := client.ExportThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 if err := client.FailoverThenPoll(ctx, id, databases.DefaultFailoverOperationOptions()); err != nil {
 	// handle the error
@@ -82,7 +83,7 @@ if err := client.FailoverThenPoll(ctx, id, databases.DefaultFailoverOperationOpt
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id, databases.DefaultGetOperationOptions())
 if err != nil {
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databases.ImportExistingDatabaseDefinition{
 	// ...
@@ -115,7 +116,7 @@ if err := client.ImportThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 // alternatively `client.ListByElasticPool(ctx, id)` can be used to do batched pagination
 items, err := client.ListByElasticPoolComplete(ctx, id)
@@ -132,7 +133,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)
@@ -149,7 +150,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListInaccessibleByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListInaccessibleByServerComplete(ctx, id)
@@ -166,7 +167,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 if err := client.PauseThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -178,7 +179,7 @@ if err := client.PauseThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databases.ResourceMoveDefinition{
 	// ...
@@ -199,7 +200,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 if err := client.ResumeThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -211,7 +212,7 @@ if err := client.ResumeThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databases.DatabaseUpdate{
 	// ...
@@ -228,7 +229,7 @@ if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := databases.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 if err := client.UpgradeDataWarehouseThenPoll(ctx, id); err != nil {
 	// handle the error

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databasesecurityalertpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databasesecurityalertpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/databasesecurityalertpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := databasesecurityalertpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := databasesecurityalertpolicies.DatabaseSecurityAlertPolicy{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databasesecurityalertpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := databasesecurityalertpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.ListByDatabase(ctx, id)` can be used to do batched pagination
 items, err := client.ListByDatabaseComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/elasticpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/elasticpools/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/elasticpools"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 payload := elasticpools.ElasticPool{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 if err := client.FailoverThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -65,7 +66,7 @@ if err := client.FailoverThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id, elasticpools.DefaultListByServerOperationOptions())` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id, elasticpools.DefaultListByServerOperationOptions())
@@ -98,7 +99,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := elasticpools.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
+id := commonids.NewSqlElasticPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "elasticPoolValue")
 
 payload := elasticpools.ElasticPoolUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/geobackuppolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/geobackuppolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/geobackuppolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := geobackuppolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := geobackuppolicies.GeoBackupPolicy{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := geobackuppolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := geobackuppolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/longtermretentionpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/longtermretentionpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/longtermretentionpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := longtermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := longtermretentionpolicies.LongTermRetentionPolicy{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := longtermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := longtermretentionpolicies.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.ListByDatabase(ctx, id)` can be used to do batched pagination
 items, err := client.ListByDatabaseComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/replicationlinks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/replicationlinks/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/replicationlinks"
 ```
 
@@ -76,7 +77,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := replicationlinks.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.ListByDatabase(ctx, id)` can be used to do batched pagination
 items, err := client.ListByDatabaseComplete(ctx, id)
@@ -93,7 +94,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := replicationlinks.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/restorabledroppeddatabases/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/restorabledroppeddatabases/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/restorabledroppeddatabases"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := restorabledroppeddatabases.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadadministrators/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadadministrators/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadadministrators"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := serverazureadadministrators.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := serverazureadadministrators.ServerAzureADAdministrator{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadadministrators.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadadministrators.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadadministrators.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadonlyauthentications/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadonlyauthentications/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverazureadonlyauthentications"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := serverazureadonlyauthentications.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := serverazureadonlyauthentications.ServerAzureADOnlyAuthentication{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadonlyauthentications.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -53,7 +54,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadonlyauthentications.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serverazureadonlyauthentications.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverconnectionpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverconnectionpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serverconnectionpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := serverconnectionpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := serverconnectionpolicies.ServerConnectionPolicy{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serverconnectionpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serverconnectionpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/servers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/servers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/servers"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := servers.CheckNameAvailabilityRequest{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := servers.Server{
 	// ...
@@ -62,7 +63,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -74,7 +75,7 @@ if err := client.DeleteThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 read, err := client.Get(ctx, id, servers.DefaultGetOperationOptions())
 if err != nil {
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := servers.ImportNewDatabaseDefinition{
 	// ...
@@ -107,7 +108,7 @@ if err := client.ImportDatabaseThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, servers.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, servers.DefaultListOperationOptions())
@@ -124,7 +125,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := servers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, servers.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, servers.DefaultListByResourceGroupOperationOptions())
@@ -141,7 +142,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 if err := client.RefreshStatusThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -153,7 +154,7 @@ if err := client.RefreshStatusThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := servers.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := servers.ServerUpdate{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serversecurityalertpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serversecurityalertpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/serversecurityalertpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := serversecurityalertpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 payload := serversecurityalertpolicies.ServerSecurityAlertPolicy{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := serversecurityalertpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := serversecurityalertpolicies.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
+id := commonids.NewSqlServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue")
 
 // alternatively `client.ListByServer(ctx, id)` can be used to do batched pagination
 items, err := client.ListByServerComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/transparentdataencryptions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/transparentdataencryptions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-02-01-preview/transparentdataencryptions"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := transparentdataencryptions.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 payload := transparentdataencryptions.LogicalDatabaseTransparentDataEncryption{
 	// ...
@@ -41,7 +42,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := transparentdataencryptions.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := transparentdataencryptions.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
+id := commonids.NewSqlDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverValue", "databaseValue")
 
 // alternatively `client.ListByDatabase(ctx, id)` can be used to do batched pagination
 items, err := client.ListByDatabaseComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachinegroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachinegroups/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachinegroups"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := sqlvirtualmachinegroups.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := sqlvirtualmachinegroups.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := sqlvirtualmachines.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := sqlvirtualmachines.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/accountmigrations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/accountmigrations/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/accountmigrations"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := accountmigrations.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := accountmigrations.StorageAccountMigration{
 	// ...
@@ -41,7 +42,7 @@ if err := client.StorageAccountsCustomerInitiatedMigrationThenPoll(ctx, id, payl
 
 ```go
 ctx := context.TODO()
-id := accountmigrations.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.StorageAccountsGetCustomerInitiatedMigration(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobcontainers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobcontainers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobcontainers"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.LegalHold{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.BlobContainer{
 	// ...
@@ -66,7 +67,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.ImmutabilityPolicy{
 	// ...
@@ -87,7 +88,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -103,7 +104,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 read, err := client.DeleteImmutabilityPolicy(ctx, id, blobcontainers.DefaultDeleteImmutabilityPolicyOperationOptions())
 if err != nil {
@@ -119,7 +120,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.ImmutabilityPolicy{
 	// ...
@@ -140,7 +141,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -156,7 +157,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 read, err := client.GetImmutabilityPolicy(ctx, id, blobcontainers.DefaultGetImmutabilityPolicyOperationOptions())
 if err != nil {
@@ -172,7 +173,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.LeaseContainerRequest{
 	// ...
@@ -193,7 +194,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 // alternatively `client.List(ctx, id, blobcontainers.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, blobcontainers.DefaultListOperationOptions())
@@ -210,7 +211,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 read, err := client.LockImmutabilityPolicy(ctx, id, blobcontainers.DefaultLockImmutabilityPolicyOperationOptions())
 if err != nil {
@@ -226,7 +227,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 if err := client.ObjectLevelWormThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -238,7 +239,7 @@ if err := client.ObjectLevelWormThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.LegalHold{
 	// ...
@@ -259,7 +260,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobcontainers.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
+id := commonids.NewStorageContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue", "containerValue")
 
 payload := blobcontainers.BlobContainer{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobinventorypolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobinventorypolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobinventorypolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := blobinventorypolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := blobinventorypolicies.BlobInventoryPolicy{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobinventorypolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobinventorypolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobinventorypolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/blobservice"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := blobservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.GetServiceProperties(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := blobservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := blobservice.BlobServiceProperties{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/deletedaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/deletedaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/deletedaccounts"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := deletedaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes"
 ```
 
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := encryptionscopes.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 // alternatively `client.List(ctx, id, encryptionscopes.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, encryptionscopes.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileservice"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := fileservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.GetServiceProperties(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fileservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fileservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := fileservice.FileServiceProperties{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileshares/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileshares/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileshares"
 ```
 
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := fileshares.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 // alternatively `client.List(ctx, id, fileshares.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, fileshares.DefaultListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/localusers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/localusers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/localusers"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := localusers.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/managementpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/managementpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/managementpolicies"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := managementpolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := managementpolicies.ManagementPolicy{
 	// ...
@@ -45,7 +46,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managementpolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := managementpolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/objectreplicationpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/objectreplicationpolicies/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/objectreplicationpolicies"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := objectreplicationpolicies.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privateendpointconnections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privateendpointconnections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privateendpointconnections"
 ```
 
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateendpointconnections.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privatelinkresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privatelinkresources/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/privatelinkresources"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := privatelinkresources.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.ListByStorageAccount(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueservice"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := queueservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 // alternatively `client.QueueList(ctx, id, queueservice.DefaultQueueListOperationOptions())` can be used to do batched pagination
 items, err := client.QueueListComplete(ctx, id, queueservice.DefaultQueueListOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueserviceproperties/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueserviceproperties/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/queueserviceproperties"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := queueserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.QueueServicesGetServiceProperties(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := queueserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.QueueServicesList(ctx, id)
 if err != nil {
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := queueserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := queueserviceproperties.QueueServiceProperties{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/skus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/skus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/skus"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := skus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.List(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 if err := client.AbortHierarchicalNamespaceMigrationThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -36,7 +37,7 @@ if err := client.AbortHierarchicalNamespaceMigrationThenPoll(ctx, id); err != ni
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := storageaccounts.StorageAccountCheckNameAvailabilityParameters{
 	// ...
@@ -57,7 +58,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.StorageAccountCreateParameters{
 	// ...
@@ -74,7 +75,7 @@ if err := client.CreateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -90,7 +91,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 if err := client.FailoverThenPoll(ctx, id, storageaccounts.DefaultFailoverOperationOptions()); err != nil {
 	// handle the error
@@ -102,7 +103,7 @@ if err := client.FailoverThenPoll(ctx, id, storageaccounts.DefaultFailoverOperat
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.GetProperties(ctx, id, storageaccounts.DefaultGetPropertiesOperationOptions())
 if err != nil {
@@ -118,7 +119,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 if err := client.HierarchicalNamespaceMigrationThenPoll(ctx, id, storageaccounts.DefaultHierarchicalNamespaceMigrationOperationOptions()); err != nil {
 	// handle the error
@@ -130,7 +131,7 @@ if err := client.HierarchicalNamespaceMigrationThenPoll(ctx, id, storageaccounts
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -147,7 +148,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.AccountSasParameters{
 	// ...
@@ -168,7 +169,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -185,7 +186,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.ListKeys(ctx, id, storageaccounts.DefaultListKeysOperationOptions())
 if err != nil {
@@ -201,7 +202,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.ServiceSasParameters{
 	// ...
@@ -222,7 +223,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.StorageAccountRegenerateKeyParameters{
 	// ...
@@ -243,7 +244,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.BlobRestoreParameters{
 	// ...
@@ -260,7 +261,7 @@ if err := client.RestoreBlobRangesThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.RevokeUserDelegationKeys(ctx, id)
 if err != nil {
@@ -276,7 +277,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storageaccounts.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := storageaccounts.StorageAccountUpdateParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableservice/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableservice/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableservice"
 ```
 
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tableservice.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 // alternatively `client.TableList(ctx, id)` can be used to do batched pagination
 items, err := client.TableListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableserviceproperties/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableserviceproperties/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/tableserviceproperties"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := tableserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.TableServicesGetServiceProperties(ctx, id)
 if err != nil {
@@ -40,7 +41,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tableserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 read, err := client.TableServicesList(ctx, id)
 if err != nil {
@@ -56,7 +57,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := tableserviceproperties.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
+id := commonids.NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageAccountValue")
 
 payload := tableserviceproperties.TableServiceProperties{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/amlfilesystems/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/amlfilesystems/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/amlfilesystems"
 ```
 
@@ -61,7 +62,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := amlfilesystems.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := amlfilesystems.AmlFilesystemSubnetInfo{
 	// ...
@@ -127,7 +128,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := amlfilesystems.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := amlfilesystems.RequiredAmlFilesystemSubnetsSizeInfo{
 	// ...
@@ -148,7 +149,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := amlfilesystems.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -165,7 +166,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := amlfilesystems.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/caches/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/caches/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/caches"
 ```
 
@@ -93,7 +94,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := caches.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -110,7 +111,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := caches.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/skus/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/skus/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/skus"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := skus.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/usagemodels/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/usagemodels/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/usagemodels"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := usagemodels.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storagemovers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -90,7 +91,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := storagemovers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools"
 ```
 
@@ -81,7 +82,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := diskpools.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -98,7 +99,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := diskpools.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storagesyncservicesresource.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.StorageSyncServicesListByResourceGroup(ctx, id)
 if err != nil {
@@ -85,7 +86,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := storagesyncservicesresource.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.StorageSyncServicesListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := clusters.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := streamingjobs.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, streamingjobs.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, streamingjobs.DefaultListOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := streamingjobs.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, streamingjobs.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, streamingjobs.DefaultListByResourceGroupOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := streamingjobs.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, streamingjobs.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, streamingjobs.DefaultListOperationOptions())
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := streamingjobs.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, streamingjobs.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, streamingjobs.DefaultListByResourceGroupOperationOptions())

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions"
 ```
 
@@ -138,7 +139,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.SubscriptionCancel(ctx, id)
 if err != nil {
@@ -154,7 +155,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.SubscriptionEnable(ctx, id)
 if err != nil {
@@ -239,7 +240,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := subscriptions.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := subscriptions.SubscriptionName{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments"
 ```
 
@@ -73,7 +74,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := environments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -89,7 +90,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := environments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/profiles/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/profiles/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/profiles"
 ```
 
@@ -97,7 +98,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := profiles.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.ListByResourceGroup(ctx, id)
 if err != nil {
@@ -113,7 +114,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := profiles.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers"
 ```
 
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := videoanalyzers.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.VideoAnalyzersList(ctx, id)
 if err != nil {
@@ -114,7 +115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := videoanalyzers.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.VideoAnalyzersListBySubscription(ctx, id)
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateclouds.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -102,7 +103,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := privateclouds.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListInSubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListInSubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-04-03/communicationsgateways/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-04-03/communicationsgateways/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-04-03/communicationsgateways"
 ```
 
@@ -69,7 +70,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := communicationsgateways.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -86,7 +87,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := communicationsgateways.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections"
 ```
 
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := connections.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 read, err := client.List(ctx, id, connections.DefaultListOperationOptions())
 if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceenvironments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceenvironments/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceenvironments"
 ```
 
@@ -41,7 +42,7 @@ if err := client.ApproveOrRejectPrivateEndpointConnectionThenPoll(ctx, id, paylo
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.VirtualNetworkProfile{
 	// ...
@@ -63,7 +64,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.AppServiceEnvironmentResource{
 	// ...
@@ -80,7 +81,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.WorkerPoolResource{
 	// ...
@@ -114,7 +115,7 @@ if err := client.CreateOrUpdateWorkerPoolThenPoll(ctx, id, payload); err != nil 
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 if err := client.DeleteThenPoll(ctx, id, appserviceenvironments.DefaultDeleteOperationOptions()); err != nil {
 	// handle the error
@@ -126,7 +127,7 @@ if err := client.DeleteThenPoll(ctx, id, appserviceenvironments.DefaultDeleteOpe
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.DeleteAseCustomDnsSuffixConfiguration(ctx, id)
 if err != nil {
@@ -154,7 +155,7 @@ if err := client.DeletePrivateEndpointConnectionThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -170,7 +171,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.GetAseCustomDnsSuffixConfiguration(ctx, id)
 if err != nil {
@@ -186,7 +187,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.GetAseV3NetworkingConfiguration(ctx, id)
 if err != nil {
@@ -218,7 +219,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.GetInboundNetworkDependenciesEndpoints(ctx, id)` can be used to do batched pagination
 items, err := client.GetInboundNetworkDependenciesEndpointsComplete(ctx, id)
@@ -235,7 +236,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.GetMultiRolePool(ctx, id)
 if err != nil {
@@ -251,7 +252,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.GetOutboundNetworkDependenciesEndpoints(ctx, id)` can be used to do batched pagination
 items, err := client.GetOutboundNetworkDependenciesEndpointsComplete(ctx, id)
@@ -284,7 +285,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.GetPrivateEndpointConnectionList(ctx, id)` can be used to do batched pagination
 items, err := client.GetPrivateEndpointConnectionListComplete(ctx, id)
@@ -301,7 +302,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.GetPrivateLinkResources(ctx, id)
 if err != nil {
@@ -317,7 +318,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.GetVipInfo(ctx, id)
 if err != nil {
@@ -349,7 +350,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -366,7 +367,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListAppServicePlans(ctx, id)` can be used to do batched pagination
 items, err := client.ListAppServicePlansComplete(ctx, id)
@@ -383,7 +384,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -400,7 +401,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListCapacities(ctx, id)` can be used to do batched pagination
 items, err := client.ListCapacitiesComplete(ctx, id)
@@ -417,7 +418,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.ListDiagnostics(ctx, id)
 if err != nil {
@@ -433,7 +434,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListMultiRoleMetricDefinitions(ctx, id)` can be used to do batched pagination
 items, err := client.ListMultiRoleMetricDefinitionsComplete(ctx, id)
@@ -467,7 +468,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListMultiRolePoolSkus(ctx, id)` can be used to do batched pagination
 items, err := client.ListMultiRolePoolSkusComplete(ctx, id)
@@ -484,7 +485,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListMultiRolePools(ctx, id)` can be used to do batched pagination
 items, err := client.ListMultiRolePoolsComplete(ctx, id)
@@ -501,7 +502,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListMultiRoleUsages(ctx, id)` can be used to do batched pagination
 items, err := client.ListMultiRoleUsagesComplete(ctx, id)
@@ -518,7 +519,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.ListOperations(ctx, id)
 if err != nil {
@@ -534,7 +535,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListUsages(ctx, id, appserviceenvironments.DefaultListUsagesOperationOptions())` can be used to do batched pagination
 items, err := client.ListUsagesComplete(ctx, id, appserviceenvironments.DefaultListUsagesOperationOptions())
@@ -551,7 +552,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListWebApps(ctx, id, appserviceenvironments.DefaultListWebAppsOperationOptions())` can be used to do batched pagination
 items, err := client.ListWebAppsComplete(ctx, id, appserviceenvironments.DefaultListWebAppsOperationOptions())
@@ -636,7 +637,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.ListWorkerPools(ctx, id)` can be used to do batched pagination
 items, err := client.ListWorkerPoolsComplete(ctx, id)
@@ -653,7 +654,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.Reboot(ctx, id)
 if err != nil {
@@ -669,7 +670,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.Resume(ctx, id)` can be used to do batched pagination
 items, err := client.ResumeComplete(ctx, id)
@@ -686,7 +687,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 // alternatively `client.Suspend(ctx, id)` can be used to do batched pagination
 items, err := client.SuspendComplete(ctx, id)
@@ -703,7 +704,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 read, err := client.TestUpgradeAvailableNotification(ctx, id)
 if err != nil {
@@ -719,7 +720,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.AppServiceEnvironmentPatchResource{
 	// ...
@@ -740,7 +741,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.CustomDnsSuffixConfiguration{
 	// ...
@@ -761,7 +762,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.AseV3NetworkingConfiguration{
 	// ...
@@ -782,7 +783,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 payload := appserviceenvironments.WorkerPoolResource{
 	// ...
@@ -824,7 +825,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceenvironments.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
+id := commonids.NewAppServiceEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostingEnvironmentValue")
 
 if err := client.UpgradeThenPoll(ctx, id); err != nil {
 	// handle the error

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceplans/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceplans/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/appserviceplans"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 payload := appserviceplans.AppServicePlan{
 	// ...
@@ -62,7 +63,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.Delete(ctx, id)
 if err != nil {
@@ -110,7 +111,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -142,7 +143,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.GetHybridConnectionPlanLimit(ctx, id)
 if err != nil {
@@ -174,7 +175,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.GetServerFarmSkus(ctx, id)
 if err != nil {
@@ -222,7 +223,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id, appserviceplans.DefaultListOperationOptions())` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id, appserviceplans.DefaultListOperationOptions())
@@ -239,7 +240,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -256,7 +257,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.ListCapabilities(ctx, id)
 if err != nil {
@@ -288,7 +289,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 // alternatively `client.ListHybridConnections(ctx, id)` can be used to do batched pagination
 items, err := client.ListHybridConnectionsComplete(ctx, id)
@@ -321,7 +322,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 // alternatively `client.ListUsages(ctx, id, appserviceplans.DefaultListUsagesOperationOptions())` can be used to do batched pagination
 items, err := client.ListUsagesComplete(ctx, id, appserviceplans.DefaultListUsagesOperationOptions())
@@ -338,7 +339,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.ListVnets(ctx, id)
 if err != nil {
@@ -354,7 +355,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 // alternatively `client.ListWebApps(ctx, id, appserviceplans.DefaultListWebAppsOperationOptions())` can be used to do batched pagination
 items, err := client.ListWebAppsComplete(ctx, id, appserviceplans.DefaultListWebAppsOperationOptions())
@@ -404,7 +405,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 read, err := client.RestartWebApps(ctx, id, appserviceplans.DefaultRestartWebAppsOperationOptions())
 if err != nil {
@@ -420,7 +421,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := appserviceplans.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
+id := commonids.NewAppServicePlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serverFarmValue")
 
 payload := appserviceplans.AppServicePlanPatchResource{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders"
 ```
 
@@ -24,7 +25,7 @@ client.Client.Authorizer = authorizer
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := resourceproviders.ResourceNameAvailabilityRequest{
 	// ...
@@ -77,7 +78,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.GetSubscriptionDeploymentLocations(ctx, id)
 if err != nil {
@@ -110,7 +111,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListAseRegions(ctx, id)` can be used to do batched pagination
 items, err := client.ListAseRegionsComplete(ctx, id)
@@ -127,7 +128,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBillingMeters(ctx, id, resourceproviders.DefaultListBillingMetersOperationOptions())` can be used to do batched pagination
 items, err := client.ListBillingMetersComplete(ctx, id, resourceproviders.DefaultListBillingMetersOperationOptions())
@@ -144,7 +145,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListCustomHostNameSites(ctx, id, resourceproviders.DefaultListCustomHostNameSitesOperationOptions())` can be used to do batched pagination
 items, err := client.ListCustomHostNameSitesComplete(ctx, id, resourceproviders.DefaultListCustomHostNameSitesOperationOptions())
@@ -161,7 +162,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListGeoRegions(ctx, id, resourceproviders.DefaultListGeoRegionsOperationOptions())` can be used to do batched pagination
 items, err := client.ListGeoRegionsComplete(ctx, id, resourceproviders.DefaultListGeoRegionsOperationOptions())
@@ -178,7 +179,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListPremierAddOnOffers(ctx, id)` can be used to do batched pagination
 items, err := client.ListPremierAddOnOffersComplete(ctx, id)
@@ -195,7 +196,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := resourceproviders.NameIdentifier{
 	// ...
@@ -217,7 +218,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 read, err := client.ListSkus(ctx, id)
 if err != nil {
@@ -250,7 +251,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourceproviders.CsmMoveResourceEnvelope{
 	// ...
@@ -312,7 +313,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourceproviders.ValidateRequest{
 	// ...
@@ -333,7 +334,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 payload := resourceproviders.CsmMoveResourceEnvelope{
 	// ...
@@ -354,7 +355,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := resourceproviders.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 payload := resourceproviders.VnetParameters{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps"
 ```
 
@@ -66,7 +67,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.AnalyzeCustomHostname(ctx, id, webapps.DefaultAnalyzeCustomHostnameOperationOptions())
 if err != nil {
@@ -98,7 +99,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmSlotEntity{
 	// ...
@@ -174,7 +175,7 @@ if err := client.ApproveOrRejectPrivateEndpointConnectionSlotThenPoll(ctx, id, p
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.BackupRequest{
 	// ...
@@ -326,7 +327,7 @@ if err := client.CreateInstanceMSDeployOperationSlotThenPoll(ctx, id, payload); 
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.MSDeploy{
 	// ...
@@ -360,7 +361,7 @@ if err := client.CreateMSDeployOperationSlotThenPoll(ctx, id, payload); err != n
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.CreateOneDeployOperation(ctx, id)
 if err != nil {
@@ -376,7 +377,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.Site{
 	// ...
@@ -393,7 +394,7 @@ if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteConfigResource{
 	// ...
@@ -746,7 +747,7 @@ if err := client.CreateOrUpdateSlotThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteSourceControl{
 	// ...
@@ -780,7 +781,7 @@ if err := client.CreateOrUpdateSourceControlSlotThenPoll(ctx, id, payload); err 
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SwiftVirtualNetwork{
 	// ...
@@ -906,7 +907,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.Delete(ctx, id, webapps.DefaultDeleteOperationOptions())
 if err != nil {
@@ -938,7 +939,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.DeleteBackupConfiguration(ctx, id)
 if err != nil {
@@ -1474,7 +1475,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.DeleteSourceControl(ctx, id, webapps.DefaultDeleteSourceControlOperationOptions())
 if err != nil {
@@ -1506,7 +1507,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.DeleteSwiftVirtualNetwork(ctx, id)
 if err != nil {
@@ -1602,7 +1603,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.WorkflowArtifacts{
 	// ...
@@ -1644,7 +1645,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.RestoreRequest{
 	// ...
@@ -1686,7 +1687,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GenerateNewSitePublishingPassword(ctx, id)
 if err != nil {
@@ -1718,7 +1719,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.Get(ctx, id)
 if err != nil {
@@ -1766,7 +1767,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.GetAppSettingsKeyVaultReferences(ctx, id)` can be used to do batched pagination
 items, err := client.GetAppSettingsKeyVaultReferencesComplete(ctx, id)
@@ -1800,7 +1801,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetAuthSettings(ctx, id)
 if err != nil {
@@ -1832,7 +1833,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetAuthSettingsV2(ctx, id)
 if err != nil {
@@ -1864,7 +1865,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetAuthSettingsV2WithoutSecrets(ctx, id)
 if err != nil {
@@ -1896,7 +1897,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetBackupConfiguration(ctx, id)
 if err != nil {
@@ -1960,7 +1961,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetConfiguration(ctx, id)
 if err != nil {
@@ -2024,7 +2025,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetContainerLogsZip(ctx, id)
 if err != nil {
@@ -2120,7 +2121,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetDiagnosticLogsConfiguration(ctx, id)
 if err != nil {
@@ -2184,7 +2185,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetFtpAllowed(ctx, id)
 if err != nil {
@@ -2232,7 +2233,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetFunctionsAdminToken(ctx, id)
 if err != nil {
@@ -2552,7 +2553,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetMSDeployLog(ctx, id)
 if err != nil {
@@ -2584,7 +2585,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetMSDeployStatus(ctx, id)
 if err != nil {
@@ -2616,7 +2617,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetMigrateMySqlStatus(ctx, id)
 if err != nil {
@@ -2712,7 +2713,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetOneDeployStatus(ctx, id)
 if err != nil {
@@ -2760,7 +2761,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetPrivateAccess(ctx, id)
 if err != nil {
@@ -2808,7 +2809,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.GetPrivateEndpointConnectionList(ctx, id)` can be used to do batched pagination
 items, err := client.GetPrivateEndpointConnectionListComplete(ctx, id)
@@ -2858,7 +2859,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetPrivateLinkResources(ctx, id)
 if err != nil {
@@ -3050,7 +3051,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetScmAllowed(ctx, id)
 if err != nil {
@@ -3114,7 +3115,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.GetSiteConnectionStringKeyVaultReferences(ctx, id)` can be used to do batched pagination
 items, err := client.GetSiteConnectionStringKeyVaultReferencesComplete(ctx, id)
@@ -3180,7 +3181,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetSitePhpErrorLogFlag(ctx, id)
 if err != nil {
@@ -3228,7 +3229,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetSourceControl(ctx, id)
 if err != nil {
@@ -3260,7 +3261,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetSwiftVirtualNetworkConnection(ctx, id)
 if err != nil {
@@ -3452,7 +3453,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.GetWebSiteContainerLogs(ctx, id)
 if err != nil {
@@ -3524,7 +3525,7 @@ if err := client.InstallSiteExtensionSlotThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.IsCloneable(ctx, id)
 if err != nil {
@@ -3556,7 +3557,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.List(ctx, id)` can be used to do batched pagination
 items, err := client.ListComplete(ctx, id)
@@ -3573,7 +3574,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListApplicationSettings(ctx, id)
 if err != nil {
@@ -3605,7 +3606,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListAzureStorageAccounts(ctx, id)
 if err != nil {
@@ -3679,7 +3680,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListBackups(ctx, id)` can be used to do batched pagination
 items, err := client.ListBackupsComplete(ctx, id)
@@ -3713,7 +3714,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListBasicPublishingCredentialsPolicies(ctx, id)` can be used to do batched pagination
 items, err := client.ListBasicPublishingCredentialsPoliciesComplete(ctx, id)
@@ -3747,7 +3748,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id, webapps.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id, webapps.DefaultListByResourceGroupOperationOptions())
@@ -3764,7 +3765,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListConfigurationSnapshotInfo(ctx, id)` can be used to do batched pagination
 items, err := client.ListConfigurationSnapshotInfoComplete(ctx, id)
@@ -3798,7 +3799,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListConfigurations(ctx, id)` can be used to do batched pagination
 items, err := client.ListConfigurationsComplete(ctx, id)
@@ -3832,7 +3833,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListConnectionStrings(ctx, id)
 if err != nil {
@@ -3864,7 +3865,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListContinuousWebJobs(ctx, id)` can be used to do batched pagination
 items, err := client.ListContinuousWebJobsComplete(ctx, id)
@@ -3930,7 +3931,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListDeployments(ctx, id)` can be used to do batched pagination
 items, err := client.ListDeploymentsComplete(ctx, id)
@@ -3964,7 +3965,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListDomainOwnershipIdentifiers(ctx, id)` can be used to do batched pagination
 items, err := client.ListDomainOwnershipIdentifiersComplete(ctx, id)
@@ -4062,7 +4063,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListFunctions(ctx, id)` can be used to do batched pagination
 items, err := client.ListFunctionsComplete(ctx, id)
@@ -4079,7 +4080,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListHostKeys(ctx, id)
 if err != nil {
@@ -4111,7 +4112,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListHostNameBindings(ctx, id)` can be used to do batched pagination
 items, err := client.ListHostNameBindingsComplete(ctx, id)
@@ -4145,7 +4146,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListHybridConnections(ctx, id)
 if err != nil {
@@ -4194,7 +4195,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListInstanceIdentifiers(ctx, id)` can be used to do batched pagination
 items, err := client.ListInstanceIdentifiersComplete(ctx, id)
@@ -4347,7 +4348,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListMetadata(ctx, id)
 if err != nil {
@@ -4411,7 +4412,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListPerfMonCounters(ctx, id, webapps.DefaultListPerfMonCountersOperationOptions())` can be used to do batched pagination
 items, err := client.ListPerfMonCountersComplete(ctx, id, webapps.DefaultListPerfMonCountersOperationOptions())
@@ -4445,7 +4446,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListPremierAddOns(ctx, id)
 if err != nil {
@@ -4545,7 +4546,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListProcesses(ctx, id)` can be used to do batched pagination
 items, err := client.ListProcessesComplete(ctx, id)
@@ -4579,7 +4580,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListProductionSiteDeploymentStatuses(ctx, id)` can be used to do batched pagination
 items, err := client.ListProductionSiteDeploymentStatusesComplete(ctx, id)
@@ -4596,7 +4597,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListPublicCertificates(ctx, id)` can be used to do batched pagination
 items, err := client.ListPublicCertificatesComplete(ctx, id)
@@ -4630,7 +4631,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 if err := client.ListPublishingCredentialsThenPoll(ctx, id); err != nil {
 	// handle the error
@@ -4654,7 +4655,7 @@ if err := client.ListPublishingCredentialsSlotThenPoll(ctx, id); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmPublishingProfileOptions{
 	// ...
@@ -4696,7 +4697,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListRelayServiceConnections(ctx, id)
 if err != nil {
@@ -4728,7 +4729,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListSiteBackups(ctx, id)` can be used to do batched pagination
 items, err := client.ListSiteBackupsComplete(ctx, id)
@@ -4762,7 +4763,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListSiteExtensions(ctx, id)` can be used to do batched pagination
 items, err := client.ListSiteExtensionsComplete(ctx, id)
@@ -4796,7 +4797,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListSitePushSettings(ctx, id)
 if err != nil {
@@ -4828,7 +4829,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListSlotConfigurationNames(ctx, id)
 if err != nil {
@@ -4844,7 +4845,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmSlotEntity{
 	// ...
@@ -4905,7 +4906,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListSlots(ctx, id)` can be used to do batched pagination
 items, err := client.ListSlotsComplete(ctx, id)
@@ -4922,7 +4923,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListSnapshots(ctx, id)` can be used to do batched pagination
 items, err := client.ListSnapshotsComplete(ctx, id)
@@ -4939,7 +4940,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListSnapshotsFromDRSecondary(ctx, id)` can be used to do batched pagination
 items, err := client.ListSnapshotsFromDRSecondaryComplete(ctx, id)
@@ -4990,7 +4991,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListSyncFunctionTriggers(ctx, id)
 if err != nil {
@@ -5022,7 +5023,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListSyncStatus(ctx, id)
 if err != nil {
@@ -5088,7 +5089,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListTriggeredWebJobs(ctx, id)` can be used to do batched pagination
 items, err := client.ListTriggeredWebJobsComplete(ctx, id)
@@ -5122,7 +5123,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListUsages(ctx, id, webapps.DefaultListUsagesOperationOptions())` can be used to do batched pagination
 items, err := client.ListUsagesComplete(ctx, id, webapps.DefaultListUsagesOperationOptions())
@@ -5156,7 +5157,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListVnetConnections(ctx, id)
 if err != nil {
@@ -5188,7 +5189,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListWebJobs(ctx, id)` can be used to do batched pagination
 items, err := client.ListWebJobsComplete(ctx, id)
@@ -5222,7 +5223,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 // alternatively `client.ListWorkflows(ctx, id)` can be used to do batched pagination
 items, err := client.ListWorkflowsComplete(ctx, id)
@@ -5239,7 +5240,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ListWorkflowsConnections(ctx, id)
 if err != nil {
@@ -5271,7 +5272,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.MigrateMySqlRequest{
 	// ...
@@ -5288,7 +5289,7 @@ if err := client.MigrateMySqlThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.StorageMigrationOptions{
 	// ...
@@ -5305,7 +5306,7 @@ if err := client.MigrateStorageThenPoll(ctx, id, payload, webapps.DefaultMigrate
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.PrivateAccess{
 	// ...
@@ -5379,7 +5380,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.ResetProductionSlotConfig(ctx, id)
 if err != nil {
@@ -5411,7 +5412,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.Restart(ctx, id, webapps.DefaultRestartOperationOptions())
 if err != nil {
@@ -5460,7 +5461,7 @@ if err := client.RestoreThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.RestoreRequest{
 	// ...
@@ -5494,7 +5495,7 @@ if err := client.RestoreFromBackupBlobSlotThenPoll(ctx, id, payload); err != nil
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.DeletedAppRestoreRequest{
 	// ...
@@ -5545,7 +5546,7 @@ if err := client.RestoreSlotThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SnapshotRestoreRequest{
 	// ...
@@ -5611,7 +5612,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.Start(ctx, id)
 if err != nil {
@@ -5659,7 +5660,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 if err := client.StartNetworkTraceThenPoll(ctx, id, webapps.DefaultStartNetworkTraceOperationOptions()); err != nil {
 	// handle the error
@@ -5699,7 +5700,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.StartWebSiteNetworkTrace(ctx, id, webapps.DefaultStartWebSiteNetworkTraceOperationOptions())
 if err != nil {
@@ -5715,7 +5716,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 if err := client.StartWebSiteNetworkTraceOperationThenPoll(ctx, id, webapps.DefaultStartWebSiteNetworkTraceOperationOperationOptions()); err != nil {
 	// handle the error
@@ -5755,7 +5756,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.Stop(ctx, id)
 if err != nil {
@@ -5803,7 +5804,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.StopNetworkTrace(ctx, id)
 if err != nil {
@@ -5851,7 +5852,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.StopWebSiteNetworkTrace(ctx, id)
 if err != nil {
@@ -5900,7 +5901,7 @@ if err := client.SwapSlotSlotThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmSlotEntity{
 	// ...
@@ -5917,7 +5918,7 @@ if err := client.SwapSlotWithProductionThenPoll(ctx, id, payload); err != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.SyncFunctionTriggers(ctx, id)
 if err != nil {
@@ -5949,7 +5950,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.SyncFunctions(ctx, id)
 if err != nil {
@@ -5981,7 +5982,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 read, err := client.SyncRepository(ctx, id)
 if err != nil {
@@ -6013,7 +6014,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SitePatchResource{
 	// ...
@@ -6034,7 +6035,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.StringDictionary{
 	// ...
@@ -6076,7 +6077,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteAuthSettings{
 	// ...
@@ -6118,7 +6119,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteAuthSettingsV2{
 	// ...
@@ -6160,7 +6161,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.AzureStoragePropertyDictionaryResource{
 	// ...
@@ -6202,7 +6203,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.BackupRequest{
 	// ...
@@ -6244,7 +6245,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteConfigResource{
 	// ...
@@ -6286,7 +6287,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.ConnectionStringDictionary{
 	// ...
@@ -6328,7 +6329,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteLogsConfig{
 	// ...
@@ -6412,7 +6413,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmPublishingCredentialsPoliciesEntity{
 	// ...
@@ -6496,7 +6497,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.StringDictionary{
 	// ...
@@ -6622,7 +6623,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.CsmPublishingCredentialsPoliciesEntity{
 	// ...
@@ -6664,7 +6665,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.PushSettings{
 	// ...
@@ -6727,7 +6728,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SlotConfigNamesResource{
 	// ...
@@ -6748,7 +6749,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SiteSourceControl{
 	// ...
@@ -6790,7 +6791,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := webapps.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
+id := commonids.NewAppServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "siteValue")
 
 payload := webapps.SwiftVirtualNetwork{
 	// ...

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/README.md
@@ -8,6 +8,7 @@ This readme covers example usages, but further information on [using this SDK ca
 ### Import Path
 
 ```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 import "github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub"
 ```
 
@@ -280,7 +281,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webpubsub.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
 items, err := client.ListByResourceGroupComplete(ctx, id)
@@ -297,7 +298,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := webpubsub.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
 items, err := client.ListBySubscriptionComplete(ctx, id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
@@ -174,6 +174,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"CancelInProgress": pollers.PollingStatusInProgress,
 			// CostManagement@2021-10-01 returns `Completed` rather than `Succeeded`: https://github.com/Azure/azure-sdk-for-go/issues/20342
 			"Completed": pollers.PollingStatusSucceeded,
+			// ServiceFabricManaged @ 2021-05-01 (NodeTypes CreateOrUpdate) returns `Created` rather than `InProgress` during Creation
+			"Created": pollers.PollingStatusInProgress,
 			// ContainerRegistry@2019-06-01-preview returns `Creating` rather than `InProgress` during creation
 			"Creating": pollers.PollingStatusInProgress,
 			// SignalR@2022-02-01 returns `Running` rather than `InProgress` during creation

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1043,7 +1043,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceprovid
 github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240201.1064937
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240206.1080438
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240201.1064937
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240206.1080438
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20240206.1080438` - further details can be found in a comment.