### PR TITLE
azurerm_container_app_environment - Add Consumption to workload profile

### DIFF
--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -37,6 +37,7 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
+						"Consumption",
 						"D4",
 						"D8",
 						"D16",

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -76,7 +76,7 @@ A `workload_profile` block supports the following:
 
 * `name` - (Required) The name of the workload profile.
 
-* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
+* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `Consumption`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
 
 * `maximum_count` - (Required) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
 


### PR DESCRIPTION
Fixes #24608 by adding `Consumption` option to the workload_profile_type validation

Running `az containerapp env workload-profile list-supported -l westeurope` shows it's a valid option.