### PR TITLE
`azurerm_kubernetes_cluster` - add support for `current_kubernetes_version`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -338,6 +338,7 @@ func TestAccKubernetesCluster_upgrade(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
+				check.That(data.ResourceName).Key("current_kubernetes_version").Exists(),
 			),
 		},
 		{
@@ -345,6 +346,7 @@ func TestAccKubernetesCluster_upgrade(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(currentKubernetesVersion),
+				check.That(data.ResourceName).Key("current_kubernetes_version").Exists(),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1268,6 +1268,11 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"current_kubernetes_version": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"node_resource_group_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -2605,6 +2610,7 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("portal_fqdn", props.AzurePortalFQDN)
 			d.Set("disk_encryption_set_id", props.DiskEncryptionSetID)
 			d.Set("kubernetes_version", props.KubernetesVersion)
+			d.Set("current_kubernetes_version", props.CurrentKubernetesVersion)
 			d.Set("enable_pod_security_policy", props.EnablePodSecurityPolicy)
 			d.Set("local_account_disabled", props.DisableLocalAccounts)
 

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -22,10 +22,10 @@ import (
 type KubernetesClusterResource struct{}
 
 var (
-	olderKubernetesVersion        = "1.25.11"
-	currentKubernetesVersion      = "1.26.6"
-	olderKubernetesVersionAlias   = "1.25"
-	currentKubernetesVersionAlias = "1.26"
+	olderKubernetesVersion        = "1.28.5"
+	currentKubernetesVersion      = "1.29.0"
+	olderKubernetesVersionAlias   = "1.28"
+	currentKubernetesVersionAlias = "1.29"
 )
 
 func TestAccKubernetesCluster_hostEncryption(t *testing.T) {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -961,6 +961,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The Kubernetes Managed Cluster ID.
 
+* `current_kubernetes_version` - The current version running on the Azure Kubernetes Managed Cluster.
+
 * `fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
 
 * `private_fqdn` - The FQDN for the Kubernetes Cluster when private link has been enabled, which is only resolvable inside the Virtual Network used by the Kubernetes Cluster.


### PR DESCRIPTION
Closes #22993

Also updates the AKS versions for the acceptance tests.