### PR TITLE
azurerm_logic_app_standard - Support field 'public_network_access_enabled' in site properties.

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -115,6 +115,12 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"site_config": schemaLogicAppStandardSiteConfig(),
 
 			"connection_string": {
@@ -294,6 +300,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	clientCertMode := d.Get("client_certificate_mode").(string)
 	clientCertEnabled := clientCertMode != ""
 	httpsOnly := d.Get("https_only").(bool)
+	publicNetworkAccess := d.Get("public_network_access_enabled").(bool)
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	VirtualNetworkSubnetID := d.Get("virtual_network_subnet_id").(string)
 	t := d.Get("tags").(map[string]interface{})
@@ -301,6 +308,11 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
 	if err != nil {
 		return err
+	}
+
+	pna := helpers.PublicNetworkAccessEnabled
+	if !publicNetworkAccess {
+		pna = helpers.PublicNetworkAccessDisabled
 	}
 
 	siteConfig, err := expandLogicAppStandardSiteConfig(d)
@@ -318,7 +330,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	appSettings = append(appSettings, basicAppSettings...)
 
 	siteConfig.AppSettings = &appSettings
-
+	
 	siteEnvelope := web.Site{
 		Kind:     &kind,
 		Location: &location,
@@ -329,6 +341,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 			ClientAffinityEnabled: utils.Bool(clientAffinityEnabled),
 			ClientCertEnabled:     utils.Bool(clientCertEnabled),
 			HTTPSOnly:             utils.Bool(httpsOnly),
+			PublicNetworkAccess:   utils.String(pna),
 			SiteConfig:            &siteConfig,
 		},
 	}
@@ -386,11 +399,17 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	clientCertMode := d.Get("client_certificate_mode").(string)
 	clientCertEnabled := clientCertMode != ""
 	httpsOnly := d.Get("https_only").(bool)
+	publicNetworkAccess := d.Get("public_network_access_enabled").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
 	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
 	if err != nil {
 		return err
+	}
+
+	pna := helpers.PublicNetworkAccessEnabled
+	if !publicNetworkAccess {
+		pna = helpers.PublicNetworkAccessDisabled
 	}
 
 	siteConfig, err := expandLogicAppStandardSiteConfig(d)
@@ -427,6 +446,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 			ClientAffinityEnabled: utils.Bool(clientAffinityEnabled),
 			ClientCertEnabled:     utils.Bool(clientCertEnabled),
 			HTTPSOnly:             utils.Bool(httpsOnly),
+			PublicNetworkAccess:   utils.String(pna),
 			SiteConfig:            &siteConfig,
 		},
 	}
@@ -561,6 +581,7 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
 		d.Set("virtual_network_subnet_id", props.VirtualNetworkSubnetID)
+		d.Set("public_network_access_enabled", props.PublicNetworkAccess)
 
 		clientCertMode := ""
 		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -872,7 +872,7 @@ func TestAccLogicAppStandard_vNetIntegrationUpdate(t *testing.T) {
 	})
 }
 
-func TestAccLogicAppStandard_publicNetworkAccessEnabled(t *testing.T) {
+func TestAccLogicAppStandard_siteConfig_publicNetworkAccessEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
 
@@ -890,6 +890,30 @@ func TestAccLogicAppStandard_publicNetworkAccessEnabled(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("site_config.0.public_network_access_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppStandard_publicNetworkAccessEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.publicNetworkAccessEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccessEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -2205,7 +2229,7 @@ resource "azurerm_logic_app_standard" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r LogicAppStandardResource) publicNetworkAccessEnabled(data acceptance.TestData, enabled bool) string {
+func (r LogicAppStandardResource) publicNetworkAccessEnabled_siteConfig(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -2224,6 +2248,27 @@ resource "azurerm_logic_app_standard" "test" {
   site_config {
     public_network_access_enabled = %t
   }
+}
+`, r.template(data), data.RandomInteger, enabled)
+}
+
+func (r LogicAppStandardResource) publicNetworkAccessEnabled(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       	= "acctest-%d-func"
+  location                   	= azurerm_resource_group.test.location
+  resource_group_name        	= azurerm_resource_group.test.name
+  app_service_plan_id        	= azurerm_app_service_plan.test.id
+  storage_account_name       	= azurerm_storage_account.test.name
+  storage_account_access_key 	= azurerm_storage_account.test.primary_access_key
+  public_network_access_enabled = %t
+
 }
 `, r.template(data), data.RandomInteger, enabled)
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web/models.go
@@ -24464,6 +24464,8 @@ type SitePatchResourceProperties struct {
 	// VirtualNetworkSubnetID - Azure Resource Manager ID of the Virtual network and subnet to be joined by Regional VNET Integration.
 	// This must be of the form /subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
 	VirtualNetworkSubnetID *string `json:"virtualNetworkSubnetId,omitempty"`
+	// PublicNetworkAccess - Property to allow or block all public traffic.
+	PublicNetworkAccess *string `json:"publicNetworkAccess,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for SitePatchResourceProperties.
@@ -24537,6 +24539,9 @@ func (spr SitePatchResourceProperties) MarshalJSON() ([]byte, error) {
 	}
 	if spr.VirtualNetworkSubnetID != nil {
 		objectMap["virtualNetworkSubnetId"] = spr.VirtualNetworkSubnetID
+	}
+	if spr.PublicNetworkAccess != nil {
+		objectMap["publicNetworkAccess"] = spr.PublicNetworkAccess
 	}
 	return json.Marshal(objectMap)
 }
@@ -24732,6 +24737,8 @@ type SiteProperties struct {
 	// VirtualNetworkSubnetID - Azure Resource Manager ID of the Virtual network and subnet to be joined by Regional VNET Integration.
 	// This must be of the form /subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
 	VirtualNetworkSubnetID *string `json:"virtualNetworkSubnetId,omitempty"`
+	// PublicNetworkAccess - Property to allow or block all public traffic.
+	PublicNetworkAccess *string `json:"publicNetworkAccess,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for SiteProperties.
@@ -24805,6 +24812,9 @@ func (s SiteProperties) MarshalJSON() ([]byte, error) {
 	}
 	if s.VirtualNetworkSubnetID != nil {
 		objectMap["virtualNetworkSubnetId"] = s.VirtualNetworkSubnetID
+	}
+	if s.PublicNetworkAccess != nil {
+		objectMap["publicNetworkAccess"] = s.PublicNetworkAccess
 	}
 	return json.Marshal(objectMap)
 }

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -139,6 +139,8 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
+* `public_network_access_enabled` - (Optional) Is public network access enabled? Defaults to `true`.
+
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Changing this forces a new resource to be created.


### PR DESCRIPTION
Add support for the 'public_network_access_enabled' flag against the Azure Logic app standard resource.

A change was made in #24257 which did not complete the requirements to allow for the enablement and disablement of public network access. This caused issues when attempting to deploy logic apps to environments were public network access was dissalowed. See definition: /providers/Microsoft.Authorization/policyDefinitions/1b5ef780-c53c-4a64-87f3-bb9c8c8094ba