### PR TITLE
`azurerm_redhat_openshift_cluster` - Allow multiple ingress_profile blocks, with a name

### DIFF
--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters"
@@ -156,6 +157,34 @@ func TestAccOpenShiftCluster_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccOpenShiftCluster_multiIngress(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redhat_openshift_cluster", "test")
+	r := OpenShiftClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiIngress(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ingress_profile.0").Exists(),
+				check.That(data.ResourceName).Key("ingress_profile.0.name").HasValue("restricted"),
+				check.That(data.ResourceName).Key("ingress_profile.0.visibility").HasValue("Public"),
+
+				check.That(data.ResourceName).Key("ingress_profile.1").Exists(),
+				check.That(data.ResourceName).Key("ingress_profile.1.name").HasValue("default"),
+				check.That(data.ResourceName).Key("ingress_profile.1.visibility").HasValue("Public"),
+
+				check.That(data.ResourceName).Key("ingress_profile.2").Exists(),
+				check.That(data.ResourceName).Key("ingress_profile.2.name").HasValue("default1"),
+				check.That(data.ResourceName).Key("ingress_profile.2.visibility").HasValue("Private"),
+				// Expect an internal IP from worker_subnet for the private ingress load balancer (10.0.2.0/23)
+				check.That(data.ResourceName).Key("ingress_profile.2.ip_address").MatchesRegex(regexp.MustCompile(`^10\.0\.[23]\.[0-9]+$`)),
+			),
+		},
+		data.ImportStep("service_principal.0.client_secret"),
 	})
 }
 
@@ -699,6 +728,67 @@ resource "azurerm_redhat_openshift_cluster" "test" {
     "azurerm_role_assignment.role_network2",
     "azurerm_role_assignment.disk_encryption_reader1",
     "azurerm_role_assignment.disk_encryption_reader2",
+  ]
+}
+  `, r.template(data), data.RandomInteger, data.RandomString)
+}
+
+func (r OpenShiftClusterResource) multiIngress(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_redhat_openshift_cluster" "test" {
+  name                = "acctestaro%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cluster_profile {
+    domain  = "aro-%[3]s.com"
+    version = "4.13.23"
+  }
+
+  network_profile {
+    pod_cidr     = "10.128.0.0/14"
+    service_cidr = "172.30.0.0/16"
+  }
+
+  main_profile {
+    vm_size   = "Standard_D8s_v3"
+    subnet_id = azurerm_subnet.main_subnet.id
+  }
+
+  api_server_profile {
+    visibility = "Public"
+  }
+
+  ingress_profile {
+    name = "restricted"
+    visibility = "Public"
+  }
+
+  ingress_profile {
+    visibility = "Public"
+  }
+
+  ingress_profile {
+    visibility = "Private"
+  }
+
+  worker_profile {
+    vm_size      = "Standard_D4s_v3"
+    disk_size_gb = 128
+    node_count   = 3
+    subnet_id    = azurerm_subnet.worker_subnet.id
+  }
+
+  service_principal {
+    client_id     = azuread_application.test.application_id
+    client_secret = azuread_service_principal_password.test.value
+  }
+
+  depends_on = [
+    "azurerm_role_assignment.role_network1",
+    "azurerm_role_assignment.role_network2",
   ]
 }
   `, r.template(data), data.RandomInteger, data.RandomString)

--- a/website/docs/r/redhat_openshift_cluster.html.markdown
+++ b/website/docs/r/redhat_openshift_cluster.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 
 * `api_server_profile` - (Required) An `api_server_profile` block as defined below. Changing this forces a new resource to be created.
 
-* `ingress_profile` - (Required) An `ingress_profile` block as defined below. Changing this forces a new resource to be created.
+* `ingress_profile` - (Required) One or more `ingress_profile` blocks as defined below. Changing this forces a new resource to be created.
 
 * `network_profile` - (Required) A `network_profile` block as defined below. Changing this forces a new resource to be created.
 
@@ -229,6 +229,8 @@ A `ingress_profile` block supports the following:
 
 * `visibility` - (Required) Cluster Ingress visibility. Supported values are `Public` and `Private`. Changing this forces a new resource to be created.
 
+* `name` - (Optional) The name of the IngressController resource on the openshift-ingress-operator namespace. Defaults to `default` but must be unique.
+
 ---
 
 ## Attributes Reference
@@ -259,7 +261,7 @@ A `api_server_profile` block exports the following:
 
 ---
 
-A `ingress_profile` block exports the following:
+A `ingress_profile` block exports a list with the following:
 
 * `name` - The name of the Ingress Profile.
 


### PR DESCRIPTION
**edit:** created an Issue for the PR with more details -> closes #25048
**edit2:** confirming that the Azure API is able to deal with two ingress blocks that have a defined name too. The patch has been verified to be able to create a new cluster with two ingress load balancers in Azure. However, no IngressController resource is created on the cluster that backs the load balancer and terraform/az rest do not list the 2nd ingress until it got explicitly applied as IngressController resouce on the cluster. Once the IngressController is present, the patched terraform accepts the two ingresses and won't recreate the cluster anymore.

Happy to see that there is a resource for managing an ARO cluster using terraform. However, it seems that I'm either not declaring the resource correctly or the resource currently is unable to deal with clusters that use multiple ingress controllers.

How to reproduce:
1) Create a new ARO cluster
2) Add a second IngressController to the cluster
3) Run terraform plan
4) The plan suggests to recreate the cluster because one ingress_profile needs to be deleted and a second ingress_profile needs to be changed. Recreating the cluster does not help - the plan still offers to recreate the cluster every time.

Assumption: It seems that the az API is able to deal with multiple ingress_profile blocks and tf plan correctly recognizes that there are two such profiles. However, it is not allowed to add a seconds ingress_profile because a) there is a "MaxItems: 1" defined and b) the "name" attribute is defined as computed, so it's not possible to distinguish two different ingress profile blocks. Luckily, the ingress_profile is already defined as an array, so it allows multiple entries theoretically.

Desired result:
azurerm_redhat_openshift_cluster allows multiple blocks for ingress_profile with an optional name which defaults to "default".

I haven't contributed to terraform resources so far and the suggested PR won't compile, likely. If the issue is confirmed I'm happy to provide a cleaner patch if possible.