### PR TITLE
azurerm_log_analytics_workspace_table - set correct max integer value for total_retention_in_days ValidateFunc

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -76,13 +76,13 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 		"retention_in_days": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
+			ValidateFunc: validation.Any(validation.IntBetween(30, 4383), validation.IntInSlice([]int{7})),
 		},
 
 		"total_retention_in_days": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
+			ValidateFunc: validation.Any(validation.IntBetween(30, 4383), validation.IntInSlice([]int{7})),
 		},
 	}
 }

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -76,7 +76,7 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 		"retention_in_days": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.Any(validation.IntBetween(30, 4383), validation.IntInSlice([]int{7})),
+			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
 		},
 
 		"total_retention_in_days": {


### PR DESCRIPTION
…value for retention ValidateFunc

Log Analytics Workspaces support up to 12 years ( = 4383 days) of retention time for so called archived logs.
https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-archive?tabs=portal-1%2Cportal-2#configure-retention-and-archive-at-the-table-level

The entire SDK/API chain supports this already, but the value of the azurerm provider's validation function currently has this incorrectly set to 730 days for archived logs as well.

I built the patched provider and validated that setting the max value of 4383 days on a test Log Analytics Workspace table works as expected.

Also passes acceptance tests:
```log
make acctests SERVICE='loganalytics' TESTARGS='-run=TestAccLogAnalyticsWorkspaceTable' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/loganalytics -run=TestAccLogAnalyticsWorkspaceTable -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== PAUSE TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== RUN   TestAccLogAnalyticsWorkspaceTable_plan
=== PAUSE TestAccLogAnalyticsWorkspaceTable_plan
=== CONT  TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== CONT  TestAccLogAnalyticsWorkspaceTable_plan
--- PASS: TestAccLogAnalyticsWorkspaceTable_updateTableRetention (257.25s)
--- PASS: TestAccLogAnalyticsWorkspaceTable_plan (319.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	322.996s
```