### PR TITLE
`azurerm_recovery_vaults`: fix creation with `SystemAssigned, UserAssigned` identity 

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -269,6 +269,16 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		vault.Properties.SecuritySettings = expandRecoveryServicesVaultSecuritySettings(immutability)
 	}
 
+	if expandedIdentity.Type == identity.TypeSystemAssignedUserAssigned {
+		// `SystemAssigned, UserAssigned` Identity require an additional update to work
+		// Trakced on https://github.com/Azure/azure-rest-api-specs/issues/27851
+		requireAdditionalUpdate = true
+		updatePatch.Identity = expandedIdentity
+		vault.Identity = &identity.SystemAndUserAssignedMap{
+			Type: identity.TypeSystemAssigned,
+		}
+	}
+
 	err = client.CreateOrUpdateThenPoll(ctx, id, vault)
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id.String(), err)

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -269,13 +269,15 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		vault.Properties.SecuritySettings = expandRecoveryServicesVaultSecuritySettings(immutability)
 	}
 
-	if expandedIdentity.Type == identity.TypeSystemAssignedUserAssigned {
-		// `SystemAssigned, UserAssigned` Identity require an additional update to work
-		// Trakced on https://github.com/Azure/azure-rest-api-specs/issues/27851
+	// Async Operaation of creation with `UserAssigned` identity is returned with 404
+	// Tracked on https://github.com/Azure/azure-rest-api-specs/issues/27869
+	// `SystemAssigned, UserAssigned` Identity require an additional update to work
+	// Trakced on https://github.com/Azure/azure-rest-api-specs/issues/27851
+	if expandedIdentity.Type == identity.TypeUserAssigned || expandedIdentity.Type == identity.TypeSystemAssignedUserAssigned {
 		requireAdditionalUpdate = true
 		updatePatch.Identity = expandedIdentity
 		vault.Identity = &identity.SystemAndUserAssignedMap{
-			Type: identity.TypeSystemAssigned,
+			Type: identity.TypeNone,
 		}
 	}
 

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -173,13 +173,20 @@ func TestAccRecoveryServicesVault_SystemAssignedIdentity(t *testing.T) {
 	})
 }
 
-func TestAccRecoveryServicesVault_UserAssignedIdentity(t *testing.T) {
+func TestAccRecoveryServicesVault_Identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
 	r := RecoveryServicesVaultResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicWithUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithSystemAssignedUserAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -728,6 +735,41 @@ resource "azurerm_recovery_services_vault" "test" {
 
   identity {
     type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  soft_delete_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (RecoveryServicesVaultResource) basicWithSystemAssignedUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest-uai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
     identity_ids = [
       azurerm_user_assigned_identity.test.id,
     ]


### PR DESCRIPTION
fix #24933 

<img width="574" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/6312d3c2-5486-4df6-bdca-17ed3ed87202">