### PR TITLE
[DO NOT REVIEW AS THERE IS A TC TEST ISSUE TO CONFIRM] `New Relic` - Stop test automation for testcases

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -13,6 +13,9 @@ package resourceproviders
 func Required() map[string]struct{} {
 	// NOTE: Resource Providers in this list are case sensitive
 	return map[string]struct{}{
+		"NewRelic.Observability":            {},
+		"Microsoft.SaaS":                    {},
+		"Microsoft.Insight":                 {},
 		"Microsoft.AppConfiguration":        {},
 		"Microsoft.ApiManagement":           {},
 		"Microsoft.AppPlatform":             {},

--- a/internal/services/newrelic/new_relic_monitor_resource_test.go
+++ b/internal/services/newrelic/new_relic_monitor_resource_test.go
@@ -22,6 +22,10 @@ import (
 type NewRelicMonitorResource struct{}
 
 func TestAccNewRelicMonitor_basic(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
@@ -38,6 +42,10 @@ func TestAccNewRelicMonitor_basic(t *testing.T) {
 }
 
 func TestAccNewRelicMonitor_requiresImport(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)

--- a/internal/services/newrelic/new_relic_tag_rule_resource_test.go
+++ b/internal/services/newrelic/new_relic_tag_rule_resource_test.go
@@ -6,6 +6,7 @@ package newrelic_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -21,6 +22,10 @@ import (
 type NewRelicTagRuleResource struct{}
 
 func TestAccNewRelicTagRule_basic(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "27362230-e2d8-4c73-9ee3-fdef83459ca3@example.com"
@@ -36,6 +41,10 @@ func TestAccNewRelicTagRule_basic(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_requiresImport(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "85b5febd-127d-4633-9c25-bcfea555af46@example.com"
@@ -54,6 +63,10 @@ func TestAccNewRelicTagRule_requiresImport(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_complete(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "672d9312-65a7-484c-870d-94584850a423@example.com"
@@ -69,6 +82,10 @@ func TestAccNewRelicTagRule_complete(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_update(t *testing.T) {
+	if os.Getenv("ARM_TEST_NEW_RELIC_ENABLED") == "" {
+		t.Skipf("Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "f0ff47c3-3aed-45b0-b239-260d9625045a@example.com"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Documentation Changes

- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Temporarily stop daily test automation due to this [discussion](https://hashicorp.slack.com/archives/C012LHU9XDJ/p1710380969298579). Will revert this change when EUAP is enabled.

## Testing Logs/Evidence

=== RUN   TestAccNewRelicMonitor_basic
    new_relic_monitor_resource_test.go:26: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicMonitor_basic (0.00s)
=== RUN   TestAccNewRelicMonitor_requiresImport
    new_relic_monitor_resource_test.go:46: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicMonitor_requiresImport (0.00s)
=== RUN   TestAccNewRelicMonitor_complete
    new_relic_monitor_resource_test.go:75: Acceptance test skipped unless env 'ARM_ACCTEST_NEW_RELIC_ACCOUNT_ID' and 'ARM_ACCTEST_NEW_RELIC_ORG_ID' set
--- SKIP: TestAccNewRelicMonitor_complete (0.00s)
=== RUN   TestAccNewRelicTagRule_basic
    new_relic_tag_rule_resource_test.go:26: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicTagRule_basic (0.00s)
=== RUN   TestAccNewRelicTagRule_requiresImport
    new_relic_tag_rule_resource_test.go:45: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicTagRule_requiresImport (0.00s)
=== RUN   TestAccNewRelicTagRule_complete
    new_relic_tag_rule_resource_test.go:67: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicTagRule_complete (0.00s)
=== RUN   TestAccNewRelicTagRule_update
    new_relic_tag_rule_resource_test.go:86: Skipping as ARM_TEST_NEW_RELIC_ENABLED is not set
--- SKIP: TestAccNewRelicTagRule_update (0.00s)
PASS

<!-- Please include your testing evidence here or an explanation on why no testing evidence can be provided. 
For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Related Issue(s)

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `New Relic` - Stop test automation for testcases


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.


