### PR TITLE
`kubernetes_cluster_*` - fix tests with ctx deadline

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -1129,6 +1130,10 @@ func (KubernetesClusterNodePoolResource) scaleNodePool(nodeCount int) acceptance
 		nodePoolName := state.Attributes["name"]
 		kubernetesClusterId := state.Attributes["kubernetes_cluster_id"]
 		parsedK8sId, err := commonids.ParseKubernetesClusterID(kubernetesClusterId)
+
+		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+		defer cancel()
+
 		if err != nil {
 			return fmt.Errorf("parsing kubernetes cluster id: %+v", err)
 		}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -6,11 +6,6 @@ package containers_test
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
@@ -21,6 +16,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
 )
 
 type KubernetesClusterNodePoolResource struct{}
@@ -1131,9 +1130,6 @@ func (KubernetesClusterNodePoolResource) scaleNodePool(nodeCount int) acceptance
 		kubernetesClusterId := state.Attributes["kubernetes_cluster_id"]
 		parsedK8sId, err := commonids.ParseKubernetesClusterID(kubernetesClusterId)
 
-		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
-		defer cancel()
-
 		if err != nil {
 			return fmt.Errorf("parsing kubernetes cluster id: %+v", err)
 		}
@@ -1156,6 +1152,9 @@ func (KubernetesClusterNodePoolResource) scaleNodePool(nodeCount int) acceptance
 		}
 
 		nodePool.Model.Properties.Count = utils.Int64(int64(nodeCount))
+
+		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+		defer cancel()
 
 		err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, parsedAgentPoolId, *nodePool.Model)
 		if err != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -6,6 +6,11 @@ package containers_test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
@@ -16,10 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"regexp"
-	"strings"
-	"testing"
-	"time"
 )
 
 type KubernetesClusterNodePoolResource struct{}

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -6,9 +6,6 @@ package containers_test
 import (
 	"context"
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
@@ -17,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"testing"
+	"time"
 )
 
 type KubernetesClusterResource struct{}
@@ -222,9 +221,6 @@ func (KubernetesClusterResource) updateDefaultNodePoolAgentCount(nodeCount int) 
 		clusterName := state.Attributes["name"]
 		resourceGroup := state.Attributes["resource_group_name"]
 
-		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
-		defer cancel()
-
 		agentPoolId := agentpools.NewAgentPoolID(clients.Account.SubscriptionId, resourceGroup, clusterName, nodePoolName)
 		nodePool, err := clients.Containers.AgentPoolsClient.Get(ctx, agentPoolId)
 		if err != nil {
@@ -240,6 +236,9 @@ func (KubernetesClusterResource) updateDefaultNodePoolAgentCount(nodeCount int) 
 		}
 
 		nodePool.Model.Properties.Count = utils.Int64(int64(nodeCount))
+
+		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+		defer cancel()
 
 		err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, agentPoolId, *nodePool.Model)
 		if err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -6,6 +6,9 @@ package containers_test
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
@@ -14,8 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"testing"
-	"time"
 )
 
 type KubernetesClusterResource struct{}

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -220,6 +221,9 @@ func (KubernetesClusterResource) updateDefaultNodePoolAgentCount(nodeCount int) 
 		nodePoolName := state.Attributes["default_node_pool.0.name"]
 		clusterName := state.Attributes["name"]
 		resourceGroup := state.Attributes["resource_group_name"]
+
+		ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+		defer cancel()
 
 		agentPoolId := agentpools.NewAgentPoolID(clients.Account.SubscriptionId, resourceGroup, clusterName, nodePoolName)
 		nodePool, err := clients.Containers.AgentPoolsClient.Get(ctx, agentPoolId)

--- a/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -110,9 +110,6 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempWithoutDefault(t *
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					client := clients.Containers.AgentPoolsClient
 
-					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
-					defer cancel()
-
 					id, err := commonids.ParseKubernetesClusterID(state.Attributes["id"])
 					if err != nil {
 						return err
@@ -132,6 +129,9 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempWithoutDefault(t *
 					profile := resp.Model
 					profile.Name = &tempNodePoolName
 					profile.Properties.VMSize = pointer.To("Standard_DS3_v2")
+
+					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+					defer cancel()
 
 					tempNodePoolId := agentpools.NewAgentPoolID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, tempNodePoolName)
 					if err := client.CreateOrUpdateThenPoll(ctx, tempNodePoolId, *profile); err != nil {

--- a/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -54,9 +54,6 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempAndDefault(t *test
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					client := clients.Containers.AgentPoolsClient
 
-					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
-					defer cancel()
-
 					id, err := commonids.ParseKubernetesClusterID(state.Attributes["id"])
 					if err != nil {
 						return err
@@ -76,6 +73,9 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempAndDefault(t *test
 					profile := resp.Model
 					profile.Name = &tempNodePoolName
 					profile.Properties.VMSize = pointer.To("Standard_DS3_v2")
+
+					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+					defer cancel()
 
 					tempNodePoolId := agentpools.NewAgentPoolID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, tempNodePoolName)
 					if err := client.CreateOrUpdateThenPoll(ctx, tempNodePoolId, *profile); err != nil {

--- a/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -52,6 +53,9 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempAndDefault(t *test
 				// create the temporary node pool to simulate the case where both old default node pool and temp node pool exist
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					client := clients.Containers.AgentPoolsClient
+
+					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+					defer cancel()
 
 					id, err := commonids.ParseKubernetesClusterID(state.Attributes["id"])
 					if err != nil {
@@ -105,6 +109,9 @@ func TestAccKubernetesCluster_updateVmSizeAfterFailureWithTempWithoutDefault(t *
 				// create the temporary node pool and delete the old default node pool to simulate the case where resizing fails when trying to bring up the new node pool
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					client := clients.Containers.AgentPoolsClient
+
+					ctx, cancel := context.WithDeadline(clients.StopContext, time.Now().Add(1*time.Hour))
+					defer cancel()
 
 					id, err := commonids.ParseKubernetesClusterID(state.Attributes["id"])
 					if err != nil {


### PR DESCRIPTION
Fix tests broken by Container Services base layer change in #24872 

```
------- Stdout: -------
=== RUN   TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== CONT  TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
    testcase.go:113: Step 1/2 error: Check failed: Check 3/3 error: Check 1/1 error: Bad: Get on agentPoolsClient: the context used must have a deadline attached for polling purposes, but got no deadline
--- FAIL: TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges (735.68s)
FAIL
```