### PR TITLE
`azurerm_system_center_virtual_machine_manager_server` - update NewClient

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -143,6 +143,7 @@ import (
 	streamAnalytics "github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/client"
 	subscription "github.com/hashicorp/terraform-provider-azurerm/internal/services/subscription/client"
 	synapse "github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/client"
+	systemCenterVirtualMachineManager "github.com/hashicorp/terraform-provider-azurerm/internal/services/systemcentervirtualmachinemanager/client"
 	trafficManager "github.com/hashicorp/terraform-provider-azurerm/internal/services/trafficmanager/client"
 	videoAnalyzer "github.com/hashicorp/terraform-provider-azurerm/internal/services/videoanalyzer/client"
 	vmware "github.com/hashicorp/terraform-provider-azurerm/internal/services/vmware/client"
@@ -632,8 +633,8 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	}
 
 	client.Synapse = synapse.NewClient(o)
-	if client.TrafficManager, err = trafficManager.NewClient(o); err != nil {
-		return fmt.Errorf("building clients for Traffic Manager: %+v", err)
+	if client.SystemCenterVirtualMachineManager, err = systemCenterVirtualMachineManager.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for System Center Virtual Machine Manager: %+v", err)
 	}
 	if client.TrafficManager, err = trafficManager.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Traffic Manager: %+v", err)

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
@@ -25,7 +25,7 @@ func TestAccSystemCenterVirtualMachineManagerServerSequential(t *testing.T) {
 
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"scvmmServer": {
-			//"basic": testAccSystemCenterVirtualMachineManagerServer_basic,
+			"basic":          testAccSystemCenterVirtualMachineManagerServer_basic,
 			"requiresImport": testAccSystemCenterVirtualMachineManagerServer_requiresImport,
 			"complete":       testAccSystemCenterVirtualMachineManagerServer_complete,
 			"update":         testAccSystemCenterVirtualMachineManagerServer_update,

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
@@ -25,7 +25,7 @@ func TestAccSystemCenterVirtualMachineManagerServerSequential(t *testing.T) {
 
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"scvmmServer": {
-			"basic":          testAccSystemCenterVirtualMachineManagerServer_basic,
+			//"basic": testAccSystemCenterVirtualMachineManagerServer_basic,
 			"requiresImport": testAccSystemCenterVirtualMachineManagerServer_requiresImport,
 			"complete":       testAccSystemCenterVirtualMachineManagerServer_complete,
 			"update":         testAccSystemCenterVirtualMachineManagerServer_update,

--- a/website/docs/r/system_center_virtual_machine_manager_server.html.markdown
+++ b/website/docs/r/system_center_virtual_machine_manager_server.html.markdown
@@ -28,11 +28,8 @@ resource "azurerm_system_center_virtual_machine_manager_server" "example" {
   location            = azurerm_resource_group.example.location
   custom_location_id  = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ExtendedLocation/customLocations/customLocation1"
   fqdn                = "example.labtest"
-
-  credential {
-    username = "testUser"
-    password = "H@Sh1CoR3!"
-  }
+  username            = "testUser"
+  password            = "H@Sh1CoR3!"
 }
 ```
 


### PR DESCRIPTION
The NewClient of TrafficManager is repeatly added and the NewClient of SystemCenterVirtualMachineManager needs to be added.

--- PASS: TestAccSystemCenterVirtualMachineManagerServerSequential/scvmmServer/basic (242.64s)
--- PASS: TestAccSystemCenterVirtualMachineManagerServerSequential/scvmmServer/requiresImport (301.28s)
--- PASS: TestAccSystemCenterVirtualMachineManagerServerSequential/scvmmServer/complete (243.60s)
--- PASS: TestAccSystemCenterVirtualMachineManagerServerSequential/scvmmServer/update (310.38s)