### PR TITLE
fix: NGINX docs formatting and spelling errors

### DIFF
--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -92,7 +92,7 @@ var services = mapOf(
         "network" to "Network",
         "networkfunction" to "Network Function",
         "newrelic" to "New Relic",
-        "nginx" to "NGINX",
+        "nginx" to "Nginx",
         "notificationhub" to "Notification Hub",
         "orbital" to "Orbital",
         "paloalto" to "Palo Alto",

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -92,7 +92,7 @@ var services = mapOf(
         "network" to "Network",
         "networkfunction" to "Network Function",
         "newrelic" to "New Relic",
-        "nginx" to "Nginx",
+        "nginx" to "NGINX",
         "notificationhub" to "Notification Hub",
         "orbital" to "Orbital",
         "paloalto" to "Palo Alto",

--- a/internal/services/nginx/registration.go
+++ b/internal/services/nginx/registration.go
@@ -23,7 +23,7 @@ func (r Registration) Name() string {
 // WebsiteCategories returns a list of categories which can be used for the sidebar
 func (r Registration) WebsiteCategories() []string {
 	return []string{
-		"Nginx",
+		"NGINX",
 	}
 }
 

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -77,11 +77,11 @@ Messaging
 Mixed Reality
 Mobile Network
 Monitor
+NGINX
 NetApp
 Network
 Network Function
 New Relic
-Nginx
 Orbital
 Palo Alto
 Policy

--- a/website/docs/d/nginx_certificate.html.markdown
+++ b/website/docs/d/nginx_certificate.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Nginx"
+subcategory: "NGINX"
 layout: "azurerm"
 page_title: "Azure Resource Manager: Data Source: azurerm_nginx_certificate"
 description: |-
-  Gets information about an existing Nginx Certificate.
+  Gets information about an existing NGINX Certificate.
 ---
 
 # Data Source: azurerm_nginx_certificate
 
-Use this data source to access information about an existing Nginx Certificate.
+Use this data source to access information about an existing NGINX Certificate.
 
 ## Example Usage
 
@@ -27,24 +27,24 @@ output "id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of this Nginx Certificate.
+* `name` - (Required) The name of the NGINX Certificate.
 
-* `nginx_deployment_id` - (Required) The ID of the Nginx Deployment that this certificate is associated with.
+* `nginx_deployment_id` - (Required) The ID of the NGINX Deployment that the certificate is associated with.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Nginx Certificate.
+* `id` - The ID of the NGINX Certificate.
 
-* `certificate_virtual_path` - The path to the certificate file of this certificate.
+* `certificate_virtual_path` - The path to the certificate file of the certificate.
 
-* `key_virtual_path` - The path to the key file of this certificate.
+* `key_virtual_path` - The path to the key file of the certificate.
 
-* `key_vault_secret_id` - The ID of the Key Vault Secret for this certificate.
+* `key_vault_secret_id` - The ID of the Key Vault Secret for the certificate.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Certificate.
+* `read` - (Defaults to 5 minutes) Used when retrieving the NGINX Certificate.

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -83,7 +83,7 @@ A `frontend_private` block exports the following:
 
 A `frontend_public` block exports the following:
 
-* `ip_address` - Specifies a list of Public IP Resource IDs for this NGINX Deployment.
+* `ip_address` - The list of Public IP Resource IDs for this NGINX Deployment.
 
 ---
 

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Nginx"
+subcategory: "NGINX"
 layout: "azurerm"
 page_title: "Azure Resource Manager: Data Source: azurerm_nginx_deployment"
 description: |-
-  Gets information about an existing Nginx Deployment.
+  Gets information about an existing NGINX Deployment.
 ---
 
 # Data Source: azurerm_nginx_deployment
 
-Use this data source to access information about an existing Nginx Deployment.
+Use this data source to access information about an existing NGINX Deployment.
 
 ## Example Usage
 
@@ -27,23 +27,23 @@ output "id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of this Nginx Deployment.
+* `name` - (Required) The name of this NGINX Deployment.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Nginx Deployment exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the NGINX Deployment exists.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Nginx Deployment.
+* `id` - The ID of the NGINX Deployment.
 
-* `capacity` - The number of NGINX capacity units for this Nginx Deployment.
+* `capacity` - The number of NGINX capacity units for this NGINX Deployment.
 
 * `auto_scale_profile` - An `auto_scale_profile` block as defined below.
 
 * `diagnose_support_enabled` - Whether diagnostic settings are enabled.
 
-* `email` - Preferred email associated with the Nginx Deployment.
+* `email` - Preferred email associated with the NGINX Deployment.
 
 * `frontend_private` - A `frontend_private` block as defined below.
 
@@ -51,53 +51,53 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `identity` - A `identity` block as defined below.
 
-* `ip_address` - The IP address of the Nginx Deployment.
+* `ip_address` - The IP address of the NGINX Deployment.
 
-* `location` - The Azure Region where the Nginx Deployment exists.
+* `location` - The Azure Region where the NGINX Deployment exists.
 
 * `logging_storage_account` - A `logging_storage_account` block as defined below.
 
-* `managed_resource_group` - Auto-generated managed resource group for the Nginx Deployment.
+* `managed_resource_group` - Auto-generated managed resource group for the NGINX Deployment.
 
 * `network_interface` - A `network_interface` block as defined below.
 
-* `nginx_version` - NGINX version of the Nginx Deployment.
+* `nginx_version` - NGINX version of the Deployment.
 
-* `sku` - The Nginx Deployment SKU. Possible values include `standard_Monthly`.
+* `sku` - The NGINX Deployment SKU. Possible values include `standard_Monthly`.
 
 * `automatic_upgrade_channel` - The automatic upgrade channel for this NGINX deployment.
 
-* `tags` - A mapping of tags assigned to the Nginx Deployment.
+* `tags` - A mapping of tags assigned to the NGINX Deployment.
 
 ---
 
 A `frontend_private` block exports the following:
 
-* `allocation_method` - The method of allocating the private IP to the Nginx Deployment.
+* `allocation_method` - The method of allocating the private IP to the NGINX Deployment.
 
-* `ip_address` - Private IP address of the Nginx Deployment.
+* `ip_address` - Private IP address of the NGINX Deployment.
 
-* `subnet_id` - The subnet ID of the Nginx Deployment.
+* `subnet_id` - The subnet ID of the NGINX Deployment.
 
 ---
 
 A `frontend_public` block exports the following:
 
-* `ip_address` - List of public IPs of the Ngix Deployment.
+* `ip_address` - Specifies a list of Public IP Resource IDs for this NGINX Deployment.
 
 ---
 
 A `identity` block exports the following:
 
-* `identity_ids` - List of identities attached to the Nginx Deployment.
+* `identity_ids` - List of identities attached to the NGINX Deployment.
 
-* `type` - Type of identity attached to the Nginx Deployment.
+* `type` - Type of identity attached to the NGINX Deployment.
 
 ---
 
 A `logging_storage_account` block exports the following:
 
-* `container_name` - the container name of Storage Account for logging.
+* `container_name` - The container name of Storage Account for logging.
 
 * `name` - The account name of the StorageAccount for logging.
 
@@ -105,7 +105,7 @@ A `logging_storage_account` block exports the following:
 
 A `network_interface` block exports the following:
 
-* `subnet_id` - The subnet resource ID of the Nginx Deployment.
+* `subnet_id` - The subnet resource ID of the NGINX Deployment.
 
 ---
 
@@ -121,4 +121,4 @@ An `auto_scale_profile` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Deployment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the NGINX Deployment.

--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Nginx"
+subcategory: "NGINX"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nginx_certificate"
 description: |-
-  Manages a Certificate for an Nginx Deployment.
+  Manages a Certificate for an NGINX Deployment.
 ---
 
 # azurerm_nginx_certificate
 
-Manages a Certificate for an NGinx Deployment.
+Manages a Certificate for an NGINX Deployment.
 
 ## Example Usage
 
@@ -123,9 +123,9 @@ resource "azurerm_nginx_certificate" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Nginx Certificate. Changing this forces a new Nginx Certificate to be created.
+* `name` - (Required) The name which should be used for this NGINX Certificate. Changing this forces a new NGINX Certificate to be created.
 
-* `nginx_deployment_id` - (Required) The ID of the Nginx Deployment that this Certificate should be associated with. Changing this forces a new Nginx Certificate to be created.
+* `nginx_deployment_id` - (Required) The ID of the NGINX Deployment that this Certificate should be associated with. Changing this forces a new NGINX Certificate to be created.
 
 * `certificate_virtual_path` - (Required) Specify the path to the certificate file of this certificate.
 
@@ -137,20 +137,20 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of this Nginx Certificate.
+* `id` - The ID of this NGINX Certificate.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Nginx Certificate.
-* `update` - (Defaults to 30 minutes) Used when updating the Nginx Certificate.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Certificate.
-* `delete` - (Defaults to 10 minutes) Used when deleting the Nginx Certificate.
+* `create` - (Defaults to 30 minutes) Used when creating the NGINX Certificate.
+* `update` - (Defaults to 30 minutes) Used when updating the NGINX Certificate.
+* `read` - (Defaults to 5 minutes) Used when retrieving the NGINX Certificate.
+* `delete` - (Defaults to 10 minutes) Used when deleting the NGINX Certificate.
 
 ## Import
 
-An Nginx Certificate can be imported using the `resource id`, e.g.
+An NGINX Certificate can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_nginx_certificate.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Nginx.NginxPlus/nginxDeployments/deploy1/certificates/cer1

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Nginx"
+subcategory: "NGINX"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nginx_deployment"
 description: |-
-  Manages a Nginx Deployment.
+  Manages an NGINX Deployment.
 ---
 
 # azurerm_nginx_deployment
 
-Manages a Nginx Deployment.
+Manages an NGINX Deployment.
 
 ## Example Usage
 
@@ -137,15 +137,15 @@ resource "azurerm_nginx_deployment" "example" {
 
 The following arguments are supported:
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Nginx Deployment should exist. Changing this forces a new Nginx Deployment to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the NGINX Deployment should exist. Changing this forces a new NGINX Deployment to be created.
 
-* `name` - (Required) The name which should be used for this Nginx Deployment. Changing this forces a new Nginx Deployment to be created.
+* `name` - (Required) The name which should be used for this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
 
-* `location` - (Required) The Azure Region where the Nginx Deployment should exist. Changing this forces a new Nginx Deployment to be created.
+* `location` - (Required) The Azure Region where the NGINX Deployment should exist. Changing this forces a new NGINX Deployment to be created.
 
-* `sku` - (Required) Specifies the Nginx Deployment SKU. Possible values include `standard_Monthly`. Changing this forces a new resource to be created.
+* `sku` - (Required) Specifies the NGINX Deployment SKU. Possible values include `standard_Monthly`. Changing this forces a new resource to be created.
 
-* `managed_resource_group` - (Optional) Specify the managed resource group to deploy VNet injection related network resources. Changing this forces a new Nginx Deployment to be created.
+* `managed_resource_group` - (Optional) Specify the managed resource group to deploy VNet injection related network resources. Changing this forces a new NGINX Deployment to be created.
 
 ---
 
@@ -157,29 +157,29 @@ The following arguments are supported:
 
 * `diagnose_support_enabled` - (Optional) Should the diagnosis support be enabled?
 
-* `email` - (Optional) Specify the preferred support contact email address of the user used for sending alerts and notification.
+* `email` - (Optional) Specify the preferred support contact email address for receiving alerts and notifications.
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `frontend_private` - (Optional) One or more `frontend_private` blocks as defined below. Changing this forces a new Nginx Deployment to be created.
+* `frontend_private` - (Optional) One or more `frontend_private` blocks as defined below. Changing this forces a new NGINX Deployment to be created.
 
-* `frontend_public` - (Optional) A `frontend_public` block as defined below. Changing this forces a new Nginx Deployment to be created.
+* `frontend_public` - (Optional) A `frontend_public` block as defined below. Changing this forces a new NGINX Deployment to be created.
 
 * `logging_storage_account` - (Optional) One or more `logging_storage_account` blocks as defined below.
 
-* `network_interface` - (Optional) One or more `network_interface` blocks as defined below. Changing this forces a new Nginx Deployment to be created.
+* `network_interface` - (Optional) One or more `network_interface` blocks as defined below. Changing this forces a new NGINX Deployment to be created.
 
 * `automatic_upgrade_channel` - (Optional) Specify the automatic upgrade channel for the NGINX deployment. Defaults to `stable`. The possible values are `stable` and `preview`.
 
 * `configuration` - (Optional) Specify a custom `configuration` block as defined below.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Nginx Deployment.
+* `tags` - (Optional) A mapping of tags which should be assigned to the NGINX Deployment.
 
 ---
 
 A `identity` block supports the following:
 
-* `type` - (Required) Specifies the identity type of the Nginx Deployment. Possible values are `UserAssigned`, `SystemAssigned`.
+* `type` - (Required) Specifies the identity type of the NGINX Deployment. Possible values are `UserAssigned`, `SystemAssigned`.
 
 * `identity_ids` - (Optional) Specifies a list of user managed identity ids to be assigned.
 
@@ -189,31 +189,31 @@ A `identity` block supports the following:
 
 A `frontend_private` block supports the following:
 
-* `allocation_method` - (Required) Specify the method of allocating the private IP. Possible values are `Static` and `Dynamic`.
+* `allocation_method` - (Required) Specify the method for allocating the private IP. Possible values are `Static` and `Dynamic`.
 
-* `ip_address` - (Required) Specify the IP Address of this private IP.
+* `ip_address` - (Required) Specify the private IP Address.
 
-* `subnet_id` - (Required) Specify the SubNet Resource ID to this Nginx Deployment.
+* `subnet_id` - (Required) Specify the Subnet Resource ID for this NGINX Deployment.
 
 ---
 
 A `frontend_public` block supports the following:
 
-* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this Nginx Deployment.
+* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this NGINX Deployment.
 
 ---
 
 A `logging_storage_account` block supports the following:
 
-* `container_name` - (Optional) Specify the container name of Storage Account for logging.
+* `container_name` - (Optional) Specify the container name in the Storage Account for logging.
 
-* `name` - (Optional) The account name of the StorageAccount for Nginx Logging.
+* `name` - (Optional) The name of the StorageAccount for NGINX Logging.
 
 ---
 
 A `network_interface` block supports the following:
 
-* `subnet_id` - (Required) Specify The SubNet Resource ID to this Nginx Deployment.
+* `subnet_id` - (Required) Specify The Subnet Resource ID for this NGINX Deployment.
 
 ---
 
@@ -262,24 +262,24 @@ An `auto_scale_profile` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Nginx Deployment.
+* `id` - The ID of the NGINX Deployment.
 
 * `ip_address` - The IP address of the deployment.
 
-* `nginx_version` - The version of deployed nginx.
+* `nginx_version` - The version of deployed NGINX.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Nginx Deployment.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Deployment.
-* `update` - (Defaults to 30 minutes) Used when updating the Nginx Deployment.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Nginx Deployment.
+* `create` - (Defaults to 30 minutes) Used when creating the NGINX Deployment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the NGINX Deployment.
+* `update` - (Defaults to 30 minutes) Used when updating the NGINX Deployment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the NGINX Deployment.
 
 ## Import
 
-Nginx Deployments can be imported using the `resource id`, e.g.
+NGINX Deployments can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_nginx_deployment.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Nginx.NginxPlus/nginxDeployments/dep1


### PR DESCRIPTION
This MR fixes formatting for NGINX and a few spelling errors.