### PR TITLE
`azurerm_servicebus_queue` - update queue partitioning check condition

### DIFF
--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -223,15 +223,13 @@ resource "azurerm_servicebus_namespace" "primary_namespace_test" {
   location                     = azurerm_resource_group.primary.location
   resource_group_name          = azurerm_resource_group.primary.name
   sku                          = "Premium"
-  capacity                     = 2
-  premium_messaging_partitions = 2
+  capacity                     = 1
+  premium_messaging_partitions = 1
 }
 
 resource "azurerm_servicebus_queue" "example" {
   name         = "queue-test"
   namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
-
-  enable_partitioning = true
 }
 
 resource "azurerm_servicebus_namespace" "secondary_namespace_test" {
@@ -239,7 +237,7 @@ resource "azurerm_servicebus_namespace" "secondary_namespace_test" {
   location                     = azurerm_resource_group.secondary.location
   resource_group_name          = azurerm_resource_group.secondary.name
   sku                          = "Premium"
-  capacity                     = "1"
+  capacity                     = 1
   premium_messaging_partitions = 1
 }
 

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -223,8 +223,8 @@ resource "azurerm_servicebus_namespace" "primary_namespace_test" {
   location                     = azurerm_resource_group.primary.location
   resource_group_name          = azurerm_resource_group.primary.name
   sku                          = "Premium"
-  capacity                     = "1"
-  premium_messaging_partitions = 1
+  capacity                     = 2
+  premium_messaging_partitions = 2
 }
 
 resource "azurerm_servicebus_queue" "example" {

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -489,33 +489,6 @@ resource "azurerm_servicebus_queue" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enabled)
 }
 
-func (ServiceBusQueueResource) partitioningForPremiumError(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_servicebus_namespace" "test" {
-  name                         = "acctestservicebusnamespace-%d"
-  resource_group_name          = azurerm_resource_group.test.name
-  location                     = azurerm_resource_group.test.location
-  sku                          = "Premium"
-  premium_messaging_partitions = 2
-  capacity                     = 2
-}
-
-resource "azurerm_servicebus_queue" "test" {
-  name         = "acctestservicebusqueue-%d"
-  namespace_id = azurerm_servicebus_namespace.test.id
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
 func (ServiceBusQueueResource) nonPartitionedPremiumNamespaceError(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -105,7 +105,7 @@ func TestAccServiceBusQueue_maxMessageSizePremium(t *testing.T) {
 	r := ServiceBusQueueResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.PremiumNamespacePartitioned(data),
+			Config: r.PremiumNamespaceNonPartitioned(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -114,23 +114,6 @@ func TestAccServiceBusQueue_maxMessageSizePremium(t *testing.T) {
 	})
 }
 
-//
-//func TestAccServiceBusQueue_defaultEnablePartitioningPremium(t *testing.T) {
-//	data := acceptance.BuildTestData(t, "azurerm_servicebus_queue", "test")
-//	r := ServiceBusQueueResource{}
-//	data.ResourceTest(t, r, []acceptance.TestStep{
-//		{
-//			Config: r.PremiumNamespacePartitioned(data),
-//			Check: acceptance.ComposeTestCheckFunc(
-//				check.That(data.ResourceName).ExistsInAzure(r),
-//				check.That(data.ResourceName).Key("enable_partitioning").HasValue("true"),
-//				check.That(data.ResourceName).Key("enable_express").HasValue("false"),
-//			),
-//		},
-//		data.ImportStep(),
-//	})
-//}
-
 func TestAccServiceBusQueue_partitionedPremiumNamespace(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_queue", "test")
 	r := ServiceBusQueueResource{}
@@ -483,7 +466,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "West US"
+  location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -503,7 +486,7 @@ resource "azurerm_servicebus_queue" "test" {
 
   max_message_size_in_kilobytes = 102400
 }
-`, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enabled)
 }
 
 func (ServiceBusQueueResource) partitioningForPremiumError(data acceptance.TestData) string {

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `enable_partitioning` - (Optional) Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. Changing this forces a new resource to be created. Defaults to `false` for Basic and Standard.
 
--> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. For premium namespace, partitioning is available at namespace creation, and all queues and topics in that namespace will be partitioned.
+-> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. For premium namespace, partitioning is available at namespace creation, and all queues and topics in the partitioned namespace will be partitioned, for the premium namespace that has `premium_messaging_partitions` sets to `1`, the namespace is not partitioned.
 
 * `enable_express` - (Optional) Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `false`.
 


### PR DESCRIPTION
Code update:
Added a stricter condition check for queue partition status, specifically, if the premium namespace is not partition-enabled, then all the entities in that namespace cannot be partition-enabled as the partitioning feature can only be available during the namespace creation for premium namespace and vice versa.

Notice: For premium namespace, if the `premiumMessagingPartitions` is set to 1, the namespace is consider as non-partitioned

Backgrounds:
According to [docs](https://learn.microsoft.com/en-us/azure/service-bus-messaging/enable-partitions-premium):
Partitioning is available at namespace **creation** for the Premium messaging SKU, and all queues and topics in that namespace will be partitioned. 

local acc tests:
```
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    345.997s
--- PASS: TestAccServiceBusQueue_defaultEnablePartitioningPremium (516.70s)
PASS
--- PASS: TestAccServiceBusQueue_partitionedPremiumNamespace (523.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    539.939s

--- PASS: TestAccServiceBusQueueAuthorizationRule_manage (519.73s)
--- PASS: TestAccServiceBusQueueAuthorizationRule_requiresImport (530.31s)
--- PASS: TestAccServiceBusQueueAuthorizationRule_listen (563.27s)
--- PASS: TestAccServiceBusQueue_enablePartitioningStandard (698.85s)
--- PASS: TestAccServiceBusQueue_maxDeliveryCount (691.80s)
--- PASS: TestAccServiceBusQueue_isoTimeSpanAttributes (466.32s)
--- PASS: TestAccServiceBusQueue_forwardTo (840.43s)
--- PASS: TestAccServiceBusQueue_forwardDeadLetteredMessagesTo (845.41s)
--- PASS: TestAccServiceBusQueue_lockDuration (684.39s)
--- PASS: TestAccServiceBusQueue_enableDeadLetteringOnMessageExpiration (658.52s)
--- PASS: TestAccServiceBusQueue_nonPartitionedPremiumNamespaceError (350.33s)
--- PASS: TestAccServiceBusQueue_enableRequiresSession (704.57s)
--- PASS: TestAccServiceBusQueueAuthorizationRule_listensend (462.68s)
--- PASS: TestAccServiceBusQueue_enableDuplicateDetection (616.85s)
--- PASS: TestAccServiceBusQueueAuthorizationRule_rightsUpdate (613.14s)
--- PASS: TestAccServiceBusQueueAuthorizationRule_send (512.93s)
--- PASS: TestAccServiceBusQueue_requiresImport (510.01s)
--- PASS: TestAccServiceBusQueue_basic (455.06s)
```
tests failure in teamCity are not relate to the code change in this PR, the error is quota limits
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/92154856/5a6f6911-de7b-403d-82d1-b13be08047a1)
