### PR TITLE
azurerm_nginx_deployment - support for the auto_scale_profile property

### DIFF
--- a/internal/services/nginx/nginx_deployment_data_source_test.go
+++ b/internal/services/nginx/nginx_deployment_data_source_test.go
@@ -43,3 +43,30 @@ data "azurerm_nginx_deployment" "test" {
 }
 `, DeploymentResource{}.basic(data))
 }
+
+func (d NginxDeploymentDataSource) basicAutoscaling(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_nginx_deployment" "test" {
+  name                = azurerm_nginx_deployment.test.name
+  resource_group_name = azurerm_nginx_deployment.test.resource_group_name
+}
+`, DeploymentResource{}.basicAutoscaling(data))
+}
+
+func TestAccNginxDeploymentDataSource_autoscaling(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_nginx_deployment", "test")
+	r := NginxDeploymentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicAutoscaling(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("auto_scale_profile.0.name").HasValue("test"),
+				check.That(data.ResourceName).Key("auto_scale_profile.0.min_capacity").HasValue("10"),
+				check.That(data.ResourceName).Key("auto_scale_profile.0.max_capacity").HasValue("30"),
+			),
+		},
+	})
+}

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -39,6 +39,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `capacity` - The number of NGINX capacity units for this Nginx Deployment.
 
+* `auto_scale_profile` - An `auto_scale_profile` block as defined below.
+
 * `diagnose_support_enabled` - Whether diagnostic settings are enabled.
 
 * `email` - Preferred email associated with the Nginx Deployment.
@@ -104,6 +106,16 @@ A `logging_storage_account` block exports the following:
 A `network_interface` block exports the following:
 
 * `subnet_id` - The subnet resource ID of the Nginx Deployment.
+
+---
+
+An `auto_scale_profile` block exports the following:
+
+* `name` - Name of the autoscaling profile.
+
+* `min_capacity` - The minimum number of NGINX capacity units for this NGINX Deployment.
+
+* `max_capacity` - The maximum number of NGINX capacity units for this NGINX Deployment.
 
 ## Timeouts
 

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -96,6 +96,8 @@ The following arguments are supported:
 
 -> **Note** For more information on NGINX capacity units, please refer to the [NGINX scaling guidance documentation](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/)
 
+* `auto_scale_profile` - (Optional) An `auto_scale_profile` block as defined below.
+
 * `diagnose_support_enabled` - (Optional) Should the diagnosis support be enabled?
 
 * `email` - (Optional) Specify the preferred support contact email address of the user used for sending alerts and notification.
@@ -154,6 +156,17 @@ A `network_interface` block supports the following:
 
 * `subnet_id` - (Required) Specify The SubNet Resource ID to this Nginx Deployment.
 
+---
+
+An `auto_scale_profile` block supports the following:
+
+* `name` - (Required) Specify the name of the autoscaling profile.
+
+* `min_capacity` - (Required) Specify the minimum number of NGINX capacity units for this NGINX Deployment.
+
+* `max_capacity` - (Required) Specify the maximum number of NGINX capacity units for this NGINX Deployment.
+
+-> **NOTE:** If you're using autoscaling, you should use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Acceptance test:

```shell
terraform-provider-azurerm $ make acctests SERVICE='nginx' TESTARGS='-run=TestAccNginxDeployment_autoscaling' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxDeployment_autoscaling -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxDeployment_autoscaling
=== PAUSE TestAccNginxDeployment_autoscaling
=== CONT  TestAccNginxDeployment_autoscaling
--- PASS: TestAccNginxDeployment_autoscaling (490.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx	493.336s
```