### PR TITLE
`azurerm_virtual_network_gateway`: remove `Static` value in documentation of `private_ip_address_allocation` field

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -451,9 +451,8 @@ resource "azurerm_virtual_network_gateway" "test" {
   sku      = "Basic"
 
   ip_configuration {
-    public_ip_address_id          = azurerm_public_ip.test.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+    subnet_id            = azurerm_subnet.test.id
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -167,7 +167,7 @@ The `ip_configuration` block supports:
 
 * `name` - (Optional) A user-defined name of the IP configuration. Defaults to `vnetGatewayConfig`.
 
-* `private_ip_address_allocation` - (Optional) Defines how the private IP address of the gateways virtual interface is assigned. The only valid value is `Dynamic` for Virutal Network Gateway. Defaults to `Dynamic`.
+* `private_ip_address_allocation` - (Optional) Defines how the private IP address of the gateways virtual interface is assigned. The only valid value is `Dynamic` for Virtual Network Gateway (`Static` is not supported by the service yet). Defaults to `Dynamic`.
 
 * `subnet_id` - (Required) The ID of the gateway subnet of a virtual network in which the virtual network gateway will be created. It is mandatory that the associated subnet is named `GatewaySubnet`. Therefore, each virtual network can contain at most a single Virtual Network Gateway.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -167,7 +167,7 @@ The `ip_configuration` block supports:
 
 * `name` - (Optional) A user-defined name of the IP configuration. Defaults to `vnetGatewayConfig`.
 
-* `private_ip_address_allocation` - (Optional) Defines how the private IP address of the gateways virtual interface is assigned. Valid options are `Static` or `Dynamic`. Defaults to `Dynamic`.
+* `private_ip_address_allocation` - (Optional) Defines how the private IP address of the gateways virtual interface is assigned. The only valid value is `Dynamic` for Virutal Network Gateway. Defaults to `Dynamic`.
 
 * `subnet_id` - (Required) The ID of the gateway subnet of a virtual network in which the virtual network gateway will be created. It is mandatory that the associated subnet is named `GatewaySubnet`. Therefore, each virtual network can contain at most a single Virtual Network Gateway.
 


### PR DESCRIPTION
‌‌‌‌‌‌‌fixes #24991.

Service team's comment in https://github.com/Azure/azure-rest-api-specs/issues/27842#issuecomment-1960100442 states that the Static value should never be used in private_ip_address_allocation of the virtual network gateway resource, even though it is defined in the API Spec. Furthermore, the resource should not specify the private_ip_address_allocation at all. However, removing the field from the schema would cause a breaking change. Therefore, this PR only updates the documentation to advise users not to use the `Static` value.