### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20240228.1133018`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.2
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240228.1133018
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.66.2
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240227.1172434
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/go-azure-helpers v0.66.2 h1:+Pzuo7pdKl0hBXXr5ymmhs4Q40tHAo2
 github.com/hashicorp/go-azure-helpers v0.66.2/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434 h1:UNp65kdO4noJDrEe99Od5NfXSnjrrTs0dEyw2MM8jK0=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434/go.mod h1:8Pmp8Bg+FDUjkbuuiLLqysKrKUu5dOIf1dX3KFKNSU8=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240227.1172434 h1:IX9e6DRUYl+1skjZPpfdhnEV3cx8dNX1qECYSVcD288=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240227.1172434/go.mod h1:IKIPyL+hfFWBHABKT0NOWlIEzlusiUBG0SxIfaiv278=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018 h1:0Fb9GzfrRQkP834GU51GdbgPtm4SmrOfpiVnKBkJRos=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018/go.mod h1:IKIPyL+hfFWBHABKT0NOWlIEzlusiUBG0SxIfaiv278=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.66.2 h1:+Pzuo7pdKl0hBXXr5ymmhs4Q40tHAo2nAvHq4WgSjx8=
 github.com/hashicorp/go-azure-helpers v0.66.2/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434 h1:UNp65kdO4noJDrEe99Od5NfXSnjrrTs0dEyw2MM8jK0=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434/go.mod h1:8Pmp8Bg+FDUjkbuuiLLqysKrKUu5dOIf1dX3KFKNSU8=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240228.1133018 h1:jW9EV3vaDAtbgNEXeXJz3N55XiHwJt1+ziwq7f1GU44=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240228.1133018/go.mod h1:EgiDjDPdTUIelDvystTj2o9C3BhoB7D6M8TnMB1kzXc=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018 h1:0Fb9GzfrRQkP834GU51GdbgPtm4SmrOfpiVnKBkJRos=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018/go.mod h1:IKIPyL+hfFWBHABKT0NOWlIEzlusiUBG0SxIfaiv278=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces/model_networkrulesetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces/model_networkrulesetproperties.go
@@ -4,7 +4,8 @@ package namespaces
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type NetworkRuleSetProperties struct {
-	DefaultAction       *DefaultAction       `json:"defaultAction,omitempty"`
-	IPRules             *[]NWRuleSetIPRules  `json:"ipRules,omitempty"`
-	PublicNetworkAccess *PublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
+	DefaultAction               *DefaultAction       `json:"defaultAction,omitempty"`
+	IPRules                     *[]NWRuleSetIPRules  `json:"ipRules,omitempty"`
+	PublicNetworkAccess         *PublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
+	TrustedServiceAccessEnabled *bool                `json:"trustedServiceAccessEnabled,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1054,7 +1054,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceprovid
 github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01
 github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240227.1172434
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240228.1133018
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240227.1172434
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240228.1133018
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20240228.1133018` - further details can be found in a comment.