### PR TITLE
Manually register kubernetes fleet manager

### DIFF
--- a/internal/services/containers/registration.go
+++ b/internal/services/containers/registration.go
@@ -74,6 +74,7 @@ func (r Registration) Resources() []sdk.Resource {
 		ContainerConnectedRegistryResource{},
 		KubernetesClusterExtensionResource{},
 		KubernetesFluxConfigurationResource{},
+		KubernetesFleetManagerResource{},
 		KubernetesFleetUpdateRunResource{},
 		KubernetesFleetUpdateStrategyResource{},
 	}


### PR DESCRIPTION
#25154 removed the registration from the generated list of registrations, adding it back to the non-generated registrations.