### PR TITLE
`azurerm_storage_account` - CMK allows `SystemAssigned, UserAssigned` identity type

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1462,8 +1462,8 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		if accountTier != string(storage.AccessTierPremium) && accountKind != string(storage.KindStorageV2) {
 			return fmt.Errorf("customer managed key can only be used with account kind `StorageV2` or account tier `Premium`")
 		}
-		if storageAccountIdentity.Type != storage.IdentityTypeUserAssigned {
-			return fmt.Errorf("customer managed key can only be used with identity type `UserAssigned`")
+		if storageAccountIdentity.Type != storage.IdentityTypeUserAssigned && storageAccountIdentity.Type != storage.IdentityTypeSystemAssignedUserAssigned {
+			return fmt.Errorf("customer managed key can only be used with identity type `UserAssigned` or `SystemAssigned, UserAssigned`")
 		}
 		encryption, err = expandStorageAccountCustomerManagedKey(ctx, keyVaultClient, id.SubscriptionId, v.([]interface{}))
 		if err != nil {


### PR DESCRIPTION
Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/24512#issuecomment-1940617990

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageAccount_customerManagedKeyForSUAI' ./internal/services/storage
=== RUN   TestAccStorageAccount_customerManagedKeyForSUAI
=== PAUSE TestAccStorageAccount_customerManagedKeyForSUAI
=== CONT  TestAccStorageAccount_customerManagedKeyForSUAI
--- PASS: TestAccStorageAccount_customerManagedKeyForSUAI (422.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       422.017s
```