### PR TITLE
`azurerm_pim_eligible_role_assignment`, `azurerm_pim_active_role_assignment` - Add nil check

### DIFF
--- a/internal/services/authorization/pim_active_role_assignment_resource.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource.go
@@ -649,10 +649,9 @@ func createActiveRoleAssignment(ctx context.Context, client *roleassignmentsched
 		// Retry deletes while that error exists.
 		result, err := client.Create(ctx, id, *payload)
 		if err != nil {
-			if *result.OData.Error.Code == "SubjectNotFound" {
+			if result.OData != nil && result.OData.Error != nil && result.OData.Error.Code != nil && *result.OData.Error.Code == "SubjectNotFound" {
 				return nil, "Exist", nil
 			}
-
 			return nil, "Exist", fmt.Errorf("creating %s: %+v", id, err)
 		}
 
@@ -700,14 +699,15 @@ func deleteActiveRoleAssignment(ctx context.Context, client *roleassignmentsched
 		// Retry deletes while that error exists.
 		result, err := client.Create(ctx, id, *payload)
 		if err != nil {
-			if *result.OData.Error.Code == "ActiveDurationTooShort" {
-				return nil, "Exist", nil
-			}
+			if result.OData != nil && result.OData.Error != nil && result.OData.Error.Code != nil {
+				if *result.OData.Error.Code == "ActiveDurationTooShort" {
+					return nil, "Exist", nil
+				}
 
-			if *result.OData.Error.Code == "RoleAssignmentDoesNotExist" {
-				return nil, "Deleted", nil
+				if *result.OData.Error.Code == "RoleAssignmentDoesNotExist" {
+					return nil, "Deleted", nil
+				}
 			}
-
 			return nil, "Exist", fmt.Errorf("creating %s: %+v", id, err)
 		}
 

--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -648,10 +648,9 @@ func createEligibilityRoleAssignment(ctx context.Context, client *roleeligibilit
 		// Retry deletes while that error exists.
 		result, err := client.Create(ctx, id, *payload)
 		if err != nil {
-			if *result.OData.Error.Code == "SubjectNotFound" {
+			if result.OData != nil && result.OData.Error != nil && result.OData.Error.Code != nil && *result.OData.Error.Code == "SubjectNotFound" {
 				return nil, "Missing", nil
 			}
-
 			return nil, "Missing", fmt.Errorf("creating %s: %+v", id, err)
 		}
 
@@ -699,14 +698,15 @@ func deleteEligibilityRoleAssignmentSchedule(ctx context.Context, client *roleel
 		// Retry deletes while that error exists.
 		result, err := client.Create(ctx, id, *payload)
 		if err != nil {
-			if *result.OData.Error.Code == "ActiveDurationTooShort" {
-				return nil, "Exist", nil
-			}
+			if result.OData != nil && result.OData.Error != nil && result.OData.Error.Code != nil {
+				if *result.OData.Error.Code == "ActiveDurationTooShort" {
+					return nil, "Exist", nil
+				}
 
-			if *result.OData.Error.Code == "RoleAssignmentDoesNotExist" {
-				return nil, "Deleted", nil
+				if *result.OData.Error.Code == "RoleAssignmentDoesNotExist" {
+					return nil, "Deleted", nil
+				}
 			}
-
 			return nil, "Exist", fmt.Errorf("creating %s: %+v", id, err)
 		}
 


### PR DESCRIPTION
<!--  All Submissions -->
Fixes: #25241 

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Documentation Changes

- [ ] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## Testing Logs/Evidence

<!-- Please include your testing evidence here or an explanation on why no testing evidence can be provided. 
For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Related Issue(s)
Fixes #0000

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.


