### PR TITLE
`azurerm_key_vault_managed_hardware_security_module`: update `ManagedHardwareSecurityModuleName` to allow hyphens

### DIFF
--- a/internal/services/managedhsm/validate/managed_hsm_name.go
+++ b/internal/services/managedhsm/validate/managed_hsm_name.go
@@ -6,6 +6,7 @@ package validate
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 func ManagedHardwareSecurityModuleName(i interface{}, k string) (warnings []string, errors []error) {
@@ -15,11 +16,9 @@ func ManagedHardwareSecurityModuleName(i interface{}, k string) (warnings []stri
 	}
 
 	// The name attribute rules are :
-	// 1. can contain only alphanumeric characters.
-	// 2. The first character must be a letter.
-	// 3. The last character must be a letter or number
-	// 4. The value must be between 3 and 24 characters long
-	if !regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d]{2,23}$`).MatchString(v) {
+	// Must be a 3-24 character string, containing only 0-9, a-z. A-Z, and -
+	// The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.
+	if strings.Contains(v, "--") || !regexp.MustCompile(`^[a-zA-Z][-a-zA-Z\d]{1,22}[a-zA-Z\d]$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%s must begin with a letter, end with a letter or number, contain only alphanumeric characters. The value must be between 3 and 24 characters long", k))
 	}
 

--- a/internal/services/managedhsm/validate/managed_hsm_name_test.go
+++ b/internal/services/managedhsm/validate/managed_hsm_name_test.go
@@ -31,8 +31,18 @@ func TestManagedHardwareSecurityModuleName(t *testing.T) {
 			expected: false,
 		},
 		{
-			// can't contain hyphen
+			// can contain non-consecutive hyphens
 			input:    "ab-c",
+			expected: true,
+		},
+		{
+			// can't contain consecutive hyphens
+			input:    "ab--c",
+			expected: false,
+		},
+		{
+			// can't end with hyphens
+			input:    "ab-cdef-",
 			expected: false,
 		},
 		{


### PR DESCRIPTION
fixes: #25099.

The latest rule of the managed hsm name is :

1. Must be a 3-24 character string, containing only 0-9, a-z. A-Z, and -
2. Managed HSM name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/83df4ee0-b0fe-482a-8b8e-bf5f0b68a927)


but It can have non-consective hyphens in the name:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/b6489876-4fbf-4514-b803-46d45a926460)
