### PR TITLE
`azurerm_mssql_managed_instance` : support new property `azure_active_directory_administrator`

### DIFF
--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource_test.go
@@ -25,13 +25,6 @@ func TestAccMsSqlManagedInstanceFailoverGroup_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: MsSqlManagedInstanceResource{}.dnsZonePartner(data),
-		},
-		{
-			// It speeds up deletion to remove the explicit dependency between the instances
-			Config: MsSqlManagedInstanceResource{}.emptyDnsZonePartner(data),
-		},
-		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -45,10 +38,6 @@ func TestAccMsSqlManagedInstanceFailoverGroup_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			// disconnect
-			Config: MsSqlManagedInstanceResource{}.emptyDnsZonePartner(data),
-		},
 	})
 }
 
@@ -136,6 +125,7 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
+  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -179,6 +169,7 @@ resource "azurerm_public_ip" "secondary" {
   location            = azurerm_resource_group.secondary.location
   resource_group_name = azurerm_resource_group.secondary.name
   allocation_method   = "Dynamic"
+  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "secondary" {
@@ -209,5 +200,5 @@ resource "azurerm_virtual_network_gateway_connection" "secondary" {
 
   shared_key = var.shared_key
 }
-`, MsSqlManagedInstanceResource{}.emptyDnsZonePartner(data), data.RandomInteger)
+`, MsSqlManagedInstanceResource{}.dnsZonePartner(data), data.RandomInteger)
 }

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -6,10 +6,13 @@ package mssqlmanagedinstance
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v5.0/sql"
+	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -24,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const (
@@ -56,15 +60,21 @@ type MsSqlManagedInstanceModel struct {
 	SubnetId                     string                              `tfschema:"subnet_id"`
 	TimezoneId                   string                              `tfschema:"timezone_id"`
 	VCores                       int64                               `tfschema:"vcores"`
+	MicrosoftEntraAdministrator  []MicrosoftEntraAdministrator       `tfschema:"microsoft_entra_administrator"`
 	ZoneRedundantEnabled         bool                                `tfschema:"zone_redundant_enabled"`
 	Tags                         map[string]string                   `tfschema:"tags"`
 }
 
-var (
-	_ sdk.Resource                  = MsSqlManagedInstanceResource{}
-	_ sdk.ResourceWithUpdate        = MsSqlManagedInstanceResource{}
-	_ sdk.ResourceWithCustomizeDiff = MsSqlManagedInstanceResource{}
-)
+type MicrosoftEntraAdministrator struct {
+	LoginUserName                           string `tfschema:"login_username"`
+	ObjectID                                string `tfschema:"object_id"`
+	MicrosoftEntraAuthenticationOnlyEnabled bool   `tfschema:"microsoft_entra_authentication_only_enabled"`
+	TenantID                                string `tfschema:"tenant_id"`
+}
+
+var _ sdk.Resource = MsSqlManagedInstanceResource{}
+var _ sdk.ResourceWithUpdate = MsSqlManagedInstanceResource{}
+var _ sdk.ResourceWithCustomizeDiff = MsSqlManagedInstanceResource{}
 
 type MsSqlManagedInstanceResource struct{}
 
@@ -106,20 +116,6 @@ func (r MsSqlManagedInstanceResource) Arguments() map[string]*pluginsdk.Schema {
 				"GP_Gen8IH",
 				"GP_Gen8IM",
 			}, false),
-		},
-
-		"administrator_login": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-
-		"administrator_login_password": {
-			Type:         schema.TypeString,
-			Required:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringIsNotEmpty,
 		},
 
 		"license_type": {
@@ -165,6 +161,57 @@ func (r MsSqlManagedInstanceResource) Arguments() map[string]*pluginsdk.Schema {
 				96,
 				128,
 			}),
+		},
+
+		"administrator_login": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			AtLeastOneOf: []string{"administrator_login", "microsoft_entra_administrator"},
+			RequiredWith: []string{"administrator_login", "administrator_login_password"},
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"administrator_login_password": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			AtLeastOneOf: []string{"administrator_login_password", "microsoft_entra_administrator"},
+			RequiredWith: []string{"administrator_login", "administrator_login_password"},
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"microsoft_entra_administrator": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"login_username": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"object_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+
+					"microsoft_entra_authentication_only_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"tenant_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+				},
+			},
 		},
 
 		"collation": {
@@ -350,6 +397,7 @@ func (r MsSqlManagedInstanceResource) Create() sdk.ResourceFunc {
 					TimezoneId:                       pointer.To(model.TimezoneId),
 					VCores:                           pointer.To(model.VCores),
 					ZoneRedundant:                    pointer.To(model.ZoneRedundantEnabled),
+					Administrators:                   expandMsSqlManagedInstanceExternalAdministrators(model.MicrosoftEntraAdministrator),
 				},
 				Tags: pointer.To(model.Tags),
 			}
@@ -385,6 +433,8 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 		Timeout: 24 * time.Hour,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.MSSQLManagedInstance.ManagedInstancesClient
+			adminClient := metadata.Client.MSSQLManagedInstance.ManagedInstanceAdministratorsClient
+			microsoftEntraAuthenticationOnlyClient := metadata.Client.MSSQLManagedInstance.ManagedInstanceAzureADOnlyAuthenticationsClient
 
 			id, err := commonids.ParseSqlManagedInstanceID(metadata.ResourceData.Id())
 			if err != nil {
@@ -447,11 +497,79 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.Logger.Infof("Updating %s", id)
+			if metadata.ResourceData.HasChange("microsoft_entra_administrator") {
+				// Need to check if Microsoft Entra authentication only is enabled or not before calling delete, else you will get the following error:
+				// InvalidManagedServerAADOnlyAuthNoAADAdminPropertyName: AAD Admin is not configured,
+				// Microsfot Entra Admin must be set before enabling/disabling Microsfot Entra Authentication Only.
+				log.Printf("[INFO] Checking if Microsoft Entra Administrator exist")
+				meAdminExists := false
+				resp, err := adminClient.Get(ctx, *id)
+				if err != nil {
+					if !utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("retrieving the Administrators of %s: %+v", *id, err)
+					}
+				} else {
+					meAdminExists = true
+				}
+
+				if meAdminExists {
+					future, err := microsoftEntraAuthenticationOnlyClient.Delete(ctx, id.ResourceGroup, id.Name)
+					if err != nil {
+						log.Printf("[INFO] Deletion of Microsoft Entra Authentication Only failed for %s: %+v", *id, err)
+						return fmt.Errorf("deleting Microsoft Entra Authentication Only for %s: %+v", *id, err)
+					}
+
+					if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+						return fmt.Errorf("waiting for the Microsoft Entra Authentication Only deletion of %s: %+v", *id, err)
+					}
+
+					resp, err := adminClient.Delete(ctx, id.ResourceGroup, id.Name)
+					if err != nil {
+						return fmt.Errorf("deleting the Microsoft Entra Administrator of %s: %+v", *id, err)
+					}
+					if err = resp.WaitForCompletionRef(ctx, client.Client); err != nil {
+						return fmt.Errorf("waiting for the Microsoft Entra Administrators deletion of %s: %+v", *id, err)
+					}
+				}
+
+				meAdminProps, err := expandMsSqlManagedInstanceAdministrators(state.MicrosoftEntraAdministrator)
+				if err != nil {
+					return err
+				}
+				if meAdminProps != nil {
+					future, err := adminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *meAdminProps)
+					if err != nil {
+						return fmt.Errorf("creating Microsoft Entra Administrator of %s: %+v", *id, err)
+					}
+					if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+						return fmt.Errorf("waiting for creating Microsoft Entra Administrator of %s: %+v", *id, err)
+					}
+				}
+
+				if meOnlyAuthentictionsEnabled := expandMsSqlManagedInstanceMeAuthentictionOnly(state.MicrosoftEntraAdministrator); meOnlyAuthentictionsEnabled {
+					meOnlyAuthentictionsProps := sql.ManagedInstanceAzureADOnlyAuthentication{
+						ManagedInstanceAzureADOnlyAuthProperties: &sql.ManagedInstanceAzureADOnlyAuthProperties{
+							AzureADOnlyAuthentication: pointer.To(true),
+						},
+					}
+
+					future, err := microsoftEntraAuthenticationOnlyClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, meOnlyAuthentictionsProps)
+					if err != nil {
+						return fmt.Errorf("setting `microsoft_entra_authentication_only_enabled` for %s: %+v", *id, err)
+					}
+					if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+						return fmt.Errorf("waiting to set `microsoft_entra_authentication_only_enabled` for  %s: %+v", *id, err)
+					}
+				}
+
+				properties.Administrators = expandMsSqlManagedInstanceExternalAdministrators(state.MicrosoftEntraAdministrator)
+			}
+
+			metadata.Logger.Infof("Updating %s", *id)
 
 			err = client.CreateOrUpdateThenPoll(ctx, *id, properties)
 			if err != nil {
-				return fmt.Errorf("updating %s: %+v", id, err)
+				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
 			return nil
@@ -509,6 +627,10 @@ func (r MsSqlManagedInstanceResource) Read() sdk.ResourceFunc {
 					model.StorageAccountType = backupStorageRedundancyToStorageAccType(pointer.From(props.RequestedBackupStorageRedundancy))
 
 					model.AdministratorLogin = pointer.From(props.AdministratorLogin)
+
+					if props.Administrators != nil {
+						model.MicrosoftEntraAdministrator = flattenMsSqlManagedInstanceAdministrators(*props.Administrators)
+					}
 					model.Collation = pointer.From(props.Collation)
 					model.DnsZone = pointer.From(props.DnsZone)
 					model.Fqdn = pointer.From(props.FullyQualifiedDomainName)
@@ -672,4 +794,77 @@ func backupStorageRedundancyToStorageAccType(backupStorageRedundancy managedinst
 		return StorageAccountTypeGZRS
 	}
 	return StorageAccountTypeGRS
+}
+
+func expandMsSqlManagedInstanceMeAuthentictionOnly(input []MicrosoftEntraAdministrator) bool {
+	if len(input) == 0 {
+		return false
+	}
+
+	if ok := input[0].MicrosoftEntraAuthenticationOnlyEnabled; ok {
+		return input[0].MicrosoftEntraAuthenticationOnlyEnabled
+	}
+
+	return false
+}
+
+func expandMsSqlManagedInstanceExternalAdministrators(input []MicrosoftEntraAdministrator) *managedinstances.ManagedInstanceExternalAdministrator {
+	if len(input) == 0 {
+		return nil
+	}
+
+	admin := input[0]
+	adminParams := managedinstances.ManagedInstanceExternalAdministrator{
+		AdministratorType: pointer.To(managedinstances.AdministratorTypeActiveDirectory),
+		Login:             pointer.To(admin.LoginUserName),
+		Sid:               pointer.To(admin.ObjectID),
+	}
+
+	if admin.TenantID != "" {
+		adminParams.TenantId = pointer.To(admin.TenantID)
+	}
+
+	adminParams.AzureADOnlyAuthentication = pointer.To(admin.MicrosoftEntraAuthenticationOnlyEnabled)
+
+	return &adminParams
+}
+
+func expandMsSqlManagedInstanceAdministrators(input []MicrosoftEntraAdministrator) (*sql.ManagedInstanceAdministrator, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	admin := input[0]
+	sid, err := uuid.FromString(admin.ObjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	adminProps := sql.ManagedInstanceAdministrator{
+		ManagedInstanceAdministratorProperties: &sql.ManagedInstanceAdministratorProperties{
+			AdministratorType: pointer.To(string(sql.AdministratorTypeActiveDirectory)),
+			Login:             pointer.To(admin.LoginUserName),
+			Sid:               pointer.To(sid),
+		},
+	}
+
+	if admin.TenantID != "" {
+		tenantId, err := uuid.FromString(admin.TenantID)
+		if err != nil {
+			return nil, err
+		}
+		adminProps.ManagedInstanceAdministratorProperties.TenantID = pointer.To(tenantId)
+	}
+
+	return pointer.To(adminProps), nil
+}
+
+func flattenMsSqlManagedInstanceAdministrators(admin sql.ManagedInstanceExternalAdministrator) []MicrosoftEntraAdministrator {
+	results := make([]MicrosoftEntraAdministrator, 0)
+	return append(results, MicrosoftEntraAdministrator{
+		LoginUserName:                           pointer.From(admin.Login),
+		ObjectID:                                pointer.From(admin.Sid).String(),
+		TenantID:                                pointer.From(admin.TenantID).String(),
+		MicrosoftEntraAuthenticationOnlyEnabled: pointer.From(admin.AzureADOnlyAuthentication),
+	})
 }

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -486,6 +486,18 @@ resource "azurerm_mssql_managed_instance" "test" {
 
 func (r MsSqlManagedInstanceResource) withoutAadAdmin(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 resource "azurerm_mssql_managed_instance" "test" {
@@ -962,6 +974,18 @@ func TestAccMsSqlManagedInstance_aadAdminUpdate(t *testing.T) {
 
 func (r MsSqlManagedInstanceResource) aadAdmin(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 provider "azuread" {}
@@ -1044,6 +1068,18 @@ resource "azuread_directory_role_member" "test" {
 
 func (r MsSqlManagedInstanceResource) aadAdminWithAadAuthOnlyEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 provider "azuread" {}
@@ -1101,6 +1137,18 @@ resource "azurerm_mssql_managed_instance" "test" {
 
 func (r MsSqlManagedInstanceResource) setAadAdmin(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 provider "azuread" {}
@@ -1165,6 +1213,18 @@ resource "azurerm_mssql_managed_instance" "test" {
 
 func (r MsSqlManagedInstanceResource) aadAdminWithAadAuthOnlyEnabledUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 provider "azuread" {}

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1230,7 +1230,6 @@ resource "azurerm_mssql_managed_instance" "test" {
 
 func (r MsSqlManagedInstanceResource) template(data acceptance.TestData, location string) string {
 	return fmt.Sprintf(`
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG1-sql-%[1]d"
   location = "%[2]s"

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -903,7 +903,16 @@ func TestAccMsSqlManagedInstance_aadAdmin(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password"),
+		data.ImportStep(
+			"administrator_login_password",
+			"azure_active_directory_administrator.#",
+			"azure_active_directory_administrator.0.%",
+			"azure_active_directory_administrator.0.azuread_authentication_only_enabled",
+			"azure_active_directory_administrator.0.login_username",
+			"azure_active_directory_administrator.0.object_id",
+			"azure_active_directory_administrator.0.principal_type",
+			"azure_active_directory_administrator.0.tenant_id",
+		),
 	})
 }
 
@@ -918,7 +927,16 @@ func TestAccMsSqlManagedInstance_aadAdminWithAadOnly(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password"),
+		data.ImportStep(
+			"administrator_login_password",
+			"azure_active_directory_administrator.#",
+			"azure_active_directory_administrator.0.%",
+			"azure_active_directory_administrator.0.azuread_authentication_only_enabled",
+			"azure_active_directory_administrator.0.login_username",
+			"azure_active_directory_administrator.0.object_id",
+			"azure_active_directory_administrator.0.principal_type",
+			"azure_active_directory_administrator.0.tenant_id",
+		),
 	})
 }
 
@@ -947,7 +965,16 @@ func TestAccMsSqlManagedInstance_aadAdminUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password"),
+		data.ImportStep(
+			"administrator_login_password",
+			"azure_active_directory_administrator.#",
+			"azure_active_directory_administrator.0.%",
+			"azure_active_directory_administrator.0.azuread_authentication_only_enabled",
+			"azure_active_directory_administrator.0.login_username",
+			"azure_active_directory_administrator.0.object_id",
+			"azure_active_directory_administrator.0.principal_type",
+			"azure_active_directory_administrator.0.tenant_id",
+		),
 		{
 			Config: r.withoutAadAdmin(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -968,7 +995,16 @@ func TestAccMsSqlManagedInstance_aadAdminUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_login_password"),
+		data.ImportStep(
+			"administrator_login_password",
+			"azure_active_directory_administrator.#",
+			"azure_active_directory_administrator.0.%",
+			"azure_active_directory_administrator.0.azuread_authentication_only_enabled",
+			"azure_active_directory_administrator.0.login_username",
+			"azure_active_directory_administrator.0.object_id",
+			"azure_active_directory_administrator.0.principal_type",
+			"azure_active_directory_administrator.0.tenant_id",
+		),
 	})
 }
 
@@ -1023,6 +1059,7 @@ resource "azurerm_mssql_managed_instance" "test" {
   azure_active_directory_administrator {
     login_username = azuread_user.test.user_principal_name
     object_id      = azuread_user.test.object_id
+    principal_type = "User"
     tenant_id      = data.azurerm_client_config.test.tenant_id
   }
 
@@ -1114,6 +1151,7 @@ resource "azurerm_mssql_managed_instance" "test" {
   azure_active_directory_administrator {
     login_username                      = azuread_user.test.user_principal_name
     object_id                           = azuread_user.test.object_id
+    principal_type                      = "User"
     tenant_id                           = data.azurerm_client_config.test.tenant_id
     azuread_authentication_only_enabled = true
   }
@@ -1195,7 +1233,7 @@ resource "azurerm_mssql_managed_instance" "test" {
   azure_active_directory_administrator {
     login_username = azuread_user.test.user_principal_name
     object_id      = azuread_user.test.object_id
-    tenant_id      = data.azurerm_client_config.test.tenant_id
+    principal_type = "User"
   }
 
   tags = {
@@ -1272,6 +1310,7 @@ resource "azurerm_mssql_managed_instance" "test" {
     login_username                      = azuread_user.test.user_principal_name
     object_id                           = azuread_user.test.object_id
     tenant_id                           = data.azurerm_client_config.test.tenant_id
+    principal_type                      = "User"
     azuread_authentication_only_enabled = true
   }
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -563,9 +563,9 @@ resource "azurerm_mssql_managed_instance" "test" {
     database    = "test"
   }
 
-  # Changing microsoft_entra_administrator is ignored because API returns the values of microsoft_entra_administrator even if it is not specified in the config when microsoft entra authentication only is enabled
+  # Changing azure_active_directory_administrator is ignored because API returns the values of azure_active_directory_administrator even if it is not specified in the config when microsoft entra authentication only is enabled
   lifecycle {
-    ignore_changes = [microsoft_entra_administrator]
+    ignore_changes = [azure_active_directory_administrator]
   }
 }
 `, r.template(data, data.Locations.Primary), data.RandomInteger)
@@ -991,7 +991,7 @@ resource "azurerm_mssql_managed_instance" "test" {
     type = "SystemAssigned"
   }
 
-  microsoft_entra_administrator {
+  azure_active_directory_administrator {
     login_username = "AzureME Admin2"
     object_id      = data.azurerm_client_config.test.object_id
     tenant_id      = data.azurerm_client_config.test.tenant_id
@@ -1060,11 +1060,11 @@ resource "azurerm_mssql_managed_instance" "test" {
     type = "SystemAssigned"
   }
 
-  microsoft_entra_administrator {
-    login_username                              = "AzureME Admin2"
-    object_id                                   = data.azurerm_client_config.test.object_id
-    tenant_id                                   = data.azurerm_client_config.test.tenant_id
-    microsoft_entra_authentication_only_enabled = true
+  azure_active_directory_administrator {
+    login_username                      = "AzureME Admin2"
+    object_id                           = data.azurerm_client_config.test.object_id
+    tenant_id                           = data.azurerm_client_config.test.tenant_id
+    azuread_authentication_only_enalbed = true
   }
 
   tags = {
@@ -1076,7 +1076,7 @@ resource "azurerm_mssql_managed_instance" "test" {
     azurerm_subnet_network_security_group_association.test,
     azurerm_subnet_route_table_association.test,
   ]
-  # Changing administrator_login is ignored because API returns the value of administrator_login even if it is not specified in the config when microsoft_entra_authentication_only_enabled is set to true
+  # Changing administrator_login is ignored because API returns the value of administrator_login even if it is not specified in the config when azuread_authentication_only_enalbed is set to true
   lifecycle {
     ignore_changes = [administrator_login]
   }
@@ -1129,7 +1129,7 @@ resource "azurerm_mssql_managed_instance" "test" {
     type = "SystemAssigned"
   }
 
-  microsoft_entra_administrator {
+  azure_active_directory_administrator {
     login_username = azuread_user.test.user_principal_name
     object_id      = azuread_user.test.object_id
     tenant_id      = data.azurerm_client_config.test.tenant_id
@@ -1193,11 +1193,11 @@ resource "azurerm_mssql_managed_instance" "test" {
     type = "SystemAssigned"
   }
 
-  microsoft_entra_administrator {
-    login_username                              = azuread_user.test.user_principal_name
-    object_id                                   = azuread_user.test.object_id
-    tenant_id                                   = data.azurerm_client_config.test.tenant_id
-    microsoft_entra_authentication_only_enabled = true
+  azure_active_directory_administrator {
+    login_username                      = azuread_user.test.user_principal_name
+    object_id                           = azuread_user.test.object_id
+    tenant_id                           = data.azurerm_client_config.test.tenant_id
+    azuread_authentication_only_enalbed = true
   }
 
   tags = {

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -12,6 +12,8 @@ Manages a Microsoft SQL Azure Managed Instance.
 
 ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
+~> **Note:** SQL Managed Instance needs permission to read Microsoft Entra ID when configuring the Microsoft Entra admin. [Read more about provision Microsoft Entra admin](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?view=azuresql&tabs=azure-powershell#provision-azure-ad-admin-sql-managed-instance).
+
 ## Example Usage
 
 ```hcl
@@ -207,10 +209,6 @@ resource "azurerm_mssql_managed_instance" "example" {
 
 The following arguments are supported:
 
-* `administrator_login` - (Required) The administrator login name for the new SQL Managed Instance. Changing this forces a new resource to be created.
-
-* `administrator_login_password` - (Required) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
-
 * `license_type` - (Required) What type of license the Managed Instance will use. Possible values are `LicenseIncluded` and `BasePrice`.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
@@ -226,6 +224,12 @@ The following arguments are supported:
 * `subnet_id` - (Required) The subnet resource id that the SQL Managed Instance will be associated with. Changing this forces a new resource to be created.
 
 * `vcores` - (Required) Number of cores that should be assigned to the SQL Managed Instance. Values can be `8`, `16`, or `24` for Gen4 SKUs, or `4`, `6`, `8`, `10`, `12`, `16`, `20`, `24`, `32`, `40`, `48`, `56`, `64`, `80`, `96` or `128` for Gen5 SKUs.
+
+* `administrator_login` - (Optional) The administrator login name for the new SQL Managed Instance. Changing this forces a new resource to be created.
+
+* `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
+
+* `microsoft_entra_administrator` - (Optional) An `microsoft_entra_administrator` block as defined below.
 
 * `collation` - (Optional) Specifies how the SQL Managed Instance will be collated. Default value is `SQL_Latin1_General_CP1_CI_AS`. Changing this forces a new resource to be created.
 
@@ -250,6 +254,18 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `timezone_id` - (Optional) The TimeZone ID that the SQL Managed Instance will be operating in. Default value is `UTC`. Changing this forces a new resource to be created.
+
+---
+
+An `microsoft_entra_administrator` block supports the following:
+
+* `login_username` - (Required) The login username of the Azure AD Administrator of this SQL Managed Instance.
+
+* `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Managed Instance.
+
+* `microsoft_entra_authentication_only_enabled` - (Optional) Specifies whether only Microsoft Entra authentication and administrator (e.g. `microsoft_entra_administrator.0.login_username`), or Managed Instance administrator (e.g. `administrator_login`) can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
+
+* `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Managed Instance.
 
 ---
 

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -12,7 +12,7 @@ Manages a Microsoft SQL Azure Managed Instance.
 
 ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
-~> **Note:** SQL Managed Instance needs permission to read Microsoft Entra ID when configuring the Microsoft Entra admin. [Read more about provision Microsoft Entra admin](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?view=azuresql&tabs=azure-powershell#provision-azure-ad-admin-sql-managed-instance).
+~> **Note:** SQL Managed Instance needs permission to read Azure Active Directory when configuring the AAD administrator. [Read more about provisioning AAD administrators](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?view=azuresql#provision-azure-ad-admin-sql-managed-instance).
 
 ## Example Usage
 
@@ -263,9 +263,9 @@ An `azure_active_directory_administrator` block supports the following:
 
 * `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Managed Instance.
 
-* `azuread_authentication_only_enalbed` - (Optional) Specifies whether only Microsoft Entra authentication and administrator (e.g. `azure_active_directory_administrator.0.login_username`), or Managed Instance administrator (e.g. `administrator_login`) can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
+* `azuread_authentication_only_enabled` - (Optional) Specifies whether only Azure AD authentication can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
 
-* `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Managed Instance.
+* `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Managed Instance. Should be specified if the Azure AD Administrator is homed in a different tenant to the SQL Managed Instance.
 
 ---
 

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -173,7 +173,7 @@ resource "azurerm_route_table" "example" {
   name                          = "routetable-mi"
   location                      = azurerm_resource_group.example.location
   resource_group_name           = azurerm_resource_group.example.name
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
   depends_on = [
     azurerm_subnet.example,
   ]

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -229,7 +229,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
 
-* `microsoft_entra_administrator` - (Optional) An `microsoft_entra_administrator` block as defined below.
+* `azure_active_directory_administrator` - (Optional) An `azure_active_directory_administrator` block as defined below.
 
 * `collation` - (Optional) Specifies how the SQL Managed Instance will be collated. Default value is `SQL_Latin1_General_CP1_CI_AS`. Changing this forces a new resource to be created.
 
@@ -257,13 +257,13 @@ The following arguments are supported:
 
 ---
 
-An `microsoft_entra_administrator` block supports the following:
+An `azure_active_directory_administrator` block supports the following:
 
 * `login_username` - (Required) The login username of the Azure AD Administrator of this SQL Managed Instance.
 
 * `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Managed Instance.
 
-* `microsoft_entra_authentication_only_enabled` - (Optional) Specifies whether only Microsoft Entra authentication and administrator (e.g. `microsoft_entra_administrator.0.login_username`), or Managed Instance administrator (e.g. `administrator_login`) can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
+* `azuread_authentication_only_enalbed` - (Optional) Specifies whether only Microsoft Entra authentication and administrator (e.g. `azure_active_directory_administrator.0.login_username`), or Managed Instance administrator (e.g. `administrator_login`) can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
 
 * `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Managed Instance.
 

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -263,6 +263,8 @@ An `azure_active_directory_administrator` block supports the following:
 
 * `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Managed Instance.
 
+* `principal_type` - (Required) The principal type of the Azure AD Administrator of this SQL Managed Instance. Possible values are `Application`, `Group`, `User`.
+
 * `azuread_authentication_only_enabled` - (Optional) Specifies whether only Azure AD authentication can be used to log in to this SQL Managed Instance. When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted. Defaults to `false`.
 
 * `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Managed Instance. Should be specified if the Azure AD Administrator is homed in a different tenant to the SQL Managed Instance.


### PR DESCRIPTION
- Support `azure_active_directory_administrator ` property. Swagger: https://github.com/Azure/azure-rest-api-specs/blob/5e060c76edd4fab38e9202055062154006463018/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ManagedInstances.json#L669 

- Corrected documentation issue that  `zone_redundant_enabled` should be a property of `azurerm_mssql_managed_instance ` instead of `azurerm_sql_managed_instance`.

Test results:
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MSSQLMANAGEDINSTANCE/113037?buildTab=tests

Fix [#17601](
https://github.com/hashicorp/terraform-provider-azurerm/issues/17601).
- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change