### PR TITLE
Add delegation support to virtual network subnet blocks

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -93,6 +93,17 @@ var subnetDelegationServiceNames = []string{
 	"Qumulo.Storage/fileSystems",
 }
 
+var subnetDelegationActions = []string{
+	"Microsoft.Network/networkinterfaces/*",
+	"Microsoft.Network/publicIPAddresses/join/action",
+	"Microsoft.Network/publicIPAddresses/read",
+	"Microsoft.Network/virtualNetworks/read",
+	"Microsoft.Network/virtualNetworks/subnets/action",
+	"Microsoft.Network/virtualNetworks/subnets/join/action",
+	"Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+	"Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+}
+
 func resourceSubnet() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
 		Create: resourceSubnetCreate,

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -59,13 +59,13 @@ resource "azurerm_virtual_network" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual network. Changing this forces a new resource to be created. 
+* `name` - (Required) The name of the virtual network. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the virtual network. Changing this forces a new resource to be created.
 
 * `address_space` - (Required) The address space that is used the virtual network. You can supply more than one address space.
 
-* `location` - (Required) The location/region where the virtual network is created. Changing this forces a new resource to be created. 
+* `location` - (Required) The location/region where the virtual network is created. Changing this forces a new resource to be created.
 
 ---
 
@@ -113,6 +113,20 @@ The `subnet` block supports:
 
 * `address_prefix` - (Required) The address prefix to use for the subnet.
 
+* `delegation` - (Optional) Can be specified multiple times to define multiple delegations. Each delegation block supports fields documented below.
+
+A delegation block supports the following:
+
+`name` - (Required) The name of the delegation.
+
+`service_delegation` - (Required) A `service_delegation` block as documented below.
+
+A service_delegation block supports the following:
+
+`name` - (Required) The name of the service to which the subnet is delegated (e.g., `Microsoft.ContainerInstance/containerGroups`).
+
+`actions` - (Optional) A list of actions that are delegated. Can include `Microsoft.Network/virtualNetworks/subnets/action` and others depending on the service.
+
 * `security_group` - (Optional) The Network Security Group to associate with the subnet. (Referenced by `id`, ie. `azurerm_network_security_group.example.id`)
 
 ## Attributes Reference
@@ -138,6 +152,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `subnet` block exports:
 
 * `id` - The ID of this subnet.
+* `delegation` - One or more delegation blocks as configured, including the name and details of the service delegation.
 
 ## Timeouts
 


### PR DESCRIPTION
- Implemented delegation configuration in `virtual_network_resource.go` to allow specifying delegation services and actions for subnets within virtual networks.
- Updated tests in `virtual_network_resource_test.go` to cover the new delegation functionality in the subnet blocks.
- Documented the delegation feature in `virtual_network.html.markdown`, providing users with guidance on how to use this new capability.
- Adjust related subnet resource code in `subnet_resource.go` for compatibility and consistency with virtual network changes.

This enhancement enables users to configure service delegations for subnets directly in the blocks, supporting scenarios that require specialized services such as Azure Container Instances or Azure NetApp Files to be associated with specific subnets.

Attempts to resolve #25025 