### PR TITLE
`azurerm_storage_account` - Support `local_user_enabled`

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -148,6 +148,10 @@ The following arguments are supported:
 
 * `large_file_share_enabled` - (Optional) Is Large File Share Enabled?
 
+* `local_user_enabled` - (Optional) Is Local User Enabled?
+
+~> **NOTE:** `local_user_enabled` support requires `sftp_enabled` to be `true`.
+
 * `azure_files_authentication` - (Optional) A `azure_files_authentication` block as defined below.
 
 * `routing` - (Optional) A `routing` block as defined below.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -148,9 +148,7 @@ The following arguments are supported:
 
 * `large_file_share_enabled` - (Optional) Is Large File Share Enabled?
 
-* `local_user_enabled` - (Optional) Is Local User Enabled?
-
-~> **NOTE:** `local_user_enabled` support requires `sftp_enabled` to be `true`.
+* `local_user_enabled` - (Optional) Is Local User Enabled? Defaults to `true`.
 
 * `azure_files_authentication` - (Optional) A `azure_files_authentication` block as defined below.
 


### PR DESCRIPTION
This PR adds a new property `local_user_enabled` to `azurerm_storage_account`.

This feature is actually used when SFTP is enabled (which in turns requires the HNS is enabled), see [this](https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support-how-to?tabs=azure-portal#configure-permissions) for details. However, the API actually accepts the `isLocalUserEnabled` properties regardless the SFTP state. Azure Portal also allows manage `isLocalUserEnabled` regardless of `sftpEnabled`, as long as the HNS is enabled so that you have access to the "SFTP" blade.

When creating the storage account without specifying the `isLocalUserEnabled` in the request, the API defaults to `true`, hence the default value set in the schema (and the init value set in `Read()`). This is to avoid breaking changes.

Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/24797

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageAccount_isLocalUserEnabled|TestAccStorageAccount_basic' ./internal/services/storage
=== RUN   TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== RUN   TestAccStorageAccount_isLocalUserEnabled
=== PAUSE TestAccStorageAccount_isLocalUserEnabled
=== CONT  TestAccStorageAccount_basic
=== CONT  TestAccStorageAccount_isLocalUserEnabled
--- PASS: TestAccStorageAccount_basic (175.51s)
--- PASS: TestAccStorageAccount_isLocalUserEnabled (188.51s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       188.535s
```