### PR TITLE
#25086-Azure VMWare Solution Documentation Changes

### DIFF
--- a/internal/services/vmware/registration.go
+++ b/internal/services/vmware/registration.go
@@ -27,7 +27,7 @@ func (r Registration) Name() string {
 // WebsiteCategories returns a list of categories which can be used for the sidebar
 func (r Registration) WebsiteCategories() []string {
 	return []string{
-		"VMware (AVS)",
+		"Azure VMware Solution",
 	}
 }
 

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -14,6 +14,7 @@ Automanage
 Automation
 Azure Managed Lustre File System
 Azure Stack HCI
+Azure VMware Solution
 Base
 Batch
 Billing
@@ -107,7 +108,6 @@ Synapse
 System Center Virtual Machine Manager
 Template
 Time Series Insights
-VMware (AVS)
 Video Analyzer
 Voice Services
 Web PubSub

--- a/website/docs/d/vmware_private_cloud.html.markdown
+++ b/website/docs/d/vmware_private_cloud.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "VMware (AVS)"
+subcategory: "Azure VMware Solution"
 layout: "azurerm"
 page_title: "Azure Resource Manager: Data Source: azurerm_vmware_private_cloud"
 description: |-

--- a/website/docs/r/vmware_cluster.html.markdown
+++ b/website/docs/r/vmware_cluster.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "VMware (AVS)"
+subcategory: "Azure VMware Solution"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vmware_cluster"
 description: |-
-  Manages a VMware Cluster.
+  Manages an Azure VMware Solution Cluster.
 ---
 
 # azurerm_vmware_cluster
 
-Manages a VMware Cluster.
+Manages an Azure VMware Solution Cluster.
 
 ## Example Usage
 
@@ -51,36 +51,36 @@ resource "azurerm_vmware_cluster" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this VMware Cluster. Changing this forces a new VMware Cluster to be created.
+* `name` - (Required) The name which should be used for this Azure VMware Solution Cluster. Changing this forces a new Azure VMware Solution Cluster to be created.
 
-* `vmware_cloud_id` - (Required) The ID of the VMware Private Cloud in which to create this VMware Cluster. Changing this forces a new VMware Cluster to be created.
+* `vmware_cloud_id` - (Required) The ID of the Azure VMware Solution Private Cloud in which to create this Cluster. Changing this forces a new Azure VMware Solution Cluster to be created.
 
-* `cluster_node_count` - (Required) The count of the VMware Cluster nodes.
+* `cluster_node_count` - (Required) The count of the Azure VMware Solution Cluster nodes.
 
-* `sku_name` - (Required) The cluster SKU to use. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new VMware Cluster to be created.
+* `sku_name` - (Required) The Cluster SKU to use. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new Azure VMware Solution Cluster to be created.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the VMware Cluster.
+* `id` - The ID of the Azure VMware Solution Cluster.
 
-* `cluster_number` - A number that identifies this VMware Cluster in its VMware Private Cloud.
+* `cluster_number` - A number that identifies this Cluster in its Azure VMware Solution Private Cloud.
 
-* `hosts` - A list of host of the VMware Cluster.
+* `hosts` - A list of hosts in the Azure VMware Solution Cluster.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 5 hours) Used when creating the VMware Cluster.
-* `read` - (Defaults to 5 minutes) Used when retrieving the VMware Cluster.
-* `update` - (Defaults to 5 hours) Used when updating the VMware Cluster.
-* `delete` - (Defaults to 5 hours) Used when deleting the VMware Cluster.
+* `create` - (Defaults to 5 hours) Used when creating the Azure VMware Solution Cluster.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure VMware Solution Cluster.
+* `update` - (Defaults to 5 hours) Used when updating the Azure VMware Solution Cluster.
+* `delete` - (Defaults to 5 hours) Used when deleting the Azure VMware Solution Cluster.
 
 ## Import
 
-VMware Clusters can be imported using the `resource id`, e.g.
+Azure VMware Solution Clusters can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_vmware_cluster.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.AVS/privateClouds/privateCloud1/clusters/cluster1

--- a/website/docs/r/vmware_express_route_authorization.html.markdown
+++ b/website/docs/r/vmware_express_route_authorization.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "VMware (AVS)"
+subcategory: "Azure VMware Solution"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vmware_express_route_authorization"
 description: |-
-  Manages an Express Route VMware Authorization.
+  Manages an Azure VMware Solution ExpressRoute Circuit Authorization.
 ---
 
 # azurerm_vmware_express_route_authorization
 
-Manages an Express Route VMware Authorization.
+Manages an Azure VMware Solution ExpressRoute Circuit Authorization.
 
 ## Example Usage
 
@@ -49,31 +49,31 @@ resource "azurerm_vmware_express_route_authorization" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Express Route VMware Authorization. Changing this forces a new VMware Authorization to be created.
+* `name` - (Required) The name which should be used for this Azure VMware Solution ExpressRoute Circuit Authorization. Changing this forces a new Azure VMware Solution ExpressRoute Circuit Authorization to be created.
 
-* `private_cloud_id` - (Required) The ID of the VMware Private Cloud in which to create this Express Route VMware Authorization. Changing this forces a new VMware Authorization to be created.
+* `private_cloud_id` - (Required) The ID of the Azure VMware Solution Private Cloud in which to create this Azure VMware Solution ExpressRoute Circuit Authorization. Changing this forces a new Azure VMware Solution ExpressRoute Circuit Authorization to be created.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the VMware Authorization.
+* `id` - The ID of the Azure VMware Solution ExpressRoute Circuit Authorization.
 
-* `express_route_authorization_id` - The ID of the Express Route Circuit Authorization.
+* `express_route_authorization_id` - The ID of the Azure VMware Solution ExpressRoute Circuit Authorization.
 
-* `express_route_authorization_key` - The key of the Express Route Circuit Authorization.
+* `express_route_authorization_key` - The key of the Azure VMware Solution ExpressRoute Circuit Authorization.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the VMware Authorization.
-* `read` - (Defaults to 5 minutes) Used when retrieving the VMware Authorization.
-* `delete` - (Defaults to 30 minutes) Used when deleting the VMware Authorization.
+* `create` - (Defaults to 30 minutes) Used when creating the Azure VMware Solution ExpressRoute Circuit Authorization.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure VMware Solution ExpressRoute Circuit Authorization.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Azure VMware Solution ExpressRoute Circuit Authorization.
 
 ## Import
 
-VMware Authorizations can be imported using the `resource id`, e.g.
+Azure VMware Solution ExpressRoute Circuit Authorizations can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_vmware_express_route_authorization.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.AVS/privateClouds/privateCloud1/authorizations/authorization1

--- a/website/docs/r/vmware_netapp_volume_attachment.html.markdown
+++ b/website/docs/r/vmware_netapp_volume_attachment.html.markdown
@@ -1,18 +1,18 @@
 ---
-subcategory: "VMware (AVS)"
+subcategory: "Azure VMware Solution"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vmware_netapp_volume_attachment"
 description: |-
-  Manages a VMware Private Cloud Netapp File Attachment.
+  Manages a Azure VMware Solution Private Cloud Netapp File Attachment.
 ---
 
 # azurerm_vmware_netapp_volume_attachment
 
-Manages a VMware Private Cloud Netapp File Attachment.
+Manages a Azure VMware Solution Private Cloud Netapp File Attachment.
 
 ## Example Usage
 
-~> **NOTE :** For Azure VMware private cloud, normal `terraform apply` could ignore this note. Please disable correlation request id for continuous operations in one build (like acctest). The continuous operations like `update` or `delete` could not be triggered when it shares the same `correlation-id` with its previous operation.
+~> **NOTE :** For Azure Azure VMware Solution Private Cloud, normal `terraform apply` could ignore this note. Please disable correlation request id for continuous operations in one build (like acctest). The continuous operations like `update` or `delete` could not be triggered when it shares the same `correlation-id` with its previous operation.
 
 ```hcl
 provider "azurerm" {
@@ -164,26 +164,26 @@ resource "azurerm_vmware_netapp_volume_attachment" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this VMware Private Cloud Netapp File Volume Attachment. Changing this forces a new VMware Private Cloud Netapp File Volume Attachment to be created.
+* `name` - (Required) The name which should be used for this Azure VMware Solution Private Cloud Netapp File Volume Attachment. Changing this forces a new Azure VMware Solution Private Cloud Netapp File Volume Attachment to be created.
 
-* `netapp_volume_id` - (Required) The netapp file volume for this VMware Private Cloud Netapp File Volume Attachment to connect to. Changing this forces a new VMware Private Cloud Netapp File Volume Attachment to be created.
+* `netapp_volume_id` - (Required) The netapp file volume for this Azure VMware Solution Private Cloud Netapp File Volume Attachment to connect to. Changing this forces a new Azure VMware Solution Private Cloud Netapp File Volume Attachment to be created.
 
-* `vmware_cluster_id` - (Required) The vmware cluster for this VMware Private Cloud Netapp File Volume Attachment to associated to. Changing this forces a new VMware Private Cloud Netapp File Volume Attachment to be created.
+* `vmware_cluster_id` - (Required) The vmware cluster for this Azure VMware Solution Private Cloud Netapp File Volume Attachment to associated to. Changing this forces a new Azure VMware Solution Private Cloud Netapp File Volume Attachment to be created.
 
-~> **NOTE :** please follow the prerequisites mentioned in this [article](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-azure-netapp-files-to-azure-vmware-solution-hosts?tabs=azure-portal#prerequisites) before associating the netapp file volume to the vmware solution hosts.
+~> **NOTE :** please follow the prerequisites mentioned in this [article](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-azure-netapp-files-to-azure-vmware-solution-hosts?tabs=azure-portal#prerequisites) before associating the netapp file volume to the Azure VMware Solution hosts.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the VMware Private Cloud Netapp File Volume Attachment.
-* `read` - (Defaults to 5 minutes) Used when retrieving the VMware Private Cloud Netapp File Volume Attachment.
-* `update` - (Defaults to 10 hours) Used when updating the VMware Private Cloud Netapp File Volume Attachment.
-* `delete` - (Defaults to 30 minutes) Used when deleting the VMware Private Cloud Netapp File Volume Attachment.
+* `create` - (Defaults to 30 minutes) Used when creating the Azure VMware Solution Private Cloud Netapp File Volume Attachment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure VMware Solution Private Cloud Netapp File Volume Attachment.
+* `update` - (Defaults to 10 hours) Used when updating the Azure VMware Solution Private Cloud Netapp File Volume Attachment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Azure VMware Solution Private Cloud Netapp File Volume Attachment.
 
 ## Import
 
-VMware Private Clouds Netapp File Volume Attachment can be imported using the `resource id`, e.g.
+Azure VMware Solution Private Clouds Netapp File Volume Attachment can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_vmware_netapp_volume_attachment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/privateCloud1/clusters/Cluster1/dataStores/datastore1

--- a/website/docs/r/vmware_private_cloud.html.markdown
+++ b/website/docs/r/vmware_private_cloud.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "VMware (AVS)"
+subcategory: "Azure VMware Solution"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vmware_private_cloud"
 description: |-
-  Manages a VMware Private Cloud.
+  Manages a Azure VMware Solution Private Cloud.
 ---
 
 # azurerm_vmware_private_cloud
 
-Manages a VMware Private Cloud.
+Manages a Azure VMware Solution Private Cloud.
 
 ## Example Usage
 
@@ -46,27 +46,27 @@ resource "azurerm_vmware_private_cloud" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this VMware Private Cloud. Changing this forces a new VMware Private Cloud to be created.
+* `name` - (Required) The name which should be used for this Azure VMware Solution Private Cloud. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the VMware Private Cloud should exist. Changing this forces a new VMware Private Cloud to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure VMware Solution Private Cloud should exist. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `location` - (Required) The Azure Region where the VMware Private Cloud should exist. Changing this forces a new VMware Private Cloud to be created.
+* `location` - (Required) The Azure Region where the Azure VMware Solution Private Cloud should exist. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
 * `management_cluster` - (Required) A `management_cluster` block as defined below.
 ~> **NOTE :** `internet_connection_enabled` and `management_cluster[0].size` cannot be updated at the same time.
 
-* `network_subnet_cidr` - (Required) The subnet which should be unique across virtual network in your subscription as well as on-premise. Changing this forces a new VMware Private Cloud to be created.
+* `network_subnet_cidr` - (Required) The subnet which should be unique across virtual network in your subscription as well as on-premise. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `sku_name` - (Required) The Name of the SKU used for this Private Cloud. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new VMware Private Cloud to be created.
+* `sku_name` - (Required) The Name of the SKU used for this Private Cloud. Possible values are `av20`, `av36`, `av36t`, `av36p`, `av36pt`, `av52`, `av52t`, and `av64`. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `internet_connection_enabled` - (Optional) Is the Private Cluster connected to the internet? This field can not updated with `management_cluster[0].size` together.
+* `internet_connection_enabled` - (Optional) Is the Azure VMware Solution Private Cloud connected to the internet? This field can not be updated with `management_cluster[0].size` together.
 ~> **NOTE :** `internet_connection_enabled` and `management_cluster[0].size` cannot be updated at the same time.
 
-* `nsxt_password` - (Optional) The password of the NSX-T Manager. Changing this forces a new VMware Private Cloud to be created.
+* `nsxt_password` - (Optional) The password of the NSX-T Manager. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `vcenter_password` - (Optional) The password of the vCenter admin. Changing this forces a new VMware Private Cloud to be created.
+* `vcenter_password` - (Optional) The password of the vCenter Server admin. Changing this forces a new Azure VMware Solution Private Cloud to be created.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the VMware Private Cloud.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Azure VMware Solution Private Cloud.
 
 ---
 
@@ -78,7 +78,7 @@ A `management_cluster` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the VMware Private Cloud.
+* `id` - The ID of the Azure VMware Solution Private Cloud.
 
 * `circuit` - A `circuit` block as defined below.
 
@@ -122,14 +122,14 @@ A `management_cluster` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 10 hours) Used when creating the VMware Private Cloud.
-* `read` - (Defaults to 5 minutes) Used when retrieving the VMware Private Cloud.
-* `update` - (Defaults to 10 hours) Used when updating the VMware Private Cloud.
-* `delete` - (Defaults to 10 hours) Used when deleting the VMware Private Cloud.
+* `create` - (Defaults to 10 hours) Used when creating the Azure VMware Solution Private Cloud.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure VMware Solution Private Cloud.
+* `update` - (Defaults to 10 hours) Used when updating the Azure VMware Solution Private Cloud.
+* `delete` - (Defaults to 10 hours) Used when deleting the Azure VMware Solution Private Cloud.
 
 ## Import
 
-VMware Private Clouds can be imported using the `resource id`, e.g.
+Azure VMware Solution Private Clouds can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_vmware_private_cloud.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/privateCloud1


### PR DESCRIPTION
Addresses issue https://github.com/hashicorp/terraform-provider-azurerm/issues/25086 opened by the Azure VMware Solution product group to address branding in the AzureRM documentation.  

Since the subcategory name changed, I would recommend someone who has done doc updates in the past review this to ensure that I caught all of the linkages for the subcategory name change.