### PR TITLE
`azurerm_data_share` should allow "-" in the name, resolves #25238

### DIFF
--- a/internal/services/datashare/validate/share_name.go
+++ b/internal/services/datashare/validate/share_name.go
@@ -12,6 +12,6 @@ import (
 
 func ShareName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile(`^\w{2,90}$`), `DataShare name can only contain alphanumeric characters and _, and must be between 2 and 90 characters long.`,
+		regexp.MustCompile(`^[\w-]{2,90}$`), `DataShare name can only contain numbers, letters, - and _, and must be between 2 and 90 characters long.`,
 	)
 }

--- a/internal/services/datashare/validate/share_name_test.go
+++ b/internal/services/datashare/validate/share_name_test.go
@@ -22,12 +22,12 @@ func TestShareName(t *testing.T) {
 			valid: false,
 		},
 		{
-			name:  "invalid character2",
+			name:  "valid",
 			input: "adgeFG-98",
-			valid: false,
+			valid: true,
 		},
 		{
-			name:  "valid",
+			name:  "valid 2",
 			input: "dfakF88u7_",
 			valid: true,
 		},


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Description

Support a data share with a "-" (dash) in the name, as per the portal:

![312636057-e19ff997-256b-4d2a-afd0-d52b42404abc](https://github.com/hashicorp/terraform-provider-azurerm/assets/7916532/efd0ae5f-5898-4c1f-8170-ac13742629eb)

## Related Issue(s)
Fixes #25238

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_share` - `name` property can now contain hyphens [GH-25238]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.


