### PR TITLE
Bugfix: wrong KeyType referenced

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1505,7 +1505,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			KeyType: storage.KeyType(queueEncryptionKeyType),
 		}
 		encryption.Services.Table = &storage.EncryptionService{
-			KeyType: storage.KeyType(queueEncryptionKeyType),
+			KeyType: storage.KeyType(tableEncryptionKeyType),
 		}
 	}
 


### PR DESCRIPTION
Minor bug fix: `encryption.Services.Table` used `queueEncryptionKeyType` instead of `tableEncryptionKeyType`