### PR TITLE
`azurerm_mssql_database` - fix typo where `restore_long_term_retention_backup_id` should be used instead of  `long_term_retention_backup_id`

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -325,8 +325,8 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 			return fmt.Errorf("'restore_dropped_database_id' is required for create_mode %s", createMode)
 		}
 	case databases.CreateModeRestoreLongTermRetentionBackup:
-		if _, dbok := d.GetOk("long_term_retention_backup_id"); !dbok {
-			return fmt.Errorf("'long_term_retention_backup_id' is required for create_mode %s", createMode)
+		if _, dbok := d.GetOk("restore_long_term_retention_backup_id"); !dbok {
+			return fmt.Errorf("'restore_long_term_retention_backup_id' is required for create_mode %s", createMode)
 		}
 	}
 


### PR DESCRIPTION
Fix #[25163](https://github.com/hashicorp/terraform-provider-azurerm/issues/25163)