### PR TITLE
Update documentation for azurerm_role_assignment

### DIFF
--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 ~> **NOTE:** The Principal ID is also known as the Object ID (ie not the "Application ID" for applications).
 
-* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set the this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
 
 ~> **NOTE:** If one of `condition` or `condition_version` is set both fields must be present.
 

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 ~> **NOTE:** The Principal ID is also known as the Object ID (ie not the "Application ID" for applications).
 
-* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created.
+* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set the this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
 
 ~> **NOTE:** If one of `condition` or `condition_version` is set both fields must be present.
 


### PR DESCRIPTION
As noted in https://github.com/hashicorp/terraform-provider-azurerm/issues/23364#issuecomment-1893777970, the attribute `principal_type` is required when the assigning principal has a constrain on the principals it is allowed to assign. 

More information on ABAC/RBAC delegation: https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-portal
