### PR TITLE
azurerm_nginx_deployment - support for the automatic_upgrade_channel property

### DIFF
--- a/internal/services/nginx/nginx_deployment_data_source.go
+++ b/internal/services/nginx/nginx_deployment_data_source.go
@@ -34,6 +34,7 @@ type DeploymentDataSourceModel struct {
 	FrontendPublic         []FrontendPublic                           `tfschema:"frontend_public"`
 	FrontendPrivate        []FrontendPrivate                          `tfschema:"frontend_private"`
 	NetworkInterface       []NetworkInterface                         `tfschema:"network_interface"`
+	UpgradeChannel         string                                     `tfschema:"automatic_upgrade_channel"`
 	Tags                   map[string]string                          `tfschema:"tags"`
 }
 
@@ -164,6 +165,11 @@ func (m DeploymentDataSource) Attributes() map[string]*pluginsdk.Schema {
 			},
 		},
 
+		"automatic_upgrade_channel": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
 		"tags": commonschema.TagsDataSource(),
 	}
 }
@@ -266,6 +272,10 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 
 					if userProfile := props.UserProfile; userProfile != nil && userProfile.PreferredEmail != nil {
 						output.Email = pointer.ToString(props.UserProfile.PreferredEmail)
+					}
+
+					if props.AutoUpgradeProfile != nil {
+						output.UpgradeChannel = props.AutoUpgradeProfile.UpgradeChannel
 					}
 				}
 			}

--- a/internal/services/nginx/nginx_deployment_data_source_test.go
+++ b/internal/services/nginx/nginx_deployment_data_source_test.go
@@ -27,6 +27,7 @@ func TestAccNginxDeploymentDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("capacity").Exists(),
 				check.That(data.ResourceName).Key("managed_resource_group").Exists(),
 				check.That(data.ResourceName).Key("ip_address").Exists(),
+				check.That(data.ResourceName).Key("automatic_upgrade_channel").Exists(),
 			),
 		},
 	})

--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -105,11 +105,12 @@ func (a DeploymentResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_nginx_deployment" "test" {
-  name                     = "acctest-%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "standard_Monthly"
-  location                 = azurerm_resource_group.test.location
-  diagnose_support_enabled = true
+  name                      = "acctest-%[2]d"
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "standard_Monthly"
+  location                  = azurerm_resource_group.test.location
+  diagnose_support_enabled  = true
+  automatic_upgrade_channel = "stable"
 
   frontend_public {
     ip_address = [azurerm_public_ip.test.id]

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -63,6 +63,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `sku` - Name of the SKU for this Nginx Deployment.
 
+* `automatic_upgrade_channel` - The automatic upgrade channel for this NGINX deployment.
+
 * `tags` - A mapping of tags assigned to the Nginx Deployment.
 
 ---

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -55,12 +55,13 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_nginx_deployment" "example" {
-  name                     = "example-nginx"
-  resource_group_name      = azurerm_resource_group.example.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
-  location                 = azurerm_resource_group.example.location
-  managed_resource_group   = "example"
-  diagnose_support_enabled = true
+  name                      = "example-nginx"
+  resource_group_name       = azurerm_resource_group.example.name
+  sku                       = "publicpreview_Monthly_gmz7xq9ge3py"
+  location                  = azurerm_resource_group.example.location
+  managed_resource_group    = "example"
+  diagnose_support_enabled  = true
+  automatic_upgrade_channel = "stable"
 
   frontend_public {
     ip_address = [azurerm_public_ip.example.id]
@@ -108,6 +109,8 @@ The following arguments are supported:
 * `logging_storage_account` - (Optional) One or more `logging_storage_account` blocks as defined below.
 
 * `network_interface` - (Optional) One or more `network_interface` blocks as defined below. Changing this forces a new Nginx Deployment to be created.
+
+* `automatic_upgrade_channel` - (Optional) Specify the automatic upgrade channel for the NGINX deployment. Defaults to `stable`. The possible values are `stable` and `preview`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Nginx Deployment.
 


### PR DESCRIPTION
Acceptance tests:

```shell
terraform-provider-azurerm $ make acctests SERVICE="nginx" TESTARGS="-run=TestAccNginxDeployment_basic" TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxDeployment_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxDeployment_basic
=== PAUSE TestAccNginxDeployment_basic
=== CONT  TestAccNginxDeployment_basic
--- PASS: TestAccNginxDeployment_basic (629.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx	633.366s
```
---------------------------------------------------------------------------------------------------
```shell
terraform-provider-azurerm $ make acctests SERVICE="nginx" TESTARGS="-run=TestAccNginxDeploymentDataSource_basic" TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxDeploymentDataSource_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxDeploymentDataSource_basic
=== PAUSE TestAccNginxDeploymentDataSource_basic
=== CONT  TestAccNginxDeploymentDataSource_basic
--- PASS: TestAccNginxDeploymentDataSource_basic (638.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx	642.960s
```