### PR TITLE
`azurerm_windows_web_app` - fix bugs caused by getting the wrong entity

### DIFF
--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -321,7 +321,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 							metadata.Logger.Warnf("could not parse App Service Environment ID determine FQDN for name availability check, defaulting to `%s.%s.appserviceenvironment.net`", webApp.Name, servicePlanId)
 						} else {
 							existingASE, err := aseClient.Get(ctx, *aseId)
-							if err != nil || existing.Model == nil {
+							if err != nil || existingASE.Model == nil {
 								metadata.Logger.Warnf("could not read App Service Environment to determine FQDN for name availability check, defaulting to `%s.%s.appserviceenvironment.net`", webApp.Name, servicePlanId)
 							} else if props := existingASE.Model.Properties; props != nil && props.DnsSuffix != nil && *props.DnsSuffix != "" {
 								nameSuffix = *props.DnsSuffix


### PR DESCRIPTION
When checking the presence of the app service environment, we need to check the ase entity, not the web app entity.

fix https://github.com/hashicorp/terraform-provider-azurerm/issues/25204
