### PR TITLE
Document hygiene: Use the standard list indice notation

### DIFF
--- a/website/docs/d/data_protection_backup_vault.html.markdown
+++ b/website/docs/d/data_protection_backup_vault.html.markdown
@@ -23,7 +23,7 @@ output "azurerm_data_protection_backup_vault_id" {
 }
 
 output "azurerm_data_protection_backup_vault_principal_id" {
-  value = data.azurerm_data_protection_backup_vault.example.identity.0.principal_id
+  value = data.azurerm_data_protection_backup_vault.example.identity[0].principal_id
 }
 ```
 

--- a/website/docs/d/databricks_workspace_private_endpoint_connection.html.markdown
+++ b/website/docs/d/databricks_workspace_private_endpoint_connection.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_databricks_workspace_private_endpoint_connection" "example" {
 }
 
 output "databricks_workspace_private_endpoint_connection_status" {
-  value = data.azurerm_databricks_workspace_private_endpoint_connection.example.connections.0.status
+  value = data.azurerm_databricks_workspace_private_endpoint_connection.example.connections[0].status
 }
 ```
 

--- a/website/docs/d/eventgrid_domain.html.markdown
+++ b/website/docs/d/eventgrid_domain.html.markdown
@@ -20,7 +20,7 @@ data "azurerm_eventgrid_domain" "example" {
 }
 
 output "eventgrid_domain_mapping_topic" {
-  value = data.azurerm_eventgrid_domain.example.input_mapping_fields.0.topic
+  value = data.azurerm_eventgrid_domain.example.input_mapping_fields[0].topic
 }
 ```
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -222,12 +222,12 @@ The `kube_admin_config` and `kube_config` blocks export the following:
 
 ```hcl
 provider "kubernetes" {
-  host                   = data.azurerm_kubernetes_cluster.main.kube_config.0.host
-  username               = data.azurerm_kubernetes_cluster.main.kube_config.0.username
-  password               = data.azurerm_kubernetes_cluster.main.kube_config.0.password
-  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)
-  client_key             = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)
+  host                   = data.azurerm_kubernetes_cluster.main.kube_config[0].host
+  username               = data.azurerm_kubernetes_cluster.main.kube_config[0].username
+  password               = data.azurerm_kubernetes_cluster.main.kube_config[0].password
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.main.kube_config[0].client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.main.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate)
 }
 ```
 

--- a/website/docs/d/private_endpoint_connection.html.markdown
+++ b/website/docs/d/private_endpoint_connection.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_private_endpoint_connection" "example" {
 }
 
 output "private_endpoint_status" {
-  value = data.azurerm_private_endpoint_connection.example.private_service_connection.0.status
+  value = data.azurerm_private_endpoint_connection.example.private_service_connection[0].status
 }
 ```
 

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_private_link_service_endpoint_connections" "example" {
 }
 
 output "private_endpoint_status" {
-  value = data.azurerm_private_link_service_endpoint_connections.example.private_endpoint_connections.0.status
+  value = data.azurerm_private_link_service_endpoint_connections.example.private_endpoint_connections[0].status
 }
 ```
 

--- a/website/docs/d/storage_containers.html.markdown
+++ b/website/docs/d/storage_containers.html.markdown
@@ -18,7 +18,7 @@ data "azurerm_storage_containers" "example" {
 }
 
 output "container_id" {
-  value = data.azurerm_storage_containers.example.containers.0.resource_manager_id
+  value = data.azurerm_storage_containers.example.containers[0].resource_manager_id
 }
 ```
 

--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -906,7 +906,7 @@ The casing on the values for the `storage_permissions` field have been updated t
 
 ### Resource: `azurerm_key_vault_certificate`
 
-The field `x509_certificate_properties.0.key_usage`  will be moved from a List to a Set, meaning that the order of these items no longer matters. Note that if you're referencing these nested items within your Terraform Configuration, then this may require some code changes.
+The field `x509_certificate_properties[0].key_usage`  will be moved from a List to a Set, meaning that the order of these items no longer matters. Note that if you're referencing these nested items within your Terraform Configuration, then this may require some code changes.
 
 ### Resource: `azurerm_key_vault_key`
 

--- a/website/docs/r/active_directory_domain_service_replica_set.html.markdown
+++ b/website/docs/r/active_directory_domain_service_replica_set.html.markdown
@@ -260,7 +260,7 @@ resource "azurerm_virtual_network_peering" "replica_primary" {
 
 resource "azurerm_virtual_network_dns_servers" "replica" {
   virtual_network_id = azurerm_virtual_network.replica.id
-  dns_servers        = azurerm_active_directory_domain_service.example.initial_replica_set.0.domain_controller_ip_addresses
+  dns_servers        = azurerm_active_directory_domain_service.example.initial_replica_set[0].domain_controller_ip_addresses
 }
 
 resource "azurerm_active_directory_domain_service_replica_set" "replica" {

--- a/website/docs/r/api_management_certificate.html.markdown
+++ b/website/docs/r/api_management_certificate.html.markdown
@@ -80,8 +80,8 @@ resource "azurerm_key_vault" "example" {
 
 resource "azurerm_key_vault_access_policy" "example" {
   key_vault_id = azurerm_key_vault.example.id
-  tenant_id    = azurerm_api_management.example.identity.0.tenant_id
-  object_id    = azurerm_api_management.example.identity.0.principal_id
+  tenant_id    = azurerm_api_management.example.identity[0].tenant_id
+  object_id    = azurerm_api_management.example.identity[0].principal_id
 
   secret_permissions = [
     "Get",

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -485,7 +485,7 @@ A `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
--> You can access the Principal ID via `azurerm_app_service.example.identity.0.principal_id` and the Tenant ID via `azurerm_app_service.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_app_service.example.identity[0].principal_id` and the Tenant ID via `azurerm_app_service.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -507,7 +507,7 @@ A `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service slot.
 
--> You can access the Principal ID via `azurerm_app_service_slot.example.identity.0.principal_id` and the Tenant ID via `azurerm_app_service_slot.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_app_service_slot.example.identity[0].principal_id` and the Tenant ID via `azurerm_app_service_slot.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -434,7 +434,7 @@ A `request_routing_rule` block supports the following:
 
 * `priority` - (Optional) Rule evaluation order can be dictated by specifying an integer value from `1` to `20000` with `1` being the highest priority and `20000` being the lowest priority.
 
--> **NOTE:** `priority` is required when `sku.0.tier` is set to `*_v2`.
+-> **NOTE:** `priority` is required when `sku[0].tier` is set to `*_v2`.
 
 ---
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -195,7 +195,7 @@ resource "azurerm_private_link_service" "example" {
   location            = azurerm_resource_group.example.location
 
   visibility_subscription_ids                 = [data.azurerm_client_config.current.subscription_id]
-  load_balancer_frontend_ip_configuration_ids = [azurerm_lb.example.frontend_ip_configuration.0.id]
+  load_balancer_frontend_ip_configuration_ids = [azurerm_lb.example.frontend_ip_configuration[0].id]
 
   nat_ip_configuration {
     name                       = "primary"

--- a/website/docs/r/cognitive_account_customer_managed_key.html.markdown
+++ b/website/docs/r/cognitive_account_customer_managed_key.html.markdown
@@ -49,8 +49,8 @@ resource "azurerm_key_vault" "example" {
   purge_protection_enabled = true
 
   access_policy {
-    tenant_id = azurerm_cognitive_account.example.identity.0.tenant_id
-    object_id = azurerm_cognitive_account.example.identity.0.principal_id
+    tenant_id = azurerm_cognitive_account.example.identity[0].tenant_id
+    object_id = azurerm_cognitive_account.example.identity[0].principal_id
     key_permissions = [
       "Get", "Create", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
     ]

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -275,7 +275,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
--> You can access the Principal ID via `azurerm_container_registry.example.identity.0.principal_id` and the Tenant ID via `azurerm_container_registry.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_container_registry.example.identity[0].principal_id` and the Tenant ID via `azurerm_container_registry.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_kusto.html.markdown
+++ b/website/docs/r/data_factory_linked_service_kusto.html.markdown
@@ -60,8 +60,8 @@ resource "azurerm_kusto_database_principal_assignment" "example" {
   cluster_name        = azurerm_kusto_cluster.example.name
   database_name       = azurerm_kusto_database.example.name
 
-  tenant_id      = azurerm_data_factory.example.identity.0.tenant_id
-  principal_id   = azurerm_data_factory.example.identity.0.principal_id
+  tenant_id      = azurerm_data_factory.example.identity[0].tenant_id
+  principal_id   = azurerm_data_factory.example.identity[0].principal_id
   principal_type = "App"
   role           = "Viewer"
 }

--- a/website/docs/r/data_protection_backup_instance_postgresql.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_postgresql.html.markdown
@@ -92,8 +92,8 @@ resource "azurerm_key_vault" "example" {
   }
 
   access_policy {
-    tenant_id = azurerm_data_protection_backup_vault.example.identity.0.tenant_id
-    object_id = azurerm_data_protection_backup_vault.example.identity.0.principal_id
+    tenant_id = azurerm_data_protection_backup_vault.example.identity[0].tenant_id
+    object_id = azurerm_data_protection_backup_vault.example.identity[0].principal_id
 
     key_permissions = ["Create", "Get"]
 
@@ -124,7 +124,7 @@ resource "azurerm_data_protection_backup_policy_postgresql" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_postgresql_server.example.id
   role_definition_name = "Reader"
-  principal_id         = azurerm_data_protection_backup_vault.example.identity.0.principal_id
+  principal_id         = azurerm_data_protection_backup_vault.example.identity[0].principal_id
 }
 
 resource "azurerm_data_protection_backup_instance_postgresql" "example" {

--- a/website/docs/r/data_protection_backup_vault.html.markdown
+++ b/website/docs/r/data_protection_backup_vault.html.markdown
@@ -79,7 +79,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Backup Vault.
 
--> You can access the Principal ID via `${azurerm_data_protection_backup_vault.example.identity.0.principal_id}` and the Tenant ID via `${azurerm_data_protection_backup_vault.example.identity.0.tenant_id}`
+-> You can access the Principal ID via `${azurerm_data_protection_backup_vault.example.identity[0].principal_id}` and the Tenant ID via `${azurerm_data_protection_backup_vault.example.identity[0].tenant_id}`
 
 ## Timeouts
 

--- a/website/docs/r/data_share_account.html.markdown
+++ b/website/docs/r/data_share_account.html.markdown
@@ -75,7 +75,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Data Share Account.
 
--> You can access the Principal ID via `${azurerm_data_share_account.example.identity.0.principal_id}` and the Tenant ID via `${azurerm_data_share_account.example.identity.0.tenant_id}`
+-> You can access the Principal ID via `${azurerm_data_share_account.example.identity[0].principal_id}` and the Tenant ID via `${azurerm_data_share_account.example.identity[0].tenant_id}`
 
 ## Timeouts
 

--- a/website/docs/r/data_share_dataset_kusto_cluster.html.markdown
+++ b/website/docs/r/data_share_dataset_kusto_cluster.html.markdown
@@ -51,7 +51,7 @@ resource "azurerm_kusto_cluster" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_kusto_cluster.example.id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_data_share_account.example.identity.0.principal_id
+  principal_id         = azurerm_data_share_account.example.identity[0].principal_id
 }
 
 resource "azurerm_data_share_dataset_kusto_cluster" "example" {

--- a/website/docs/r/data_share_dataset_kusto_database.html.markdown
+++ b/website/docs/r/data_share_dataset_kusto_database.html.markdown
@@ -58,7 +58,7 @@ resource "azurerm_kusto_database" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_kusto_cluster.example.id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_data_share_account.example.identity.0.principal_id
+  principal_id         = azurerm_data_share_account.example.identity[0].principal_id
 }
 
 resource "azurerm_data_share_dataset_kusto_database" "example" {

--- a/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
@@ -94,8 +94,8 @@ resource "azurerm_key_vault_access_policy" "databricks" {
   depends_on = [azurerm_databricks_workspace.example]
 
   key_vault_id = azurerm_key_vault.example.id
-  tenant_id    = azurerm_databricks_workspace.example.storage_account_identity.0.tenant_id
-  object_id    = azurerm_databricks_workspace.example.storage_account_identity.0.principal_id
+  tenant_id    = azurerm_databricks_workspace.example.storage_account_identity[0].tenant_id
+  object_id    = azurerm_databricks_workspace.example.storage_account_identity[0].principal_id
 
   key_permissions = [
     "Create",

--- a/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
@@ -92,8 +92,8 @@ resource "azurerm_key_vault_access_policy" "databricks" {
   depends_on = [azurerm_databricks_workspace.example]
 
   key_vault_id = azurerm_key_vault.example.id
-  tenant_id    = azurerm_databricks_workspace.example.storage_account_identity.0.tenant_id
-  object_id    = azurerm_databricks_workspace.example.storage_account_identity.0.principal_id
+  tenant_id    = azurerm_databricks_workspace.example.storage_account_identity[0].tenant_id
+  object_id    = azurerm_databricks_workspace.example.storage_account_identity[0].principal_id
 
   key_permissions = [
     "Create",

--- a/website/docs/r/datadog_monitors.html.markdown
+++ b/website/docs/r/datadog_monitors.html.markdown
@@ -111,7 +111,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Datadog Monitor.
 
--> You can access the Principal ID via `${azurerm_datadog_monitor.example.identity.0.principal_id}` and the Tenant ID via `${azurerm_datadog_monitor.example.identity.0.tenant_id}`
+-> You can access the Principal ID via `${azurerm_datadog_monitor.example.identity[0].principal_id}` and the Tenant ID via `${azurerm_datadog_monitor.example.identity[0].tenant_id}`
 
 ## Role Assignment
 
@@ -129,7 +129,7 @@ data "azurerm_role_definition" "monitoring_reader" {
 resource "azurerm_role_assignment" "example" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = data.azurerm_role_definition.monitoring_reader.role_definition_id
-  principal_id       = azurerm_datadog_monitor.example.identity.0.principal_id
+  principal_id       = azurerm_datadog_monitor.example.identity[0].principal_id
 }
 ```
 

--- a/website/docs/r/digital_twins_time_series_database_connection.html.markdown
+++ b/website/docs/r/digital_twins_time_series_database_connection.html.markdown
@@ -70,13 +70,13 @@ resource "azurerm_kusto_database" "example" {
 
 resource "azurerm_role_assignment" "database_contributor" {
   scope                = azurerm_kusto_database.example.id
-  principal_id         = azurerm_digital_twins_instance.example.identity.0.principal_id
+  principal_id         = azurerm_digital_twins_instance.example.identity[0].principal_id
   role_definition_name = "Contributor"
 }
 
 resource "azurerm_role_assignment" "eventhub_data_owner" {
   scope                = azurerm_eventhub.example.id
-  principal_id         = azurerm_digital_twins_instance.example.identity.0.principal_id
+  principal_id         = azurerm_digital_twins_instance.example.identity[0].principal_id
   role_definition_name = "Azure Event Hubs Data Owner"
 }
 
@@ -86,8 +86,8 @@ resource "azurerm_kusto_database_principal_assignment" "example" {
   cluster_name        = azurerm_kusto_cluster.example.name
   database_name       = azurerm_kusto_database.example.name
 
-  tenant_id      = azurerm_digital_twins_instance.example.identity.0.tenant_id
-  principal_id   = azurerm_digital_twins_instance.example.identity.0.principal_id
+  tenant_id      = azurerm_digital_twins_instance.example.identity[0].tenant_id
+  principal_id   = azurerm_digital_twins_instance.example.identity[0].principal_id
   principal_type = "App"
   role           = "Admin"
 }

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -64,8 +64,8 @@ resource "azurerm_disk_encryption_set" "example" {
 resource "azurerm_key_vault_access_policy" "example-disk" {
   key_vault_id = azurerm_key_vault.example.id
 
-  tenant_id = azurerm_disk_encryption_set.example.identity.0.tenant_id
-  object_id = azurerm_disk_encryption_set.example.identity.0.principal_id
+  tenant_id = azurerm_disk_encryption_set.example.identity[0].tenant_id
+  object_id = azurerm_disk_encryption_set.example.identity[0].principal_id
 
   key_permissions = [
     "Create",
@@ -103,7 +103,7 @@ resource "azurerm_key_vault_access_policy" "example-user" {
 resource "azurerm_role_assignment" "example-disk" {
   scope                = azurerm_key_vault.example.id
   role_definition_name = "Key Vault Crypto Service Encryption User"
-  principal_id         = azurerm_disk_encryption_set.example.identity.0.principal_id
+  principal_id         = azurerm_disk_encryption_set.example.identity[0].principal_id
 }
 
 ```
@@ -164,8 +164,8 @@ resource "azurerm_disk_encryption_set" "example" {
 resource "azurerm_key_vault_access_policy" "example-disk" {
   key_vault_id = azurerm_key_vault.example.id
 
-  tenant_id = azurerm_disk_encryption_set.example.identity.0.tenant_id
-  object_id = azurerm_disk_encryption_set.example.identity.0.principal_id
+  tenant_id = azurerm_disk_encryption_set.example.identity[0].tenant_id
+  object_id = azurerm_disk_encryption_set.example.identity[0].principal_id
 
   key_permissions = [
     "Create",
@@ -203,7 +203,7 @@ resource "azurerm_key_vault_access_policy" "example-user" {
 resource "azurerm_role_assignment" "example-disk" {
   scope                = azurerm_key_vault.example.id
   role_definition_name = "Key Vault Crypto Service Encryption User"
-  principal_id         = azurerm_disk_encryption_set.example.identity.0.principal_id
+  principal_id         = azurerm_disk_encryption_set.example.identity[0].principal_id
 }
 
 ```

--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -52,8 +52,8 @@ resource "azurerm_key_vault" "example" {
 
 resource "azurerm_key_vault_access_policy" "example" {
   key_vault_id = azurerm_key_vault.example.id
-  tenant_id    = azurerm_eventhub_namespace.example.identity.0.tenant_id
-  object_id    = azurerm_eventhub_namespace.example.identity.0.principal_id
+  tenant_id    = azurerm_eventhub_namespace.example.identity[0].tenant_id
+  object_id    = azurerm_eventhub_namespace.example.identity[0].principal_id
 
   key_permissions = ["Get", "UnwrapKey", "WrapKey"]
 }

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -509,7 +509,7 @@ The `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
--> You can access the Principal ID via `azurerm_app_service.example.identity.0.principal_id` and the Tenant ID via `azurerm_app_service.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_app_service.example.identity[0].principal_id` and the Tenant ID via `azurerm_app_service.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/iot_time_series_insights_event_source_iothub.html.markdown
+++ b/website/docs/r/iot_time_series_insights_event_source_iothub.html.markdown
@@ -62,8 +62,8 @@ resource "azurerm_iot_time_series_insights_event_source_iothub" "example" {
   location                 = azurerm_resource_group.example.location
   environment_id           = azurerm_iot_time_series_insights_gen2_environment.example.id
   iothub_name              = azurerm_iothub.example.name
-  shared_access_key        = azurerm_iothub.example.shared_access_policy.0.primary_key
-  shared_access_key_name   = azurerm_iothub.example.shared_access_policy.0.key_name
+  shared_access_key        = azurerm_iothub.example.shared_access_policy[0].primary_key
+  shared_access_key_name   = azurerm_iothub.example.shared_access_policy[0].key_name
   consumer_group_name      = azurerm_iothub_consumer_group.example.name
   event_source_resource_id = azurerm_iothub.example.id
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -48,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 }
 
 output "client_certificate" {
-  value     = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
+  value     = azurerm_kubernetes_cluster.example.kube_config[0].client_certificate
   sensitive = true
 }
 
@@ -941,7 +941,7 @@ A `http_proxy_config` block supports the following:
 
 * `no_proxy` - (Optional) The list of domains that will not use the proxy for communication.
 
--> **Note:** If you specify the `default_node_pool.0.vnet_subnet_id`, be sure to include the Subnet CIDR in the `no_proxy` list.
+-> **Note:** If you specify the `default_node_pool[0].vnet_subnet_id`, be sure to include the Subnet CIDR in the `no_proxy` list.
 
 -> **Note:** You may wish to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore the changes to this field.
 
@@ -1063,12 +1063,12 @@ The `kube_admin_config` and `kube_config` blocks export the following:
 
 ```hcl
 provider "kubernetes" {
-  host                   = azurerm_kubernetes_cluster.main.kube_config.0.host
-  username               = azurerm_kubernetes_cluster.main.kube_config.0.username
-  password               = azurerm_kubernetes_cluster.main.kube_config.0.password
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)
+  host                   = azurerm_kubernetes_cluster.main.kube_config[0].host
+  username               = azurerm_kubernetes_cluster.main.kube_config[0].username
+  password               = azurerm_kubernetes_cluster.main.kube_config[0].password
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.main.kube_config[0].client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.main.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate)
 }
 ```
 

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_key_vault" "example" {
 resource "azurerm_key_vault_access_policy" "cluster" {
   key_vault_id = azurerm_key_vault.example.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_kusto_cluster.example.identity.0.principal_id
+  object_id    = azurerm_kusto_cluster.example.identity[0].principal_id
 
   key_permissions = ["Get", "UnwrapKey", "WrapKey"]
 }

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -840,7 +840,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
--> You can access the Principal ID via `azurerm_linux_web_app.example.identity.0.principal_id` and the Tenant ID via `azurerm_linux_web_app.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_linux_web_app.example.identity[0].principal_id` and the Tenant ID via `azurerm_linux_web_app.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -840,7 +840,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
--> You can access the Principal ID via `azurerm_linux_web_app.example.identity.0.principal_id` and the Tenant ID via `azurerm_linux_web_app.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_linux_web_app.example.identity[0].principal_id` and the Tenant ID via `azurerm_linux_web_app.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -81,7 +81,7 @@ An `identity` block exports the following:
 
 * `type` - (Required) The identity type of this Managed Service Identity.
 
--> You can access the Principal ID via `azurerm_log_analytics_cluster.example.identity.0.principal_id` and the Tenant ID via `azurerm_log_analytics_cluster.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_log_analytics_cluster.example.identity[0].principal_id` and the Tenant ID via `azurerm_log_analytics_cluster.example.identity[0].tenant_id`
 
 ## Timeouts
 

--- a/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
@@ -63,8 +63,8 @@ resource "azurerm_key_vault" "example" {
   }
 
   access_policy {
-    tenant_id = azurerm_log_analytics_cluster.example.identity.0.tenant_id
-    object_id = azurerm_log_analytics_cluster.example.identity.0.principal_id
+    tenant_id = azurerm_log_analytics_cluster.example.identity[0].tenant_id
+    object_id = azurerm_log_analytics_cluster.example.identity[0].principal_id
 
     key_permissions = [
       "Get",

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -324,7 +324,7 @@ The `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
--> You can access the Principal ID via `azurerm_app_service.example.identity.0.principal_id` and the Tenant ID via `azurerm_app_service.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_app_service.example.identity[0].principal_id` and the Tenant ID via `azurerm_app_service.example.identity[0].tenant_id`
 
 ---
 

--- a/website/docs/r/machine_learning_inference_cluster.html.markdown
+++ b/website/docs/r/machine_learning_inference_cluster.html.markdown
@@ -151,15 +151,15 @@ An `identity` block supports the following:
 
 A `ssl` block supports the following:
 
-* `cert` - (Optional) The certificate for the SSL configuration.Conflicts with `ssl.0.leaf_domain_label`,`ssl.0.overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
+* `cert` - (Optional) The certificate for the SSL configuration.Conflicts with `ssl[0].leaf_domain_label`,`ssl[0].overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
 
-* `cname` - (Optional) The cname of the SSL configuration.Conflicts with `ssl.0.leaf_domain_label`,`ssl.0.overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
+* `cname` - (Optional) The cname of the SSL configuration.Conflicts with `ssl[0].leaf_domain_label`,`ssl[0].overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
 
-* `key` - (Optional) The key content for the SSL configuration.Conflicts with `ssl.0.leaf_domain_label`,`ssl.0.overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
+* `key` - (Optional) The key content for the SSL configuration.Conflicts with `ssl[0].leaf_domain_label`,`ssl[0].overwrite_existing_domain`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
 
-* `leaf_domain_label` - (Optional) The leaf domain label for the SSL configuration. Conflicts with `ssl.0.cert`,`ssl.0.key`,`ssl.0.cname`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
+* `leaf_domain_label` - (Optional) The leaf domain label for the SSL configuration. Conflicts with `ssl[0].cert`,`ssl[0].key`,`ssl[0].cname`. Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
 
-* `overwrite_existing_domain` - (Optional) Whether or not to overwrite existing leaf domain. Conflicts with `ssl.0.cert`,`ssl.0.key`,`ssl.0.cname` Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
+* `overwrite_existing_domain` - (Optional) Whether or not to overwrite existing leaf domain. Conflicts with `ssl[0].cert`,`ssl[0].key`,`ssl[0].cname` Changing this forces a new Machine Learning Inference Cluster to be created. Defaults to `""`.
 
 ## Attributes Reference
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -319,7 +319,7 @@ A `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Database.
 
--> You can access the Principal ID via `azurerm_mssql_database.example.identity.0.principal_id` and the Tenant ID via `azurerm_mssql_database.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_mssql_database.example.identity[0].principal_id` and the Tenant ID via `azurerm_mssql_database.example.identity[0].tenant_id`
 
 ## Timeouts
 

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -275,7 +275,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Managed Instance.
 
--> You can access the Principal ID via `azurerm_mssql_managed_instance.example.identity.0.principal_id` and the Tenant ID via `azurerm_mssql_managed_instance.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_mssql_managed_instance.example.identity[0].principal_id` and the Tenant ID via `azurerm_mssql_managed_instance.example.identity[0].tenant_id`
 
 ## Timeouts
 

--- a/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
+++ b/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
@@ -60,7 +60,7 @@ resource "azuread_directory_role" "reader" {
 
 resource "azuread_directory_role_member" "example" {
   role_object_id   = azuread_directory_role.reader.object_id
-  member_object_id = azurerm_mssql_managed_instance.example.identity.0.principal_id
+  member_object_id = azurerm_mssql_managed_instance.example.identity[0].principal_id
 }
 
 resource "azuread_user" "admin" {

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -187,7 +187,7 @@ An `azuread_administrator` block supports the following:
 
 * `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Server.
 
-* `azuread_authentication_only` - (Optional) Specifies whether only AD Users and administrators (e.g. `azuread_administrator.0.login_username`) can be used to login, or also local database users (e.g. `administrator_login`). When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted.
+* `azuread_authentication_only` - (Optional) Specifies whether only AD Users and administrators (e.g. `azuread_administrator[0].login_username`) can be used to login, or also local database users (e.g. `administrator_login`). When `true`, the `administrator_login` and `administrator_login_password` properties can be omitted.
 
 ## Attributes Reference
 
@@ -207,7 +207,7 @@ A `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Server.
 
--> You can access the Principal ID via `azurerm_mssql_server.example.identity.0.principal_id` and the Tenant ID via `azurerm_mssql_server.example.identity.0.tenant_id`
+-> You can access the Principal ID via `azurerm_mssql_server.example.identity[0].principal_id` and the Tenant ID via `azurerm_mssql_server.example.identity[0].tenant_id`
 
 ### Timeouts
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -85,7 +85,7 @@ resource "azurerm_subnet" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = azurerm_mssql_server.example.identity.0.principal_id
+  principal_id         = azurerm_mssql_server.example.identity[0].principal_id
 }
 
 resource "azurerm_mssql_server" "example" {

--- a/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
@@ -83,7 +83,7 @@ resource "azurerm_subnet" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = azurerm_mssql_server.example.identity.0.principal_id
+  principal_id         = azurerm_mssql_server.example.identity[0].principal_id
 }
 
 resource "azurerm_mssql_server" "example" {

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `zone` - (Optional) Specifies the Availability Zone in which this MySQL Flexible Server should be located. Possible values are `1`, `2` and `3`.
 
--> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the MySQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability.0.standby_availability_zone` fields should you wish for Terraform to not migrate the MySQL Flexible Server back to it's primary Availability Zone after a fail-over.
+-> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the MySQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability[0].standby_availability_zone` fields should you wish for Terraform to not migrate the MySQL Flexible Server back to it's primary Availability Zone after a fail-over.
 
 -> **Note:** The Availability Zones available depend on the Azure Region that the MySQL Flexible Server is being deployed into - see [the Azure Availability Zones documentation](https://azure.microsoft.com/global-infrastructure/geographies/#geographies) for more information on which Availability Zones are available in each Azure Region.
 
@@ -165,11 +165,11 @@ A `high_availability` block supports the following:
 
 * `mode` - (Required) The high availability mode for the MySQL Flexible Server. Possibles values are `SameZone` and `ZoneRedundant`.
 
-~> **NOTE:** `storage.0.auto_grow_enabled` must be enabled when `high_availability` is enabled. To change the `high_availability` for a MySQL Flexible Server created with `high_availability` disabled during creation, the resource has to be recreated.
+~> **NOTE:** `storage[0].auto_grow_enabled` must be enabled when `high_availability` is enabled. To change the `high_availability` for a MySQL Flexible Server created with `high_availability` disabled during creation, the resource has to be recreated.
 
 * `standby_availability_zone` - (Optional) Specifies the Availability Zone in which the standby Flexible Server should be located. Possible values are `1`, `2` and `3`.
 
--> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the MySQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability.0.standby_availability_zone` fields should you wish for Terraform to not migrate the MySQL Flexible Server back to it's primary Availability Zone after a fail-over.
+-> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the MySQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability[0].standby_availability_zone` fields should you wish for Terraform to not migrate the MySQL Flexible Server back to it's primary Availability Zone after a fail-over.
 
 -> **Note:** The Availability Zones available depend on the Azure Region that the MySQL Flexible Server is being deployed into - see [the Azure Availability Zones documentation](https://azure.microsoft.com/global-infrastructure/geographies/#geographies) for more information on which Availability Zones are available in each Azure Region.
 

--- a/website/docs/r/mysql_server_key.html.markdown
+++ b/website/docs/r/mysql_server_key.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_key_vault" "example" {
 resource "azurerm_key_vault_access_policy" "server" {
   key_vault_id       = azurerm_key_vault.example.id
   tenant_id          = data.azurerm_client_config.current.tenant_id
-  object_id          = azurerm_mysql_server.example.identity.0.principal_id
+  object_id          = azurerm_mysql_server.example.identity[0].principal_id
   key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
   secret_permissions = ["Get"]
 }

--- a/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
@@ -108,9 +108,9 @@ A `destination_nat` block supports the following:
 
 A `dns_settings` block supports the following:
 
-* `dns_servers` - (Optional) Specifies a list of DNS servers to proxy. Conflicts with `dns_settings.0.use_azure_dns`.
+* `dns_servers` - (Optional) Specifies a list of DNS servers to proxy. Conflicts with `dns_settings[0].use_azure_dns`.
 
-* `use_azure_dns` - (Optional) Should Azure DNS servers be used? Conflicts with `dns_settings.0.dns_servers`. Defaults to `false`.
+* `use_azure_dns` - (Optional) Should Azure DNS servers be used? Conflicts with `dns_settings[0].dns_servers`. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/palo_alto_next_generation_firewall_vhub_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_vhub_panorama.html.markdown
@@ -113,9 +113,9 @@ A `destination_nat` block supports the following:
 
 A `dns_settings` block supports the following:
 
-* `dns_servers` - (Optional) Specifies a list of DNS servers to proxy. Conflicts with `dns_settings.0.use_azure_dns`.
+* `dns_servers` - (Optional) Specifies a list of DNS servers to proxy. Conflicts with `dns_settings[0].use_azure_dns`.
 
-* `use_azure_dns` - (Optional) Should Azure DNS servers be used? Conflicts with `dns_settings.0.dns_servers`. Defaults to `false`.
+* `use_azure_dns` - (Optional) Should Azure DNS servers be used? Conflicts with `dns_settings[0].dns_servers`. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -173,9 +173,9 @@ A `destination_nat` block supports the following:
 
 A `dns_settings` block supports the following:
 
-* `dns_servers` - (Optional) Specifies a list of DNS servers to use. Conflicts with `dns_settings.0.use_azure_dns`.
+* `dns_servers` - (Optional) Specifies a list of DNS servers to use. Conflicts with `dns_settings[0].use_azure_dns`.
 
-* `use_azure_dns` - (Optional) Should the Firewall use Azure Supplied DNS servers. Conflicts with `dns_settings.0.dns_servers`. Defaults to `false`.
+* `use_azure_dns` - (Optional) Should the Firewall use Azure Supplied DNS servers. Conflicts with `dns_settings[0].dns_servers`. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
@@ -153,9 +153,9 @@ A `destination_nat` block supports the following:
 
 A `dns_settings` block supports the following:
 
-* `dns_servers` - (Optional) Specifies a list of DNS servers to use. Conflicts with `dns_settings.0.use_azure_dns`.
+* `dns_servers` - (Optional) Specifies a list of DNS servers to use. Conflicts with `dns_settings[0].use_azure_dns`.
 
-* `use_azure_dns` - (Optional) Should the Firewall use Azure Supplied DNS servers. Conflicts with `dns_settings.0.dns_servers`. Defaults to `false`.
+* `use_azure_dns` - (Optional) Should the Firewall use Azure Supplied DNS servers. Conflicts with `dns_settings[0].dns_servers`. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/pim_active_role_assignment.html.markdown
+++ b/website/docs/r/pim_active_role_assignment.html.markdown
@@ -102,11 +102,11 @@ The following arguments are supported:
 
 A `expiration` block supports the following:
 
-* `duration_days` - (Optional) The duration of the role assignment in days. Conflicts with `schedule.0.expiration.0.duration_hours`,`schedule.0.expiration.0.end_date_time` Changing this forces a new Pim Active Role Assignment to be created.
+* `duration_days` - (Optional) The duration of the role assignment in days. Conflicts with `schedule[0].expiration[0].duration_hours`,`schedule[0].expiration[0].end_date_time` Changing this forces a new Pim Active Role Assignment to be created.
 
-* `duration_hours` - (Optional) The duration of the role assignment in hours. Conflicts with `schedule.0.expiration.0.duration_days`,`schedule.0.expiration.0.end_date_time` Changing this forces a new Pim Active Role Assignment to be created.
+* `duration_hours` - (Optional) The duration of the role assignment in hours. Conflicts with `schedule[0].expiration[0].duration_days`,`schedule[0].expiration[0].end_date_time` Changing this forces a new Pim Active Role Assignment to be created.
 
-* `end_date_time` - (Optional) The end date time of the role assignment. Conflicts with `schedule.0.expiration.0.duration_days`,`schedule.0.expiration.0.duration_hours` Changing this forces a new Pim Active Role Assignment to be created.
+* `end_date_time` - (Optional) The end date time of the role assignment. Conflicts with `schedule[0].expiration[0].duration_days`,`schedule[0].expiration[0].duration_hours` Changing this forces a new Pim Active Role Assignment to be created.
 
 ---
 

--- a/website/docs/r/pim_eligible_role_assignment.html.markdown
+++ b/website/docs/r/pim_eligible_role_assignment.html.markdown
@@ -105,11 +105,11 @@ The following arguments are supported:
 
 A `expiration` block supports the following:
 
-* `duration_days` - (Optional) The duration of the role assignment in days. Conflicts with `schedule.0.expiration.0.duration_hours`,`schedule.0.expiration.0.end_date_time` Changing this forces a new Pim Eligible Role Assignment to be created.
+* `duration_days` - (Optional) The duration of the role assignment in days. Conflicts with `schedule[0].expiration[0].duration_hours`,`schedule[0].expiration[0].end_date_time` Changing this forces a new Pim Eligible Role Assignment to be created.
 
-* `duration_hours` - (Optional) The duration of the role assignment in hours. Conflicts with `schedule.0.expiration.0.duration_days`,`schedule.0.expiration.0.end_date_time` Changing this forces a new Pim Eligible Role Assignment to be created.
+* `duration_hours` - (Optional) The duration of the role assignment in hours. Conflicts with `schedule[0].expiration[0].duration_days`,`schedule[0].expiration[0].end_date_time` Changing this forces a new Pim Eligible Role Assignment to be created.
 
-* `end_date_time` - (Optional) The end date time of the role assignment. Conflicts with `schedule.0.expiration.0.duration_days`,`schedule.0.expiration.0.duration_hours` Changing this forces a new Pim Eligible Role Assignment to be created.
+* `end_date_time` - (Optional) The end date time of the role assignment. Conflicts with `schedule[0].expiration[0].duration_days`,`schedule[0].expiration[0].duration_hours` Changing this forces a new Pim Eligible Role Assignment to be created.
 
 ---
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 
--> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability.0.standby_availability_zone` fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.
+-> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability[0].standby_availability_zone` fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.
 
 -> **Note:** The Availability Zones available depend on the Azure Region that the PostgreSQL Flexible Server is being deployed into - see [the Azure Availability Zones documentation](https://azure.microsoft.com/global-infrastructure/geographies/#geographies) for more information on which Availability Zones are available in each Azure Region.
 
@@ -210,7 +210,7 @@ A `high_availability` block supports the following:
 
 * `standby_availability_zone` - (Optional) Specifies the Availability Zone in which the standby Flexible Server should be located.
 
--> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability.0.standby_availability_zone` fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.
+-> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability[0].standby_availability_zone` fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.
 
 -> **Note:** The Availability Zones available depend on the Azure Region that the PostgreSQL Flexible Server is being deployed into - see [the Azure Availability Zones documentation](https://azure.microsoft.com/global-infrastructure/geographies/#geographies) for more information on which Availability Zones are available in each Azure Region.
 

--- a/website/docs/r/postgresql_server_key.html.markdown
+++ b/website/docs/r/postgresql_server_key.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_key_vault" "example" {
 resource "azurerm_key_vault_access_policy" "server" {
   key_vault_id = azurerm_key_vault.example.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_postgresql_server.example.identity.0.principal_id
+  object_id    = azurerm_postgresql_server.example.identity[0].principal_id
 
   key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
   secret_permissions = ["Get"]

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -77,7 +77,7 @@ resource "azurerm_private_link_service" "example" {
   }
 
   load_balancer_frontend_ip_configuration_ids = [
-    azurerm_lb.example.frontend_ip_configuration.0.id,
+    azurerm_lb.example.frontend_ip_configuration[0].id,
   ]
 }
 

--- a/website/docs/r/private_endpoint_application_security_group_association.html.markdown
+++ b/website/docs/r/private_endpoint_application_security_group_association.html.markdown
@@ -83,7 +83,7 @@ resource "azurerm_private_link_service" "example" {
   }
 
   load_balancer_frontend_ip_configuration_ids = [
-    azurerm_lb.example.frontend_ip_configuration.0.id
+    azurerm_lb.example.frontend_ip_configuration[0].id
   ]
 }
 

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -62,7 +62,7 @@ resource "azurerm_private_link_service" "example" {
 
   auto_approval_subscription_ids              = ["00000000-0000-0000-0000-000000000000"]
   visibility_subscription_ids                 = ["00000000-0000-0000-0000-000000000000"]
-  load_balancer_frontend_ip_configuration_ids = [azurerm_lb.example.frontend_ip_configuration.0.id]
+  load_balancer_frontend_ip_configuration_ids = [azurerm_lb.example.frontend_ip_configuration[0].id]
 
   nat_ip_configuration {
     name                       = "primary"

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -165,7 +165,7 @@ redis_configuration {
 ```hcl
 resource "azurerm_redis_cache" "example" {
   # ...
-  ignore_changes = [redis_configuration.0.rdb_storage_connection_string]
+  ignore_changes = [redis_configuration[0].rdb_storage_connection_string]
 }
 ```
 

--- a/website/docs/r/spring_cloud_customized_accelerator.html.markdown
+++ b/website/docs/r/spring_cloud_customized_accelerator.html.markdown
@@ -79,7 +79,7 @@ A `git_repository` block supports the following:
 
 * `url` - (Required) Specifies Git repository URL for the accelerator.
 
-* `basic_auth` - (Optional) A `basic_auth` block as defined below. Conflicts with `git_repository.0.ssh_auth`. Changing this forces a new Spring Cloud Customized Accelerator to be created.
+* `basic_auth` - (Optional) A `basic_auth` block as defined below. Conflicts with `git_repository[0].ssh_auth`. Changing this forces a new Spring Cloud Customized Accelerator to be created.
 
 * `branch` - (Optional) Specifies the Git repository branch to be used.
 
@@ -91,7 +91,7 @@ A `git_repository` block supports the following:
 
 * `interval_in_seconds` - (Optional) Specifies the interval for checking for updates to Git or image repository. It should be greater than 10.
 
-* `ssh_auth` - (Optional) A `ssh_auth` block as defined below. Conflicts with `git_repository.0.basic_auth`. Changing this forces a new Spring Cloud Customized Accelerator to be created.
+* `ssh_auth` - (Optional) A `ssh_auth` block as defined below. Conflicts with `git_repository[0].basic_auth`. Changing this forces a new Spring Cloud Customized Accelerator to be created.
 
 * `path` - (Optional) Specifies the path under the git repository to be treated as the root directory of the accelerator or the fragment (depending on `accelerator_type`).
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -104,7 +104,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Server.
 
--> You can access the Principal ID via `${azurerm_mssql_server.example.identity.0.principal_id}` and the Tenant ID via `${azurerm_mssql_server.example.identity.0.tenant_id}`
+-> You can access the Principal ID via `${azurerm_mssql_server.example.identity[0].principal_id}` and the Tenant ID via `${azurerm_mssql_server.example.identity[0].tenant_id}`
 
 ### Timeouts
 

--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -75,7 +75,7 @@ An `identity` block exports the following:
 
 * `principal_id` - (Optional) The Principal ID associated with this Managed Service Identity.
 
--> You can access the Principal ID via `azurerm_static_site.example.identity.0.principal_id`
+-> You can access the Principal ID via `azurerm_static_site.example.identity[0].principal_id`
 
 ## Timeouts
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -604,7 +604,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Storage Account.
 
--> You can access the Principal ID via `${azurerm_storage_account.example.identity.0.principal_id}` and the Tenant ID via `${azurerm_storage_account.example.identity.0.tenant_id}`
+-> You can access the Principal ID via `${azurerm_storage_account.example.identity[0].principal_id}` and the Tenant ID via `${azurerm_storage_account.example.identity[0].tenant_id}`
 
 ## Timeouts
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_key_vault" "example" {
 resource "azurerm_key_vault_access_policy" "storage" {
   key_vault_id = azurerm_key_vault.example.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_storage_account.example.identity.0.principal_id
+  object_id    = azurerm_storage_account.example.identity[0].principal_id
 
   secret_permissions = ["Get"]
   key_permissions = [

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -404,7 +404,7 @@ An `identity` block exports the following:
 
 * `principal_id` - The Principal ID associated with this Managed Service Identity.
 
--> You can access the Principal ID via `${azurerm_virtual_machine.example.identity.0.principal_id}`
+-> You can access the Principal ID via `${azurerm_virtual_machine.example.identity[0].principal_id}`
 
 ## Timeouts
 

--- a/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
+++ b/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
@@ -66,7 +66,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "example" {
   virtual_network_gateway_id = data.azurerm_virtual_network_gateway.example.id
   mode                       = "EgressSnat"
   type                       = "Dynamic"
-  ip_configuration_id        = data.azurerm_virtual_network_gateway.example.ip_configuration.0.id
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.example.ip_configuration[0].id
 
   external_mapping {
     address_space = "10.2.0.0/26"

--- a/website/docs/r/vmware_private_cloud.html.markdown
+++ b/website/docs/r/vmware_private_cloud.html.markdown
@@ -53,14 +53,14 @@ The following arguments are supported:
 * `location` - (Required) The Azure Region where the VMware Private Cloud should exist. Changing this forces a new VMware Private Cloud to be created.
 
 * `management_cluster` - (Required) A `management_cluster` block as defined below.
-~> **NOTE :** `internet_connection_enabled` and `management_cluster.0.size` cannot be updated at the same time.
+~> **NOTE :** `internet_connection_enabled` and `management_cluster[0].size` cannot be updated at the same time.
 
 * `network_subnet_cidr` - (Required) The subnet which should be unique across virtual network in your subscription as well as on-premise. Changing this forces a new VMware Private Cloud to be created.
 
 * `sku_name` - (Required) The Name of the SKU used for this Private Cloud. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new VMware Private Cloud to be created.
 
-* `internet_connection_enabled` - (Optional) Is the Private Cluster connected to the internet? This field can not updated with `management_cluster.0.size` together.
-~> **NOTE :** `internet_connection_enabled` and `management_cluster.0.size` cannot be updated at the same time.
+* `internet_connection_enabled` - (Optional) Is the Private Cluster connected to the internet? This field can not updated with `management_cluster[0].size` together.
+~> **NOTE :** `internet_connection_enabled` and `management_cluster[0].size` cannot be updated at the same time.
 
 * `nsxt_password` - (Optional) The password of the NSX-T Manager. Changing this forces a new VMware Private Cloud to be created.
 


### PR DESCRIPTION
Terraform official document uses the square-bracket index notation, like `local.list[3]` notation for list element access. Whilst there are a couple of places in the provider documents using the legacy notation, e.g. `local.list.3`.

This PR fixes all the legacy notion to using the square-bracket index notation.

This is done by:

1. Ensure only `*.0` appears in the doc, but not `*.1` or `*.2`, etc:

    ```
    💤  grep -Er "[a-zA-Z]+\.[1-9]\." .
    ./r/container_group.html.markdown:* `options` - (Optional) A list of [resolver configuration options](https://man7.org/linux/man-pages/man5/resolv.conf.5.html). Changing this forces a new resource to be created.
    ./r/automation_powershell72_module.html.markdown:    uri = "https://devopsgallerystorage.blob.core.windows.net/packages/xactivedirectory.2.19.0.nupkg"
    ./r/automation_module.html.markdown:    uri = "https://devopsgallerystorage.blob.core.windows.net/packages/xactivedirectory.2.19.0.nupkg"
    ./r/spring_cloud_customized_accelerator.html.markdown:    git_tag             = "spring.version.2.0.3"
    ```

    The grep out are not interesting, can be ignored.

2. Replacing all the `*.0` to `*[0]`, via `find . -type f | xargs sed -i 's;\([a-zA-Z]\+\)\.0;\1[0];g'`, under the *website/docs* directory
3. Review the diff and remove some false positives

Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/25060