### PR TITLE
`azurerm_container_registry` - Avoid unnecessary recreate when georeplication.tags update

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -419,7 +419,7 @@ func applyGeoReplicationLocations(ctx context.Context, meta interface{}, registr
 		// each properties are non-nil. Whilst we are still doing nil check here in case.
 		if oprop, nprop := oldRepl.Properties, newRepl.Properties; oprop != nil && nprop != nil {
 			// zoneRedundency can't be updated in place
-			if oprop.ZoneRedundancy != nprop.ZoneRedundancy {
+			if ov, nv := oprop.ZoneRedundancy, nprop.ZoneRedundancy; ov != nil && nv != nil && *ov != *nv {
 				needUpdate = true
 				needReplace = true
 			}

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -730,18 +730,6 @@ func expandExportPolicy(enabled bool) *registries.ExportPolicy {
 	return &exportPolicy
 }
 
-func expandReplicationsFromLocations(p []interface{}) []replications.Replication {
-	reps := make([]replications.Replication, 0)
-	for _, value := range p {
-		location := azure.NormalizeLocation(value)
-		reps = append(reps, replications.Replication{
-			Location: location,
-			Name:     &location,
-		})
-	}
-	return reps
-}
-
 func expandReplications(p []interface{}) []replications.Replication {
 	reps := make([]replications.Replication, 0)
 	if p == nil {

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -6,6 +6,7 @@ package containers_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -208,8 +209,11 @@ func TestAccContainerRegistry_geoReplicationLocation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_registry", "test")
 	r := ContainerRegistryResource{}
 
-	secondaryLocation := location.Normalize(data.Locations.Secondary)
-	ternaryLocation := location.Normalize(data.Locations.Ternary)
+	locs := []string{location.Normalize(data.Locations.Secondary), location.Normalize(data.Locations.Ternary)}
+	// Sorting the secondary and ternary locations to ensure the order as is expected by this resource (see its Read() function)
+	slices.Sort(locs)
+	secondaryLocation := locs[0]
+	ternaryLocation := locs[1]
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		// creates an ACR with locations


### PR DESCRIPTION
This PR fixes two things:

- The first commit fixes some problematic code introduced in https://github.com/hashicorp/terraform-provider-azurerm/pull/15340, where those code only handles v2.0 correctly, but are meaningless for v3.0
- The second commit fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24960, where the georeplication's zone redundency enabled flag is checked by pointer, instead of value,to tell whether a recreate of those georeplications are needed.