### PR TITLE
`azurerm_storage_data_lake_gen2_path` - Add context deadline in importer

### DIFF
--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -35,6 +35,9 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 			_, err := paths.ParsePathID(id, storageDomainSuffix)
 			return err
 		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+			ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+			defer cancel()
+
 			storageClient := meta.(*clients.Client).Storage
 
 			id, err := paths.ParsePathID(d.Id(), storageClient.StorageDomainSuffix)

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -35,7 +35,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 			_, err := paths.ParsePathID(id, storageDomainSuffix)
 			return err
 		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
-			ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+			ctx, cancel := context.WithTimeout(ctx, d.Timeout(pluginsdk.TimeoutRead))
 			defer cancel()
 
 			storageClient := meta.(*clients.Client).Storage


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Documentation Changes

- [ ] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes the failing test cases (as detected in the teamcity), which returns error as below:

```shell
------- Stdout: -------
=== RUN   TestAccStorageDataLakeGen2Path_withSuperUsers
=== PAUSE TestAccStorageDataLakeGen2Path_withSuperUsers
=== CONT  TestAccStorageDataLakeGen2Path_withSuperUsers
    testcase.go:113: Step 2/2 error running import: exit status 1
        Error: retrieving File System "fstest" for Data Lake Gen2 Path "testpath" in Account "acctestaccqhdei": building request: internal-error: the context used must have a deadline attached for polling purposes, but got no deadline
--- FAIL: TestAccStorageDataLakeGen2Path_withSuperUsers (174.49s)
FAIL
```

## Testing Logs/Evidence

<!-- Please include your testing evidence here or an explanation on why no testing evidence can be provided. 
For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

> TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageDataLakeGen2Path_basic'
=== RUN   TestAccStorageDataLakeGen2Path_basic
=== PAUSE TestAccStorageDataLakeGen2Path_basic
=== CONT  TestAccStorageDataLakeGen2Path_basic
--- PASS: TestAccStorageDataLakeGen2Path_basic (326.94s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       326.958s


## Related Issue(s)

This PR fixes the acctests as is detected in https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_STORAGE/118781?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildTestsSection=true

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_data_lake_gen2_path` - Fix an import error [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.


