### PR TITLE
feat: add tag maps to azurerm_key_vault_secrets and azurerm_key_vault_certificates data sources

### DIFF
--- a/internal/services/keyvault/key_vault_certificates_data_source.go
+++ b/internal/services/keyvault/key_vault_certificates_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -62,6 +63,8 @@ func dataSourceKeyVaultCertificates() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
+
+						"tags": tags.SchemaDataSource(),
 					},
 				},
 			},
@@ -125,8 +128,14 @@ func expandCertificate(name string, item keyvault.CertificateItem) map[string]in
 		"name": name,
 		"id":   *item.ID,
 	}
+
 	if item.Attributes != nil && item.Attributes.Enabled != nil {
 		cert["enabled"] = *item.Attributes.Enabled
 	}
+
+	if item.Tags != nil {
+		cert["tags"] = tags.Flatten(item.Tags)
+	}
+
 	return cert
 }

--- a/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -57,6 +58,8 @@ func dataSourceKeyVaultSecrets() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
+
+						"tags": tags.SchemaDataSource(),
 					},
 				},
 			},
@@ -132,8 +135,14 @@ func expandSecrets(name string, item keyvault.SecretItem) map[string]interface{}
 		"id":   *item.ID,
 		"name": name,
 	}
+
 	if item.Attributes != nil && item.Attributes.Enabled != nil {
 		res["enabled"] = *item.Attributes.Enabled
 	}
+
+	if item.Tags != nil {
+		res["tags"] = tags.Flatten(item.Tags)
+	}
+
 	return res
 }

--- a/website/docs/d/key_vault_certificates.html.markdown
+++ b/website/docs/d/key_vault_certificates.html.markdown
@@ -49,9 +49,13 @@ In addition to the arguments above, the following attributes are exported:
 
 A `certificates` block supports following:
 
-* `name` - The name of secret.
+* `name` - The name of certificate.
 
-* `enabled` - Whether this secret is enabled.
+* `enabled` - Whether this certificate is enabled.
+
+* `id` - The ID of this certificate.
+
+* `tags` - The tags of this certificate.
 
 ## Timeouts
 

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -51,6 +51,8 @@ A `secrets` block supports following:
 
 * `id` - The ID of this secret.
 
+* `tags` - The tags of this secret.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
It can be useful when looking up secrets/certificates in Azure Key Vault to find them by tags instead of by names. Currently if you want to achieve this, you have to use the list (e.g. azurerm_key_vault_secrets) data source, and then pull in the actual data (e.g. azurerm_key_vault_secret) to be able to find secrets/certs by tags.

This also results in the (secret) values for every secret/cert in the Key Vault being pulled in to the state file to achieve the behaviour, which is not necessarily ideal.

This change allows accessing the tags of the secrets/certs without necessarily needing to pull in all the secret values.

Looking at the existing tests in `key_vault_certificates_data_source_test.go` and `key_vault_secrets_data_source_test.go` the existing tests weren't doing any checks on the inner attributes of `certificates` and `secrets` so I've not updated the tests for this change.