### PR TITLE
azurerm_netapp_pool - support for the encryption_type property

### DIFF
--- a/internal/services/netapp/netapp_pool_data_source.go
+++ b/internal/services/netapp/netapp_pool_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -51,6 +52,11 @@ func dataSourceNetAppPool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
 			},
+
+			"encryption_type": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -80,6 +86,7 @@ func dataSourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("location", location.NormalizeNilable(&model.Location))
 		d.Set("service_level", string(model.Properties.ServiceLevel))
 		d.Set("size_in_tb", model.Properties.Size/1099511627776)
+		d.Set("encryption_type", string(pointer.From(model.Properties.EncryptionType)))
 	}
 
 	return nil

--- a/internal/services/netapp/netapp_pool_data_source_test.go
+++ b/internal/services/netapp/netapp_pool_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccDataSourceNetAppPool_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("account_name").Exists(),
 				check.That(data.ResourceName).Key("service_level").Exists(),
 				check.That(data.ResourceName).Key("size_in_tb").Exists(),
+				check.That(data.ResourceName).Key("encryption_type").Exists(),
 			),
 		},
 	})

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -88,6 +89,17 @@ func resourceNetAppPool() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"encryption_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(capacitypools.EncryptionTypeSingle),
+					string(capacitypools.EncryptionTypeDouble),
+				}, false),
+			},
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -116,11 +128,19 @@ func resourceNetAppPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	sizeInMB := sizeInTB * 1024 * 1024
 	sizeInBytes := sizeInMB * 1024 * 1024
 
+	var encryptionType capacitypools.EncryptionType
+	encryptionTypeString := d.Get("encryption_type").(string)
+	if encryptionTypeString == "" {
+		encryptionType = capacitypools.EncryptionTypeSingle
+	}
+	encryptionType = capacitypools.EncryptionType(encryptionTypeString)
+
 	capacityPoolParameters := capacitypools.CapacityPool{
 		Location: azure.NormalizeLocation(d.Get("location").(string)),
 		Properties: capacitypools.PoolProperties{
-			ServiceLevel: capacitypools.ServiceLevel(d.Get("service_level").(string)),
-			Size:         sizeInBytes,
+			ServiceLevel:   capacitypools.ServiceLevel(d.Get("service_level").(string)),
+			Size:           sizeInBytes,
+			EncryptionType: &encryptionType,
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -234,6 +254,7 @@ func resourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			qosType = string(*poolProperties.QosType)
 		}
 		d.Set("qos_type", qosType)
+		d.Set("encryption_type", string(pointer.From(poolProperties.EncryptionType)))
 
 		return tags.FlattenAndSet(d, model.Tags)
 	}

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -92,8 +92,8 @@ func resourceNetAppPool() *pluginsdk.Resource {
 			"encryption_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
+				Default:  capacitypools.EncryptionTypeSingle,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(capacitypools.EncryptionTypeSingle),
 					string(capacitypools.EncryptionTypeDouble),
@@ -128,12 +128,7 @@ func resourceNetAppPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	sizeInMB := sizeInTB * 1024 * 1024
 	sizeInBytes := sizeInMB * 1024 * 1024
 
-	var encryptionType capacitypools.EncryptionType
-	encryptionTypeString := d.Get("encryption_type").(string)
-	if encryptionTypeString == "" {
-		encryptionType = capacitypools.EncryptionTypeSingle
-	}
-	encryptionType = capacitypools.EncryptionType(encryptionTypeString)
+	encryptionType := capacitypools.EncryptionType(d.Get("encryption_type").(string))
 
 	capacityPoolParameters := capacitypools.CapacityPool{
 		Location: azure.NormalizeLocation(d.Get("location").(string)),

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -44,6 +44,8 @@ The following attributes are exported:
 
 * `size_in_tb` - Provisioned size of the pool in TB.
 
+* `encryption_type` - The encryption type of the pool.
+
 ---
 
 ## Timeouts

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -46,13 +46,15 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `service_level` - (Required) The service level of the file system. Valid values include `Premium`, `Standard`, or `Ultra`. Changing this forces a new resource to be created.
+* `service_level` - (Required) The service level of the file system. Valid values include `Premium`, `Standard`, and `Ultra`. Changing this forces a new resource to be created.
 
 * `size_in_tb` - (Required) Provisioned size of the pool in TB. Value must be between `2` and `500`.
 
 ~> **NOTE** `2` TB capacity pool sizing is currently in preview. You can only take advantage of the `2` TB minimum if all the volumes in the capacity pool are using `Standard` network features. If any volume is using `Basic` network features, the minimum size is `4` TB. Please see the product [documentation](https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-set-up-capacity-pool) for more information.
 
 * `qos_type` - (Optional) QoS Type of the pool. Valid values include `Auto` or `Manual`.
+
+* `encryption_type` - (Optional) The encryption type of the pool. Valid values include `Single`, and `Double`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `qos_type` - (Optional) QoS Type of the pool. Valid values include `Auto` or `Manual`.
 
-* `encryption_type` - (Optional) The encryption type of the pool. Valid values include `Single`, and `Double`. Changing this forces a new resource to be created.
+* `encryption_type` - (Optional) The encryption type of the pool. Valid values include `Single`, and `Double`. Defaults to `Single`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
This PR adds support for double encryption for ANF capacity pools and corresponding tests and documentation. Below are the results of the tests:

```
user [ ~/go/src/github.com/terraform-providers/terraform-provider-azurerm ]$ make acctests SERVICE='netapp' TESTARGS=' -parallel 5 -run=TestAccNetAppPool_' TESTTIMEOUT='1200m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 5 -run=TestAccNetAppPool_ -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetAppPool_basic
=== PAUSE TestAccNetAppPool_basic
=== RUN   TestAccNetAppPool_requiresImport
=== PAUSE TestAccNetAppPool_requiresImport
=== RUN   TestAccNetAppPool_complete
=== PAUSE TestAccNetAppPool_complete
=== RUN   TestAccNetAppPool_update
=== PAUSE TestAccNetAppPool_update
=== RUN   TestAccNetAppPool_doubleEncryption
=== PAUSE TestAccNetAppPool_doubleEncryption
=== CONT  TestAccNetAppPool_basic
=== CONT  TestAccNetAppPool_update
=== CONT  TestAccNetAppPool_requiresImport
=== CONT  TestAccNetAppPool_doubleEncryption
=== CONT  TestAccNetAppPool_complete
--- PASS: TestAccNetAppPool_doubleEncryption (208.13s)
--- PASS: TestAccNetAppPool_basic (212.30s)
--- PASS: TestAccNetAppPool_requiresImport (216.54s)
--- PASS: TestAccNetAppPool_complete (219.55s)
--- PASS: TestAccNetAppPool_update (359.96s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        (cached)
user [ ~/go/src/github.com/terraform-providers/terraform-provider-azurerm ]$ make acctests SERVICE='netapp' TESTARGS=' -parallel 5 -run=TestAccDataSourceNetAppPool_' TESTTIMEOUT='1200m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 5 -run=TestAccDataSourceNetAppPool_ -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceNetAppPool_basic
=== PAUSE TestAccDataSourceNetAppPool_basic
=== CONT  TestAccDataSourceNetAppPool_basic
--- PASS: TestAccDataSourceNetAppPool_basic (207.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        207.559s
user [ ~/go/src/github.com/terraform-providers/terraform-provider-azurerm ]$
```