### PR TITLE
`azurerm_virtual_machine_run_command` - fix update 

### DIFF
--- a/internal/services/compute/virtual_machine_run_command_resource.go
+++ b/internal/services/compute/virtual_machine_run_command_resource.go
@@ -22,8 +22,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-var _ sdk.Resource = VirtualMachineRunCommandResource{}
-var _ sdk.ResourceWithUpdate = VirtualMachineRunCommandResource{}
+var (
+	_ sdk.Resource           = VirtualMachineRunCommandResource{}
+	_ sdk.ResourceWithUpdate = VirtualMachineRunCommandResource{}
+)
 
 type VirtualMachineRunCommandResource struct{}
 
@@ -304,7 +306,6 @@ func (r VirtualMachineRunCommandResource) Arguments() map[string]*pluginsdk.Sche
 
 		"tags": commonschema.Tags(),
 	}
-
 }
 
 func (r VirtualMachineRunCommandResource) Attributes() map[string]*pluginsdk.Schema {
@@ -515,17 +516,21 @@ func (r VirtualMachineRunCommandResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
+			resp, err := client.GetByVirtualMachine(ctx, *id, virtualmachineruncommands.GetByVirtualMachineOperationOptions{
+				// otherwise, the response will not contain instanceView
+				Expand: pointer.To("instanceView"),
+			})
+			if resp.Model == nil {
+				return fmt.Errorf("unexpected null model of %s", *id)
+			}
+			payload := resp.Model
+			if payload.Properties == nil {
+				return fmt.Errorf("unexpected null properties of %s", *id)
+			}
+
 			var config VirtualMachineRunCommandResourceSchema
 			if err := metadata.Decode(&config); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
-			}
-
-			payload := virtualmachineruncommands.VirtualMachineRunCommandUpdate{
-				Properties: &virtualmachineruncommands.VirtualMachineRunCommandProperties{
-					TreatFailureAsDeploymentFailure: pointer.To(true),
-					AsyncExecution:                  pointer.To(false),
-					TimeoutInSeconds:                pointer.To(int64(metadata.ResourceData.Timeout(pluginsdk.TimeoutUpdate).Seconds())),
-				},
 			}
 
 			if metadata.ResourceData.HasChange("error_blob_managed_identity") {
@@ -568,7 +573,7 @@ func (r VirtualMachineRunCommandResource) Update() sdk.ResourceFunc {
 				payload.Tags = tags.Expand(config.Tags)
 			}
 
-			if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 

--- a/internal/services/compute/virtual_machine_run_command_resource.go
+++ b/internal/services/compute/virtual_machine_run_command_resource.go
@@ -520,6 +520,9 @@ func (r VirtualMachineRunCommandResource) Update() sdk.ResourceFunc {
 				// otherwise, the response will not contain instanceView
 				Expand: pointer.To("instanceView"),
 			})
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
 			if resp.Model == nil {
 				return fmt.Errorf("unexpected null model of %s", *id)
 			}

--- a/internal/services/compute/virtual_machine_run_command_resource_test.go
+++ b/internal/services/compute/virtual_machine_run_command_resource_test.go
@@ -1,8 +1,5 @@
 package compute_test
 
-// NOTE: this file is generated - manual changes will be overwritten.
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 import (
 	"context"
 	"fmt"
@@ -128,6 +125,28 @@ func TestAccVirtualMachineRunCommand_complete(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineRunCommand_updateParameters(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_run_command", "test")
+	r := VirtualMachineRunCommandTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithParameters(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("protected_parameter"),
+	})
+}
+
 func TestAccVirtualMachineRunCommand_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_run_command", "test")
 	r := VirtualMachineRunCommandTestResource{}
@@ -203,6 +222,35 @@ resource "azurerm_virtual_machine_run_command" "import" {
   }
 }
 `, r.basic(data))
+}
+
+func (r VirtualMachineRunCommandTestResource) basicWithParameters(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_virtual_machine_run_command" "test" {
+  name               = "acctestvmrc-${var.random_string}"
+  location           = azurerm_resource_group.test.location
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  source {
+    script = "echo 'hello world'"
+  }
+
+  parameter {
+    name  = "acctestvmrc-${var.random_string}"
+    value = "val-${var.random_string}"
+  }
+
+  protected_parameter {
+    name  = "acctestvmrc2-${var.random_string}"
+    value = "val-${var.random_string}"
+  }
+}
+`, r.template(data))
 }
 
 func (r VirtualMachineRunCommandTestResource) basicWithScriptError(data acceptance.TestData) string {


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/25177

due to https://github.com/Azure/azure-rest-api-specs/issues/28173, use `CreateOrUpdateThenPoll` which is a PUT method in `update` function.