### PR TITLE
`azurerm_mysql_flexible_server` - read `create_mode` from config

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -506,6 +506,7 @@ func resourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("zone", props.AvailabilityZone)
 			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
+			d.Set("create_mode", d.Get("create_mode").(string))
 
 			if network := props.Network; network != nil {
 				d.Set("public_network_access_enabled", *network.PublicNetworkAccess == servers.EnableStatusEnumEnabled)


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/25165

Symptom: Though "create_mode" is set in the tf config and request payload but API doesn't return the value. So API doesn't set it in state file while importing the resource. Hence, TF would cause diff.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/e41e2f38-eb58-4a0c-b48d-a4c8d2aae1bc)
