### PR TITLE
`azurerm_stack_hci_cluster` - support for `identity`, export `cloud_id`, `service_endpoint`, `resource_provider_object_id`

### DIFF
--- a/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
@@ -38,7 +38,7 @@ func TestAccStackHCIClusterDataSource_identity(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.identity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
 				check.That(data.ResourceName).Key("identity.0.principal_id").IsNotEmpty(),

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
@@ -24,6 +24,25 @@ func TestAccStackHCIClusterDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("location").IsNotEmpty(),
 				check.That(data.ResourceName).Key("client_id").IsNotEmpty(),
 				check.That(data.ResourceName).Key("tenant_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("cloud_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("service_endpoint").IsNotEmpty(),
+				check.That(data.ResourceName).Key("resource_provider_object_id").IsNotEmpty(),
+			),
+		},
+	})
+}
+
+func TestAccStackHCIClusterDataSource_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsNotEmpty(),
 			),
 		},
 	})
@@ -38,4 +57,15 @@ data "azurerm_stack_hci_cluster" "test" {
   resource_group_name = azurerm_stack_hci_cluster.test.resource_group_name
 }
 `, StackHCIClusterResource{}.basic(data))
+}
+
+func (d StackHCIClusterDataSource) identity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_stack_hci_cluster" "test" {
+  name                = azurerm_stack_hci_cluster.test.name
+  resource_group_name = azurerm_stack_hci_cluster.test.resource_group_name
+}
+`, StackHCIClusterResource{}.systemAssignedIdentity(data))
 }

--- a/internal/services/azurestackhci/stack_hci_cluster_resource.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource.go
@@ -127,11 +127,7 @@ func resourceArmStackHCIClusterCreate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if v, ok := d.GetOk("identity"); ok {
-		expandedIdentity, err := expandSystemAssigned(v.([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding identity: %+v", err)
-		}
-		cluster.Identity = expandedIdentity
+		cluster.Identity = expandSystemAssigned(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("tenant_id"); ok {
@@ -262,11 +258,7 @@ func resourceArmStackHCIClusterUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("identity") {
-		expandedIdentity, err := expandSystemAssigned(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding identity: %+v", err)
-		}
-		cluster.Identity = expandedIdentity
+		cluster.Identity = expandSystemAssigned(d.Get("identity").([]interface{}))
 	}
 
 	if _, err := client.Update(ctx, *id, cluster); err != nil {
@@ -346,16 +338,16 @@ func resourceArmStackHCIClusterDelete(d *pluginsdk.ResourceData, meta interface{
 	return nil
 }
 
-func expandSystemAssigned(input []interface{}) (*identity.SystemAndUserAssignedMap, error) {
+func expandSystemAssigned(input []interface{}) *identity.SystemAndUserAssignedMap {
 	if len(input) == 0 || input[0] == nil {
 		return &identity.SystemAndUserAssignedMap{
 			Type: identity.TypeNone,
-		}, nil
+		}
 	}
 
 	return &identity.SystemAndUserAssignedMap{
 		Type: identity.TypeSystemAssigned,
-	}, nil
+	}
 }
 
 func flattenSystemAssigned(input *identity.SystemAndUserAssignedMap) []interface{} {

--- a/internal/services/azurestackhci/stack_hci_cluster_resource.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource.go
@@ -338,6 +338,7 @@ func resourceArmStackHCIClusterDelete(d *pluginsdk.ResourceData, meta interface{
 	return nil
 }
 
+// API does not accept userAssignedIdentity as in swagger https://github.com/Azure/azure-rest-api-specs/issues/28260
 func expandSystemAssigned(input []interface{}) *identity.SystemAndUserAssignedMap {
 	if len(input) == 0 || input[0] == nil {
 		return &identity.SystemAndUserAssignedMap{

--- a/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -49,6 +49,94 @@ func TestAccStackHCICluster_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccStackHCICluster_systemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStackHCICluster_systemAssignedIdentityUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStackHCICluster_softwareAssurance(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.softwareAssurance(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStackHCICluster_softwareAssuranceUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.softwareAssurance(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStackHCICluster_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
 	r := StackHCIClusterResource{}
@@ -158,6 +246,40 @@ resource "azurerm_stack_hci_cluster" "import" {
 `, config)
 }
 
+func (r StackHCIClusterResource) systemAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stack_hci_cluster" "test" {
+  name                = "acctest-StackHCICluster-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  client_id           = azuread_application.test.application_id
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r StackHCIClusterResource) softwareAssurance(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stack_hci_cluster" "test" {
+  name                     = "acctest-StackHCICluster-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  client_id                = azuread_application.test.application_id
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  softwareAssuranceEnabled = true
+}
+`, template, data.RandomInteger)
+}
+
 func (r StackHCIClusterResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
@@ -169,6 +291,9 @@ resource "azurerm_stack_hci_cluster" "test" {
   location            = azurerm_resource_group.test.location
   client_id           = azuread_application.test.application_id
   tenant_id           = data.azurerm_client_config.current.tenant_id
+  identity {
+    type = "SystemAssigned"
+  }
 
   tags = {
     ENV = "Test"

--- a/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -28,6 +28,9 @@ func TestAccStackHCICluster_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cloud_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("service_endpoint").IsNotEmpty(),
+				check.That(data.ResourceName).Key("resource_provider_object_id").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -58,6 +61,9 @@ func TestAccStackHCICluster_systemAssignedIdentity(t *testing.T) {
 			Config: r.systemAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -78,50 +84,6 @@ func TestAccStackHCICluster_systemAssignedIdentityUpdate(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.systemAssignedIdentity(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccStackHCICluster_softwareAssurance(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
-	r := StackHCIClusterResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.softwareAssurance(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccStackHCICluster_softwareAssuranceUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
-	r := StackHCIClusterResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.softwareAssurance(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -260,22 +222,6 @@ resource "azurerm_stack_hci_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-}
-`, template, data.RandomInteger)
-}
-
-func (r StackHCIClusterResource) softwareAssurance(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_stack_hci_cluster" "test" {
-  name                     = "acctest-StackHCICluster-%d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  client_id                = azuread_application.test.application_id
-  tenant_id                = data.azurerm_client_config.current.tenant_id
-  softwareAssuranceEnabled = true
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/d/stack_hci_cluster.html.markdown
+++ b/website/docs/d/stack_hci_cluster.html.markdown
@@ -69,7 +69,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 An `identity` block exports the following:
 
-* `type` - (Required) The type of Managed Service Identity that configured on the Azure Stack HCI Cluster.
+* `type` - (Required) The type of Managed Service Identity configured on the Azure Stack HCI Cluster.
 
 * `principal_id` - The Principal ID associated with this Managed Service Identity.
 

--- a/website/docs/d/stack_hci_cluster.html.markdown
+++ b/website/docs/d/stack_hci_cluster.html.markdown
@@ -47,15 +47,33 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Azure Stack HCI Cluster.
 
-* `location` - The Azure Region where the Azure Stack HCI Cluster exists.
+* `automanage_configuration_id` - The ID of the Automanage Configuration assigned to the Azure Stack HCI Cluster.
 
 * `client_id` - The Client ID of the Azure Active Directory used by the Azure Stack HCI Cluster.
+
+* `cloud_id` - An immutable UUID for the Azure Stack HCI Cluster.
+
+* `identity` - An `identity` block as defined below.
+
+* `location` - The Azure Region where the Azure Stack HCI Cluster exists.
+
+* `resource_provider_object_id` - The object ID of the Resource Provider Service Principal.
+
+* `service_endpoint` - The region specific Data Path Endpoint of the Azure Stack HCI Cluster.
 
 * `tenant_id` - The Tenant ID of the Azure Active Directory used by the Azure Stack HCI Cluster.
 
 * `tags` - A mapping of tags assigned to the Azure Stack HCI Cluster.
 
-* `automanage_configuration_id` - The ID of the Automanage Configuration assigned to the Azure Stack HCI Cluster.
+---
+
+An `identity` block exports the following:
+
+* `type` - (Required) The type of Managed Service Identity that configured on the Azure Stack HCI Cluster.
+
+* `principal_id` - The Principal ID associated with this Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
 ## Timeouts
 

--- a/website/docs/r/stack_hci_cluster.html.markdown
+++ b/website/docs/r/stack_hci_cluster.html.markdown
@@ -30,6 +30,9 @@ resource "azurerm_stack_hci_cluster" "example" {
   location            = azurerm_resource_group.example.location
   client_id           = data.azuread_application.example.application_id
   tenant_id           = data.azurerm_client_config.current.tenant_id
+  identity {
+    type = "SystemAssigned"
+  }
 }
 ```
 
@@ -45,6 +48,8 @@ The following arguments are supported:
 
 * `client_id` - (Required) The Client ID of the Azure Active Directory which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `tenant_id` - (Optional) The Tenant ID of the Azure Active Directory which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
 
 ~> **NOTE** If unspecified the Tenant ID of the Provider will be used.
@@ -53,11 +58,36 @@ The following arguments are supported:
 
 * `automanage_configuration_id` - (Optional) The ID of the Automanage Configuration assigned to the Azure Stack HCI Cluster.
 
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on the Azure Stack HCI Cluster. Possible value is `SystemAssigned`.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Azure Stack HCI Cluster.
+* `id` - The resource ID of the Azure Stack HCI Cluster.
+
+* `cloud_id` - An immutable UUID for the Azure Stack HCI Cluster.
+
+
+* `resource_provider_object_id` - The object ID of the Resource Provider Service Principal.
+
+* `identity` - An `identity` block as defined below.
+
+* `service_endpoint` - The region specific Data Path Endpoint of the Azure Stack HCI Cluster.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID associated with this Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
+
+-> You can access the Principal ID via `azurerm_stack_hci_cluster.example.identity.0.principal_id`
 
 ## Timeouts
 

--- a/website/docs/r/stack_hci_cluster.html.markdown
+++ b/website/docs/r/stack_hci_cluster.html.markdown
@@ -72,7 +72,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `cloud_id` - An immutable UUID for the Azure Stack HCI Cluster.
 
-
 * `resource_provider_object_id` - The object ID of the Resource Provider Service Principal.
 
 * `identity` - An `identity` block as defined below.


### PR DESCRIPTION
swagger: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2023-08-01/clusters.json