### PR TITLE
`azurerm_servicebus_queue` - update premium partitioning behavior

### DIFF
--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -230,6 +230,8 @@ resource "azurerm_servicebus_namespace" "primary_namespace_test" {
 resource "azurerm_servicebus_queue" "example" {
   name         = "queue-test"
   namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
+
+enable_partitioning = true
 }
 
 resource "azurerm_servicebus_namespace" "secondary_namespace_test" {

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -231,7 +231,7 @@ resource "azurerm_servicebus_queue" "example" {
   name         = "queue-test"
   namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
 
-enable_partitioning = true
+  enable_partitioning = true
 }
 
 resource "azurerm_servicebus_namespace" "secondary_namespace_test" {

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -196,24 +196,6 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	id := queues.NewQueueID(namespaceId.SubscriptionId, namespaceId.ResourceGroupName, namespaceId.NamespaceName, d.Get("name").(string))
 
-	isPartitioningEnabled := false
-	if d.HasChange("enable_partitioning") {
-		existingQueue, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existingQueue.HttpResponse) {
-				return fmt.Errorf("retrieving %s: %+v", id, err)
-			}
-		}
-
-		if model := existingQueue.Model; model != nil {
-			if props := model.Properties; props != nil {
-				if model.Id != nil && props.EnablePartitioning != nil && *props.EnablePartitioning {
-					isPartitioningEnabled = true
-				}
-			}
-		}
-	}
-
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
@@ -313,8 +295,8 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("%s does not support Express Entities in Premium SKU and must be disabled", id)
 	}
 
-	if sku == namespaces.SkuNamePremium && enablePartitioning && !isPartitioningEnabled {
-		return fmt.Errorf("partitioning Entities is not supported in Premium SKU and must be disabled")
+	if sku == namespaces.SkuNamePremium && !enablePartitioning {
+		return fmt.Errorf("non-partitioned entities are not allowed in partitioned namespace")
 	}
 
 	// output of `max_message_size_in_kilobytes` is also set in non-Premium namespaces, with a value of 256

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -136,7 +136,7 @@ func TestAccServiceBusQueue_enablePartitioningForPremiumError(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.partitioningForPremiumError(data),
-			ExpectError: regexp.MustCompile("Non-partitioned entities are not allowed in partitioned namespace"),
+			ExpectError: regexp.MustCompile("non-partitioned entities are not allowed in partitioned namespace"),
 		},
 	})
 }

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -122,7 +122,7 @@ func TestAccServiceBusQueue_defaultEnablePartitioningPremium(t *testing.T) {
 			Config: r.Premium(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enable_partitioning").HasValue("false"),
+				check.That(data.ResourceName).Key("enable_partitioning").HasValue("true"),
 				check.That(data.ResourceName).Key("enable_express").HasValue("false"),
 			),
 		},
@@ -135,8 +135,8 @@ func TestAccServiceBusQueue_enablePartitioningForPremiumError(t *testing.T) {
 	r := ServiceBusQueueResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enablePartitioningForPremiumError(data),
-			ExpectError: regexp.MustCompile("partitioning Entities is not supported in Premium SKU and must be disabled"),
+			Config:      r.partitioningForPremiumError(data),
+			ExpectError: regexp.MustCompile("Non-partitioned entities are not allowed in partitioned namespace"),
 		},
 	})
 }
@@ -446,7 +446,7 @@ resource "azurerm_servicebus_namespace" "test" {
 resource "azurerm_servicebus_queue" "test" {
   name                = "acctestservicebusqueue-%d"
   namespace_id        = azurerm_servicebus_namespace.test.id
-  enable_partitioning = false
+  enable_partitioning = true
   enable_express      = false
 
   max_message_size_in_kilobytes = 102400
@@ -454,7 +454,7 @@ resource "azurerm_servicebus_queue" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (ServiceBusQueueResource) enablePartitioningForPremiumError(data acceptance.TestData) string {
+func (ServiceBusQueueResource) partitioningForPremiumError(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -475,9 +475,8 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  namespace_id        = azurerm_servicebus_namespace.test.id
-  enable_partitioning = true
+  name         = "acctestservicebusqueue-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `enable_partitioning` - (Optional) Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. Changing this forces a new resource to be created. Defaults to `false` for Basic and Standard.
 
--> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning) for more information.
+-> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. For premium namespace, partitioning is available at namespace creation, and all queues and topics in that namespace will be partitioned.
 
 * `enable_express` - (Optional) Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `false`.
 


### PR DESCRIPTION
The partitioning is not available for servicebus premium namespace, thus we threw error to block us from enabling the messaging partition for premium namespace, but the behvavior changed to "all the entities (queues/ topics) in a premium namespace must be partitioned."

see docs:https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning

resolve https://github.com/hashicorp/terraform-provider-azurerm/issues/25073