### PR TITLE
`azurerm_subscription` - fix checkExistingAliases

### DIFF
--- a/internal/services/subscription/subscription_resource.go
+++ b/internal/services/subscription/subscription_resource.go
@@ -503,10 +503,6 @@ func checkExistingAliases(ctx context.Context, client subscriptionAlias.Subscrip
 		return nil, 0, fmt.Errorf("could not List existing Subscription Aliases")
 	}
 
-	if len(aliasList.Items) == 0 {
-		return nil, 0, fmt.Errorf("failed reading Subscription Alias list: no aliases were returned")
-	}
-
 	for _, v := range aliasList.Items {
 		if v.Properties != nil && v.Properties.SubscriptionId != nil && subscriptionId == *v.Properties.SubscriptionId {
 			return v.Name, len(aliasList.Items), nil


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/25164

related with https://github.com/hashicorp/terraform-provider-azurerm/commit/7a71d3702e3831c37ea2bca18fab13f7ab7cf871#diff-7a898f7000607cd3fe4064bff824a14a22ac263988337e492bccb9ef70691049L506-R507

seems no need to fire error if no alias is found.