### PR TITLE
Upgrade Subnet API version from 2022-07-01 to 2023-09-01

### DIFF
--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -46,6 +46,7 @@ type Client struct {
 	ServiceAssociationLinkClient           *network.ServiceAssociationLinksClient
 	ServiceEndpointPoliciesClient          *network.ServiceEndpointPoliciesClient
 	ServiceEndpointPolicyDefinitionsClient *network.ServiceEndpointPolicyDefinitionsClient
+	LegacySubnetsClient                    *network.SubnetsClient
 	SubnetsClient                          *subnets.SubnetsClient
 	NatGatewayClient                       *network.NatGatewaysClient
 	VirtualHubBgpConnectionClient          *network.VirtualHubBgpConnectionClient
@@ -144,6 +145,9 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	ServiceEndpointPolicyDefinitionsClient := network.NewServiceEndpointPolicyDefinitionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&ServiceEndpointPolicyDefinitionsClient.Client, o.ResourceManagerAuthorizer)
 
+	LegacySubnetsClient := network.NewSubnetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&LegacySubnetsClient.Client, o.ResourceManagerAuthorizer)
+
 	SubnetsClient, err := subnets.NewSubnetsClientWithBaseURI(o.Environment.ResourceManager)
 	o.Configure(SubnetsClient.Client, o.Authorizers.ResourceManager)
 	if err != nil {
@@ -214,6 +218,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		SecurityPartnerProviderClient:          &SecurityPartnerProviderClient,
 		ServiceEndpointPoliciesClient:          &ServiceEndpointPoliciesClient,
 		ServiceEndpointPolicyDefinitionsClient: &ServiceEndpointPolicyDefinitionsClient,
+		LegacySubnetsClient:                    &LegacySubnetsClient,
 		SubnetsClient:                          SubnetsClient,
 		NatGatewayClient:                       &NatGatewayClient,
 		VirtualHubBgpConnectionClient:          &VirtualHubBgpConnectionClient,

--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	network_2023_06_01 "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
@@ -45,7 +46,7 @@ type Client struct {
 	ServiceAssociationLinkClient           *network.ServiceAssociationLinksClient
 	ServiceEndpointPoliciesClient          *network.ServiceEndpointPoliciesClient
 	ServiceEndpointPolicyDefinitionsClient *network.ServiceEndpointPolicyDefinitionsClient
-	SubnetsClient                          *network.SubnetsClient
+	SubnetsClient                          *subnets.SubnetsClient
 	NatGatewayClient                       *network.NatGatewaysClient
 	VirtualHubBgpConnectionClient          *network.VirtualHubBgpConnectionClient
 	VirtualHubIPClient                     *network.VirtualHubIPConfigurationClient
@@ -143,8 +144,11 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	ServiceEndpointPolicyDefinitionsClient := network.NewServiceEndpointPolicyDefinitionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&ServiceEndpointPolicyDefinitionsClient.Client, o.ResourceManagerAuthorizer)
 
-	SubnetsClient := network.NewSubnetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&SubnetsClient.Client, o.ResourceManagerAuthorizer)
+	SubnetsClient, err := subnets.NewSubnetsClientWithBaseURI(o.Environment.ResourceManager)
+	o.Configure(SubnetsClient.Client, o.Authorizers.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Subnets client: %+v", err)
+	}
 
 	VirtualHubBgpConnectionClient := network.NewVirtualHubBgpConnectionClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&VirtualHubBgpConnectionClient.Client, o.ResourceManagerAuthorizer)
@@ -210,7 +214,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		SecurityPartnerProviderClient:          &SecurityPartnerProviderClient,
 		ServiceEndpointPoliciesClient:          &ServiceEndpointPoliciesClient,
 		ServiceEndpointPolicyDefinitionsClient: &ServiceEndpointPolicyDefinitionsClient,
-		SubnetsClient:                          &SubnetsClient,
+		SubnetsClient:                          SubnetsClient,
 		NatGatewayClient:                       &NatGatewayClient,
 		VirtualHubBgpConnectionClient:          &VirtualHubBgpConnectionClient,
 		VirtualHubIPClient:                     &VirtualHubIPClient,

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -5,10 +5,9 @@ package network
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceSubnet() *pluginsdk.Resource {

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -5,16 +5,19 @@ package network
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceSubnet() *pluginsdk.Resource {
@@ -102,9 +105,9 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	defer cancel()
 
 	id := commonids.NewSubnetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_network_name").(string), d.Get("name").(string))
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -115,41 +118,43 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", id.VirtualNetworkName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if props := resp.SubnetPropertiesFormat; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
-		if props.AddressPrefixes == nil {
-			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
-				d.Set("address_prefixes", []string{*props.AddressPrefix})
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+			if props.AddressPrefixes == nil {
+				if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+					d.Set("address_prefixes", []string{*props.AddressPrefix})
+				} else {
+					d.Set("address_prefixes", []string{})
+				}
 			} else {
-				d.Set("address_prefixes", []string{})
+				d.Set("address_prefixes", utils.FlattenStringSlice(props.AddressPrefixes))
 			}
-		} else {
-			d.Set("address_prefixes", utils.FlattenStringSlice(props.AddressPrefixes))
-		}
 
-		if !features.FourPointOhBeta() {
-			d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(props.PrivateEndpointNetworkPolicies)))
-			d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(props.PrivateLinkServiceNetworkPolicies)))
-		}
+			if !features.FourPointOhBeta() {
+				d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(pointer.From(props.PrivateEndpointNetworkPolicies))))
+				d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
+			}
 
-		d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(props.PrivateEndpointNetworkPolicies)))
-		d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(props.PrivateLinkServiceNetworkPolicies)))
+			d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateEndpointNetworkPolicies))))
+			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 
-		networkSecurityGroupId := ""
-		if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.ID != nil {
-			networkSecurityGroupId = *props.NetworkSecurityGroup.ID
-		}
-		d.Set("network_security_group_id", networkSecurityGroupId)
+			networkSecurityGroupId := ""
+			if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
+				networkSecurityGroupId = *props.NetworkSecurityGroup.Id
+			}
+			d.Set("network_security_group_id", networkSecurityGroupId)
 
-		routeTableId := ""
-		if props.RouteTable != nil && props.RouteTable.ID != nil {
-			routeTableId = *props.RouteTable.ID
-		}
-		d.Set("route_table_id", routeTableId)
+			routeTableId := ""
+			if props.RouteTable != nil && props.RouteTable.Id != nil {
+				routeTableId = *props.RouteTable.Id
+			}
+			d.Set("route_table_id", routeTableId)
 
-		serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-		if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
-			return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
+			if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
+				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			}
 		}
 	}
 

--- a/internal/services/network/subnet_data_source_test.go
+++ b/internal/services/network/subnet_data_source_test.go
@@ -32,7 +32,7 @@ func TestAccDataSourceSubnet_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAzureRMSubnet_basic_addressPrefixes(t *testing.T) {
+func TestAccDataSourceSubnet_basic_addressPrefixes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_subnet", "test")
 	r := SubnetDataSource{}
 

--- a/internal/services/network/subnet_nat_gateway_association_resource.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource.go
@@ -56,7 +56,7 @@ func resourceSubnetNatGatewayAssociation() *pluginsdk.Resource {
 }
 
 func resourceSubnetNatGatewayAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -114,7 +114,7 @@ func resourceSubnetNatGatewayAssociationCreate(d *pluginsdk.ResourceData, meta i
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(network.ProvisioningStateUpdating)},
 		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
+		Refresh:    LegacySubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
@@ -140,7 +140,7 @@ func resourceSubnetNatGatewayAssociationCreate(d *pluginsdk.ResourceData, meta i
 }
 
 func resourceSubnetNatGatewayAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -177,7 +177,7 @@ func resourceSubnetNatGatewayAssociationRead(d *pluginsdk.ResourceData, meta int
 }
 
 func resourceSubnetNatGatewayAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_nat_gateway_association_resource_test.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource_test.go
@@ -126,7 +126,7 @@ func (SubnetNatGatewayAssociationResource) destroy(ctx context.Context, client *
 	virtualNetworkName := parsedSubnetId.VirtualNetworkName
 	subnetName := parsedSubnetId.SubnetName
 
-	subnet, err := client.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
+	subnet, err := client.Network.LegacySubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
 		if !utils.ResponseWasNotFound(subnet.Response) {
 			return fmt.Errorf("retrieving Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
@@ -140,12 +140,12 @@ func (SubnetNatGatewayAssociationResource) destroy(ctx context.Context, client *
 	}
 	props.NatGateway = nil
 
-	future, err := client.Network.SubnetsClient.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, subnet)
+	future, err := client.Network.LegacySubnetsClient.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, subnet)
 	if err != nil {
 		return fmt.Errorf("updating Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Network.SubnetsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, client.Network.LegacySubnetsClient.Client); err != nil {
 		return fmt.Errorf("waiting for completion of Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
 	}
 	return nil

--- a/internal/services/network/subnet_nat_gateway_association_resource_test.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource_test.go
@@ -103,7 +103,7 @@ func (t SubnetNatGatewayAssociationResource) Exists(ctx context.Context, clients
 	virtualNetworkName := id.VirtualNetworkName
 	subnetName := id.SubnetName
 
-	resp, err := clients.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
+	resp, err := clients.Network.LegacySubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
 		return nil, fmt.Errorf("reading Subnet Nat Gateway Association (%s): %+v", id, err)
 	}

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -56,7 +56,7 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 }
 
 func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -121,7 +121,7 @@ func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceDa
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(network.ProvisioningStateUpdating)},
 		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
+		Refresh:    LegacySubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
@@ -147,7 +147,7 @@ func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceDa
 }
 
 func resourceSubnetNetworkSecurityGroupAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -185,7 +185,7 @@ func resourceSubnetNetworkSecurityGroupAssociationRead(d *pluginsdk.ResourceData
 }
 
 func resourceSubnetNetworkSecurityGroupAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_network_security_group_association_resource_test.go
+++ b/internal/services/network/subnet_network_security_group_association_resource_test.go
@@ -120,7 +120,7 @@ func (SubnetNetworkSecurityGroupAssociationResource) destroy(ctx context.Context
 		return err
 	}
 
-	read, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	read, err := client.Network.LegacySubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
 	if err != nil {
 		if !utils.ResponseWasNotFound(read.Response) {
 			return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -129,11 +129,11 @@ func (SubnetNetworkSecurityGroupAssociationResource) destroy(ctx context.Context
 
 	read.SubnetPropertiesFormat.NetworkSecurityGroup = nil
 
-	future, err := client.Network.SubnetsClient.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, read)
+	future, err := client.Network.LegacySubnetsClient.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, read)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Network.SubnetsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, client.Network.LegacySubnetsClient.Client); err != nil {
 		return fmt.Errorf("waiting for completion of %s: %+v", id, err)
 	}
 

--- a/internal/services/network/subnet_network_security_group_association_resource_test.go
+++ b/internal/services/network/subnet_network_security_group_association_resource_test.go
@@ -100,7 +100,7 @@ func (SubnetNetworkSecurityGroupAssociationResource) Exists(ctx context.Context,
 		return nil, err
 	}
 
-	resp, err := clients.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := clients.Network.LegacySubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -6,6 +6,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"log"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -22,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 var SubnetResourceName = "azurerm_subnet"
@@ -273,21 +274,21 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] preparing arguments for Azure ARM Subnet creation.")
 
 	id := commonids.NewSubnetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_network_name").(string), d.Get("name").(string))
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	existing, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(existing.Response) {
+	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_subnet", id.ID())
 	}
 
 	locks.ByName(id.VirtualNetworkName, VirtualNetworkResourceName)
 	defer locks.UnlockByName(id.VirtualNetworkName, VirtualNetworkResourceName)
 
-	properties := network.SubnetPropertiesFormat{}
+	properties := subnets.SubnetPropertiesFormat{}
 	if value, ok := d.GetOk("address_prefixes"); ok {
 		var addressPrefixes []string
 		for _, item := range value.([]interface{}) {
@@ -302,15 +303,15 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	// To enable private endpoints you must disable the network policies for the subnet because
 	// Network policies like network security groups are not supported by private endpoints.
-	var privateEndpointNetworkPolicies network.VirtualNetworkPrivateEndpointNetworkPolicies
-	var privateLinkServiceNetworkPolicies network.VirtualNetworkPrivateLinkServiceNetworkPolicies
+	var privateEndpointNetworkPolicies subnets.VirtualNetworkPrivateEndpointNetworkPolicies
+	var privateLinkServiceNetworkPolicies subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies
 
 	if features.FourPointOhBeta() {
 		privateEndpointNetworkPoliciesRaw := d.Get("private_endpoint_network_policies_enabled").(bool)
 		privateLinkServiceNetworkPoliciesRaw := d.Get("private_link_service_network_policies_enabled").(bool)
 
-		privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
-		privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
+		privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+		privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
 	} else {
 		var enforceOk bool
 		var enforceServiceOk bool
@@ -322,8 +323,8 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		var privateLinkServiceNetworkPoliciesRaw bool
 
 		// Set the legacy default value since they are now computed optional
-		privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled
-		privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled
+		privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled
+		privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled
 
 		// This is the only way I was able to figure out if the fields are actually in the config or not,
 		// which is needed here because these are all now optional computed fields...
@@ -351,23 +352,23 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		// if neither of them are set use the default values
 		if enforceOk || enableOk {
 			if enforceOk {
-				privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
 			} else if enableOk {
-				privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
 			}
 		}
 
 		if enforceServiceOk || enableServiceOk {
 			if enforceServiceOk {
-				privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateLinkServiceNetworkPoliciesRaw))
+				privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateLinkServiceNetworkPoliciesRaw))
 			} else if enableServiceOk {
-				privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
+				privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
 			}
 		}
 	}
 
-	properties.PrivateEndpointNetworkPolicies = privateEndpointNetworkPolicies
-	properties.PrivateLinkServiceNetworkPolicies = privateLinkServiceNetworkPolicies
+	properties.PrivateEndpointNetworkPolicies = pointer.To(privateEndpointNetworkPolicies)
+	properties.PrivateLinkServiceNetworkPolicies = pointer.To(privateLinkServiceNetworkPolicies)
 
 	serviceEndpointPoliciesRaw := d.Get("service_endpoint_policy_ids").(*pluginsdk.Set).List()
 	properties.ServiceEndpointPolicies = expandSubnetServiceEndpointPolicies(serviceEndpointPoliciesRaw)
@@ -378,25 +379,20 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	delegationsRaw := d.Get("delegation").([]interface{})
 	properties.Delegations = expandSubnetDelegation(delegationsRaw)
 
-	subnet := network.Subnet{
-		Name:                   utils.String(id.SubnetName),
-		SubnetPropertiesFormat: &properties,
+	subnet := subnets.Subnet{
+		Name:       utils.String(id.SubnetName),
+		Properties: &properties,
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, subnet)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, subnet); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	timeout, _ := ctx.Deadline()
 
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, id),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -407,8 +403,8 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	vnetId := commonids.NewVirtualNetworkID(id.SubscriptionId, id.ResourceGroupName, id.VirtualNetworkName)
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -438,18 +434,22 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	locks.ByName(id.SubnetName, SubnetResourceName)
 	defer locks.UnlockByName(id.SubnetName, SubnetResourceName)
 
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	existing, err := client.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	if existing.SubnetPropertiesFormat == nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
 
 	// TODO: locking on the NSG/Route Table if applicable
 
-	props := *existing.SubnetPropertiesFormat
+	props := *existing.Model.Properties
 
 	if d.HasChange("address_prefixes") {
 		addressPrefixesRaw := d.Get("address_prefixes").([]interface{})
@@ -476,12 +476,12 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	if features.FourPointOhBeta() {
 		if d.HasChange("private_endpoint_network_policies_enabled") {
 			v := d.Get("private_endpoint_network_policies_enabled").(bool)
-			props.PrivateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(v))
+			props.PrivateEndpointNetworkPolicies = pointer.To(subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(v)))
 		}
 
 		if d.HasChange("private_link_service_network_policies_enabled") {
 			v := d.Get("private_link_service_network_policies_enabled").(bool)
-			props.PrivateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(v))
+			props.PrivateLinkServiceNetworkPolicies = pointer.To(subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(v)))
 		}
 	} else {
 		// This is the best case we can do in this state since they are computed optional fields now
@@ -489,20 +489,20 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		// one it will update it to the value that was changed and in the read the other value will be
 		// updated as well to reflect the new value so it is safe to toggle between which field you want
 		// to use to define this behavior...
-		var privateEndpointNetworkPolicies network.VirtualNetworkPrivateEndpointNetworkPolicies
-		var privateLinkServiceNetworkPolicies network.VirtualNetworkPrivateLinkServiceNetworkPolicies
+		var privateEndpointNetworkPolicies subnets.VirtualNetworkPrivateEndpointNetworkPolicies
+		var privateLinkServiceNetworkPolicies subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies
 
 		if d.HasChange("enforce_private_link_endpoint_network_policies") || d.HasChange("private_endpoint_network_policies_enabled") {
 			enforcePrivateEndpointNetworkPoliciesRaw := d.Get("enforce_private_link_endpoint_network_policies").(bool)
 			privateEndpointNetworkPoliciesRaw := d.Get("private_endpoint_network_policies_enabled").(bool)
 
 			if d.HasChange("enforce_private_link_endpoint_network_policies") {
-				privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
 			} else if d.HasChange("private_endpoint_network_policies_enabled") {
-				privateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
 			}
 
-			props.PrivateEndpointNetworkPolicies = privateEndpointNetworkPolicies
+			props.PrivateEndpointNetworkPolicies = pointer.To(privateEndpointNetworkPolicies)
 		}
 
 		if d.HasChange("enforce_private_link_service_network_policies") || d.HasChange("private_link_service_network_policies_enabled") {
@@ -510,12 +510,12 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			privateLinkServiceNetworkPoliciesRaw := d.Get("private_link_service_network_policies_enabled").(bool)
 
 			if d.HasChange("enforce_private_link_service_network_policies") {
-				privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateLinkServiceNetworkPoliciesRaw))
+				privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateLinkServiceNetworkPoliciesRaw))
 			} else if d.HasChange("private_link_service_network_policies_enabled") {
-				privateLinkServiceNetworkPolicies = network.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
+				privateLinkServiceNetworkPolicies = subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies(expandSubnetNetworkPolicy(privateLinkServiceNetworkPoliciesRaw))
 			}
 
-			props.PrivateLinkServiceNetworkPolicies = privateLinkServiceNetworkPolicies
+			props.PrivateLinkServiceNetworkPolicies = pointer.To(privateLinkServiceNetworkPolicies)
 		}
 	}
 
@@ -529,25 +529,20 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		props.ServiceEndpointPolicies = expandSubnetServiceEndpointPolicies(serviceEndpointPoliciesRaw)
 	}
 
-	subnet := network.Subnet{
-		Name:                   utils.String(id.SubnetName),
-		SubnetPropertiesFormat: &props,
+	subnet := subnets.Subnet{
+		Name:       utils.String(id.SubnetName),
+		Properties: &props,
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, subnet)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, subnet); err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s: %+v", *id, err)
 	}
 
 	timeout, _ := ctx.Deadline()
 
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *id),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -558,8 +553,8 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	vnetId := commonids.NewVirtualNetworkID(id.SubscriptionId, id.ResourceGroupName, id.VirtualNetworkName)
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -582,9 +577,9 @@ func resourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := client.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
@@ -595,38 +590,40 @@ func resourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", id.VirtualNetworkName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if props := resp.SubnetPropertiesFormat; props != nil {
-		if props.AddressPrefixes == nil {
-			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
-				d.Set("address_prefixes", []string{*props.AddressPrefix})
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.AddressPrefixes == nil {
+				if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+					d.Set("address_prefixes", []string{*props.AddressPrefix})
+				} else {
+					d.Set("address_prefixes", []string{})
+				}
 			} else {
-				d.Set("address_prefixes", []string{})
+				d.Set("address_prefixes", props.AddressPrefixes)
 			}
-		} else {
-			d.Set("address_prefixes", props.AddressPrefixes)
-		}
 
-		delegation := flattenSubnetDelegation(props.Delegations)
-		if err := d.Set("delegation", delegation); err != nil {
-			return fmt.Errorf("flattening `delegation`: %+v", err)
-		}
+			delegation := flattenSubnetDelegation(props.Delegations)
+			if err := d.Set("delegation", delegation); err != nil {
+				return fmt.Errorf("flattening `delegation`: %+v", err)
+			}
 
-		if !features.FourPointOhBeta() {
-			d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(props.PrivateEndpointNetworkPolicies)))
-			d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(props.PrivateLinkServiceNetworkPolicies)))
-		}
+			if !features.FourPointOhBeta() {
+				d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(pointer.From(props.PrivateEndpointNetworkPolicies))))
+				d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
+			}
 
-		d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(props.PrivateEndpointNetworkPolicies)))
-		d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(props.PrivateLinkServiceNetworkPolicies)))
+			d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateEndpointNetworkPolicies))))
+			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 
-		serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-		if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
-			return fmt.Errorf("setting `service_endpoints`: %+v", err)
-		}
+			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
+			if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
+				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			}
 
-		serviceEndpointPolicies := flattenSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)
-		if err := d.Set("service_endpoint_policy_ids", serviceEndpointPolicies); err != nil {
-			return fmt.Errorf("setting `service_endpoint_policy_ids`: %+v", err)
+			serviceEndpointPolicies := flattenSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)
+			if err := d.Set("service_endpoint_policy_ids", serviceEndpointPolicies); err != nil {
+				return fmt.Errorf("setting `service_endpoint_policy_ids`: %+v", err)
+			}
 		}
 	}
 
@@ -649,13 +646,13 @@ func resourceSubnetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	locks.ByName(id.SubnetName, SubnetResourceName)
 	defer locks.UnlockByName(id.SubnetName, SubnetResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName)
+	future, err := client.Delete(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		if !response.WasNotFound(future.Response()) {
+	if err := future.Poller.PollUntilDone(ctx); err != nil {
+		if !response.WasNotFound(future.HttpResponse) {
 			return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 		}
 	}
@@ -663,12 +660,12 @@ func resourceSubnetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandSubnetServiceEndpoints(input []interface{}) *[]network.ServiceEndpointPropertiesFormat {
-	endpoints := make([]network.ServiceEndpointPropertiesFormat, 0)
+func expandSubnetServiceEndpoints(input []interface{}) *[]subnets.ServiceEndpointPropertiesFormat {
+	endpoints := make([]subnets.ServiceEndpointPropertiesFormat, 0)
 
 	for _, svcEndpointRaw := range input {
 		if svc, ok := svcEndpointRaw.(string); ok {
-			endpoint := network.ServiceEndpointPropertiesFormat{
+			endpoint := subnets.ServiceEndpointPropertiesFormat{
 				Service: &svc,
 			}
 			endpoints = append(endpoints, endpoint)
@@ -678,7 +675,7 @@ func expandSubnetServiceEndpoints(input []interface{}) *[]network.ServiceEndpoin
 	return &endpoints
 }
 
-func flattenSubnetServiceEndpoints(serviceEndpoints *[]network.ServiceEndpointPropertiesFormat) []interface{} {
+func flattenSubnetServiceEndpoints(serviceEndpoints *[]subnets.ServiceEndpointPropertiesFormat) []interface{} {
 	endpoints := make([]interface{}, 0)
 
 	if serviceEndpoints == nil {
@@ -694,8 +691,8 @@ func flattenSubnetServiceEndpoints(serviceEndpoints *[]network.ServiceEndpointPr
 	return endpoints
 }
 
-func expandSubnetDelegation(input []interface{}) *[]network.Delegation {
-	retDelegations := make([]network.Delegation, 0)
+func expandSubnetDelegation(input []interface{}) *[]subnets.Delegation {
+	retDelegations := make([]subnets.Delegation, 0)
 
 	for _, deleValue := range input {
 		deleData := deleValue.(map[string]interface{})
@@ -711,9 +708,9 @@ func expandSubnetDelegation(input []interface{}) *[]network.Delegation {
 			retSrvActions = append(retSrvActions, srvActionData)
 		}
 
-		retDelegation := network.Delegation{
+		retDelegation := subnets.Delegation{
 			Name: &deleName,
-			ServiceDelegationPropertiesFormat: &network.ServiceDelegationPropertiesFormat{
+			Properties: &subnets.ServiceDelegationPropertiesFormat{
 				ServiceName: &srvName,
 				Actions:     &retSrvActions,
 			},
@@ -725,7 +722,7 @@ func expandSubnetDelegation(input []interface{}) *[]network.Delegation {
 	return &retDelegations
 }
 
-func flattenSubnetDelegation(delegations *[]network.Delegation) []interface{} {
+func flattenSubnetDelegation(delegations *[]subnets.Delegation) []interface{} {
 	if delegations == nil {
 		return []interface{}{}
 	}
@@ -745,7 +742,7 @@ func flattenSubnetDelegation(delegations *[]network.Delegation) []interface{} {
 
 		svcDeles := make([]interface{}, 0)
 		svcDele := make(map[string]interface{})
-		if props := dele.ServiceDelegationPropertiesFormat; props != nil {
+		if props := dele.Properties; props != nil {
 			if v := props.ServiceName; v != nil {
 				name := *v
 				if nv, ok := normalizeServiceName[strings.ToLower(name)]; ok {
@@ -775,18 +772,18 @@ func expandEnforceSubnetNetworkPolicy(enabled bool) string {
 	// I exposed it with the same name that the Azure CLI does to be consistent
 	// between the tool sets, which means true == Disabled.
 	if enabled {
-		return string(network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)
+		return string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)
 	}
 
-	return string(network.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)
+	return string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)
 }
 
 func expandSubnetNetworkPolicy(enabled bool) string {
 	if enabled {
-		return string(network.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)
+		return string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)
 	}
 
-	return string(network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)
+	return string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)
 }
 
 // TODO 4.0: Remove flattenEnforceSubnetPrivateLinkNetworkPolicy function
@@ -794,23 +791,23 @@ func flattenEnforceSubnetNetworkPolicy(input string) bool {
 	// This is strange logic, but to get the schema to make sense for the end user
 	// I exposed it with the same name that the Azure CLI does to be consistent
 	// between the tool sets, which means true == Disabled.
-	return strings.EqualFold(input, string(network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled))
+	return strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled))
 }
 
 func flattenSubnetNetworkPolicy(input string) bool {
-	return strings.EqualFold(input, string(network.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled))
+	return strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled))
 }
 
-func expandSubnetServiceEndpointPolicies(input []interface{}) *[]network.ServiceEndpointPolicy {
-	output := make([]network.ServiceEndpointPolicy, 0)
+func expandSubnetServiceEndpointPolicies(input []interface{}) *[]subnets.ServiceEndpointPolicy {
+	output := make([]subnets.ServiceEndpointPolicy, 0)
 	for _, policy := range input {
 		policy := policy.(string)
-		output = append(output, network.ServiceEndpointPolicy{ID: &policy})
+		output = append(output, subnets.ServiceEndpointPolicy{Id: &policy})
 	}
 	return &output
 }
 
-func flattenSubnetServiceEndpointPolicies(input *[]network.ServiceEndpointPolicy) []interface{} {
+func flattenSubnetServiceEndpointPolicies(input *[]subnets.ServiceEndpointPolicy) []interface{} {
 	if input == nil {
 		return nil
 	}
@@ -818,21 +815,24 @@ func flattenSubnetServiceEndpointPolicies(input *[]network.ServiceEndpointPolicy
 	var output []interface{}
 	for _, policy := range *input {
 		id := ""
-		if policy.ID != nil {
-			id = *policy.ID
+		if policy.Id != nil {
+			id = *policy.Id
 		}
 		output = append(output, id)
 	}
 	return output
 }
 
-func SubnetProvisioningStateRefreshFunc(ctx context.Context, client *network.SubnetsClient, id commonids.SubnetId) pluginsdk.StateRefreshFunc {
+func SubnetProvisioningStateRefreshFunc(ctx context.Context, client *subnets.SubnetsClient, id commonids.SubnetId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+		res, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())
 		if err != nil {
 			return nil, "", fmt.Errorf("polling for %s: %+v", id.String(), err)
 		}
 
-		return res, string(res.ProvisioningState), nil
+		if res.Model != nil && res.Model.Properties != nil && res.Model.Properties.ProvisioningState != nil {
+			return res, string(*res.Model.Properties.ProvisioningState), nil
+		}
+		return nil, "", fmt.Errorf("unable to read provisioning state")
 	}
 }

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -6,11 +6,11 @@ package network
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 var SubnetResourceName = "azurerm_subnet"
@@ -834,5 +835,16 @@ func SubnetProvisioningStateRefreshFunc(ctx context.Context, client *subnets.Sub
 			return res, string(*res.Model.Properties.ProvisioningState), nil
 		}
 		return nil, "", fmt.Errorf("unable to read provisioning state")
+	}
+}
+
+func LegacySubnetProvisioningStateRefreshFunc(ctx context.Context, client *network.SubnetsClient, id commonids.SubnetId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("polling for %s: %+v", id.String(), err)
+		}
+
+		return res, string(res.ProvisioningState), nil
 	}
 }

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -557,12 +559,12 @@ func (t SubnetResource) Exists(ctx context.Context, clients *clients.Client, sta
 		return nil, err
 	}
 
-	resp, err := clients.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := clients.Network.SubnetsClient.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("reading Subnet (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (SubnetResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -571,13 +573,8 @@ func (SubnetResource) Destroy(ctx context.Context, client *clients.Client, state
 		return nil, err
 	}
 
-	future, err := client.Network.SubnetsClient.Delete(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName)
-	if err != nil {
+	if err := client.Network.SubnetsClient.DeleteThenPoll(ctx, *id); err != nil {
 		return nil, fmt.Errorf("deleting Subnet %q: %+v", id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Network.SubnetsClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for deletion of Subnet %q: %+v", id, err)
 	}
 
 	return utils.Bool(true), nil
@@ -589,21 +586,25 @@ func (SubnetResource) hasNoNatGateway(ctx context.Context, client *clients.Clien
 		return err
 	}
 
-	subnet, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	subnet, err := client.Network.SubnetsClient.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(subnet.Response) {
+		if response.WasNotFound(subnet.HttpResponse) {
 			return fmt.Errorf("%s does not exist", id)
 		}
 		return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 	}
 
-	props := subnet.SubnetPropertiesFormat
+	if subnet.Model == nil {
+		return fmt.Errorf("model was nil for %s", id)
+	}
+
+	props := subnet.Model.Properties
 	if props == nil {
 		return fmt.Errorf("properties was nil for %s", id)
 	}
 
-	if props.NatGateway != nil && ((props.NatGateway.ID == nil) || (props.NatGateway.ID != nil && *props.NatGateway.ID == "")) {
-		return fmt.Errorf("no Route Table should exist for %s but got %q", id, *props.RouteTable.ID)
+	if props.NatGateway != nil && ((props.NatGateway.Id == nil) || (props.NatGateway.Id != nil && *props.NatGateway.Id == "")) {
+		return fmt.Errorf("no Route Table should exist for %s but got %q", id, *props.RouteTable.Id)
 	}
 	return nil
 }
@@ -614,22 +615,26 @@ func (SubnetResource) hasNoNetworkSecurityGroup(ctx context.Context, client *cli
 		return err
 	}
 
-	resp, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := client.Network.SubnetsClient.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s does not exist", id)
 		}
 
 		return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 	}
 
-	props := resp.SubnetPropertiesFormat
+	if resp.Model == nil {
+		return fmt.Errorf("model was nil for %s", id)
+	}
+
+	props := resp.Model.Properties
 	if props == nil {
 		return fmt.Errorf("properties was nil for %s", id)
 	}
 
-	if props.NetworkSecurityGroup != nil && ((props.NetworkSecurityGroup.ID == nil) || (props.NetworkSecurityGroup.ID != nil && *props.NetworkSecurityGroup.ID == "")) {
-		return fmt.Errorf("no Network Security Group should exist for %s but got %q", id, *props.NetworkSecurityGroup.ID)
+	if props.NetworkSecurityGroup != nil && ((props.NetworkSecurityGroup.Id == nil) || (props.NetworkSecurityGroup.Id != nil && *props.NetworkSecurityGroup.Id == "")) {
+		return fmt.Errorf("no Network Security Group should exist for %s but got %q", id, *props.NetworkSecurityGroup.Id)
 	}
 
 	return nil
@@ -641,22 +646,26 @@ func (SubnetResource) hasNoRouteTable(ctx context.Context, client *clients.Clien
 		return err
 	}
 
-	resp, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroupName, id.VirtualNetworkName, id.SubnetName, "")
+	resp, err := client.Network.SubnetsClient.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s does not exist", id)
 		}
 
 		return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 	}
 
-	props := resp.SubnetPropertiesFormat
+	if resp.Model == nil {
+		return fmt.Errorf("model was nil for %s", id)
+	}
+
+	props := resp.Model.Properties
 	if props == nil {
 		return fmt.Errorf("properties was nil for %s", id)
 	}
 
-	if props.RouteTable != nil && ((props.RouteTable.ID == nil) || (props.RouteTable.ID != nil && *props.RouteTable.ID == "")) {
-		return fmt.Errorf("no Route Table should exist for %s but got %q", id, *props.RouteTable.ID)
+	if props.RouteTable != nil && ((props.RouteTable.Id == nil) || (props.RouteTable.Id != nil && *props.RouteTable.Id == "")) {
+		return fmt.Errorf("no Route Table should exist for %s but got %q", id, *props.RouteTable.Id)
 	}
 
 	return nil

--- a/internal/services/network/subnet_route_table_association_resource.go
+++ b/internal/services/network/subnet_route_table_association_resource.go
@@ -55,7 +55,7 @@ func resourceSubnetRouteTableAssociation() *pluginsdk.Resource {
 }
 
 func resourceSubnetRouteTableAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -121,7 +121,7 @@ func resourceSubnetRouteTableAssociationCreate(d *pluginsdk.ResourceData, meta i
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(network.ProvisioningStateUpdating)},
 		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
+		Refresh:    LegacySubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
@@ -147,7 +147,7 @@ func resourceSubnetRouteTableAssociationCreate(d *pluginsdk.ResourceData, meta i
 }
 
 func resourceSubnetRouteTableAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -188,7 +188,7 @@ func resourceSubnetRouteTableAssociationRead(d *pluginsdk.ResourceData, meta int
 }
 
 func resourceSubnetRouteTableAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SubnetsClient
+	client := meta.(*clients.Client).Network.LegacySubnetsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_route_table_association_resource_test.go
+++ b/internal/services/network/subnet_route_table_association_resource_test.go
@@ -103,7 +103,7 @@ func (SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *
 	virtualNetworkName := id.VirtualNetworkName
 	subnetName := id.SubnetName
 
-	resp, err := clients.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
+	resp, err := clients.Network.LegacySubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
 		return nil, fmt.Errorf("reading Subnet Route Table Association (%s): %+v", id, err)
 	}

--- a/internal/services/network/subnet_route_table_association_resource_test.go
+++ b/internal/services/network/subnet_route_table_association_resource_test.go
@@ -126,7 +126,7 @@ func (SubnetRouteTableAssociationResource) destroy(ctx context.Context, client *
 	virtualNetworkName := parsedId.VirtualNetworkName
 	subnetName := parsedId.SubnetName
 
-	read, err := client.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
+	read, err := client.Network.LegacySubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
 		if !utils.ResponseWasNotFound(read.Response) {
 			return fmt.Errorf("retrieving Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
@@ -135,11 +135,11 @@ func (SubnetRouteTableAssociationResource) destroy(ctx context.Context, client *
 
 	read.SubnetPropertiesFormat.RouteTable = nil
 
-	future, err := client.Network.SubnetsClient.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, read)
+	future, err := client.Network.LegacySubnetsClient.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, read)
 	if err != nil {
 		return fmt.Errorf("updating Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Network.SubnetsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, client.Network.LegacySubnetsClient.Client); err != nil {
 		return fmt.Errorf("waiting for completion of Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
 	}
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -541,7 +541,7 @@ func resourceAzureSubnetHash(v interface{}) int {
 }
 
 func getExistingSubnet(ctx context.Context, resGroup string, vnetName string, subnetName string, meta interface{}) (*network.Subnet, error) {
-	subnetClient := meta.(*clients.Client).Network.SubnetsClient
+	subnetClient := meta.(*clients.Client).Network.LegacySubnetsClient
 	resp, err := subnetClient.Get(ctx, resGroup, vnetName, subnetName, "")
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/README.md
@@ -1,0 +1,83 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets` Documentation
+
+The `subnets` SDK allows for interaction with the Azure Resource Manager Service `network` (API Version `2023-09-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
+```
+
+
+### Client Initialization
+
+```go
+client := subnets.NewSubnetsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `SubnetsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+
+payload := subnets.Subnet{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `SubnetsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `SubnetsClient.Get`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue", "subnetValue")
+
+read, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SubnetsClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/client.go
@@ -1,0 +1,26 @@
+package subnets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewSubnetsClientWithBaseURI(sdkApi sdkEnv.Api) (*SubnetsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "subnets", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating SubnetsClient: %+v", err)
+	}
+
+	return &SubnetsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/constants.go
@@ -1,0 +1,1157 @@
+package subnets
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosSettingsProtectionMode string
+
+const (
+	DdosSettingsProtectionModeDisabled                DdosSettingsProtectionMode = "Disabled"
+	DdosSettingsProtectionModeEnabled                 DdosSettingsProtectionMode = "Enabled"
+	DdosSettingsProtectionModeVirtualNetworkInherited DdosSettingsProtectionMode = "VirtualNetworkInherited"
+)
+
+func PossibleValuesForDdosSettingsProtectionMode() []string {
+	return []string{
+		string(DdosSettingsProtectionModeDisabled),
+		string(DdosSettingsProtectionModeEnabled),
+		string(DdosSettingsProtectionModeVirtualNetworkInherited),
+	}
+}
+
+func (s *DdosSettingsProtectionMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDdosSettingsProtectionMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDdosSettingsProtectionMode(input string) (*DdosSettingsProtectionMode, error) {
+	vals := map[string]DdosSettingsProtectionMode{
+		"disabled":                DdosSettingsProtectionModeDisabled,
+		"enabled":                 DdosSettingsProtectionModeEnabled,
+		"virtualnetworkinherited": DdosSettingsProtectionModeVirtualNetworkInherited,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DdosSettingsProtectionMode(input)
+	return &out, nil
+}
+
+type DeleteOptions string
+
+const (
+	DeleteOptionsDelete DeleteOptions = "Delete"
+	DeleteOptionsDetach DeleteOptions = "Detach"
+)
+
+func PossibleValuesForDeleteOptions() []string {
+	return []string{
+		string(DeleteOptionsDelete),
+		string(DeleteOptionsDetach),
+	}
+}
+
+func (s *DeleteOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeleteOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeleteOptions(input string) (*DeleteOptions, error) {
+	vals := map[string]DeleteOptions{
+		"delete": DeleteOptionsDelete,
+		"detach": DeleteOptionsDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeleteOptions(input)
+	return &out, nil
+}
+
+type FlowLogFormatType string
+
+const (
+	FlowLogFormatTypeJSON FlowLogFormatType = "JSON"
+)
+
+func PossibleValuesForFlowLogFormatType() []string {
+	return []string{
+		string(FlowLogFormatTypeJSON),
+	}
+}
+
+func (s *FlowLogFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseFlowLogFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseFlowLogFormatType(input string) (*FlowLogFormatType, error) {
+	vals := map[string]FlowLogFormatType{
+		"json": FlowLogFormatTypeJSON,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FlowLogFormatType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelInterfaceType string
+
+const (
+	GatewayLoadBalancerTunnelInterfaceTypeExternal GatewayLoadBalancerTunnelInterfaceType = "External"
+	GatewayLoadBalancerTunnelInterfaceTypeInternal GatewayLoadBalancerTunnelInterfaceType = "Internal"
+	GatewayLoadBalancerTunnelInterfaceTypeNone     GatewayLoadBalancerTunnelInterfaceType = "None"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelInterfaceType() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelInterfaceTypeExternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeInternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeNone),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelInterfaceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelInterfaceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelInterfaceType(input string) (*GatewayLoadBalancerTunnelInterfaceType, error) {
+	vals := map[string]GatewayLoadBalancerTunnelInterfaceType{
+		"external": GatewayLoadBalancerTunnelInterfaceTypeExternal,
+		"internal": GatewayLoadBalancerTunnelInterfaceTypeInternal,
+		"none":     GatewayLoadBalancerTunnelInterfaceTypeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelInterfaceType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelProtocol string
+
+const (
+	GatewayLoadBalancerTunnelProtocolNative GatewayLoadBalancerTunnelProtocol = "Native"
+	GatewayLoadBalancerTunnelProtocolNone   GatewayLoadBalancerTunnelProtocol = "None"
+	GatewayLoadBalancerTunnelProtocolVXLAN  GatewayLoadBalancerTunnelProtocol = "VXLAN"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelProtocol() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelProtocolNative),
+		string(GatewayLoadBalancerTunnelProtocolNone),
+		string(GatewayLoadBalancerTunnelProtocolVXLAN),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelProtocol(input string) (*GatewayLoadBalancerTunnelProtocol, error) {
+	vals := map[string]GatewayLoadBalancerTunnelProtocol{
+		"native": GatewayLoadBalancerTunnelProtocolNative,
+		"none":   GatewayLoadBalancerTunnelProtocolNone,
+		"vxlan":  GatewayLoadBalancerTunnelProtocolVXLAN,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelProtocol(input)
+	return &out, nil
+}
+
+type IPAllocationMethod string
+
+const (
+	IPAllocationMethodDynamic IPAllocationMethod = "Dynamic"
+	IPAllocationMethodStatic  IPAllocationMethod = "Static"
+)
+
+func PossibleValuesForIPAllocationMethod() []string {
+	return []string{
+		string(IPAllocationMethodDynamic),
+		string(IPAllocationMethodStatic),
+	}
+}
+
+func (s *IPAllocationMethod) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPAllocationMethod(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPAllocationMethod(input string) (*IPAllocationMethod, error) {
+	vals := map[string]IPAllocationMethod{
+		"dynamic": IPAllocationMethodDynamic,
+		"static":  IPAllocationMethodStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPAllocationMethod(input)
+	return &out, nil
+}
+
+type IPVersion string
+
+const (
+	IPVersionIPvFour IPVersion = "IPv4"
+	IPVersionIPvSix  IPVersion = "IPv6"
+)
+
+func PossibleValuesForIPVersion() []string {
+	return []string{
+		string(IPVersionIPvFour),
+		string(IPVersionIPvSix),
+	}
+}
+
+func (s *IPVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersion(input string) (*IPVersion, error) {
+	vals := map[string]IPVersion{
+		"ipv4": IPVersionIPvFour,
+		"ipv6": IPVersionIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersion(input)
+	return &out, nil
+}
+
+type LoadBalancerBackendAddressAdminState string
+
+const (
+	LoadBalancerBackendAddressAdminStateDown LoadBalancerBackendAddressAdminState = "Down"
+	LoadBalancerBackendAddressAdminStateNone LoadBalancerBackendAddressAdminState = "None"
+	LoadBalancerBackendAddressAdminStateUp   LoadBalancerBackendAddressAdminState = "Up"
+)
+
+func PossibleValuesForLoadBalancerBackendAddressAdminState() []string {
+	return []string{
+		string(LoadBalancerBackendAddressAdminStateDown),
+		string(LoadBalancerBackendAddressAdminStateNone),
+		string(LoadBalancerBackendAddressAdminStateUp),
+	}
+}
+
+func (s *LoadBalancerBackendAddressAdminState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerBackendAddressAdminState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerBackendAddressAdminState(input string) (*LoadBalancerBackendAddressAdminState, error) {
+	vals := map[string]LoadBalancerBackendAddressAdminState{
+		"down": LoadBalancerBackendAddressAdminStateDown,
+		"none": LoadBalancerBackendAddressAdminStateNone,
+		"up":   LoadBalancerBackendAddressAdminStateUp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerBackendAddressAdminState(input)
+	return &out, nil
+}
+
+type NatGatewaySkuName string
+
+const (
+	NatGatewaySkuNameStandard NatGatewaySkuName = "Standard"
+)
+
+func PossibleValuesForNatGatewaySkuName() []string {
+	return []string{
+		string(NatGatewaySkuNameStandard),
+	}
+}
+
+func (s *NatGatewaySkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNatGatewaySkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNatGatewaySkuName(input string) (*NatGatewaySkuName, error) {
+	vals := map[string]NatGatewaySkuName{
+		"standard": NatGatewaySkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NatGatewaySkuName(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliaryMode string
+
+const (
+	NetworkInterfaceAuxiliaryModeAcceleratedConnections NetworkInterfaceAuxiliaryMode = "AcceleratedConnections"
+	NetworkInterfaceAuxiliaryModeFloating               NetworkInterfaceAuxiliaryMode = "Floating"
+	NetworkInterfaceAuxiliaryModeMaxConnections         NetworkInterfaceAuxiliaryMode = "MaxConnections"
+	NetworkInterfaceAuxiliaryModeNone                   NetworkInterfaceAuxiliaryMode = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliaryMode() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+		string(NetworkInterfaceAuxiliaryModeFloating),
+		string(NetworkInterfaceAuxiliaryModeMaxConnections),
+		string(NetworkInterfaceAuxiliaryModeNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliaryMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliaryMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliaryMode(input string) (*NetworkInterfaceAuxiliaryMode, error) {
+	vals := map[string]NetworkInterfaceAuxiliaryMode{
+		"acceleratedconnections": NetworkInterfaceAuxiliaryModeAcceleratedConnections,
+		"floating":               NetworkInterfaceAuxiliaryModeFloating,
+		"maxconnections":         NetworkInterfaceAuxiliaryModeMaxConnections,
+		"none":                   NetworkInterfaceAuxiliaryModeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliaryMode(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliarySku string
+
+const (
+	NetworkInterfaceAuxiliarySkuAEight NetworkInterfaceAuxiliarySku = "A8"
+	NetworkInterfaceAuxiliarySkuAFour  NetworkInterfaceAuxiliarySku = "A4"
+	NetworkInterfaceAuxiliarySkuAOne   NetworkInterfaceAuxiliarySku = "A1"
+	NetworkInterfaceAuxiliarySkuATwo   NetworkInterfaceAuxiliarySku = "A2"
+	NetworkInterfaceAuxiliarySkuNone   NetworkInterfaceAuxiliarySku = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliarySku() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliarySkuAEight),
+		string(NetworkInterfaceAuxiliarySkuAFour),
+		string(NetworkInterfaceAuxiliarySkuAOne),
+		string(NetworkInterfaceAuxiliarySkuATwo),
+		string(NetworkInterfaceAuxiliarySkuNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliarySku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliarySku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliarySku(input string) (*NetworkInterfaceAuxiliarySku, error) {
+	vals := map[string]NetworkInterfaceAuxiliarySku{
+		"a8":   NetworkInterfaceAuxiliarySkuAEight,
+		"a4":   NetworkInterfaceAuxiliarySkuAFour,
+		"a1":   NetworkInterfaceAuxiliarySkuAOne,
+		"a2":   NetworkInterfaceAuxiliarySkuATwo,
+		"none": NetworkInterfaceAuxiliarySkuNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliarySku(input)
+	return &out, nil
+}
+
+type NetworkInterfaceMigrationPhase string
+
+const (
+	NetworkInterfaceMigrationPhaseAbort     NetworkInterfaceMigrationPhase = "Abort"
+	NetworkInterfaceMigrationPhaseCommit    NetworkInterfaceMigrationPhase = "Commit"
+	NetworkInterfaceMigrationPhaseCommitted NetworkInterfaceMigrationPhase = "Committed"
+	NetworkInterfaceMigrationPhaseNone      NetworkInterfaceMigrationPhase = "None"
+	NetworkInterfaceMigrationPhasePrepare   NetworkInterfaceMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForNetworkInterfaceMigrationPhase() []string {
+	return []string{
+		string(NetworkInterfaceMigrationPhaseAbort),
+		string(NetworkInterfaceMigrationPhaseCommit),
+		string(NetworkInterfaceMigrationPhaseCommitted),
+		string(NetworkInterfaceMigrationPhaseNone),
+		string(NetworkInterfaceMigrationPhasePrepare),
+	}
+}
+
+func (s *NetworkInterfaceMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceMigrationPhase(input string) (*NetworkInterfaceMigrationPhase, error) {
+	vals := map[string]NetworkInterfaceMigrationPhase{
+		"abort":     NetworkInterfaceMigrationPhaseAbort,
+		"commit":    NetworkInterfaceMigrationPhaseCommit,
+		"committed": NetworkInterfaceMigrationPhaseCommitted,
+		"none":      NetworkInterfaceMigrationPhaseNone,
+		"prepare":   NetworkInterfaceMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceMigrationPhase(input)
+	return &out, nil
+}
+
+type NetworkInterfaceNicType string
+
+const (
+	NetworkInterfaceNicTypeElastic  NetworkInterfaceNicType = "Elastic"
+	NetworkInterfaceNicTypeStandard NetworkInterfaceNicType = "Standard"
+)
+
+func PossibleValuesForNetworkInterfaceNicType() []string {
+	return []string{
+		string(NetworkInterfaceNicTypeElastic),
+		string(NetworkInterfaceNicTypeStandard),
+	}
+}
+
+func (s *NetworkInterfaceNicType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceNicType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceNicType(input string) (*NetworkInterfaceNicType, error) {
+	vals := map[string]NetworkInterfaceNicType{
+		"elastic":  NetworkInterfaceNicTypeElastic,
+		"standard": NetworkInterfaceNicTypeStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceNicType(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating  ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"updating":  ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type PublicIPAddressDnsSettingsDomainNameLabelScope string
+
+const (
+	PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse            PublicIPAddressDnsSettingsDomainNameLabelScope = "NoReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse PublicIPAddressDnsSettingsDomainNameLabelScope = "ResourceGroupReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse  PublicIPAddressDnsSettingsDomainNameLabelScope = "SubscriptionReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse        PublicIPAddressDnsSettingsDomainNameLabelScope = "TenantReuse"
+)
+
+func PossibleValuesForPublicIPAddressDnsSettingsDomainNameLabelScope() []string {
+	return []string{
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse),
+	}
+}
+
+func (s *PublicIPAddressDnsSettingsDomainNameLabelScope) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressDnsSettingsDomainNameLabelScope(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressDnsSettingsDomainNameLabelScope(input string) (*PublicIPAddressDnsSettingsDomainNameLabelScope, error) {
+	vals := map[string]PublicIPAddressDnsSettingsDomainNameLabelScope{
+		"noreuse":            PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse,
+		"resourcegroupreuse": PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse,
+		"subscriptionreuse":  PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse,
+		"tenantreuse":        PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressDnsSettingsDomainNameLabelScope(input)
+	return &out, nil
+}
+
+type PublicIPAddressMigrationPhase string
+
+const (
+	PublicIPAddressMigrationPhaseAbort     PublicIPAddressMigrationPhase = "Abort"
+	PublicIPAddressMigrationPhaseCommit    PublicIPAddressMigrationPhase = "Commit"
+	PublicIPAddressMigrationPhaseCommitted PublicIPAddressMigrationPhase = "Committed"
+	PublicIPAddressMigrationPhaseNone      PublicIPAddressMigrationPhase = "None"
+	PublicIPAddressMigrationPhasePrepare   PublicIPAddressMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForPublicIPAddressMigrationPhase() []string {
+	return []string{
+		string(PublicIPAddressMigrationPhaseAbort),
+		string(PublicIPAddressMigrationPhaseCommit),
+		string(PublicIPAddressMigrationPhaseCommitted),
+		string(PublicIPAddressMigrationPhaseNone),
+		string(PublicIPAddressMigrationPhasePrepare),
+	}
+}
+
+func (s *PublicIPAddressMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressMigrationPhase(input string) (*PublicIPAddressMigrationPhase, error) {
+	vals := map[string]PublicIPAddressMigrationPhase{
+		"abort":     PublicIPAddressMigrationPhaseAbort,
+		"commit":    PublicIPAddressMigrationPhaseCommit,
+		"committed": PublicIPAddressMigrationPhaseCommitted,
+		"none":      PublicIPAddressMigrationPhaseNone,
+		"prepare":   PublicIPAddressMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressMigrationPhase(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuName string
+
+const (
+	PublicIPAddressSkuNameBasic    PublicIPAddressSkuName = "Basic"
+	PublicIPAddressSkuNameStandard PublicIPAddressSkuName = "Standard"
+)
+
+func PossibleValuesForPublicIPAddressSkuName() []string {
+	return []string{
+		string(PublicIPAddressSkuNameBasic),
+		string(PublicIPAddressSkuNameStandard),
+	}
+}
+
+func (s *PublicIPAddressSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuName(input string) (*PublicIPAddressSkuName, error) {
+	vals := map[string]PublicIPAddressSkuName{
+		"basic":    PublicIPAddressSkuNameBasic,
+		"standard": PublicIPAddressSkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuName(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuTier string
+
+const (
+	PublicIPAddressSkuTierGlobal   PublicIPAddressSkuTier = "Global"
+	PublicIPAddressSkuTierRegional PublicIPAddressSkuTier = "Regional"
+)
+
+func PossibleValuesForPublicIPAddressSkuTier() []string {
+	return []string{
+		string(PublicIPAddressSkuTierGlobal),
+		string(PublicIPAddressSkuTierRegional),
+	}
+}
+
+func (s *PublicIPAddressSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuTier(input string) (*PublicIPAddressSkuTier, error) {
+	vals := map[string]PublicIPAddressSkuTier{
+		"global":   PublicIPAddressSkuTierGlobal,
+		"regional": PublicIPAddressSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuTier(input)
+	return &out, nil
+}
+
+type RouteNextHopType string
+
+const (
+	RouteNextHopTypeInternet              RouteNextHopType = "Internet"
+	RouteNextHopTypeNone                  RouteNextHopType = "None"
+	RouteNextHopTypeVirtualAppliance      RouteNextHopType = "VirtualAppliance"
+	RouteNextHopTypeVirtualNetworkGateway RouteNextHopType = "VirtualNetworkGateway"
+	RouteNextHopTypeVnetLocal             RouteNextHopType = "VnetLocal"
+)
+
+func PossibleValuesForRouteNextHopType() []string {
+	return []string{
+		string(RouteNextHopTypeInternet),
+		string(RouteNextHopTypeNone),
+		string(RouteNextHopTypeVirtualAppliance),
+		string(RouteNextHopTypeVirtualNetworkGateway),
+		string(RouteNextHopTypeVnetLocal),
+	}
+}
+
+func (s *RouteNextHopType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRouteNextHopType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRouteNextHopType(input string) (*RouteNextHopType, error) {
+	vals := map[string]RouteNextHopType{
+		"internet":              RouteNextHopTypeInternet,
+		"none":                  RouteNextHopTypeNone,
+		"virtualappliance":      RouteNextHopTypeVirtualAppliance,
+		"virtualnetworkgateway": RouteNextHopTypeVirtualNetworkGateway,
+		"vnetlocal":             RouteNextHopTypeVnetLocal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RouteNextHopType(input)
+	return &out, nil
+}
+
+type SecurityRuleAccess string
+
+const (
+	SecurityRuleAccessAllow SecurityRuleAccess = "Allow"
+	SecurityRuleAccessDeny  SecurityRuleAccess = "Deny"
+)
+
+func PossibleValuesForSecurityRuleAccess() []string {
+	return []string{
+		string(SecurityRuleAccessAllow),
+		string(SecurityRuleAccessDeny),
+	}
+}
+
+func (s *SecurityRuleAccess) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleAccess(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleAccess(input string) (*SecurityRuleAccess, error) {
+	vals := map[string]SecurityRuleAccess{
+		"allow": SecurityRuleAccessAllow,
+		"deny":  SecurityRuleAccessDeny,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleAccess(input)
+	return &out, nil
+}
+
+type SecurityRuleDirection string
+
+const (
+	SecurityRuleDirectionInbound  SecurityRuleDirection = "Inbound"
+	SecurityRuleDirectionOutbound SecurityRuleDirection = "Outbound"
+)
+
+func PossibleValuesForSecurityRuleDirection() []string {
+	return []string{
+		string(SecurityRuleDirectionInbound),
+		string(SecurityRuleDirectionOutbound),
+	}
+}
+
+func (s *SecurityRuleDirection) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleDirection(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleDirection(input string) (*SecurityRuleDirection, error) {
+	vals := map[string]SecurityRuleDirection{
+		"inbound":  SecurityRuleDirectionInbound,
+		"outbound": SecurityRuleDirectionOutbound,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleDirection(input)
+	return &out, nil
+}
+
+type SecurityRuleProtocol string
+
+const (
+	SecurityRuleProtocolAh   SecurityRuleProtocol = "Ah"
+	SecurityRuleProtocolAny  SecurityRuleProtocol = "*"
+	SecurityRuleProtocolEsp  SecurityRuleProtocol = "Esp"
+	SecurityRuleProtocolIcmp SecurityRuleProtocol = "Icmp"
+	SecurityRuleProtocolTcp  SecurityRuleProtocol = "Tcp"
+	SecurityRuleProtocolUdp  SecurityRuleProtocol = "Udp"
+)
+
+func PossibleValuesForSecurityRuleProtocol() []string {
+	return []string{
+		string(SecurityRuleProtocolAh),
+		string(SecurityRuleProtocolAny),
+		string(SecurityRuleProtocolEsp),
+		string(SecurityRuleProtocolIcmp),
+		string(SecurityRuleProtocolTcp),
+		string(SecurityRuleProtocolUdp),
+	}
+}
+
+func (s *SecurityRuleProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleProtocol(input string) (*SecurityRuleProtocol, error) {
+	vals := map[string]SecurityRuleProtocol{
+		"ah":   SecurityRuleProtocolAh,
+		"*":    SecurityRuleProtocolAny,
+		"esp":  SecurityRuleProtocolEsp,
+		"icmp": SecurityRuleProtocolIcmp,
+		"tcp":  SecurityRuleProtocolTcp,
+		"udp":  SecurityRuleProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleProtocol(input)
+	return &out, nil
+}
+
+type SyncMode string
+
+const (
+	SyncModeAutomatic SyncMode = "Automatic"
+	SyncModeManual    SyncMode = "Manual"
+)
+
+func PossibleValuesForSyncMode() []string {
+	return []string{
+		string(SyncModeAutomatic),
+		string(SyncModeManual),
+	}
+}
+
+func (s *SyncMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSyncMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSyncMode(input string) (*SyncMode, error) {
+	vals := map[string]SyncMode{
+		"automatic": SyncModeAutomatic,
+		"manual":    SyncModeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SyncMode(input)
+	return &out, nil
+}
+
+type TransportProtocol string
+
+const (
+	TransportProtocolAll TransportProtocol = "All"
+	TransportProtocolTcp TransportProtocol = "Tcp"
+	TransportProtocolUdp TransportProtocol = "Udp"
+)
+
+func PossibleValuesForTransportProtocol() []string {
+	return []string{
+		string(TransportProtocolAll),
+		string(TransportProtocolTcp),
+		string(TransportProtocolUdp),
+	}
+}
+
+func (s *TransportProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTransportProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTransportProtocol(input string) (*TransportProtocol, error) {
+	vals := map[string]TransportProtocol{
+		"all": TransportProtocolAll,
+		"tcp": TransportProtocolTcp,
+		"udp": TransportProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TransportProtocol(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateEndpointNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateEndpointNetworkPoliciesDisabled                    VirtualNetworkPrivateEndpointNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesEnabled                     VirtualNetworkPrivateEndpointNetworkPolicies = "Enabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled VirtualNetworkPrivateEndpointNetworkPolicies = "NetworkSecurityGroupEnabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled           VirtualNetworkPrivateEndpointNetworkPolicies = "RouteTableEnabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateEndpointNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesEnabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateEndpointNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateEndpointNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateEndpointNetworkPolicies(input string) (*VirtualNetworkPrivateEndpointNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateEndpointNetworkPolicies{
+		"disabled":                    VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
+		"enabled":                     VirtualNetworkPrivateEndpointNetworkPoliciesEnabled,
+		"networksecuritygroupenabled": VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled,
+		"routetableenabled":           VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateEndpointNetworkPolicies(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateLinkServiceNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled VirtualNetworkPrivateLinkServiceNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled  VirtualNetworkPrivateLinkServiceNetworkPolicies = "Enabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateLinkServiceNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateLinkServiceNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateLinkServiceNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateLinkServiceNetworkPolicies(input string) (*VirtualNetworkPrivateLinkServiceNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateLinkServiceNetworkPolicies{
+		"disabled": VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
+		"enabled":  VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateLinkServiceNetworkPolicies(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_createorupdate.go
@@ -1,0 +1,76 @@
+package subnets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Subnet
+}
+
+// CreateOrUpdate ...
+func (c SubnetsClient) CreateOrUpdate(ctx context.Context, id commonids.SubnetId, input Subnet) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c SubnetsClient) CreateOrUpdateThenPoll(ctx context.Context, id commonids.SubnetId, input Subnet) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_delete.go
@@ -1,0 +1,72 @@
+package subnets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c SubnetsClient) Delete(ctx context.Context, id commonids.SubnetId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c SubnetsClient) DeleteThenPoll(ctx context.Context, id commonids.SubnetId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_get.go
@@ -1,0 +1,81 @@
+package subnets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Subnet
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c SubnetsClient) Get(ctx context.Context, id commonids.SubnetId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/method_list.go
@@ -1,0 +1,92 @@
+package subnets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Subnet
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Subnet
+}
+
+// List ...
+func (c SubnetsClient) List(ctx context.Context, id commonids.VirtualNetworkId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/subnets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Subnet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c SubnetsClient) ListComplete(ctx context.Context, id commonids.VirtualNetworkId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, SubnetOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c SubnetsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.VirtualNetworkId, predicate SubnetOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]Subnet, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddress.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddress struct {
+	Fqdn      *string `json:"fqdn,omitempty"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddresspool.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPool struct {
+	Etag       *string                                               `json:"etag,omitempty"`
+	Id         *string                                               `json:"id,omitempty"`
+	Name       *string                                               `json:"name,omitempty"`
+	Properties *ApplicationGatewayBackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewaybackendaddresspoolpropertiesformat.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
+	BackendAddresses        *[]ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendIPConfigurations *[]NetworkInterfaceIPConfiguration  `json:"backendIPConfigurations,omitempty"`
+	ProvisioningState       *ProvisioningState                  `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewayipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewayipconfiguration.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfiguration struct {
+	Etag       *string                                            `json:"etag,omitempty"`
+	Id         *string                                            `json:"id,omitempty"`
+	Name       *string                                            `json:"name,omitempty"`
+	Properties *ApplicationGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewayipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationgatewayipconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *SubResource       `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationsecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationsecuritygroup.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroup struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Id         *string                                   `json:"id,omitempty"`
+	Location   *string                                   `json:"location,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *ApplicationSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                        `json:"tags,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationsecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_applicationsecuritygrouppropertiesformat.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroupPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ResourceGuid      *string            `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_backendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_backendaddresspool.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPool struct {
+	Etag       *string                             `json:"etag,omitempty"`
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *BackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_backendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_backendaddresspoolpropertiesformat.go
@@ -1,0 +1,19 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPoolPropertiesFormat struct {
+	BackendIPConfigurations      *[]NetworkInterfaceIPConfiguration    `json:"backendIPConfigurations,omitempty"`
+	DrainPeriodInSeconds         *int64                                `json:"drainPeriodInSeconds,omitempty"`
+	InboundNatRules              *[]SubResource                        `json:"inboundNatRules,omitempty"`
+	LoadBalancerBackendAddresses *[]LoadBalancerBackendAddress         `json:"loadBalancerBackendAddresses,omitempty"`
+	LoadBalancingRules           *[]SubResource                        `json:"loadBalancingRules,omitempty"`
+	Location                     *string                               `json:"location,omitempty"`
+	OutboundRule                 *SubResource                          `json:"outboundRule,omitempty"`
+	OutboundRules                *[]SubResource                        `json:"outboundRules,omitempty"`
+	ProvisioningState            *ProvisioningState                    `json:"provisioningState,omitempty"`
+	SyncMode                     *SyncMode                             `json:"syncMode,omitempty"`
+	TunnelInterfaces             *[]GatewayLoadBalancerTunnelInterface `json:"tunnelInterfaces,omitempty"`
+	VirtualNetwork               *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_customdnsconfigpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_customdnsconfigpropertiesformat.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomDnsConfigPropertiesFormat struct {
+	Fqdn        *string   `json:"fqdn,omitempty"`
+	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ddossettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ddossettings.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosSettings struct {
+	DdosProtectionPlan *SubResource                `json:"ddosProtectionPlan,omitempty"`
+	ProtectionMode     *DdosSettingsProtectionMode `json:"protectionMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_delegation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_delegation.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Delegation struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *ServiceDelegationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlog.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlog.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLog struct {
+	Etag       *string                  `json:"etag,omitempty"`
+	Id         *string                  `json:"id,omitempty"`
+	Location   *string                  `json:"location,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *FlowLogPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string       `json:"tags,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlogformatparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlogformatparameters.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogFormatParameters struct {
+	Type    *FlowLogFormatType `json:"type,omitempty"`
+	Version *int64             `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlogpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_flowlogpropertiesformat.go
@@ -1,0 +1,15 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogPropertiesFormat struct {
+	Enabled                    *bool                       `json:"enabled,omitempty"`
+	FlowAnalyticsConfiguration *TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
+	Format                     *FlowLogFormatParameters    `json:"format,omitempty"`
+	ProvisioningState          *ProvisioningState          `json:"provisioningState,omitempty"`
+	RetentionPolicy            *RetentionPolicyParameters  `json:"retentionPolicy,omitempty"`
+	StorageId                  string                      `json:"storageId"`
+	TargetResourceGuid         *string                     `json:"targetResourceGuid,omitempty"`
+	TargetResourceId           string                      `json:"targetResourceId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_frontendipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_frontendipconfiguration.go
@@ -1,0 +1,17 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfiguration struct {
+	Etag       *string                                  `json:"etag,omitempty"`
+	Id         *string                                  `json:"id,omitempty"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *FrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+	Zones      *zones.Schema                            `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_frontendipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_frontendipconfigurationpropertiesformat.go
@@ -1,0 +1,19 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfigurationPropertiesFormat struct {
+	GatewayLoadBalancer       *SubResource        `json:"gatewayLoadBalancer,omitempty"`
+	InboundNatPools           *[]SubResource      `json:"inboundNatPools,omitempty"`
+	InboundNatRules           *[]SubResource      `json:"inboundNatRules,omitempty"`
+	LoadBalancingRules        *[]SubResource      `json:"loadBalancingRules,omitempty"`
+	OutboundRules             *[]SubResource      `json:"outboundRules,omitempty"`
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion          `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress    `json:"publicIPAddress,omitempty"`
+	PublicIPPrefix            *SubResource        `json:"publicIPPrefix,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_gatewayloadbalancertunnelinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_gatewayloadbalancertunnelinterface.go
@@ -1,0 +1,11 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GatewayLoadBalancerTunnelInterface struct {
+	Identifier *int64                                  `json:"identifier,omitempty"`
+	Port       *int64                                  `json:"port,omitempty"`
+	Protocol   *GatewayLoadBalancerTunnelProtocol      `json:"protocol,omitempty"`
+	Type       *GatewayLoadBalancerTunnelInterfaceType `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_inboundnatrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_inboundnatrule.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRule struct {
+	Etag       *string                         `json:"etag,omitempty"`
+	Id         *string                         `json:"id,omitempty"`
+	Name       *string                         `json:"name,omitempty"`
+	Properties *InboundNatRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_inboundnatrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_inboundnatrulepropertiesformat.go
@@ -1,0 +1,19 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRulePropertiesFormat struct {
+	BackendAddressPool      *SubResource                     `json:"backendAddressPool,omitempty"`
+	BackendIPConfiguration  *NetworkInterfaceIPConfiguration `json:"backendIPConfiguration,omitempty"`
+	BackendPort             *int64                           `json:"backendPort,omitempty"`
+	EnableFloatingIP        *bool                            `json:"enableFloatingIP,omitempty"`
+	EnableTcpReset          *bool                            `json:"enableTcpReset,omitempty"`
+	FrontendIPConfiguration *SubResource                     `json:"frontendIPConfiguration,omitempty"`
+	FrontendPort            *int64                           `json:"frontendPort,omitempty"`
+	FrontendPortRangeEnd    *int64                           `json:"frontendPortRangeEnd,omitempty"`
+	FrontendPortRangeStart  *int64                           `json:"frontendPortRangeStart,omitempty"`
+	IdleTimeoutInMinutes    *int64                           `json:"idleTimeoutInMinutes,omitempty"`
+	Protocol                *TransportProtocol               `json:"protocol,omitempty"`
+	ProvisioningState       *ProvisioningState               `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfiguration.go
@@ -1,0 +1,11 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfiguration struct {
+	Etag       *string                          `json:"etag,omitempty"`
+	Id         *string                          `json:"id,omitempty"`
+	Name       *string                          `json:"name,omitempty"`
+	Properties *IPConfigurationPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationprofile.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfile struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *IPConfigurationProfilePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationprofilepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationprofilepropertiesformat.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfilePropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *Subnet            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_ipconfigurationpropertiesformat.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationPropertiesFormat struct {
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress    `json:"publicIPAddress,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_iptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_iptag.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_loadbalancerbackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_loadbalancerbackendaddress.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddress struct {
+	Name       *string                                     `json:"name,omitempty"`
+	Properties *LoadBalancerBackendAddressPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_loadbalancerbackendaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_loadbalancerbackendaddresspropertiesformat.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddressPropertiesFormat struct {
+	AdminState                          *LoadBalancerBackendAddressAdminState `json:"adminState,omitempty"`
+	IPAddress                           *string                               `json:"ipAddress,omitempty"`
+	InboundNatRulesPortMapping          *[]NatRulePortMapping                 `json:"inboundNatRulesPortMapping,omitempty"`
+	LoadBalancerFrontendIPConfiguration *SubResource                          `json:"loadBalancerFrontendIPConfiguration,omitempty"`
+	NetworkInterfaceIPConfiguration     *SubResource                          `json:"networkInterfaceIPConfiguration,omitempty"`
+	Subnet                              *SubResource                          `json:"subnet,omitempty"`
+	VirtualNetwork                      *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgateway.go
@@ -1,0 +1,20 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGateway struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *NatGatewayPropertiesFormat `json:"properties,omitempty"`
+	Sku        *NatGatewaySku              `json:"sku,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+	Zones      *zones.Schema               `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgatewaypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgatewaypropertiesformat.go
@@ -1,0 +1,13 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewayPropertiesFormat struct {
+	IdleTimeoutInMinutes *int64             `json:"idleTimeoutInMinutes,omitempty"`
+	ProvisioningState    *ProvisioningState `json:"provisioningState,omitempty"`
+	PublicIPAddresses    *[]SubResource     `json:"publicIpAddresses,omitempty"`
+	PublicIPPrefixes     *[]SubResource     `json:"publicIpPrefixes,omitempty"`
+	ResourceGuid         *string            `json:"resourceGuid,omitempty"`
+	Subnets              *[]SubResource     `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgatewaysku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natgatewaysku.go
@@ -1,0 +1,8 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewaySku struct {
+	Name *NatGatewaySkuName `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natruleportmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_natruleportmapping.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatRulePortMapping struct {
+	BackendPort        *int64  `json:"backendPort,omitempty"`
+	FrontendPort       *int64  `json:"frontendPort,omitempty"`
+	InboundNatRuleName *string `json:"inboundNatRuleName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterface.go
@@ -1,0 +1,19 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterface struct {
+	Etag             *string                           `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                  `json:"extendedLocation,omitempty"`
+	Id               *string                           `json:"id,omitempty"`
+	Location         *string                           `json:"location,omitempty"`
+	Name             *string                           `json:"name,omitempty"`
+	Properties       *NetworkInterfacePropertiesFormat `json:"properties,omitempty"`
+	Tags             *map[string]string                `json:"tags,omitempty"`
+	Type             *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacednssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacednssettings.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceDnsSettings struct {
+	AppliedDnsServers        *[]string `json:"appliedDnsServers,omitempty"`
+	DnsServers               *[]string `json:"dnsServers,omitempty"`
+	InternalDnsNameLabel     *string   `json:"internalDnsNameLabel,omitempty"`
+	InternalDomainNameSuffix *string   `json:"internalDomainNameSuffix,omitempty"`
+	InternalFqdn             *string   `json:"internalFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfiguration.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfiguration struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *NetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
+	Fqdns              *[]string `json:"fqdns,omitempty"`
+	GroupId            *string   `json:"groupId,omitempty"`
+	RequiredMemberName *string   `json:"requiredMemberName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfaceipconfigurationpropertiesformat.go
@@ -1,0 +1,21 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPropertiesFormat struct {
+	ApplicationGatewayBackendAddressPools *[]ApplicationGatewayBackendAddressPool                         `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]ApplicationSecurityGroup                                     `json:"applicationSecurityGroups,omitempty"`
+	GatewayLoadBalancer                   *SubResource                                                    `json:"gatewayLoadBalancer,omitempty"`
+	LoadBalancerBackendAddressPools       *[]BackendAddressPool                                           `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatRules           *[]InboundNatRule                                               `json:"loadBalancerInboundNatRules,omitempty"`
+	Primary                               *bool                                                           `json:"primary,omitempty"`
+	PrivateIPAddress                      *string                                                         `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                                      `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod             *IPAllocationMethod                                             `json:"privateIPAllocationMethod,omitempty"`
+	PrivateLinkConnectionProperties       *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty"`
+	ProvisioningState                     *ProvisioningState                                              `json:"provisioningState,omitempty"`
+	PublicIPAddress                       *PublicIPAddress                                                `json:"publicIPAddress,omitempty"`
+	Subnet                                *Subnet                                                         `json:"subnet,omitempty"`
+	VirtualNetworkTaps                    *[]VirtualNetworkTap                                            `json:"virtualNetworkTaps,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacepropertiesformat.go
@@ -1,0 +1,29 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfacePropertiesFormat struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode      `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku       `json:"auxiliarySku,omitempty"`
+	DisableTcpStateTracking     *bool                               `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *NetworkInterfaceDnsSettings        `json:"dnsSettings,omitempty"`
+	DscpConfiguration           *SubResource                        `json:"dscpConfiguration,omitempty"`
+	EnableAcceleratedNetworking *bool                               `json:"enableAcceleratedNetworking,omitempty"`
+	EnableIPForwarding          *bool                               `json:"enableIPForwarding,omitempty"`
+	HostedWorkloads             *[]string                           `json:"hostedWorkloads,omitempty"`
+	IPConfigurations            *[]NetworkInterfaceIPConfiguration  `json:"ipConfigurations,omitempty"`
+	MacAddress                  *string                             `json:"macAddress,omitempty"`
+	MigrationPhase              *NetworkInterfaceMigrationPhase     `json:"migrationPhase,omitempty"`
+	NetworkSecurityGroup        *NetworkSecurityGroup               `json:"networkSecurityGroup,omitempty"`
+	NicType                     *NetworkInterfaceNicType            `json:"nicType,omitempty"`
+	Primary                     *bool                               `json:"primary,omitempty"`
+	PrivateEndpoint             *PrivateEndpoint                    `json:"privateEndpoint,omitempty"`
+	PrivateLinkService          *PrivateLinkService                 `json:"privateLinkService,omitempty"`
+	ProvisioningState           *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                *string                             `json:"resourceGuid,omitempty"`
+	TapConfigurations           *[]NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty"`
+	VirtualMachine              *SubResource                        `json:"virtualMachine,omitempty"`
+	VnetEncryptionSupported     *bool                               `json:"vnetEncryptionSupported,omitempty"`
+	WorkloadType                *string                             `json:"workloadType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacetapconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacetapconfiguration.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfiguration struct {
+	Etag       *string                                           `json:"etag,omitempty"`
+	Id         *string                                           `json:"id,omitempty"`
+	Name       *string                                           `json:"name,omitempty"`
+	Properties *NetworkInterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacetapconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networkinterfacetapconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networksecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networksecuritygroup.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroup struct {
+	Etag       *string                               `json:"etag,omitempty"`
+	Id         *string                               `json:"id,omitempty"`
+	Location   *string                               `json:"location,omitempty"`
+	Name       *string                               `json:"name,omitempty"`
+	Properties *NetworkSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                    `json:"tags,omitempty"`
+	Type       *string                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networksecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_networksecuritygrouppropertiesformat.go
@@ -1,0 +1,15 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroupPropertiesFormat struct {
+	DefaultSecurityRules *[]SecurityRule     `json:"defaultSecurityRules,omitempty"`
+	FlowLogs             *[]FlowLog          `json:"flowLogs,omitempty"`
+	FlushConnection      *bool               `json:"flushConnection,omitempty"`
+	NetworkInterfaces    *[]NetworkInterface `json:"networkInterfaces,omitempty"`
+	ProvisioningState    *ProvisioningState  `json:"provisioningState,omitempty"`
+	ResourceGuid         *string             `json:"resourceGuid,omitempty"`
+	SecurityRules        *[]SecurityRule     `json:"securityRules,omitempty"`
+	Subnets              *[]Subnet           `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpoint.go
@@ -1,0 +1,19 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpoint struct {
+	Etag             *string                    `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model           `json:"extendedLocation,omitempty"`
+	Id               *string                    `json:"id,omitempty"`
+	Location         *string                    `json:"location,omitempty"`
+	Name             *string                    `json:"name,omitempty"`
+	Properties       *PrivateEndpointProperties `json:"properties,omitempty"`
+	Tags             *map[string]string         `json:"tags,omitempty"`
+	Type             *string                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointconnection.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnection struct {
+	Etag       *string                              `json:"etag,omitempty"`
+	Id         *string                              `json:"id,omitempty"`
+	Name       *string                              `json:"name,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Type       *string                              `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointconnectionproperties.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	LinkIdentifier                    *string                            `json:"linkIdentifier,omitempty"`
+	PrivateEndpoint                   *PrivateEndpoint                   `json:"privateEndpoint,omitempty"`
+	PrivateEndpointLocation           *string                            `json:"privateEndpointLocation,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointipconfiguration.go
@@ -1,0 +1,11 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfiguration struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *PrivateEndpointIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointipconfigurationproperties.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfigurationProperties struct {
+	GroupId          *string `json:"groupId,omitempty"`
+	MemberName       *string `json:"memberName,omitempty"`
+	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privateendpointproperties.go
@@ -1,0 +1,16 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointProperties struct {
+	ApplicationSecurityGroups           *[]ApplicationSecurityGroup        `json:"applicationSecurityGroups,omitempty"`
+	CustomDnsConfigs                    *[]CustomDnsConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomNetworkInterfaceName          *string                            `json:"customNetworkInterfaceName,omitempty"`
+	IPConfigurations                    *[]PrivateEndpointIPConfiguration  `json:"ipConfigurations,omitempty"`
+	ManualPrivateLinkServiceConnections *[]PrivateLinkServiceConnection    `json:"manualPrivateLinkServiceConnections,omitempty"`
+	NetworkInterfaces                   *[]NetworkInterface                `json:"networkInterfaces,omitempty"`
+	PrivateLinkServiceConnections       *[]PrivateLinkServiceConnection    `json:"privateLinkServiceConnections,omitempty"`
+	ProvisioningState                   *ProvisioningState                 `json:"provisioningState,omitempty"`
+	Subnet                              *Subnet                            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkservice.go
@@ -1,0 +1,19 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkService struct {
+	Etag             *string                       `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model              `json:"extendedLocation,omitempty"`
+	Id               *string                       `json:"id,omitempty"`
+	Location         *string                       `json:"location,omitempty"`
+	Name             *string                       `json:"name,omitempty"`
+	Properties       *PrivateLinkServiceProperties `json:"properties,omitempty"`
+	Tags             *map[string]string            `json:"tags,omitempty"`
+	Type             *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnection.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnection struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *PrivateLinkServiceConnectionProperties `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnectionproperties.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionProperties struct {
+	GroupIds                          *[]string                          `json:"groupIds,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceId              *string                            `json:"privateLinkServiceId,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	RequestMessage                    *string                            `json:"requestMessage,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionState struct {
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
+	Description     *string `json:"description,omitempty"`
+	Status          *string `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceipconfiguration.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfiguration struct {
+	Etag       *string                                      `json:"etag,omitempty"`
+	Id         *string                                      `json:"id,omitempty"`
+	Name       *string                                      `json:"name,omitempty"`
+	Properties *PrivateLinkServiceIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceipconfigurationproperties.go
@@ -1,0 +1,13 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfigurationProperties struct {
+	Primary                   *bool               `json:"primary,omitempty"`
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion          `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_privatelinkserviceproperties.go
@@ -1,0 +1,17 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceProperties struct {
+	Alias                                *string                              `json:"alias,omitempty"`
+	AutoApproval                         *ResourceSet                         `json:"autoApproval,omitempty"`
+	EnableProxyProtocol                  *bool                                `json:"enableProxyProtocol,omitempty"`
+	Fqdns                                *[]string                            `json:"fqdns,omitempty"`
+	IPConfigurations                     *[]PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations *[]FrontendIPConfiguration           `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	NetworkInterfaces                    *[]NetworkInterface                  `json:"networkInterfaces,omitempty"`
+	PrivateEndpointConnections           *[]PrivateEndpointConnection         `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState                    *ProvisioningState                   `json:"provisioningState,omitempty"`
+	Visibility                           *ResourceSet                         `json:"visibility,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddress.go
@@ -1,0 +1,22 @@
+package subnets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddress struct {
+	Etag             *string                          `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                 `json:"extendedLocation,omitempty"`
+	Id               *string                          `json:"id,omitempty"`
+	Location         *string                          `json:"location,omitempty"`
+	Name             *string                          `json:"name,omitempty"`
+	Properties       *PublicIPAddressPropertiesFormat `json:"properties,omitempty"`
+	Sku              *PublicIPAddressSku              `json:"sku,omitempty"`
+	Tags             *map[string]string               `json:"tags,omitempty"`
+	Type             *string                          `json:"type,omitempty"`
+	Zones            *zones.Schema                    `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddressdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddressdnssettings.go
@@ -1,0 +1,11 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressDnsSettings struct {
+	DomainNameLabel      *string                                         `json:"domainNameLabel,omitempty"`
+	DomainNameLabelScope *PublicIPAddressDnsSettingsDomainNameLabelScope `json:"domainNameLabelScope,omitempty"`
+	Fqdn                 *string                                         `json:"fqdn,omitempty"`
+	ReverseFqdn          *string                                         `json:"reverseFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddresspropertiesformat.go
@@ -1,0 +1,23 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressPropertiesFormat struct {
+	DdosSettings             *DdosSettings                  `json:"ddosSettings,omitempty"`
+	DeleteOption             *DeleteOptions                 `json:"deleteOption,omitempty"`
+	DnsSettings              *PublicIPAddressDnsSettings    `json:"dnsSettings,omitempty"`
+	IPAddress                *string                        `json:"ipAddress,omitempty"`
+	IPConfiguration          *IPConfiguration               `json:"ipConfiguration,omitempty"`
+	IPTags                   *[]IPTag                       `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes     *int64                         `json:"idleTimeoutInMinutes,omitempty"`
+	LinkedPublicIPAddress    *PublicIPAddress               `json:"linkedPublicIPAddress,omitempty"`
+	MigrationPhase           *PublicIPAddressMigrationPhase `json:"migrationPhase,omitempty"`
+	NatGateway               *NatGateway                    `json:"natGateway,omitempty"`
+	ProvisioningState        *ProvisioningState             `json:"provisioningState,omitempty"`
+	PublicIPAddressVersion   *IPVersion                     `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAllocationMethod *IPAllocationMethod            `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPPrefix           *SubResource                   `json:"publicIPPrefix,omitempty"`
+	ResourceGuid             *string                        `json:"resourceGuid,omitempty"`
+	ServicePublicIPAddress   *PublicIPAddress               `json:"servicePublicIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddresssku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_publicipaddresssku.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressSku struct {
+	Name *PublicIPAddressSkuName `json:"name,omitempty"`
+	Tier *PublicIPAddressSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourcenavigationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourcenavigationlink.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLink struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *ResourceNavigationLinkFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourcenavigationlinkformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourcenavigationlinkformat.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLinkFormat struct {
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourceset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_resourceset.go
@@ -1,0 +1,8 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceSet struct {
+	Subscriptions *[]string `json:"subscriptions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_retentionpolicyparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_retentionpolicyparameters.go
@@ -1,0 +1,9 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetentionPolicyParameters struct {
+	Days    *int64 `json:"days,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_route.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_route.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Route struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RoutePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routepropertiesformat.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RoutePropertiesFormat struct {
+	AddressPrefix     *string            `json:"addressPrefix,omitempty"`
+	HasBgpOverride    *bool              `json:"hasBgpOverride,omitempty"`
+	NextHopIPAddress  *string            `json:"nextHopIpAddress,omitempty"`
+	NextHopType       RouteNextHopType   `json:"nextHopType"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routetable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routetable.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTable struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *RouteTablePropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routetablepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_routetablepropertiesformat.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTablePropertiesFormat struct {
+	DisableBgpRoutePropagation *bool              `json:"disableBgpRoutePropagation,omitempty"`
+	ProvisioningState          *ProvisioningState `json:"provisioningState,omitempty"`
+	ResourceGuid               *string            `json:"resourceGuid,omitempty"`
+	Routes                     *[]Route           `json:"routes,omitempty"`
+	Subnets                    *[]Subnet          `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_securityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_securityrule.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRule struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *SecurityRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_securityrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_securityrulepropertiesformat.go
@@ -1,0 +1,23 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRulePropertiesFormat struct {
+	Access                               SecurityRuleAccess          `json:"access"`
+	Description                          *string                     `json:"description,omitempty"`
+	DestinationAddressPrefix             *string                     `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefixes           *[]string                   `json:"destinationAddressPrefixes,omitempty"`
+	DestinationApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationPortRange                 *string                     `json:"destinationPortRange,omitempty"`
+	DestinationPortRanges                *[]string                   `json:"destinationPortRanges,omitempty"`
+	Direction                            SecurityRuleDirection       `json:"direction"`
+	Priority                             int64                       `json:"priority"`
+	Protocol                             SecurityRuleProtocol        `json:"protocol"`
+	ProvisioningState                    *ProvisioningState          `json:"provisioningState,omitempty"`
+	SourceAddressPrefix                  *string                     `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefixes                *[]string                   `json:"sourceAddressPrefixes,omitempty"`
+	SourceApplicationSecurityGroups      *[]ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourcePortRange                      *string                     `json:"sourcePortRange,omitempty"`
+	SourcePortRanges                     *[]string                   `json:"sourcePortRanges,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceassociationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceassociationlink.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLink struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *ServiceAssociationLinkPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceassociationlinkpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceassociationlinkpropertiesformat.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLinkPropertiesFormat struct {
+	AllowDelete        *bool              `json:"allowDelete,omitempty"`
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	Locations          *[]string          `json:"locations,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_servicedelegationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_servicedelegationpropertiesformat.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceDelegationPropertiesFormat struct {
+	Actions           *[]string          `json:"actions,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ServiceName       *string            `json:"serviceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicy.go
@@ -1,0 +1,15 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicy struct {
+	Etag       *string                                `json:"etag,omitempty"`
+	Id         *string                                `json:"id,omitempty"`
+	Kind       *string                                `json:"kind,omitempty"`
+	Location   *string                                `json:"location,omitempty"`
+	Name       *string                                `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                     `json:"tags,omitempty"`
+	Type       *string                                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicydefinition.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinition struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicydefinitionpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicydefinitionpropertiesformat.go
@@ -1,0 +1,11 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
+	Description       *string            `json:"description,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+	ServiceResources  *[]string          `json:"serviceResources,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpolicypropertiesformat.go
@@ -1,0 +1,13 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyPropertiesFormat struct {
+	ContextualServiceEndpointPolicies *[]string                          `json:"contextualServiceEndpointPolicies,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	ResourceGuid                      *string                            `json:"resourceGuid,omitempty"`
+	ServiceAlias                      *string                            `json:"serviceAlias,omitempty"`
+	ServiceEndpointPolicyDefinitions  *[]ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	Subnets                           *[]Subnet                          `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_serviceendpointpropertiesformat.go
@@ -1,0 +1,10 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPropertiesFormat struct {
+	Locations         *[]string          `json:"locations,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subnet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subnet.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Subnet struct {
+	Etag       *string                 `json:"etag,omitempty"`
+	Id         *string                 `json:"id,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *SubnetPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subnetpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subnetpropertiesformat.go
@@ -1,0 +1,27 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetPropertiesFormat struct {
+	AddressPrefix                      *string                                          `json:"addressPrefix,omitempty"`
+	AddressPrefixes                    *[]string                                        `json:"addressPrefixes,omitempty"`
+	ApplicationGatewayIPConfigurations *[]ApplicationGatewayIPConfiguration             `json:"applicationGatewayIPConfigurations,omitempty"`
+	DefaultOutboundAccess              *bool                                            `json:"defaultOutboundAccess,omitempty"`
+	Delegations                        *[]Delegation                                    `json:"delegations,omitempty"`
+	IPAllocations                      *[]SubResource                                   `json:"ipAllocations,omitempty"`
+	IPConfigurationProfiles            *[]IPConfigurationProfile                        `json:"ipConfigurationProfiles,omitempty"`
+	IPConfigurations                   *[]IPConfiguration                               `json:"ipConfigurations,omitempty"`
+	NatGateway                         *SubResource                                     `json:"natGateway,omitempty"`
+	NetworkSecurityGroup               *NetworkSecurityGroup                            `json:"networkSecurityGroup,omitempty"`
+	PrivateEndpointNetworkPolicies     *VirtualNetworkPrivateEndpointNetworkPolicies    `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateEndpoints                   *[]PrivateEndpoint                               `json:"privateEndpoints,omitempty"`
+	PrivateLinkServiceNetworkPolicies  *VirtualNetworkPrivateLinkServiceNetworkPolicies `json:"privateLinkServiceNetworkPolicies,omitempty"`
+	ProvisioningState                  *ProvisioningState                               `json:"provisioningState,omitempty"`
+	Purpose                            *string                                          `json:"purpose,omitempty"`
+	ResourceNavigationLinks            *[]ResourceNavigationLink                        `json:"resourceNavigationLinks,omitempty"`
+	RouteTable                         *RouteTable                                      `json:"routeTable,omitempty"`
+	ServiceAssociationLinks            *[]ServiceAssociationLink                        `json:"serviceAssociationLinks,omitempty"`
+	ServiceEndpointPolicies            *[]ServiceEndpointPolicy                         `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpoints                   *[]ServiceEndpointPropertiesFormat               `json:"serviceEndpoints,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_subresource.go
@@ -1,0 +1,8 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_trafficanalyticsconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_trafficanalyticsconfigurationproperties.go
@@ -1,0 +1,12 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsConfigurationProperties struct {
+	Enabled                  *bool   `json:"enabled,omitempty"`
+	TrafficAnalyticsInterval *int64  `json:"trafficAnalyticsInterval,omitempty"`
+	WorkspaceId              *string `json:"workspaceId,omitempty"`
+	WorkspaceRegion          *string `json:"workspaceRegion,omitempty"`
+	WorkspaceResourceId      *string `json:"workspaceResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_trafficanalyticsproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_trafficanalyticsproperties.go
@@ -1,0 +1,8 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsProperties struct {
+	NetworkWatcherFlowAnalyticsConfiguration *TrafficAnalyticsConfigurationProperties `json:"networkWatcherFlowAnalyticsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_virtualnetworktap.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_virtualnetworktap.go
@@ -1,0 +1,14 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTap struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualNetworkTapPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_virtualnetworktappropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/model_virtualnetworktappropertiesformat.go
@@ -1,0 +1,13 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTapPropertiesFormat struct {
+	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration            `json:"destinationLoadBalancerFrontEndIPConfiguration,omitempty"`
+	DestinationNetworkInterfaceIPConfiguration     *NetworkInterfaceIPConfiguration    `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
+	DestinationPort                                *int64                              `json:"destinationPort,omitempty"`
+	NetworkInterfaceTapConfigurations              *[]NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty"`
+	ProvisioningState                              *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                                   *string                             `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/predicates.go
@@ -1,0 +1,32 @@
+package subnets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p SubnetOperationPredicate) Matches(input Subnet) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets/version.go
@@ -1,0 +1,12 @@
+package subnets
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-09-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/subnets/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -794,6 +794,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/vpnserverc
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/vpnsites
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webapplicationfirewallpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-06-01/webcategories
+github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets
 github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors
 github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/collectorpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2022-07-01/monitors


### PR DESCRIPTION
Service team is reaching us for supporting new enum values "NetworkSecurityGroupEnabled" and "RouteTableEnabled" for the "[privateEndpointNetworkPolicies](https://github.com/Azure/azure-rest-api-specs/blob/77df3b1680a95566a3e6a3a2cd07c9a4960b2af3/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/virtualNetwork.json#L1602)" property in "azurerm_subnet". This new feature only exists in the latest API version 2023-09-01.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/464858be-ccd6-4599-a441-da6fec266fed)
