### PR TITLE
`azurerm_storage_account` - Fix acctest `TestAccAzureRMStorageAccount_routing`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -3898,6 +3898,22 @@ func flattenAndSetAzureRmStorageAccountPrimaryEndpoints(d *pluginsdk.ResourceDat
 		if err := setEndpointAndHost(d, "primary", primary.InternetEndpoints.Web, "web_internet"); err != nil {
 			return err
 		}
+	} else {
+		if err := setEndpointAndHost(d, "primary", nil, "blob_internet"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "dfs_internet"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "file_internet"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "web_internet"); err != nil {
+			return err
+		}
 	}
 
 	if routingInputs != nil && routingInputs.PublishMicrosoftEndpoints != nil && *routingInputs.PublishMicrosoftEndpoints {
@@ -3922,6 +3938,30 @@ func flattenAndSetAzureRmStorageAccountPrimaryEndpoints(d *pluginsdk.ResourceDat
 		}
 
 		if err := setEndpointAndHost(d, "primary", primary.MicrosoftEndpoints.Queue, "queue_microsoft"); err != nil {
+			return err
+		}
+	} else {
+		if err := setEndpointAndHost(d, "primary", nil, "blob_microsoft"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "dfs_microsoft"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "file_microsoft"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "web_microsoft"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "table_microsoft"); err != nil {
+			return err
+		}
+
+		if err := setEndpointAndHost(d, "primary", nil, "queue_microsoft"); err != nil {
 			return err
 		}
 	}

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -972,6 +972,14 @@ func TestAccAzureRMStorageAccount_routing(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.routing(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("primary_blob_microsoft_endpoint").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),


### PR DESCRIPTION
Currently, the test case is failing like below:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/7970698/86054c4b-9974-487d-a790-3c7e9a3bc4ce)


This PR ensures the computed attributes related to routing are always set, which fixes the acctest `TestAccAzureRMStorageAccount_routing`.

## Test

```shell
terraform-provider-azurerm on  storage_account_update via 🐹 v1.22.0 took 16s
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccAzureRMStorageAccount_routing'
=== RUN   TestAccAzureRMStorageAccount_routing
=== PAUSE TestAccAzureRMStorageAccount_routing
=== CONT  TestAccAzureRMStorageAccount_routing
--- PASS: TestAccAzureRMStorageAccount_routing (247.23s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       247.247s

```