### PR TITLE
azurerm_container_app_custom_domain - Fix resource ID parsing bug preventing import

### DIFF
--- a/internal/services/containerapps/parse/container_app_custom_domain.go
+++ b/internal/services/containerapps/parse/container_app_custom_domain.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
-var _ resourceids.ResourceId = ContainerAppCustomDomainId{}
+var _ resourceids.ResourceId = &ContainerAppCustomDomainId{}
 
 // ContainerAppCustomDomainId is a struct representing the Resource ID for a Container App
 type ContainerAppCustomDomainId struct {
@@ -32,7 +32,7 @@ func NewContainerAppCustomDomainId(subscriptionId string, resourceGroupName stri
 
 // ContainerAppCustomDomainID parses 'input' into a ContainerAppCustomDomainId
 func ContainerAppCustomDomainID(input string) (*ContainerAppCustomDomainId, error) {
-	parser := resourceids.NewParserFromResourceIdType(ContainerAppCustomDomainId{})
+	parser := resourceids.NewParserFromResourceIdType(&ContainerAppCustomDomainId{})
 	parsed, err := parser.Parse(input, false)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)
@@ -49,7 +49,7 @@ func ContainerAppCustomDomainID(input string) (*ContainerAppCustomDomainId, erro
 // ContainerAppCustomDomainIDInsensitively parses 'input' case-insensitively into a ContainerAppCustomDomainId
 // note: this method should only be used for API response data and not user input
 func ContainerAppCustomDomainIDInsensitively(input string) (*ContainerAppCustomDomainId, error) {
-	parser := resourceids.NewParserFromResourceIdType(ContainerAppCustomDomainId{})
+	parser := resourceids.NewParserFromResourceIdType(&ContainerAppCustomDomainId{})
 	parsed, err := parser.Parse(input, true)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)
@@ -63,7 +63,7 @@ func ContainerAppCustomDomainIDInsensitively(input string) (*ContainerAppCustomD
 	return &id, nil
 }
 
-func (id ContainerAppCustomDomainId) FromParseResult(input resourceids.ParseResult) error {
+func (id *ContainerAppCustomDomainId) FromParseResult(input resourceids.ParseResult) error {
 	var ok bool
 
 	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
@@ -102,7 +102,7 @@ func (id ContainerAppCustomDomainId) Segments() []resourceids.Segment {
 		resourceids.ResourceProviderSegment("staticMicrosoftApp", "Microsoft.App", "Microsoft.App"),
 		resourceids.StaticSegment("staticContainerApps", "containerApps", "containerApps"),
 		resourceids.UserSpecifiedSegment("containerAppName", "containerAppValue"),
-		resourceids.StaticSegment("staticCustomDomainName", "customDomainName", "customDomain"),
+		resourceids.StaticSegment("staticCustomDomainName", "customDomainName", "customDomainName"),
 		resourceids.UserSpecifiedSegment("customDomainName", "customDomainNameValue"),
 	}
 }
@@ -115,5 +115,5 @@ func (id ContainerAppCustomDomainId) String() string {
 		fmt.Sprintf("Container App Name: %q", id.ContainerAppName),
 		fmt.Sprintf("Custom Domain Name: %q", id.CustomDomainName),
 	}
-	return fmt.Sprintf("Container App (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Container App Custom Domain (%s)", strings.Join(components, "\n"))
 }


### PR DESCRIPTION
I was unable to do an import for the new `azurerm_container_app_custom_domain` resource in 3.95.0 and I tracked it down to a bug in how the resource IDs are being parsed. The error message that I was getting was this, where everything in the resource ID structs for both the custom domain and its parent container app are empty (slightly sanitized):

```
azurerm_container_app_custom_domain.example: Import prepared!
  Prepared azurerm_container_app_custom_domain for import
azurerm_container_app_custom_domain.example: Refreshing state... [id=/subscriptions/...]
╷
│ Error: retrieving Container App (Subscription: ""
│ Resource Group Name: ""
│ Container App Name: "") to read Container App (Subscription: ""
│ Resource Group Name: ""
│ Container App Name: ""
│ Custom Domain Name: "")
│ 
│ retrieving Container App (Subscription: ""
│ Resource Group Name: ""
│ Container App Name: "") to read Container App (Subscription: ""
│ Resource Group Name: ""
│ Container App Name: ""
│ Custom Domain Name: "")
```

This just ends up being due to the wrong receiver semantics being used for the FromParseResult function in the custom resource id implementation for this virtual resource.

I also fixed two minor copy/paste issues that I saw that probably only impact debug outputs.