### PR TITLE
`azurerm_linux_virtual_machine_scale_set`,`azurerm_windows_virtual_machine_scale_set` - Support `max_surge_enabled`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -55,6 +56,17 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 		// https://github.com/Azure/azure-rest-api-specs/pull/7246
 
 		Schema: resourceLinuxVirtualMachineScaleSetSchema(),
+
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
+			overprovision := diff.Get("overprovision").(bool)
+			maxSurgeEnabled := diff.Get("rolling_upgrade_policy.0.max_surge_enabled").(bool)
+
+			if overprovision && maxSurgeEnabled {
+				return fmt.Errorf("'overprovision' and 'max_surge_enabled' cannot be set to 'true' simultaneously")
+			}
+
+			return nil
+		},
 	}
 }
 

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1796,6 +1796,11 @@ func VirtualMachineScaleSetRollingUpgradePolicySchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeInt,
 					Required: true,
 				},
+				"max_surge_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 				"max_unhealthy_instance_percent": {
 					Type:     pluginsdk.TypeInt,
 					Required: true,
@@ -1827,6 +1832,7 @@ func ExpandVirtualMachineScaleSetRollingUpgradePolicy(input []interface{}, isZon
 
 	rollingUpgradePolicy := &compute.RollingUpgradePolicy{
 		MaxBatchInstancePercent:             utils.Int32(int32(raw["max_batch_instance_percent"].(int))),
+		MaxSurge:                            utils.Bool(raw["max_surge_enabled"].(bool)),
 		MaxUnhealthyInstancePercent:         utils.Int32(int32(raw["max_unhealthy_instance_percent"].(int))),
 		MaxUnhealthyUpgradedInstancePercent: utils.Int32(int32(raw["max_unhealthy_upgraded_instance_percent"].(int))),
 		PauseTimeBetweenBatches:             utils.String(raw["pause_time_between_batches"].(string)),
@@ -1859,6 +1865,11 @@ func FlattenVirtualMachineScaleSetRollingUpgradePolicy(input *compute.RollingUpg
 		maxBatchInstancePercent = int(*input.MaxBatchInstancePercent)
 	}
 
+	maxSurgeEnabled := false
+	if input.MaxSurge != nil {
+		maxSurgeEnabled = *input.MaxSurge
+	}
+
 	maxUnhealthyInstancePercent := 0
 	if input.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent = int(*input.MaxUnhealthyInstancePercent)
@@ -1883,6 +1894,7 @@ func FlattenVirtualMachineScaleSetRollingUpgradePolicy(input *compute.RollingUpg
 		map[string]interface{}{
 			"cross_zone_upgrades_enabled":             enableCrossZoneUpgrade,
 			"max_batch_instance_percent":              maxBatchInstancePercent,
+			"max_surge_enabled":                       maxSurgeEnabled,
 			"max_unhealthy_instance_percent":          maxUnhealthyInstancePercent,
 			"max_unhealthy_upgraded_instance_percent": maxUnhealthyUpgradedInstancePercent,
 			"pause_time_between_batches":              pauseTimeBetweenBatches,

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -55,6 +56,17 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 		// https://github.com/Azure/azure-rest-api-specs/pull/7246
 
 		Schema: resourceWindowsVirtualMachineScaleSetSchema(),
+
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
+			overprovision := diff.Get("overprovision").(bool)
+			maxSurgeEnabled := diff.Get("rolling_upgrade_policy.0.max_surge_enabled").(bool)
+
+			if overprovision && maxSurgeEnabled {
+				return fmt.Errorf("'overprovision' and 'max_surge_enabled' cannot be set to 'true' simultaneously")
+			}
+
+			return nil
+		},
 	}
 }
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -532,6 +532,10 @@ A `rolling_upgrade_policy` block supports the following:
 
 * `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
 
+* `max_surge_enabled` - (Optional) Specifies whether to create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines.
+
+-> **Note:** This requires that the Preview Feature `Microsoft.Compute/MaxSurgeRollingUpgrade` is enabled and the Resource Provider is re-registered, see [the documentation](https://review.learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-configure-rolling-upgrades) for more information.
+
 * `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
 
 * `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -521,6 +521,10 @@ A `rolling_upgrade_policy` block supports the following:
 
 * `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
 
+* `max_surge_enabled` - (Optional) Specifies whether to create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines.
+
+-> **Note:** This requires that the Preview Feature `Microsoft.Compute/MaxSurgeRollingUpgrade` is enabled and the Resource Provider is re-registered, see [the documentation](https://review.learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-configure-rolling-upgrades) for more information.
+
 * `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
 
 * `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.


### PR DESCRIPTION
## Prerequisites

Run `Register-AzProviderFeature` to enroll in this feature:

`Register-AzProviderFeature -FeatureName MaxSurgeRollingUpgrade -ProviderNamespace Microsoft.Compute`

## Related Document
[Swagger](https://github.com/Azure/azure-rest-api-specs/blob/6bc6d5759767ea537c0b63b28d785e7e6ea0a90b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/virtualMachineScaleSet.json#L3683)
[MS-DOC](https://review.learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-upgrade-policy?branch=pr-en-us-263323)

## Test Result

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate (618.00s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge (15.79s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherOverProvisionNotSupportMaxSurge (16.77s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate (641.66s)