### PR TITLE
`azurerm_chaos_studio_experiment` - set the `type` of `targetReference` to the unique possible value `ChaosTarget`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -51,6 +51,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // CDN is only available in certain locations
         "cdn" to testConfiguration(locationOverride = LocationConfiguration("centralus", "eastus2", "westeurope", true)),
 
+        // Chaosstudio is only available in certain locations
+        "chaosstudio" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus", "westus", false)),
+
         // "cognitive" is expensive - Monday, Wednesday, Friday
         // cognitive is only available in certain locations
         "cognitive" to testConfiguration(daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true)),


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24899

Service team confirmed that the type of targetReference only supports enum value "ChaosTarget". This is the property [definition](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/chaos/resource-manager/Microsoft.Chaos/stable/2024-01-01/types/experiments.json#L481) in azure-rest-api-spec. So service team confirmed that it's a bug and they will fix it to not allow other values. In the meanwhile, we also need to fix it in TF.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/8397f52a-2dea-46e2-bfaf-ed6d8495010b)
