### PR TITLE
`azurerm_container_app_environment` - add support for Consumption workload profile

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -6,7 +6,6 @@ package containerapps
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -431,7 +430,7 @@ func consumptionIsExplicitlyDefined(metadata sdk.ResourceMetaData) bool {
 		return false
 	}
 	for _, v := range config.WorkloadProfiles {
-		if strings.EqualFold(v.Name, string(helpers.WorkloadProfileSkuConsumption)) {
+		if v.Name == string(helpers.WorkloadProfileSkuConsumption) {
 			return true
 		}
 	}

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -34,6 +34,21 @@ func TestAccContainerAppEnvironment_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppEnvironment_consumptionWorkloadProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.consumptionWorkloadProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id", "workload_profile"),
+	})
+}
+
 func TestAccContainerAppEnvironment_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentResource{}
@@ -225,6 +240,28 @@ resource "azurerm_container_app_environment" "test" {
 `, r.templateVNet(data), data.RandomInteger)
 }
 
+func (r ContainerAppEnvironmentResource) consumptionWorkloadProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                       = "acctest-CAEnv%[2]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
+}
+`, r.templateVNet(data), data.RandomInteger)
+}
+
 func (r ContainerAppEnvironmentResource) completeUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -281,6 +318,13 @@ resource "azurerm_container_app_environment" "test" {
     maximum_count         = 2
     minimum_count         = 0
     name                  = "E4-01"
+    workload_profile_type = "E4"
+  }
+
+  workload_profile {
+    maximum_count         = 2
+    minimum_count         = 0
+    name                  = "D4-02"
     workload_profile_type = "E4"
   }
 

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -8,15 +8,42 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-const consumption = "Consumption"
+type WorkloadProfileSku string
+
+const (
+	WorkloadProfileSkuConsumption WorkloadProfileSku = "Consumption"
+	WorkloadProfileSkuD4          WorkloadProfileSku = "D4"
+	WorkloadProfileSkuD8          WorkloadProfileSku = "D8"
+	WorkloadProfileSkuD16         WorkloadProfileSku = "D16"
+	WorkloadProfileSkuD32         WorkloadProfileSku = "D32"
+	WorkloadProfileSkuE4          WorkloadProfileSku = "E4"
+	WorkloadProfileSkuE8          WorkloadProfileSku = "E8"
+	WorkloadProfileSkuE16         WorkloadProfileSku = "E16"
+	WorkloadProfileSkuE32         WorkloadProfileSku = "E32"
+)
+
+func PossibleValuesForWorkloadProfileSku() []string {
+	return []string{
+		string(WorkloadProfileSkuConsumption),
+		string(WorkloadProfileSkuD4),
+		string(WorkloadProfileSkuD8),
+		string(WorkloadProfileSkuD16),
+		string(WorkloadProfileSkuD32),
+		string(WorkloadProfileSkuE4),
+		string(WorkloadProfileSkuE8),
+		string(WorkloadProfileSkuE16),
+		string(WorkloadProfileSkuE32),
+	}
+}
 
 type WorkloadProfileModel struct {
-	MaximumCount        int    `tfschema:"maximum_count"`
-	MinimumCount        int    `tfschema:"minimum_count"`
+	MaximumCount        int64  `tfschema:"maximum_count"`
+	MinimumCount        int64  `tfschema:"minimum_count"`
 	Name                string `tfschema:"name"`
 	WorkloadProfileType string `tfschema:"workload_profile_type"`
 }
@@ -34,28 +61,19 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 				},
 
 				"workload_profile_type": {
-					Type:     pluginsdk.TypeString,
-					Required: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"D4",
-						"D8",
-						"D16",
-						"D32",
-						"E4",
-						"E8",
-						"E16",
-						"E32",
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(PossibleValuesForWorkloadProfileSku(), false),
 				},
 
 				"maximum_count": {
 					Type:     pluginsdk.TypeInt,
-					Required: true,
+					Optional: true,
 				},
 
 				"minimum_count": {
 					Type:     pluginsdk.TypeInt,
-					Required: true,
+					Optional: true,
 				},
 			},
 		},
@@ -69,42 +87,49 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 
 	result := make([]managedenvironments.WorkloadProfile, 0)
 
+	consumptionDefined := false
+
 	for _, v := range input {
 		r := managedenvironments.WorkloadProfile{
-			Name:                v.Name,
-			WorkloadProfileType: v.WorkloadProfileType,
+			Name: v.Name,
 		}
 
-		if v.Name != consumption {
-			r.MaximumCount = pointer.To(int64(v.MaximumCount))
-			r.MinimumCount = pointer.To(int64(v.MinimumCount))
+		if !strings.EqualFold(v.Name, string(WorkloadProfileSkuConsumption)) {
+			r.WorkloadProfileType = v.WorkloadProfileType
+			r.MaximumCount = pointer.To(v.MaximumCount)
+			r.MinimumCount = pointer.To(v.MinimumCount)
+		} else {
+			r.WorkloadProfileType = string(WorkloadProfileSkuConsumption)
+			consumptionDefined = true
 		}
 
 		result = append(result, r)
 	}
 
-	result = append(result, managedenvironments.WorkloadProfile{
-		Name:                consumption,
-		WorkloadProfileType: consumption,
-	})
+	if !features.FourPointOhBeta() && !consumptionDefined {
+		result = append(result, managedenvironments.WorkloadProfile{
+			Name:                string(WorkloadProfileSkuConsumption),
+			WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+		})
+	}
 
 	return &result
 }
 
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, consumptionDefined bool) []WorkloadProfileModel {
 	if input == nil || len(*input) == 0 {
 		return []WorkloadProfileModel{}
 	}
 	result := make([]WorkloadProfileModel, 0)
 
 	for _, v := range *input {
-		if strings.EqualFold(v.WorkloadProfileType, consumption) {
+		if strings.EqualFold(v.WorkloadProfileType, string(WorkloadProfileSkuConsumption)) && !consumptionDefined {
 			continue
 		}
 		result = append(result, WorkloadProfileModel{
 			Name:                v.Name,
-			MaximumCount:        int(pointer.From(v.MaximumCount)),
-			MinimumCount:        int(pointer.From(v.MinimumCount)),
+			MaximumCount:        pointer.From(v.MaximumCount),
+			MinimumCount:        pointer.From(v.MinimumCount),
 			WorkloadProfileType: v.WorkloadProfileType,
 		})
 	}

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -15,6 +15,7 @@ import (
 
 type WorkloadProfileSku string
 
+// NOTE: the Workload Profile SKUs aren't defined in the Swagger definition so we define them here
 const (
 	WorkloadProfileSkuConsumption WorkloadProfileSku = "Consumption"
 	WorkloadProfileSkuD4          WorkloadProfileSku = "D4"
@@ -94,7 +95,7 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 			Name: v.Name,
 		}
 
-		if !strings.EqualFold(v.Name, string(WorkloadProfileSkuConsumption)) {
+		if v.Name != string(WorkloadProfileSkuConsumption) {
 			r.WorkloadProfileType = v.WorkloadProfileType
 			r.MaximumCount = pointer.To(v.MaximumCount)
 			r.MinimumCount = pointer.To(v.MinimumCount)

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -76,7 +76,11 @@ A `workload_profile` block supports the following:
 
 * `name` - (Required) The name of the workload profile.
 
-* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
+* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `Consumption`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
+
+~> **NOTE:** A `Consumption` type must have a name of `Consumption` and an environment may only have one `Consumption` Workload Profile.  
+
+~> **NOTE:** Defining a `Consumption` profile is optional, however, Environments created without an initial Workload Profile cannot have them added at a later time and must be recreated. Similarly, an environment created with Profiles must always have at least one defined Profile, removing all profiles will force a recreation of the resource. 
 
 * `maximum_count` - (Required) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”



<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## New Feature Submissions

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why below)


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Documentation Changes

- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.


## Description

This PR adds support for the `Consumption` workload profile SKU. Environments created without any profiles cannot have them added later. The `Consumption` profile is always present, so can be omitted from configurations that already use at least one other Workload Profile. This option is included to facilitate the ability to create an `azurerm_container_app_environment` that can have Workload Profiles added and removed at a later time.  

Note: This resource will be conditionally `ForceNew` if all profiles are removed from the configuration, or if a profile is introduced to an existing resource which was created without any `workload_profile` blocks.

## Testing Logs/Evidence

## Related Issue(s)
Fixes #24198

Supersedes #24277 

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app_environment` - add support for Consumption workload profile 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


