### PR TITLE
`azurerm_orbital_contact_profile`: remove `ForceNew` for `Channels`

### DIFF
--- a/internal/services/orbital/contact_profile_resource_test.go
+++ b/internal/services/orbital/contact_profile_resource_test.go
@@ -49,6 +49,28 @@ func TestAccContactProfile_multipleChannels(t *testing.T) {
 	})
 }
 
+func TestAccContactProfile_addChannel(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
+	r := ContactProfileResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleChannels(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContactProfile_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}

--- a/internal/services/orbital/helper.go
+++ b/internal/services/orbital/helper.go
@@ -89,7 +89,6 @@ func ChannelSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Required: true,
-		ForceNew: true,
 		MinItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*schema.Schema{

--- a/website/docs/r/orbital_contact_profile.html.markdown
+++ b/website/docs/r/orbital_contact_profile.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 
 A `links` block supports the following:
 
-* `channels` - (Required) A list of contact profile link channels. A `channels` block as defined below. Changing this forces a new resource to be created.
+* `channels` - (Required) A list of contact profile link channels. A `channels` block as defined below.
 
 * `direction` - (Required) Direction of the link. Possible values are `Uplink` and `Downlink`.
 


### PR DESCRIPTION
fix #25078 

<img width="438" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/4383765c-f2a5-4174-99e1-a19c9223fdd0">