### PR TITLE
`azurerm_data_factory_integration_runtime_managed` - support for the `credential_name` property

### DIFF
--- a/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
@@ -205,6 +206,12 @@ func resourceDataFactoryIntegrationRuntimeManaged() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"credential_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -328,6 +335,10 @@ func resourceDataFactoryIntegrationRuntimeManagedRead(d *pluginsdk.ResourceData,
 		if err := d.Set("custom_setup_script", flattenDataFactoryIntegrationRuntimeManagedSsisCustomSetupScript(ssisProps.CustomSetupScriptProperties, d)); err != nil {
 			return fmt.Errorf("setting `vnet_integration`: %+v", err)
 		}
+
+		if ssisProps.Credential != nil {
+			d.Set("credential_name", pointer.From(ssisProps.Credential.ReferenceName))
+		}
 	}
 
 	return nil
@@ -410,6 +421,12 @@ func expandDataFactoryIntegrationRuntimeManagedSsisProperties(d *pluginsdk.Resou
 		ssisProperties.CustomSetupScriptProperties = &datafactory.IntegrationRuntimeCustomSetupScriptProperties{
 			BlobContainerURI: utils.String(customSetupScript["blob_container_uri"].(string)),
 			SasToken:         sasToken,
+		}
+	}
+
+	if credentialName := d.Get("credential_name").(string); credentialName != "" {
+		ssisProperties.Credential = &datafactory.CredentialReference{
+			ReferenceName: pointer.To(credentialName),
 		}
 	}
 

--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 * `catalog_info` - (Optional) A `catalog_info` block as defined below.
 
+* `credential_name` - (Optional) The name of the credential to use for the Managed Integration Runtime.
+
 * `custom_setup_script` - (Optional) A `custom_setup_script` block as defined below.
 
 * `vnet_integration` - (Optional) A `vnet_integration` block as defined below.


### PR DESCRIPTION
<img width="833" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/79895375/0bc2c5f3-0d83-47fa-839f-e3d602abe2ee">

fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24742