### PR TITLE
#24902: disk_size_gb and lun parameters of data_disks are optional now with vmss flex

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -524,13 +524,15 @@ func OrchestratedVirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 
 				"disk_size_gb": {
 					Type:         pluginsdk.TypeInt,
-					Required:     true,
+					Optional:     true,
+					Computed:     true,
 					ValidateFunc: validation.IntBetween(1, 32767),
 				},
 
 				"lun": {
 					Type:         pluginsdk.TypeInt,
-					Required:     true,
+					Optional:     true,
+					Computed:     true,
 					ValidateFunc: validation.IntBetween(0, 2000), // TODO: confirm upper bounds
 				},
 
@@ -1271,14 +1273,20 @@ func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultra
 
 		storageAccountType := compute.StorageAccountTypes(raw["storage_account_type"].(string))
 		disk := compute.VirtualMachineScaleSetDataDisk{
-			Caching:    compute.CachingTypes(raw["caching"].(string)),
-			DiskSizeGB: utils.Int32(int32(raw["disk_size_gb"].(int))),
-			Lun:        utils.Int32(int32(raw["lun"].(int))),
+			Caching: compute.CachingTypes(raw["caching"].(string)),
 			ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
 				StorageAccountType: storageAccountType,
 			},
 			WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
 			CreateOption:            compute.DiskCreateOptionTypes(raw["create_option"].(string)),
+		}
+
+		if dataDiskSize := raw["disk_size_gb"].(int); dataDiskSize > 0 {
+			disk.DiskSizeGB = utils.Int32(int32(dataDiskSize))
+		}
+
+		if lun := raw["lun"].(int); lun >= 0 {
+			disk.Lun = utils.Int32(int32(lun))
 		}
 
 		if id := raw["disk_encryption_set_id"].(string); id != "" {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_data_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_data_test.go
@@ -161,6 +161,23 @@ func TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUl
 	})
 }
 
+func TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskSizeFromMarketPlaceImage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dataDiskMarketPlaceImage(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("data_disk.0.disk_size_gb").HasValue("900"),
+				check.That(data.ResourceName).Key("data_disk.0.lun").HasValue("0"),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
 func (OrchestratedVirtualMachineScaleSetResource) basicLinux_managedDisk(data acceptance.TestData) string {
 	r := OrchestratedVirtualMachineScaleSetResource{}
 	return fmt.Sprintf(`
@@ -707,6 +724,118 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-lts"
     version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) dataDiskMarketPlaceImage(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/8"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsn-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku = "Standard"
+
+  frontend_ip_configuration {
+    name                          = "default"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name            = "acctestbap-%[1]d"
+  loadbalancer_id = azurerm_lb.test.id
+}
+
+resource "azurerm_marketplace_agreement" "barracuda" {
+  publisher = "micro-focus"
+  offer     = "arcsight-logger"
+  plan      = "arcsight_logger_72_byol"
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku_name  = "Standard_F2"
+  instances = 1
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+
+    linux_configuration {
+      computer_name_prefix = "testvm-test"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    caching              = "ReadWrite"
+    disk_size_gb         = 900
+    create_option        = "FromImage"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "micro-focus"
+    offer     = "arcsight-logger"
+    sku       = "arcsight_logger_72_byol"
+    version   = "7.2.0"
+  }
+
+  plan {
+    name      = "arcsight_logger_72_byol"
+    product   = "arcsight-logger"
+    publisher = "micro-focus"
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -293,9 +293,9 @@ A `data_disk` block supports the following:
 
 * `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are Empty and FromImage. Defaults to `Empty`. (FromImage should only be used if the source image includes data disks).
 
-* `disk_size_gb` - (Required) The size of the Data Disk which should be created.
+* `disk_size_gb` - (Optional) The size of the Data Disk which should be created. Required if `create_option` is specified as `Empty`.
 
-* `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.
+* `lun` - (Optional) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine. Required if `create_option` is specified as `Empty`.
 
 * `storage_account_type` - (Required) The Type of Storage Account which should back this Data Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS` and `UltraSSD_LRS`.
 


### PR DESCRIPTION
Fixes #24902. 

Currently, `disk_size_gb` & `lun` parameters part of `data_disk` are required fields even when `create_option` is set to `FromImage`. 

This PR aims to fix this issue by making them optional & could be fetched from API response when not passed. 
