### PR TITLE
`azurerm_key_vault_key` - `expiration_date` can be updated if newer date is ahead

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -211,6 +211,22 @@ func TestAccKeyVaultKey_updatedExternally(t *testing.T) {
 			Config: r.basicECUpdatedExternally(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.updateExpiryDate("2050-02-02T12:59:00Z")),
+			),
+			ExpectNonEmptyPlan: true,
+		},
+		{
+			Config: r.basicECUpdatedExternally(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.updateExpiryDate("2029-02-01T12:59:00Z")),
+			),
+			ExpectNonEmptyPlan: true,
+		},
+		{
+			Config: r.basicECUpdatedExternally(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		{

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -109,7 +109,9 @@ The following arguments are supported:
 
 * `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 
-* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
+~> **Note:** Once `expiration_date` is set, it's not possible to unset the key even if it is deleted & recreated as underlying Azure API uses the restore of the purged key.
+
+* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
`expiration_date` to be updated if newer date is ahead of current date in `azurerm_key_vault_key`. 

Prior to [#3.74.0](https://github.com/hashicorp/terraform-provider-azurerm/pull/23327) versions, this field could be updated to a further date. In most cases, we use `timestamp()` & calculate an expiry date of further time. 

Post 3.74.0 versions, the keys are force updated on each terraform run. This is not acceptable as the keys being replaced are used by disk encryption sets which are forcing VMs loose their disks encrypted with these CMK keys. Wish it was considered as a breaking change before adding that code snippet. 

As far as this PR is concerned, 

- we update the `expiration_date` parameter when it's ahead of the current date which is stored in the state file (azure API does allow the update). 
- In other cases, we force create the key (like trying to use expired key or prior date than the one in state file)
- documentation update highlighting the stubbornness of this parameter once it's specified in the configuration & the force creation in case of using prior dates (although azure API doesn't allow such updates)

Partially fixes #24965. 