### PR TITLE
`azurerm_cosmosdb_postgresql_cluster`: add server names information t…

### DIFF
--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -36,7 +36,7 @@ type CosmosDbPostgreSQLClusterModel struct {
 	SourceLocation                   string              `tfschema:"source_location"`
 	SourceResourceId                 string              `tfschema:"source_resource_id"`
 	MaintenanceWindow                []MaintenanceWindow `tfschema:"maintenance_window"`
-	ServerNames                      []ServerNameItem    `tfschema:"server_names"`
+	ServerNames                      []ServerNameItem    `tfschema:"servers"`
 	NodeCount                        int64               `tfschema:"node_count"`
 	NodePublicIPAccessEnabled        bool                `tfschema:"node_public_ip_access_enabled"`
 	NodeServerEdition                string              `tfschema:"node_server_edition"`
@@ -310,7 +310,7 @@ func (r CosmosDbPostgreSQLClusterResource) Attributes() map[string]*pluginsdk.Sc
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
-		"server_names": {
+		"servers": {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
 			Elem: &pluginsdk.Resource{
@@ -580,7 +580,7 @@ func (r CosmosDbPostgreSQLClusterResource) Read() sdk.ResourceFunc {
 				state.CoordinatorServerEdition = pointer.From(props.CoordinatorServerEdition)
 				state.CoordinatorStorageQuotaInMb = pointer.From(props.CoordinatorStorageQuotaInMb)
 				state.CoordinatorVCoreCount = pointer.From(props.CoordinatorVCores)
-				state.ServerNames = formatServerNames(props.ServerNames)
+				state.ServerNames = flattenServerNames(props.ServerNames)
 				state.HaEnabled = pointer.From(props.EnableHa)
 				state.NodeCount = pointer.From(props.NodeCount)
 				state.NodePublicIPAccessEnabled = pointer.From(props.NodeEnablePublicIPAccess)
@@ -660,12 +660,13 @@ func flattenMaintenanceWindow(input *clusters.MaintenanceWindow) []MaintenanceWi
 	}
 }
 
-func formatServerNames(input *[]clusters.ServerNameItem) []ServerNameItem {
+func flattenServerNames(input *[]clusters.ServerNameItem) []ServerNameItem {
+	var output []ServerNameItem
+
 	if input == nil {
-		return nil
+		return output
 	}
 
-	var output []ServerNameItem
 	for _, v := range *input {
 		output = append(output, ServerNameItem{
 			FullyQualifiedDomainName: *v.FullyQualifiedDomainName,

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -36,6 +36,7 @@ type CosmosDbPostgreSQLClusterModel struct {
 	SourceLocation                   string              `tfschema:"source_location"`
 	SourceResourceId                 string              `tfschema:"source_resource_id"`
 	MaintenanceWindow                []MaintenanceWindow `tfschema:"maintenance_window"`
+	ServerNames                      []ServerNameItem    `tfschema:"server_names"`
 	NodeCount                        int64               `tfschema:"node_count"`
 	NodePublicIPAccessEnabled        bool                `tfschema:"node_public_ip_access_enabled"`
 	NodeServerEdition                string              `tfschema:"node_server_edition"`
@@ -46,6 +47,11 @@ type CosmosDbPostgreSQLClusterModel struct {
 	SqlVersion                       string              `tfschema:"sql_version"`
 	Tags                             map[string]string   `tfschema:"tags"`
 	EarliestRestoreTime              string              `tfschema:"earliest_restore_time"`
+}
+
+type ServerNameItem struct {
+	Name                     string `tfschema:"name"`
+	FullyQualifiedDomainName string `tfschema:"fqdn"`
 }
 
 type MaintenanceWindow struct {
@@ -304,6 +310,22 @@ func (r CosmosDbPostgreSQLClusterResource) Attributes() map[string]*pluginsdk.Sc
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
+		"server_names": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"fqdn": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -558,6 +580,7 @@ func (r CosmosDbPostgreSQLClusterResource) Read() sdk.ResourceFunc {
 				state.CoordinatorServerEdition = pointer.From(props.CoordinatorServerEdition)
 				state.CoordinatorStorageQuotaInMb = pointer.From(props.CoordinatorStorageQuotaInMb)
 				state.CoordinatorVCoreCount = pointer.From(props.CoordinatorVCores)
+				state.ServerNames = formatServerNames(props.ServerNames)
 				state.HaEnabled = pointer.From(props.EnableHa)
 				state.NodeCount = pointer.From(props.NodeCount)
 				state.NodePublicIPAccessEnabled = pointer.From(props.NodeEnablePublicIPAccess)
@@ -635,4 +658,20 @@ func flattenMaintenanceWindow(input *clusters.MaintenanceWindow) []MaintenanceWi
 			StartMinute: pointer.From(input.StartMinute),
 		},
 	}
+}
+
+func formatServerNames(input *[]clusters.ServerNameItem) []ServerNameItem {
+	if input == nil {
+		return nil
+	}
+
+	var output []ServerNameItem
+	for _, v := range *input {
+		output = append(output, ServerNameItem{
+			FullyQualifiedDomainName: *v.FullyQualifiedDomainName,
+			Name:                     *v.Name,
+		})
+	}
+
+	return output
 }

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -29,8 +29,8 @@ func TestAccCosmosDbPostgreSQLCluster_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("server_names.0.fqdn").IsNotEmpty(),
-				check.That(data.ResourceName).Key("server_names.0.name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("servers.0.fqdn").IsNotEmpty(),
+				check.That(data.ResourceName).Key("servers.0.name").IsNotEmpty(),
 			),
 		},
 		data.ImportStep("administrator_login_password"),

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -29,6 +29,8 @@ func TestAccCosmosDbPostgreSQLCluster_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("server_names.0.fqdn").IsNotEmpty(),
+				check.That(data.ResourceName).Key("server_names.0.name").IsNotEmpty(),
 			),
 		},
 		data.ImportStep("administrator_login_password"),

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -99,6 +99,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `earliest_restore_time` - The earliest restore point time (ISO8601 format) for the Azure Cosmos DB for PostgreSQL Cluster.
 
+* `server_names` - The name of the servers and its fully qualified domain name
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -99,7 +99,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `earliest_restore_time` - The earliest restore point time (ISO8601 format) for the Azure Cosmos DB for PostgreSQL Cluster.
 
-* `server_names` - The name of the servers and its fully qualified domain name
+* `servers` - A `servers` block as defined below.
+
+---
+
+A `servers` block exports the following:
+
+* `fqdn` - The Fully Qualified Domain Name of the server.
+
+* `name` - The name of the server.
 
 ## Timeouts
 


### PR DESCRIPTION
I have tried to deploy CosmosDB Postgres, but with some of the updates they added a random hexadecimal string to coordinator domain (from c-acctestcluster240313222245905652.postgres.cosmos.azure.com -> c-acctestcluster240313222245905652.**efyg2q5iqomwly**.postgres.cosmos.azure.com). When I wanted to use this domain to be passed to other modules I couldn't as I can derive the domain from the service name. Therefore I just propagated the server_names property to the attributes, which means it can be used as for example a output.


## Testing Logs/Evidence

I added the attribute to the basic test as seen in internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go and successfully ran test locally.


## Change Log

* `azurerm_cosmosdb_postgresql_cluster` - add fully qualified domain name to attributes


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change