### PR TITLE
`azurerm_log_analytics_workspace_table` - Update total_retention_in_days to 4383

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -82,7 +82,7 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 		"total_retention_in_days": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
+			ValidateFunc: validation.Any(validation.IntBetween(30, 4383), validation.IntInSlice([]int{7})),
 		},
 	}
 }


### PR DESCRIPTION
For issue #24860. Documentation already reflects the correct integer.

https://learn.microsoft.com/en-us/rest/api/loganalytics/tables/create-or-update?view=rest-loganalytics-2023-09-01&tabs=HTTP

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/28938328/459aabba-bd66-4347-afe2-2906269ba744)
