### PR TITLE
`azurerm_linux_virtual_machine_scale_set`, `azurerm_windows_virtual_machine_scale_set` - add `public_ip_prefix_id` when patching the VMSS

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
@@ -429,6 +429,13 @@ func TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix(t *testing.T) 
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config: r.networkPublicIPFromPrefixUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -1603,8 +1610,62 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
       subnet_id = azurerm_subnet.test.id
 
       public_ip_address {
-        name                = "first"
-        public_ip_prefix_id = azurerm_public_ip_prefix.test.id
+        name                    = "first"
+        idle_timeout_in_minutes = 4
+        public_ip_prefix_id     = azurerm_public_ip_prefix.test.id
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkPublicIPFromPrefixUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "first"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "first"
+        idle_timeout_in_minutes = 5
+        public_ip_prefix_id     = azurerm_public_ip_prefix.test.id
       }
     }
   }

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1114,6 +1114,12 @@ func expandVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{
 		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.IdleTimeoutInMinutes = utils.Int32(int32(raw["idle_timeout_in_minutes"].(int)))
 	}
 
+	if publicIPPrefixID := raw["public_ip_prefix_id"].(string); publicIPPrefixID != "" {
+		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.PublicIPPrefix = &compute.SubResource{
+			ID: utils.String(publicIPPrefixID),
+		}
+	}
+
 	return &publicIPAddressConfig
 }
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
@@ -429,6 +429,13 @@ func TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix(t *testing.T
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config: r.networkPublicIPFromPrefixUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -1566,8 +1573,60 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
       subnet_id = azurerm_subnet.test.id
 
       public_ip_address {
-        name                = "first"
-        public_ip_prefix_id = azurerm_public_ip_prefix.test.id
+        name                    = "first"
+        idle_timeout_in_minutes = 4
+        public_ip_prefix_id     = azurerm_public_ip_prefix.test.id
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkPublicIPFromPrefixUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "first"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "first"
+        idle_timeout_in_minutes = 5
+        public_ip_prefix_id     = azurerm_public_ip_prefix.test.id
       }
     }
   }


### PR DESCRIPTION
Fix https://github.com/Azure/azure-rest-api-specs/issues/10190

## Test Result

=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix (465.64s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix (492.59s)
