### PR TITLE
#24910: Use ParseFirewallPolicyIDInsensitively for parsing API response

### DIFF
--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -537,7 +537,7 @@ func resourceFirewallDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 
 		if read.Model.Properties != nil && read.Model.Properties.FirewallPolicy != nil && read.Model.Properties.FirewallPolicy.Id != nil {
-			id, _ := firewallpolicies.ParseFirewallPolicyID(*read.Model.Properties.FirewallPolicy.Id)
+			id, _ := firewallpolicies.ParseFirewallPolicyIDInsensitively(*read.Model.Properties.FirewallPolicy.Id)
 			locks.ByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 			defer locks.UnlockByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 		}

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -537,7 +537,10 @@ func resourceFirewallDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 
 		if read.Model.Properties != nil && read.Model.Properties.FirewallPolicy != nil && read.Model.Properties.FirewallPolicy.Id != nil {
-			id, _ := firewallpolicies.ParseFirewallPolicyIDInsensitively(*read.Model.Properties.FirewallPolicy.Id)
+			id, err := firewallpolicies.ParseFirewallPolicyIDInsensitively(*read.Model.Properties.FirewallPolicy.Id)
+			if err != nil {
+				return err
+			}
 			locks.ByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 			defer locks.UnlockByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 		}


### PR DESCRIPTION
Use `ParseFirewallPolicyIDInsensitively` for parsing API response rather `ParseFirewallPolicyID` as per below comment mentioned [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/firewallpolicies/id_firewallpolicy.go#L47-L48). 

```
// ParseFirewallPolicyIDInsensitively parses 'input' case-insensitively into a FirewallPolicyId
// note: this method should only be used for API response data and not user input
```

Reads are from API response, so `ParseFirewallPolicyIDInsensitively` needs to be used. 

Fixes #24910. 