### PR TITLE
`azurerm_windows_web_app_slot` - fix doc discrepancy 

### DIFF
--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -242,7 +242,7 @@ func SiteConfigSchemaWindowsFunctionAppSlot() *pluginsdk.Schema {
 					Type:        pluginsdk.TypeBool,
 					Optional:    true,
 					Default:     true,
-					Description: "Should the Windows Web App use a 32-bit worker.",
+					Description: "Should the Windows Function App use a 32-bit worker.",
 				},
 
 				"websockets_enabled": {

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -754,7 +754,7 @@ A `site_config` block supports the following:
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Windows Web App Slot `ip_restriction` configuration be used for the SCM also.
 
-* `use_32_bit_worker` - (Optional) Should the Windows Web App Slotuse a 32-bit worker. Defaults to `true`.
+* `use_32_bit_worker` - (Optional) Should the Windows Web App Slot use a 32-bit worker. The default value varies from different service plans.
 
 * `virtual_application` - (Optional) One or more `virtual_application` blocks as defined below.
 


### PR DESCRIPTION
1. There isn't a default value of the property `use_32_bit_worker` for windows web app slot. The default value varies from the different service plans
2. fix description error for function app.

fix https://github.com/hashicorp/terraform-provider-azurerm/issues/25224
