### PR TITLE
Don't remove the revison suffix from the api_id of the API tag

### DIFF
--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/tag"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -67,7 +68,7 @@ func resourceApiManagementApiTagCreate(d *pluginsdk.ResourceData, meta interface
 	tagId := tag.NewTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, d.Get("name").(string))
 
 	id := apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiId.ApiId, d.Get("name").(string))
-	
+
 	if !features.FourPointOh() {
 		apiName := getApiName(apiId.ApiId)
 		id = apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiName, d.Get("name").(string))
@@ -115,9 +116,9 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 
 	if !features.FourPointOh() {
-		apiName := getApiName(id.ApiId)  
-        apiId = api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName)
-        tagId = apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
+		apiName := getApiName(id.ApiId)
+		apiId = api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName)
+		tagId = apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
 	}
 
 	resp, err := client.TagGetByApi(ctx, tagId)
@@ -149,10 +150,10 @@ func resourceApiManagementApiTagDelete(d *pluginsdk.ResourceData, meta interface
 
 	newId := apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 
-	if !features.FourPointOh() {  
-        name := getApiName(id.ApiId)  
-        newId = apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, name, id.TagId)
-    }  
+	if !features.FourPointOh() {
+		name := getApiName(id.ApiId)
+		newId = apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, name, id.TagId)
+	}
 
 	if _, err = client.TagDetachFromApi(ctx, newId); err != nil {
 		return fmt.Errorf("detaching api tag %q: %+v", newId, err)

--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -67,6 +67,11 @@ func resourceApiManagementApiTagCreate(d *pluginsdk.ResourceData, meta interface
 	tagId := tag.NewTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, d.Get("name").(string))
 
 	id := apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiId.ApiId, d.Get("name").(string))
+	
+	if !features.FourPointOh() {
+		apiName := getApiName(apiId.ApiId)
+		id = apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiName, d.Get("name").(string))
+	}
 
 	tagExists, err := tagClient.Get(ctx, tagId)
 	if err != nil {
@@ -109,6 +114,12 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 	apiId := api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId)
 	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 
+	if !features.FourPointOh() {
+		apiName := getApiName(id.ApiId)  
+        apiId = api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName)
+        tagId = apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
+	}
+
 	resp, err := client.TagGetByApi(ctx, tagId)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -137,6 +148,12 @@ func resourceApiManagementApiTagDelete(d *pluginsdk.ResourceData, meta interface
 	}
 
 	newId := apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
+
+	if !features.FourPointOh() {  
+        name := getApiName(id.ApiId)  
+        newId = apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, name, id.TagId)
+    }  
+
 	if _, err = client.TagDetachFromApi(ctx, newId); err != nil {
 		return fmt.Errorf("detaching api tag %q: %+v", newId, err)
 	}

--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -110,7 +110,6 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 
 	apiName := getApiName(id.ApiId)
 
-	apiId := api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName)
 	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
 
 	resp, err := client.TagGetByApi(ctx, tagId)
@@ -124,7 +123,6 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("retrieving %q: %+v", tagId, err)
 	}
 
-	d.Set("api_id", apiId.ID())
 	d.Set("name", id.TagId)
 
 	return nil

--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -66,9 +66,7 @@ func resourceApiManagementApiTagCreate(d *pluginsdk.ResourceData, meta interface
 
 	tagId := tag.NewTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, d.Get("name").(string))
 
-	apiName := getApiName(apiId.ApiId)
-
-	id := apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiName, d.Get("name").(string))
+	id := apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiId.ApiId, d.Get("name").(string))
 
 	tagExists, err := tagClient.Get(ctx, tagId)
 	if err != nil {
@@ -108,9 +106,8 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	apiName := getApiName(id.ApiId)
-
-	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
+	apiId := api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId)
+	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 
 	resp, err := client.TagGetByApi(ctx, tagId)
 	if err != nil {
@@ -123,6 +120,7 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("retrieving %q: %+v", tagId, err)
 	}
 
+	d.Set("api_id", apiId.ID())
 	d.Set("name", id.TagId)
 
 	return nil

--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -136,9 +136,7 @@ func resourceApiManagementApiTagDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	name := getApiName(id.ApiId)
-
-	newId := apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, name, id.TagId)
+	newId := apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 	if _, err = client.TagDetachFromApi(ctx, newId); err != nil {
 		return fmt.Errorf("detaching api tag %q: %+v", newId, err)
 	}


### PR DESCRIPTION
This fixes #24705 by removing the code that stripped the API ID of the `;rev=XYZ` revision segment in the ID. This was causing the API tag to be recreated on each run, even if the tag did not change.