### PR TITLE
`azurerm_subnet` - adding property `default_outbound_access_enabled`

### DIFF
--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -71,6 +71,12 @@ func dataSourceSubnet() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
+
+			"default_outbound_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"private_endpoint_network_policies": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -141,6 +147,10 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 				d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(*props.PrivateEndpointNetworkPolicies)))
 				d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(*props.PrivateEndpointNetworkPolicies)))
 				d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(*props.PrivateLinkServiceNetworkPolicies)))
+			}
+
+			if props.DefaultOutboundAccess != nil {
+				d.Set("default_outbound_access_enabled", props.DefaultOutboundAccess)
 			}
 
 			d.Set("private_endpoint_network_policies", string(pointer.From(props.PrivateEndpointNetworkPolicies)))

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -149,9 +149,11 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 				d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(*props.PrivateLinkServiceNetworkPolicies)))
 			}
 
+			defaultOutboundAccessEnabled := true
 			if props.DefaultOutboundAccess != nil {
-				d.Set("default_outbound_access_enabled", props.DefaultOutboundAccess)
+				defaultOutboundAccessEnabled = *props.DefaultOutboundAccess
 			}
+			d.Set("default_outbound_access_enabled", defaultOutboundAccessEnabled)
 
 			d.Set("private_endpoint_network_policies", string(pointer.From(props.PrivateEndpointNetworkPolicies)))
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(*props.PrivateLinkServiceNetworkPolicies)))

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -207,8 +207,8 @@ func resourceSubnet() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			"private_endpoint_network_policies_enabled": {
-				Type: pluginsdk.TypeBool,
+			"private_endpoint_network_policies": {
+				Type: pluginsdk.TypeString,
 				Computed: func() bool {
 					return !features.FourPointOh()
 				}(),
@@ -364,6 +364,11 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		if !pluginsdk.IsExplicitlyNullInConfig(d, "private_link_service_network_policies_enabled") {
 			enableServiceOk = true
 			privateLinkServiceNetworkPoliciesRaw = d.Get("private_link_service_network_policies_enabled").(bool)
+		}
+
+		if !pluginsdk.IsExplicitlyNullInConfig(d, "private_endpoint_network_policies") {
+			privateEndpointNetworkPoliciesOk = true
+			privateEndpointNetworkPoliciesStringRaw = d.Get("private_endpoint_network_policies").(string)
 		}
 
 		// Only one of these values can be set since they conflict with each other

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -843,18 +843,18 @@ func (r SubnetResource) defaultOutbound(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 resource "azurerm_subnet" "internal" {
-	name                            = "internal"
-	resource_group_name             = azurerm_resource_group.test.name
-	virtual_network_name            = azurerm_virtual_network.test.name
-	address_prefixes                = ["10.0.2.0/24"]
-	default_outbound_access_enabled = false
+  name                            = "internal"
+  resource_group_name             = azurerm_resource_group.test.name
+  virtual_network_name            = azurerm_virtual_network.test.name
+  address_prefixes                = ["10.0.2.0/24"]
+  default_outbound_access_enabled = false
 }
 resource "azurerm_subnet" "public" {
-	name                            = "public"
-	resource_group_name             = azurerm_resource_group.test.name
-	virtual_network_name            = azurerm_virtual_network.test.name
-	address_prefixes                = ["10.0.3.0/24"]
-	default_outbound_access_enabled = true
+  name                            = "public"
+  resource_group_name             = azurerm_resource_group.test.name
+  virtual_network_name            = azurerm_virtual_network.test.name
+  address_prefixes                = ["10.0.3.0/24"]
+  default_outbound_access_enabled = true
 }
 `, r.template(data))
 }

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -126,6 +126,24 @@ func TestAccSubnet_disappears(t *testing.T) {
 	})
 }
 
+func TestAccSubnet_defaultOutbound(t *testing.T) {
+	dataInternal := acceptance.BuildTestData(t, "azurerm_subnet", "internal")
+	dataPublic := acceptance.BuildTestData(t, "azurerm_subnet", "public")
+	r := SubnetResource{}
+
+	dataInternal.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultOutbound(dataInternal),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(dataInternal.ResourceName).ExistsInAzure(r),
+				check.That(dataInternal.ResourceName).Key("default_outbound_access_enabled").HasValue("false"),
+				check.That(dataPublic.ResourceName).ExistsInAzure(r),
+				check.That(dataPublic.ResourceName).Key("default_outbound_access_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
 func TestAccSubnet_delegation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
@@ -817,6 +835,26 @@ resource "azurerm_subnet" "test" {
       ]
     }
   }
+}
+`, r.template(data))
+}
+
+func (r SubnetResource) defaultOutbound(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_subnet" "internal" {
+	name                            = "internal"
+	resource_group_name             = azurerm_resource_group.test.name
+	virtual_network_name            = azurerm_virtual_network.test.name
+	address_prefixes                = ["10.0.2.0/24"]
+	default_outbound_access_enabled = false
+}
+resource "azurerm_subnet" "public" {
+	name                            = "public"
+	resource_group_name             = azurerm_resource_group.test.name
+	virtual_network_name            = azurerm_virtual_network.test.name
+	address_prefixes                = ["10.0.3.0/24"]
+	default_outbound_access_enabled = true
 }
 `, r.template(data))
 }

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -37,6 +37,7 @@ output "subnet_id" {
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
 * `service_endpoints` - A list of Service Endpoints within this subnet.
+* `default_outbound_access_enabled` - Is the default outbound access enabled for the subnet.
 * `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.
 * `private_link_service_network_policies_enabled` - Enable or Disable network policies for the private link service on the subnet.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `delegation` - (Optional) One or more `delegation` blocks as defined below.
 
+* `default_outbound_access_enabled` - (Optional) Enable default outbound access to the internet for the subnet. Setting to `false` creates a private subnet.
+
 * `private_endpoint_network_policies` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Possible values are `Disabled`, `Enabled`, `NetworkSecurityGroupEnabled` and `RouteTableEnabled`. Defaults to `Disabled`.
 
 -> **NOTE:** Network policies, like network security groups (NSG), are not supported for Private Link Endpoints or Private Link Services. In order to deploy a Private Link Endpoint on a given subnet, you must set the `private_endpoint_network_policies` attribute to `Disabled`. This setting is only applicable for the Private Link Endpoint, for all other resources in the subnet access is controlled based via the Network Security Group which can be configured using the `azurerm_subnet_network_security_group_association` resource.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `delegation` - (Optional) One or more `delegation` blocks as defined below.
 
-* `default_outbound_access_enabled` - (Optional) Enable default outbound access to the internet for the subnet. Setting to `false` creates a private subnet.
+* `default_outbound_access_enabled` - (Optional) Enable default outbound access to the internet for the subnet. Defaults to `true`.
 
 * `private_endpoint_network_policies` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Possible values are `Disabled`, `Enabled`, `NetworkSecurityGroupEnabled` and `RouteTableEnabled`. Defaults to `Disabled`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Documentation Changes

- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Microsoft is moving to [remove default internet access](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/default-outbound-access) from subnets. For now they have introduced a property on the subnet resource to enable moving to this model before it becomes the default. This PR adds the `default_outbound_access` property to the subnet resource.

To achieve this, we need to use the `2023-05-01` API. This PR moves only the subnet resource to the `2023-09-01` API, and also moves from `kermit` to `go-azure-sdk` in the process. To avoid refactoring the `azurerm_virtual_network` resource, the old kermit 2023-05-01 client is left in the package as `SubnetKermitClient`. All other resources in the network package which leverage subnets are migrated to the `go-azure-sdk` client.

## Testing Logs/Evidence

<!-- Please include your testing evidence here or an explanation on why no testing evidence can be provided. 
For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
TF_ACC=1 go test -v ./internal/services/network -run="TestAcc(Subnet_defaultOutbound|DataSourceSubnet_basic)" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceSubnet_basic
=== PAUSE TestAccDataSourceSubnet_basic
=== RUN   TestAccSubnet_defaultOutbound
=== PAUSE TestAccSubnet_defaultOutbound
=== CONT  TestAccDataSourceSubnet_basic
=== CONT  TestAccSubnet_defaultOutbound
--- PASS: TestAccDataSourceSubnet_basic (135.04s)
--- PASS: TestAccSubnet_defaultOutbound (163.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       166.267s
```

## Related Issue(s)
Fixes #24279
Closes tombuildsstuff/kermit#363

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_subnet` - support for the `default_outbound_access_enabled` property [GH-25259]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

