### PR TITLE
`containerapps` - enable rotation test to mitigate resource exhausted in a single region

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -65,6 +65,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southcentralus","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
+        // Enable rotation test to mitigate resource burden in a single region
         "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("eastus2","westus2","southcentralus", true)),
 
         // The AKS API has a low rate limit

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -65,7 +65,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southcentralus","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
-        "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("westeurope","eastus","canadacentral", false)),
+        "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("eastus2","westus2","southcentralus", true)),
 
         // The AKS API has a low rate limit
         "containers" to testConfiguration(parallelism = 5, locationOverride = LocationConfiguration("eastus","westeurope","eastus2", false), timeout = 18),


### PR DESCRIPTION
## Test Results

#### Note: Failed testcases are not caused by the quota limitation.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/3fd07da6-504a-4d1d-89c4-99632f398645)
