### PR TITLE
`azurerm_cognitive_deployment` - Make `version_upgrade_option` updatable

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -115,7 +115,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"version_upgrade_option": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 			Default:  string(deployments.DeploymentModelVersionUpgradeOptionOnceNewDefaultVersionAvailable),
 			ValidateFunc: validation.StringInSlice([]string{
 				string(deployments.DeploymentModelVersionUpgradeOptionOnceCurrentVersionExpired),
@@ -314,6 +313,8 @@ func (r CognitiveDeploymentResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("model.0.version") {
 				properties.Properties.Model.Version = pointer.To(model.Model[0].Version)
 			}
+
+			properties.Properties.VersionUpgradeOption = pointer.To(deployments.DeploymentModelVersionUpgradeOption(model.VersionUpgradeOption))
 
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `rai_policy_name` - (Optional) The name of RAI policy.
 
-* `version_upgrade_option` - (Optional) Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`. Changing this forces a new resource to be created.
+* `version_upgrade_option` - (Optional) Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`.
 
 ---
 


### PR DESCRIPTION
This pr removed `ForceNew` from `version_upgrade_option` and made it updatable.