### PR TITLE
New Resource: api_management_policy_fragment

### DIFF
--- a/internal/services/apimanagement/api_management_policy_fragment_resource.go
+++ b/internal/services/apimanagement/api_management_policy_fragment_resource.go
@@ -1,0 +1,197 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apimanagement
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func resourceApiManagementPolicyFragment() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceApiManagementPolicyFragmentCreateUpdate,
+		Read:   resourceApiManagementPolicyFragmentRead,
+		Update: resourceApiManagementPolicyFragmentCreateUpdate,
+		Delete: resourceApiManagementPolicyFragmentDelete,
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
+			_, err := policyfragment.ParsePolicyFragmentIDInsensitively(id)
+			return err
+		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+			client := meta.(*clients.Client).ApiManagement.PolicyFragmentClient
+
+			id, err := policyfragment.ParsePolicyFragmentIDInsensitively(d.Id())
+
+			resp, err := client.Get(ctx, *id, policyfragment.GetOperationOptions{
+				Format: pointer.To(policyfragment.PolicyFragmentContentFormatXml),
+			})
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return nil, fmt.Errorf("Api Management Policy Fragment %q was not found in Api Management instance %q in Resource Group %q", id.PolicyFragmentName, id.ServiceName, id.ResourceGroupName)
+				}
+
+				return nil, fmt.Errorf("retrieving Api Management Policy Fragment %q (Api Management: %q, Resource Group %q): %+v", id.PolicyFragmentName, id.ServiceName, id.ResourceGroupName, err)
+			}
+
+			d.Set("format", policyfragment.PolicyFragmentContentFormatXml)
+
+			return []*pluginsdk.ResourceData{d}, nil
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": schemaz.SchemaApiManagementChildName(),
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"api_management_name": schemaz.SchemaApiManagementName(),
+
+			"format": {
+				Type:     pluginsdk.TypeString,
+				ForceNew: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(policyfragment.PolicyFragmentContentFormatRawxml),
+					string(policyfragment.PolicyFragmentContentFormatXml),
+				}, false),
+				Default: policyfragment.PolicyFragmentContentFormatXml,
+			},
+
+			"value": {
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				DiffSuppressFunc: XmlWithDotNetInterpolationsDiffSuppress,
+			},
+
+			"description": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceApiManagementPolicyFragmentCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.PolicyFragmentClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	defer cancel()
+
+	id := policyfragment.NewPolicyFragmentID(subscriptionId, d.Get("resource_group_name").(string), d.Get("api_management_name").(string), d.Get("name").(string))
+	format := policyfragment.PolicyFragmentContentFormat(d.Get("format").(string))
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id, policyfragment.GetOperationOptions{
+			Format: &format,
+		})
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+			}
+		}
+
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_api_management_policy_fragment", id.ID())
+		}
+	}
+
+	description := d.Get("description").(string)
+	value := d.Get("value").(string)
+
+	parameters := policyfragment.PolicyFragmentContract{
+		Properties: &policyfragment.PolicyFragmentContractProperties{
+			Description: pointer.To(description),
+			Format:      pointer.To(format),
+			Value:       value,
+		},
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, policyfragment.CreateOrUpdateOperationOptions{}); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceApiManagementPolicyFragmentRead(d, meta)
+}
+
+func resourceApiManagementPolicyFragmentRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.PolicyFragmentClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := policyfragment.ParsePolicyFragmentIDInsensitively(d.Id())
+	if err != nil {
+		return err
+	}
+
+	format := policyfragment.PolicyFragmentContentFormat(d.Get("format").(string))
+	resp, err := client.Get(ctx, *id, policyfragment.GetOperationOptions{
+		Format: &format,
+	})
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[DEBUG] %s does not exist - removing from state!", *id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", id.PolicyFragmentName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("api_management_name", id.ServiceName)
+
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("description", pointer.From(props.Description))
+			d.Set("value", props.Value)
+			// the api only returns a format field when it's requested in the GET request as param '?format=rawxml' and only does so when it's not 'xml'
+			if props.Format == nil {
+				d.Set("format", "xml")
+			} else {
+				d.Set("format", string(pointer.From(props.Format)))
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceApiManagementPolicyFragmentDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.PolicyFragmentClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := policyfragment.ParsePolicyFragmentIDInsensitively(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.Delete(ctx, *id, policyfragment.DeleteOperationOptions{}); err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("deleting %s: %s", id, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/apimanagement/api_management_policy_fragment_resource_test.go
+++ b/internal/services/apimanagement/api_management_policy_fragment_resource_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apimanagement_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ApiManagementPolicyFragmentResource struct{}
+
+func TestAccApiManagementPolicyFragment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
+	r := ApiManagementPolicyFragmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("description").HasValue("Some descriptive text"),
+				check.That(data.ResourceName).Key("format").HasValue("xml"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementPolicyFragment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
+	r := ApiManagementPolicyFragmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccApiManagementPolicyFragment_updateDescription(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
+	r := ApiManagementPolicyFragmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("description").HasValue("Some descriptive text"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("description").HasValue("Some descriptive text which is updated"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementPolicyFragment_rawxml(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
+	r := ApiManagementPolicyFragmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.rawxml(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (ApiManagementPolicyFragmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := policyfragment.ParsePolicyFragmentIDInsensitively(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.ApiManagement.PolicyFragmentClient.Get(ctx, *id, policyfragment.GetOperationOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return pointer.To(resp.Model != nil && resp.Model.Id != nil), nil
+}
+
+func (r ApiManagementPolicyFragmentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_policy_fragment" "test" {
+  name                = azurerm_api_management.test.name
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  description         = "Some descriptive text"
+  value               = file("testdata/api_management_policy_fragment_test_xml.xml")
+}
+`, r.template(data))
+}
+
+func (r ApiManagementPolicyFragmentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_policy_fragment" "import" {
+  name                = azurerm_api_management_policy_fragment.test.name
+  api_management_name = azurerm_api_management_policy_fragment.test.api_management_name
+  resource_group_name = azurerm_api_management_policy_fragment.test.resource_group_name
+  description         = azurerm_api_management_policy_fragment.test.description
+  value               = azurerm_api_management_policy_fragment.test.value
+}
+`, r.basic(data))
+}
+
+func (r ApiManagementPolicyFragmentResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_policy_fragment" "test" {
+  name                = azurerm_api_management.test.name
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  description         = "Some descriptive text which is updated"
+  value               = file("testdata/api_management_policy_fragment_test_xml.xml")
+}
+`, r.template(data))
+}
+
+func (r ApiManagementPolicyFragmentResource) rawxml(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_policy_fragment" "test" {
+  name                = azurerm_api_management.test.name
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  description         = "Some descriptive text"
+  format              = "rawxml"
+  value               = file("testdata/api_management_policy_fragment_test_rawxml.xml")
+}
+`, r.template(data))
+}
+
+func (ApiManagementPolicyFragmentResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/apimanagement/client/client.go
+++ b/internal/services/apimanagement/client/client.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/notificationrecipientuser"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/openidconnectprovider"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policy"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/product"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/productapi"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/productgroup"
@@ -90,6 +91,7 @@ type Client struct {
 	NotificationRecipientUserClient    *notificationrecipientuser.NotificationRecipientUserClient
 	OpenIdConnectClient                *openidconnectprovider.OpenidConnectProviderClient
 	PolicyClient                       *policy.PolicyClient
+	PolicyFragmentClient               *policyfragment.PolicyFragmentClient
 	ProductApisClient                  *productapi.ProductApiClient
 	ProductGroupsClient                *productgroup.ProductGroupClient
 	ProductPoliciesClient              *productpolicy.ProductPolicyClient
@@ -309,6 +311,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(policyClient.Client, o.Authorizers.ResourceManager)
 
+	policyFragmentClient, err := policyfragment.NewPolicyFragmentClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Policy Fragment client: %+v", err)
+	}
+	o.Configure(policyFragmentClient.Client, o.Authorizers.ResourceManager)
+
 	productsClient, err := product.NewProductClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building Products client: %+v", err)
@@ -416,6 +424,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		NotificationRecipientUserClient:    notificationRecipientUserClient,
 		OpenIdConnectClient:                openIdConnectClient,
 		PolicyClient:                       policyClient,
+		PolicyFragmentClient:               policyFragmentClient,
 		ProductApisClient:                  productApisClient,
 		ProductGroupsClient:                productGroupsClient,
 		ProductPoliciesClient:              productPoliciesClient,

--- a/internal/services/apimanagement/registration.go
+++ b/internal/services/apimanagement/registration.go
@@ -80,6 +80,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_api_management_named_value":                     resourceApiManagementNamedValue(),
 		"azurerm_api_management_openid_connect_provider":         resourceApiManagementOpenIDConnectProvider(),
 		"azurerm_api_management_policy":                          resourceApiManagementPolicy(),
+		"azurerm_api_management_policy_fragment":                 resourceApiManagementPolicyFragment(),
 		"azurerm_api_management_product":                         resourceApiManagementProduct(),
 		"azurerm_api_management_product_api":                     resourceApiManagementProductApi(),
 		"azurerm_api_management_product_group":                   resourceApiManagementProductGroup(),

--- a/internal/services/apimanagement/testdata/api_management_policy_fragment_test_rawxml.xml
+++ b/internal/services/apimanagement/testdata/api_management_policy_fragment_test_rawxml.xml
@@ -1,0 +1,3 @@
+<fragment>
+  <set-variable name="var" value="@("user id:" + context.User?.Id)" />
+</fragment>

--- a/internal/services/apimanagement/testdata/api_management_policy_fragment_test_xml.xml
+++ b/internal/services/apimanagement/testdata/api_management_policy_fragment_test_xml.xml
@@ -1,0 +1,3 @@
+<fragment>
+  <json-to-xml apply="always" consider-accept-header="false" />
+</fragment>

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/README.md
@@ -1,0 +1,117 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment` Documentation
+
+The `policyfragment` SDK allows for interaction with the Azure Resource Manager Service `apimanagement` (API Version `2022-08-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment"
+```
+
+
+### Client Initialization
+
+```go
+client := policyfragment.NewPolicyFragmentClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `PolicyFragmentClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewPolicyFragmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue", "policyFragmentValue")
+
+payload := policyfragment.PolicyFragmentContract{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload, policyfragment.DefaultCreateOrUpdateOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `PolicyFragmentClient.Delete`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewPolicyFragmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue", "policyFragmentValue")
+
+read, err := client.Delete(ctx, id, policyfragment.DefaultDeleteOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicyFragmentClient.Get`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewPolicyFragmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue", "policyFragmentValue")
+
+read, err := client.Get(ctx, id, policyfragment.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicyFragmentClient.GetEntityTag`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewPolicyFragmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue", "policyFragmentValue")
+
+read, err := client.GetEntityTag(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicyFragmentClient.ListByService`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue")
+
+read, err := client.ListByService(ctx, id, policyfragment.DefaultListByServiceOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicyFragmentClient.ListReferences`
+
+```go
+ctx := context.TODO()
+id := policyfragment.NewPolicyFragmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "serviceValue", "policyFragmentValue")
+
+read, err := client.ListReferences(ctx, id, policyfragment.DefaultListReferencesOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/client.go
@@ -1,0 +1,26 @@
+package policyfragment
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyFragmentClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewPolicyFragmentClientWithBaseURI(sdkApi sdkEnv.Api) (*PolicyFragmentClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "policyfragment", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating PolicyFragmentClient: %+v", err)
+	}
+
+	return &PolicyFragmentClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/constants.go
@@ -1,0 +1,51 @@
+package policyfragment
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyFragmentContentFormat string
+
+const (
+	PolicyFragmentContentFormatRawxml PolicyFragmentContentFormat = "rawxml"
+	PolicyFragmentContentFormatXml    PolicyFragmentContentFormat = "xml"
+)
+
+func PossibleValuesForPolicyFragmentContentFormat() []string {
+	return []string{
+		string(PolicyFragmentContentFormatRawxml),
+		string(PolicyFragmentContentFormatXml),
+	}
+}
+
+func (s *PolicyFragmentContentFormat) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePolicyFragmentContentFormat(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePolicyFragmentContentFormat(input string) (*PolicyFragmentContentFormat, error) {
+	vals := map[string]PolicyFragmentContentFormat{
+		"rawxml": PolicyFragmentContentFormatRawxml,
+		"xml":    PolicyFragmentContentFormatXml,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyFragmentContentFormat(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/id_policyfragment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/id_policyfragment.go
@@ -1,0 +1,134 @@
+package policyfragment
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &PolicyFragmentId{}
+
+// PolicyFragmentId is a struct representing the Resource ID for a Policy Fragment
+type PolicyFragmentId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	ServiceName        string
+	PolicyFragmentName string
+}
+
+// NewPolicyFragmentID returns a new PolicyFragmentId struct
+func NewPolicyFragmentID(subscriptionId string, resourceGroupName string, serviceName string, policyFragmentName string) PolicyFragmentId {
+	return PolicyFragmentId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		ServiceName:        serviceName,
+		PolicyFragmentName: policyFragmentName,
+	}
+}
+
+// ParsePolicyFragmentID parses 'input' into a PolicyFragmentId
+func ParsePolicyFragmentID(input string) (*PolicyFragmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PolicyFragmentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PolicyFragmentId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParsePolicyFragmentIDInsensitively parses 'input' case-insensitively into a PolicyFragmentId
+// note: this method should only be used for API response data and not user input
+func ParsePolicyFragmentIDInsensitively(input string) (*PolicyFragmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PolicyFragmentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PolicyFragmentId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *PolicyFragmentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ServiceName, ok = input.Parsed["serviceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "serviceName", input)
+	}
+
+	if id.PolicyFragmentName, ok = input.Parsed["policyFragmentName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "policyFragmentName", input)
+	}
+
+	return nil
+}
+
+// ValidatePolicyFragmentID checks that 'input' can be parsed as a Policy Fragment ID
+func ValidatePolicyFragmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePolicyFragmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Policy Fragment ID
+func (id PolicyFragmentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/policyFragments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ServiceName, id.PolicyFragmentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Policy Fragment ID
+func (id PolicyFragmentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftApiManagement", "Microsoft.ApiManagement", "Microsoft.ApiManagement"),
+		resourceids.StaticSegment("staticService", "service", "service"),
+		resourceids.UserSpecifiedSegment("serviceName", "serviceValue"),
+		resourceids.StaticSegment("staticPolicyFragments", "policyFragments", "policyFragments"),
+		resourceids.UserSpecifiedSegment("policyFragmentName", "policyFragmentValue"),
+	}
+}
+
+// String returns a human-readable description of this Policy Fragment ID
+func (id PolicyFragmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Service Name: %q", id.ServiceName),
+		fmt.Sprintf("Policy Fragment Name: %q", id.PolicyFragmentName),
+	}
+	return fmt.Sprintf("Policy Fragment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/id_service.go
@@ -1,0 +1,125 @@
+package policyfragment
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &ServiceId{}
+
+// ServiceId is a struct representing the Resource ID for a Service
+type ServiceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ServiceName       string
+}
+
+// NewServiceID returns a new ServiceId struct
+func NewServiceID(subscriptionId string, resourceGroupName string, serviceName string) ServiceId {
+	return ServiceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ServiceName:       serviceName,
+	}
+}
+
+// ParseServiceID parses 'input' into a ServiceId
+func ParseServiceID(input string) (*ServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ServiceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ServiceId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseServiceIDInsensitively parses 'input' case-insensitively into a ServiceId
+// note: this method should only be used for API response data and not user input
+func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ServiceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ServiceId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ServiceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ServiceName, ok = input.Parsed["serviceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "serviceName", input)
+	}
+
+	return nil
+}
+
+// ValidateServiceID checks that 'input' can be parsed as a Service ID
+func ValidateServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Service ID
+func (id ServiceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ServiceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Service ID
+func (id ServiceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftApiManagement", "Microsoft.ApiManagement", "Microsoft.ApiManagement"),
+		resourceids.StaticSegment("staticService", "service", "service"),
+		resourceids.UserSpecifiedSegment("serviceName", "serviceValue"),
+	}
+}
+
+// String returns a human-readable description of this Service ID
+func (id ServiceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Service Name: %q", id.ServiceName),
+	}
+	return fmt.Sprintf("Service (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_createorupdate.go
@@ -1,0 +1,104 @@
+package policyfragment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicyFragmentContract
+}
+
+type CreateOrUpdateOperationOptions struct {
+	IfMatch *string
+}
+
+func DefaultCreateOrUpdateOperationOptions() CreateOrUpdateOperationOptions {
+	return CreateOrUpdateOperationOptions{}
+}
+
+func (o CreateOrUpdateOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	if o.IfMatch != nil {
+		out.Append("If-Match", fmt.Sprintf("%v", *o.IfMatch))
+	}
+	return &out
+}
+
+func (o CreateOrUpdateOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o CreateOrUpdateOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+
+	return &out
+}
+
+// CreateOrUpdate ...
+func (c PolicyFragmentClient) CreateOrUpdate(ctx context.Context, id PolicyFragmentId, input PolicyFragmentContract, options CreateOrUpdateOperationOptions) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPut,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c PolicyFragmentClient) CreateOrUpdateThenPoll(ctx context.Context, id PolicyFragmentId, input PolicyFragmentContract, options CreateOrUpdateOperationOptions) error {
+	result, err := c.CreateOrUpdate(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_delete.go
@@ -1,0 +1,76 @@
+package policyfragment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteOperationOptions struct {
+	IfMatch *string
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	if o.IfMatch != nil {
+		out.Append("If-Match", fmt.Sprintf("%v", *o.IfMatch))
+	}
+	return &out
+}
+
+func (o DeleteOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeleteOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+
+	return &out
+}
+
+// Delete ...
+func (c PolicyFragmentClient) Delete(ctx context.Context, id PolicyFragmentId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_get.go
@@ -1,0 +1,80 @@
+package policyfragment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicyFragmentContract
+}
+
+type GetOperationOptions struct {
+	Format *PolicyFragmentContentFormat
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Format != nil {
+		out.Append("format", fmt.Sprintf("%v", *o.Format))
+	}
+	return &out
+}
+
+// Get ...
+func (c PolicyFragmentClient) Get(ctx context.Context, id PolicyFragmentId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_getentitytag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_getentitytag.go
@@ -1,0 +1,46 @@
+package policyfragment
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetEntityTagOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// GetEntityTag ...
+func (c PolicyFragmentClient) GetEntityTag(ctx context.Context, id PolicyFragmentId) (result GetEntityTagOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodHead,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_listbyservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_listbyservice.go
@@ -1,0 +1,92 @@
+package policyfragment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByServiceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicyFragmentCollection
+}
+
+type ListByServiceOperationOptions struct {
+	Filter  *string
+	Orderby *string
+	Skip    *int64
+	Top     *int64
+}
+
+func DefaultListByServiceOperationOptions() ListByServiceOperationOptions {
+	return ListByServiceOperationOptions{}
+}
+
+func (o ListByServiceOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByServiceOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListByServiceOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Orderby != nil {
+		out.Append("$orderby", fmt.Sprintf("%v", *o.Orderby))
+	}
+	if o.Skip != nil {
+		out.Append("$skip", fmt.Sprintf("%v", *o.Skip))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// ListByService ...
+func (c PolicyFragmentClient) ListByService(ctx context.Context, id ServiceId, options ListByServiceOperationOptions) (result ListByServiceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/policyFragments", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_listreferences.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/method_listreferences.go
@@ -1,0 +1,84 @@
+package policyfragment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListReferencesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ResourceCollection
+}
+
+type ListReferencesOperationOptions struct {
+	Skip *int64
+	Top  *int64
+}
+
+func DefaultListReferencesOperationOptions() ListReferencesOperationOptions {
+	return ListReferencesOperationOptions{}
+}
+
+func (o ListReferencesOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListReferencesOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListReferencesOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Skip != nil {
+		out.Append("$skip", fmt.Sprintf("%v", *o.Skip))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// ListReferences ...
+func (c PolicyFragmentClient) ListReferences(ctx context.Context, id PolicyFragmentId, options ListReferencesOperationOptions) (result ListReferencesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/listReferences", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcollection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcollection.go
@@ -1,0 +1,10 @@
+package policyfragment
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyFragmentCollection struct {
+	Count    *int64                    `json:"count,omitempty"`
+	NextLink *string                   `json:"nextLink,omitempty"`
+	Value    *[]PolicyFragmentContract `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcontract.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcontract.go
@@ -1,0 +1,11 @@
+package policyfragment
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyFragmentContract struct {
+	Id         *string                           `json:"id,omitempty"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *PolicyFragmentContractProperties `json:"properties,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcontractproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_policyfragmentcontractproperties.go
@@ -1,0 +1,10 @@
+package policyfragment
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyFragmentContractProperties struct {
+	Description *string                      `json:"description,omitempty"`
+	Format      *PolicyFragmentContentFormat `json:"format,omitempty"`
+	Value       string                       `json:"value"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_resource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_resource.go
@@ -1,0 +1,10 @@
+package policyfragment
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Resource struct {
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_resourcecollection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/model_resourcecollection.go
@@ -1,0 +1,10 @@
+package policyfragment
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceCollection struct {
+	Count    *int64      `json:"count,omitempty"`
+	NextLink *string     `json:"nextLink,omitempty"`
+	Value    *[]Resource `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment/version.go
@@ -1,0 +1,12 @@
+package policyfragment
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-08-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/policyfragment/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -198,6 +198,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/noti
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/notificationrecipientuser
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/openidconnectprovider
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policy
+github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/policyfragment
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/product
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/productapi
 github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/productgroup

--- a/website/docs/r/api_management_policy_fragment.html.markdown
+++ b/website/docs/r/api_management_policy_fragment.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_policy_fragment"
+description: |-
+  Manages a Api Management Policy Fragment.
+---
+
+# azurerm_api_management_policy_fragment
+
+Manages a Api Management Policy Fragment.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-apim"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku_name = "Developer_1"
+}
+
+resource "azurerm_api_management_policy_fragment" "example" {
+  name                = "example-policy-fragment"
+  api_management_name = azurerm_api_management.example.name
+  resource_group_name = azurerm_api_management.example.name
+  format              = "xml"
+  value               = file("policy-fragment-1.xml")
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The name of the API Management Service. Changing this forces a new Api Management Policy Fragment to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new Api Management Policy Fragment to be created.
+
+* `name` - (Required) The name which should be used for this Api Management Policy Fragment. Changing this forces a new Api Management Policy Fragment to be created.
+
+* `format` - (Required) The format of the Policy Fragment. Possible values are `xml` or `rawxml`. Changing this forces a new Api Management Policy Fragment to be created.
+
+* `value` - (Required) The value of the Policy Fragment.
+
+~> **NOTE:** Be aware of the two format possibilities. If the `value` is not applied / continuous to have changes the format could be wrong.
+
+---
+
+* `description` - (Optional) The description for the Policy Fragment.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Api Management Policy Fragment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Api Management Policy Fragment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Api Management Policy Fragment.
+* `update` - (Defaults to 30 minutes) Used when updating the Api Management Policy Fragment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Api Management Policy Fragment.
+
+## Import
+
+Api Management Policy Fragments can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_policy_fragment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/policyFragments/policyFragment1
+```


### PR DESCRIPTION
Hey,

goal is that this PR closes #17016

introduces a new resource `azurerm_api_management_policy_fragment`

Notable points & questions:

1. In the current implementation I use the same DiffSuppressFunc as in the `api_management_policy` resource for the actual value / content of the policy fragment (`DiffSuppressFunc: XmlWithDotNetInterpolationsDiffSuppress`). This seems to catch the formatting changes that the api management service does when it saves the policy fragment and returns when reading the resource.

---

2. Telegraph errors/diffs:
When defining the following policy fragment for example
```hcl
resource "azurerm_api_management_policy_fragment" "test" {
  name = "example-1"
  resource_group_name = data.azurerm_api_management.test.resource_group_name
  api_management_name = data.azurerm_api_management.test.name
  format = "xml" # rawxml or xml
  value = <<EOF
<fragment>
  <json-to-xml apply="always" consider-accept-header="false" />
  <set-variable name="var" value="@("user id:" + context.User?.Id)" />
</fragment>
EOF
}
```
then this is not accepted by the azure API as format `xml`.

The issue I'm seeing here is that there is no error returned. The api does not return an error but it also does not set the content accordingly. The diff will just show up in the next *terraform apply* again.
However it is accepted as `rawxml`. For it to be accepted as `xml` one would need to escape the inner quotes. So `@("user id:" +` -> `@(&quot;user id:&quot; +`.
Should or can the error be telegraphed in a better way?
Another way I could see is to not expose `xml` as a format option and to always just use `rawxml`. Not sure if there is any downside of this, but that does not seem like a great idea either.
Two mutual-exclusiv variables `xml_content` and `rawxml_content` (content or value), also does not really seem to solve the problem.
To avoid weird states I set format to force a replace when updated, not sure if thats the way to go.

See [What is the difference between 'xml' and 'rawxml' ...](https://stackoverflow.com/questions/70278751/what-is-the-difference-between-xml-and-rawxml-formats-when-defining-apim-pol/70310169#70310169) and [PolicyFragmentContentFormat](https://learn.microsoft.com/de-de/rest/api/apimanagement/policy-fragment/get?view=rest-apimanagement-2022-08-01&tabs=HTTP#policyfragmentcontentformat)

---

3. Extra Importer
I'm not sure how to differentiate between the formats (`xml` and `rawxml`) when importing the resource. (currently the implementation of the explicitly defined Importer defaults to `xml`). If both formats are supported I'd need to know the format when importing. Also using the standard import without the `then`-function I'd miss the format for the actual import api call. I would always get a 400 response and saw the GET call having `.../policyFragments/test1?api-version=2022-08-01&format=` an empty format parameter.

shortened provider log:
```
...
GET /subscriptions/ID/resourceGroups/RG/providers/Microsoft.ApiManagement/service/APIM/policyFragments/FRAGMENT?api-version=2022-08-01&format= HTTP/1.1
...
HTTP/2.0 400 Bad Request
...
{"error":{"code":"ValidationError","message":"One or more fields contain incorrect values:","details":[{"code":"ValidationError","target":"PolicyFragmentContentFormatContract","message":"A value is required but was not present in the request."}]}}
...
TIMESTAMP [ERROR] vertex "import azurerm_api_management_policy_fragment.test result" error: retrieving Policy Fragment (Subscription: "ID"
Resource Group Name: "RG"
Service Name: "APIM"
Policy Fragment Name: "FRAGMENT"): unexpected status 400 with error: ValidationError: One or more fields contain incorrect values:
...
```

---

4. Through running the acctest `_updateDescription` it looked like the description update did not happen, it would always still have the initial description. I figured to use `CreateOrUpdateThenPoll` which solved the issue.

---

Any feedback, discussion and proposals are welcome. You can also try it out yourself (I'm not an expert)