### PR TITLE
#16342: donot create subnets when vnet update and subnet deletion happening in parallel

### DIFF
--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -240,6 +240,7 @@ func TestAccVirtualNetwork_subnetResource(t *testing.T) {
 			Config: r.withSubnetDelete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 			),
 		},
 		{
@@ -620,6 +621,10 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    environment = "Production"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
We do have a bug #16342  when `azurerm_virtual_network` updates & `azurerm_subnet` deletion are happening in parallel. 

There are locks set in `azurerm_subnet` delete function guaranteeing updates to `azurerm_virtual_network` resource are delayed until the subnets are deleted but we return an empty object [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/a74f3357580a2c470a020def87004fe3f6f16c6a/internal/services/network/virtual_network_resource.go#L548) instead of `nil` response & setting the object later [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/a74f3357580a2c470a020def87004fe3f6f16c6a/internal/services/network/virtual_network_resource.go#L379-L398). This I think is the root cause, if the subnet is not present (deleted on Azure but present in state), we shouldn't set from state file & recreate it. 
- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change