### PR TITLE
Allow named value display name length of up to 256 characters

### DIFF
--- a/internal/services/apimanagement/validate/api_management.go
+++ b/internal/services/apimanagement/validate/api_management.go
@@ -97,7 +97,8 @@ func ApiManagementNamedValueDisplayName(v interface{}, k string) (warnings []str
 	value := v.(string)
 
 	// From the portal: `Name may contain only letters, digits, periods, dash, and underscore.`
-	if matched := regexp.MustCompile(`^[0-9a-zA-Z_.-]$`).Match([]byte(value)); !matched {
+	// `The value must have a length of at most 256.`
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z_.-]{1,256}$`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, periods, underscores and dashes", k))
 	}
 


### PR DESCRIPTION
Fixes #24831 
Related to changes introduced in #24749

Length of named value display name can be between 1 and 256 characters.