### PR TITLE
`azurerm_firewall_policy_rule_collection_group`: use resource id's subscription instead of client subscriptio id for `fireall_policy_id `field

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -509,7 +509,6 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 }
 
 func resourceFirewallPolicyRuleCollectionGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Network.FirewallPolicyRuleCollectionGroups
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -531,7 +530,7 @@ func resourceFirewallPolicyRuleCollectionGroupRead(d *pluginsdk.ResourceData, me
 	}
 
 	d.Set("name", id.RuleCollectionGroupName)
-	d.Set("firewall_policy_id", firewallpolicies.NewFirewallPolicyID(subscriptionId, id.ResourceGroupName, id.FirewallPolicyName).ID())
+	d.Set("firewall_policy_id", firewallpolicies.NewFirewallPolicyID(id.SubscriptionId, id.ResourceGroupName, id.FirewallPolicyName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {


### PR DESCRIPTION
fixes: #24546.

Use the subscription ID from the resource ID instead of the client's subscription ID.