### PR TITLE
`azurerm_data_factory_pipeline`: correctly handle empty headers for `WebActivity`

### DIFF
--- a/internal/services/datafactory/azuresdkhacks/models.go
+++ b/internal/services/datafactory/azuresdkhacks/models.go
@@ -18,7 +18,7 @@ import (
 type WebActivityTypeProperties struct {
 	Method                datafactory.WebActivityMethod            `json:"method,omitempty"`
 	URL                   interface{}                              `json:"url,omitempty"`
-	Headers               interface{}                              `json:"headers"`
+	Headers               interface{}                              `json:"headers,omitempty"`
 	Body                  interface{}                              `json:"body,omitempty"`
 	Authentication        *datafactory.WebActivityAuthentication   `json:"authentication,omitempty"`
 	DisableCertValidation *bool                                    `json:"disableCertValidation,omitempty"`


### PR DESCRIPTION
<img width="392" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/c3f3d146-d3db-4855-bb37-addfef6cb7ef">