### PR TITLE
refactor: `azurerm_dev_center_gallery` is no longer a generated resource

### DIFF
--- a/internal/services/devcenter/dev_center_gallery_resource.go
+++ b/internal/services/devcenter/dev_center_gallery_resource.go
@@ -1,8 +1,8 @@
 package devcenter
 
-// NOTE: this file is generated - manual changes will be overwritten.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
 import (
 	"context"
 	"fmt"
@@ -86,11 +86,11 @@ func (r DevCenterGalleryResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			var payload galleries.Gallery
-			if err := r.mapDevCenterGalleryResourceSchemaToGallery(config, &payload); err != nil {
-				return fmt.Errorf("mapping schema model to sdk model: %+v", err)
+			payload := galleries.Gallery{
+				Properties: &galleries.GalleryProperties{
+					GalleryResourceId: config.GalleryResourceId,
+				},
 			}
-
 			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
@@ -125,8 +125,9 @@ func (r DevCenterGalleryResource) Read() sdk.ResourceFunc {
 			if model := resp.Model; model != nil {
 				schema.DevCenterId = devCenterId.ID()
 				schema.Name = id.GalleryName
-				if err := r.mapGalleryToDevCenterGalleryResourceSchema(*model, &schema); err != nil {
-					return fmt.Errorf("flattening model: %+v", err)
+
+				if props := model.Properties; props != nil {
+					schema.GalleryResourceId = props.GalleryResourceId
 				}
 			}
 
@@ -152,38 +153,4 @@ func (r DevCenterGalleryResource) Delete() sdk.ResourceFunc {
 			return nil
 		},
 	}
-}
-
-func (r DevCenterGalleryResource) mapDevCenterGalleryResourceSchemaToGalleryProperties(input DevCenterGalleryResourceSchema, output *galleries.GalleryProperties) error {
-	output.GalleryResourceId = input.GalleryResourceId
-	return nil
-}
-
-func (r DevCenterGalleryResource) mapGalleryPropertiesToDevCenterGalleryResourceSchema(input galleries.GalleryProperties, output *DevCenterGalleryResourceSchema) error {
-	output.GalleryResourceId = input.GalleryResourceId
-	return nil
-}
-
-func (r DevCenterGalleryResource) mapDevCenterGalleryResourceSchemaToGallery(input DevCenterGalleryResourceSchema, output *galleries.Gallery) error {
-
-	if output.Properties == nil {
-		output.Properties = &galleries.GalleryProperties{}
-	}
-	if err := r.mapDevCenterGalleryResourceSchemaToGalleryProperties(input, output.Properties); err != nil {
-		return fmt.Errorf("mapping Schema to SDK Field %q / Model %q: %+v", "GalleryProperties", "Properties", err)
-	}
-
-	return nil
-}
-
-func (r DevCenterGalleryResource) mapGalleryToDevCenterGalleryResourceSchema(input galleries.Gallery, output *DevCenterGalleryResourceSchema) error {
-
-	if input.Properties == nil {
-		input.Properties = &galleries.GalleryProperties{}
-	}
-	if err := r.mapGalleryPropertiesToDevCenterGalleryResourceSchema(*input.Properties, output); err != nil {
-		return fmt.Errorf("mapping SDK Field %q / Model %q to Schema: %+v", "GalleryProperties", "Properties", err)
-	}
-
-	return nil
 }

--- a/internal/services/devcenter/dev_center_gallery_resource_test.go
+++ b/internal/services/devcenter/dev_center_gallery_resource_test.go
@@ -1,8 +1,8 @@
 package devcenter_test
 
-// NOTE: this file is generated - manual changes will be overwritten.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
 import (
 	"context"
 	"fmt"

--- a/internal/services/devcenter/registration.go
+++ b/internal/services/devcenter/registration.go
@@ -30,5 +30,8 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return r.autoRegistration.Resources()
+	resources := []sdk.Resource{
+		DevCenterGalleryResource{},
+	}
+	return append(resources, r.autoRegistration.Resources()...)
 }

--- a/internal/services/devcenter/registration_gen.go
+++ b/internal/services/devcenter/registration_gen.go
@@ -19,7 +19,6 @@ func (autoRegistration) DataSources() []sdk.DataSource {
 
 func (autoRegistration) Resources() []sdk.Resource {
 	return []sdk.Resource{
-		DevCenterGalleryResource{},
 		DevCenterProjectResource{},
 		DevCenterResource{},
 	}

--- a/website/docs/r/dev_center_gallery.html.markdown
+++ b/website/docs/r/dev_center_gallery.html.markdown
@@ -6,8 +6,6 @@ description: |-
   Manages a Dev Center Gallery.
 ---
 
-<!-- Note: This documentation is generated. Any manual changes will be overwritten -->
-
 # azurerm_dev_center_gallery
 
 Manages a Dev Center Gallery.
@@ -15,23 +13,34 @@ Manages a Dev Center Gallery.
 ## Example Usage
 
 ```hcl
-resource "azurerm_dev_center" "example" {
-  name                = "example"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
-  identity {
-    type = "example-value"
-  }
-}
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
+
+resource "azurerm_dev_center" "test" {
+  name                = "example-devcenter"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "example-uai"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
 resource "azurerm_shared_image_gallery" "example" {
-  name                = "example"
+  name                = "example-image-gallery"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 }
+
 resource "azurerm_dev_center_gallery" "example" {
   dev_center_id     = azurerm_dev_center.example.id
   shared_gallery_id = azurerm_shared_image_gallery.example.id
@@ -43,9 +52,9 @@ resource "azurerm_dev_center_gallery" "example" {
 
 The following arguments are supported:
 
-* `dev_center_id` - (Required) Specifies the Dev Center Id within which this Dev Center Gallery should exist. Changing this forces a new Dev Center Gallery to be created.
+* `dev_center_id` - (Required) Specifies the ID of the Dev Center within which this Dev Center Gallery should exist. Changing this forces a new Dev Center Gallery to be created.
 
-* `shared_gallery_id` - (Required) The resource ID of the backing Azure Compute Gallery. Changing this forces a new Dev Center Gallery to be created.
+* `shared_gallery_id` - (Required) The ID of the Shared Gallery which should be connected to the Dev Center Gallery. Changing this forces a new Dev Center Gallery to be created.
 
 * `name` - (Required) Specifies the name of this Dev Center Gallery. Changing this forces a new Dev Center Gallery to be created.
 
@@ -54,10 +63,6 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Dev Center Gallery.
-
----
-
-
 
 ## Timeouts
 


### PR DESCRIPTION
This [isn't actually a generated resource](https://github.com/hashicorp/pandora/pull/3271) and so shouldn't be marked as such else it'll be removed by the automation as in #24805