### PR TITLE
`azurerm_kubernetes_cluster` - add support for `node_provisioning_mode`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -978,6 +978,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"node_provisioning_mode": "",
+
 			"key_management_service": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/24503
Depends on https://github.com/hashicorp/go-azure-sdk/issues/912
Relates to https://github.com/Azure/karpenter-provider-azure/issues/63