### PR TITLE
doc: Update description for resource_group_name argument

### DIFF
--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -56,7 +56,7 @@ resource "azurerm_backup_protected_vm" "vm1" {
 
 The following arguments are supported:
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Recovery Services Vault. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group **associated with** the Recovery Services Vault to use. Changing this forces a new resource to be created.
 
 * `recovery_vault_name` - (Required) Specifies the name of the Recovery Services Vault to use. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Documentation Changes
- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.

## Description
The way the resource is written currently, the `resource_group_name` argument is specifically needing the Resource Group of the target Recovery Services Vault. To be honest, I'm not sure why the `resource_group_name` and `recovery_vault_name` arguments are being used instead of the more common/modern approach of using a `recovery_services_vault_id` or `recovery_vault_id` argument.


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.