### PR TITLE
`azurerm_kubernetes_cluster` - various 4.0 changes

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
@@ -490,53 +491,60 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
+	autoUpgradeChannel := "automatic_upgrade_channel"
+	nodeOsUpgradeChannel := "node_os_upgrade_channel"
+	if !features.FourPointOhBeta() {
+		autoUpgradeChannel = "automatic_channel_upgrade"
+		nodeOsUpgradeChannel = "node_os_channel_upgrade"
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "rapid"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
-				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("rapid"),
+				check.That(data.ResourceName).Key(autoUpgradeChannel).HasValue("rapid"),
 			),
 		},
-		data.ImportStep("node_os_channel_upgrade"),
+		data.ImportStep(nodeOsUpgradeChannel),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "patch"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
-				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("patch"),
+				check.That(data.ResourceName).Key(autoUpgradeChannel).HasValue("patch"),
 			),
 		},
-		data.ImportStep("node_os_channel_upgrade"),
+		data.ImportStep(nodeOsUpgradeChannel),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "node-image"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
-				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("node-image"),
+				check.That(data.ResourceName).Key(autoUpgradeChannel).HasValue("node-image"),
 			),
 		},
-		data.ImportStep("node_os_channel_upgrade"),
+		data.ImportStep(nodeOsUpgradeChannel),
 		{
 			// unset = none
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
-				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue(""),
+				check.That(data.ResourceName).Key(autoUpgradeChannel).HasValue(""),
 			),
 		},
-		data.ImportStep("node_os_channel_upgrade"),
+		data.ImportStep(nodeOsUpgradeChannel),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "stable"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
-				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("stable"),
+				check.That(data.ResourceName).Key(autoUpgradeChannel).HasValue("stable"),
 			),
 		},
-		data.ImportStep("node_os_channel_upgrade"),
+		data.ImportStep(nodeOsUpgradeChannel),
 	})
 }
 
@@ -957,12 +965,16 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
+	nodeOsUpgradeChannel := "node_os_upgrade_channel"
+	if !features.FourPointOhBeta() {
+		nodeOsUpgradeChannel = "node_os_channel_upgrade"
+	}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.nodeOsUpgradeChannel(data, "Unmanaged"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("Unmanaged"),
+				check.That(data.ResourceName).Key(nodeOsUpgradeChannel).HasValue("Unmanaged"),
 			),
 		},
 		// TODO add this back in when upgrading to 2023-06-02-preview
@@ -972,7 +984,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 			Config: r.nodeOsUpgradeChannel(data, "SecurityPatch"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("SecurityPatch"),
+				check.That(data.ResourceName).Key(nodeOsUpgradeChannel).HasValue("SecurityPatch"),
 			),
 		},
 		// data.ImportStep(),
@@ -980,7 +992,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 			Config: r.nodeOsUpgradeChannel(data, "NodeImage"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("NodeImage"),
+				check.That(data.ResourceName).Key(nodeOsUpgradeChannel).HasValue("NodeImage"),
 			),
 		},
 		// data.ImportStep(),
@@ -988,7 +1000,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 			Config: r.nodeOsUpgradeChannel(data, "None"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("None"),
+				check.That(data.ResourceName).Key(nodeOsUpgradeChannel).HasValue("None"),
 			),
 		},
 		// data.ImportStep(),
@@ -2220,7 +2232,8 @@ func (KubernetesClusterResource) upgradeChannelConfig(data acceptance.TestData, 
 		upgradeChannel = "null"
 	}
 
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -2238,6 +2251,37 @@ resource "azurerm_kubernetes_cluster" "test" {
   kubernetes_version        = %q
   automatic_channel_upgrade = %s
   node_os_channel_upgrade   = "NodeImage"
+
+  default_node_pool {
+    name       = "default"
+    vm_size    = "Standard_DS2_v2"
+    node_count = 1
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, upgradeChannel)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                      = "acctestaks%d"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  dns_prefix                = "acctestaks%d"
+  kubernetes_version        = %q
+  automatic_upgrade_channel = %s
+  node_os_upgrade_channel   = "NodeImage"
 
   default_node_pool {
     name       = "default"
@@ -3104,7 +3148,8 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func (KubernetesClusterResource) nodeOsUpgradeChannel(data acceptance.TestData, nodeOsUpgradeChannel string) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -3118,6 +3163,31 @@ resource "azurerm_kubernetes_cluster" "test" {
   resource_group_name     = azurerm_resource_group.test.name
   dns_prefix              = "acctestaks%d"
   node_os_channel_upgrade = "%s"
+  default_node_pool {
+    name       = "default"
+    vm_size    = "Standard_DS2_v2"
+    node_count = 1
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, nodeOsUpgradeChannel)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+resource "azurerm_kubernetes_cluster" "test" {
+  name                    = "acctestaks%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  dns_prefix              = "acctestaks%d"
+  node_os_upgrade_channel = "%s"
   default_node_pool {
     name       = "default"
     vm_size    = "Standard_DS2_v2"

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -178,17 +178,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
-			"automatic_channel_upgrade": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(managedclusters.UpgradeChannelPatch),
-					string(managedclusters.UpgradeChannelRapid),
-					string(managedclusters.UpgradeChannelStable),
-					string(managedclusters.UpgradeChannelNodeNegativeimage),
-				}, false),
-			},
-
 			"auto_scaler_profile": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -966,17 +955,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
-			"node_os_channel_upgrade": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(managedclusters.NodeOSUpgradeChannelNodeImage),
-					string(managedclusters.NodeOSUpgradeChannelNone),
-					string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
-					string(managedclusters.NodeOSUpgradeChannelUnmanaged),
-				}, false),
-			},
-
 			"key_management_service": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -1592,6 +1570,49 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			Default:      48,
 			ValidateFunc: validation.IntBetween(24, 2160),
 		}
+		resource.Schema["automatic_channel_upgrade"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(managedclusters.UpgradeChannelPatch),
+				string(managedclusters.UpgradeChannelRapid),
+				string(managedclusters.UpgradeChannelStable),
+				string(managedclusters.UpgradeChannelNodeNegativeimage),
+			}, false),
+		}
+		resource.Schema["node_os_channel_upgrade"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(managedclusters.NodeOSUpgradeChannelNodeImage),
+				string(managedclusters.NodeOSUpgradeChannelNone),
+				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
+				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
+			}, false),
+		}
+	}
+
+	if features.FourPointOhBeta() {
+		resource.Schema["automatic_upgrade_channel"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(managedclusters.UpgradeChannelPatch),
+				string(managedclusters.UpgradeChannelRapid),
+				string(managedclusters.UpgradeChannelStable),
+				string(managedclusters.UpgradeChannelNodeNegativeimage),
+			}, false),
+		}
+		resource.Schema["node_os_upgrade_channel"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(managedclusters.NodeOSUpgradeChannelNodeImage),
+				string(managedclusters.NodeOSUpgradeChannelNone),
+				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
+				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
+			}, false),
+		}
 	}
 
 	return resource
@@ -1742,13 +1763,21 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	autoUpgradeProfile := &managedclusters.ManagedClusterAutoUpgradeProfile{}
-	autoChannelUpgrade := d.Get("automatic_channel_upgrade").(string)
-	nodeOsChannelUpgrade := d.Get("node_os_channel_upgrade").(string)
+
+	autoChannelUpgrade := d.Get("automatic_upgrade_channel").(string)
+	nodeOsChannelUpgrade := d.Get("node_os_upgrade_channel").(string)
+	if !features.FourPointOhBeta() {
+		autoChannelUpgrade = d.Get("automatic_channel_upgrade").(string)
+		nodeOsChannelUpgrade = d.Get("node_os_channel_upgrade").(string)
+	}
 
 	// this check needs to be separate and gated since node_os_channel_upgrade is a preview feature
 	if nodeOsChannelUpgrade != "" && autoChannelUpgrade != "" {
 		if autoChannelUpgrade == string(managedclusters.UpgradeChannelNodeNegativeimage) && nodeOsChannelUpgrade != string(managedclusters.NodeOSUpgradeChannelNodeImage) {
-			return fmt.Errorf("`node_os_channel_upgrade` cannot be set to a value other than `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
+			if !features.FourPointOhBeta() {
+				return fmt.Errorf("`node_os_channel_upgrade` cannot be set to a value other than `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
+			}
+			return fmt.Errorf("`node_os_upgrade_channel` cannot be set to a value other than `NodeImage` if `automatic_upgrade_channel` is set to `node-image`")
 		}
 	}
 
@@ -2231,27 +2260,36 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		existing.Model.Sku.Tier = &skuTier
 	}
 
-	if d.HasChange("automatic_channel_upgrade") {
+	autoUpgradeChannel := "automatic_upgrade_channel"
+	nodeOsUpgradeChannel := "node_os_upgrade_channel"
+	if !features.FourPointOhBeta() {
+		autoUpgradeChannel = "automatic_channel_upgrade"
+		nodeOsUpgradeChannel = "node_os_channel_upgrade"
+	}
+	if d.HasChange(autoUpgradeChannel) {
 		updateCluster = true
 		if existing.Model.Properties.AutoUpgradeProfile == nil {
 			existing.Model.Properties.AutoUpgradeProfile = &managedclusters.ManagedClusterAutoUpgradeProfile{}
 		}
-		channel := d.Get("automatic_channel_upgrade").(string)
+		channel := d.Get(autoUpgradeChannel).(string)
 		if channel == "" {
 			channel = string(managedclusters.UpgradeChannelNone)
 		}
 		existing.Model.Properties.AutoUpgradeProfile.UpgradeChannel = pointer.To(managedclusters.UpgradeChannel(channel))
 	}
 
-	if d.HasChange("node_os_channel_upgrade") {
+	if d.HasChange(nodeOsUpgradeChannel) {
 		updateCluster = true
-		if d.Get("automatic_channel_upgrade").(string) == string(managedclusters.UpgradeChannelNodeNegativeimage) && d.Get("node_os_channel_upgrade").(string) != string(managedclusters.NodeOSUpgradeChannelNodeImage) {
-			return fmt.Errorf("`node_os_channel_upgrade` must be set to `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
+		if d.Get(autoUpgradeChannel).(string) == string(managedclusters.UpgradeChannelNodeNegativeimage) && d.Get(nodeOsUpgradeChannel).(string) != string(managedclusters.NodeOSUpgradeChannelNodeImage) {
+			if !features.FourPointOhBeta() {
+				return fmt.Errorf("`node_os_channel_upgrade` must be set to `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
+			}
+			return fmt.Errorf("`node_os_upgrade_channel` must be set to `NodeImage` if `automatic_upgrade_channel` is set to `node-image`")
 		}
 		if existing.Model.Properties.AutoUpgradeProfile == nil {
 			existing.Model.Properties.AutoUpgradeProfile = &managedclusters.ManagedClusterAutoUpgradeProfile{}
 		}
-		existing.Model.Properties.AutoUpgradeProfile.NodeOSUpgradeChannel = pointer.To(managedclusters.NodeOSUpgradeChannel(d.Get("node_os_channel_upgrade").(string)))
+		existing.Model.Properties.AutoUpgradeProfile.NodeOSUpgradeChannel = pointer.To(managedclusters.NodeOSUpgradeChannel(d.Get(nodeOsUpgradeChannel).(string)))
 	}
 
 	if d.HasChange("http_proxy_config") {
@@ -2650,12 +2688,23 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 					nodeOSUpgradeChannel = string(*profile.NodeOSUpgradeChannel)
 				}
 			}
-			d.Set("automatic_channel_upgrade", upgradeChannel)
+
+			if !features.FourPointOhBeta() {
+				d.Set("automatic_channel_upgrade", upgradeChannel)
+			} else {
+				d.Set("automatic_upgrade_channel", upgradeChannel)
+			}
 
 			// the API returns `node_os_channel_upgrade` when `automatic_channel_upgrade` is set to `node-image`
 			// since it's a preview feature we will only set this if it's explicitly been set in the config for the time being
-			if v, ok := d.GetOk("node_os_channel_upgrade"); ok && v.(string) != "" {
-				d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
+			if !features.FourPointOhBeta() {
+				if v, ok := d.GetOk("node_os_channel_upgrade"); ok && v.(string) != "" {
+					d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
+				}
+			} else {
+				if v, ok := d.GetOk("node_os_upgrade_channel"); ok && v.(string) != "" {
+					d.Set("node_os_upgrade_channel", nodeOSUpgradeChannel)
+				}
 			}
 
 			customCaTrustCertList := flattenCustomCaTrustCerts(props.SecurityProfile)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1136,15 +1136,10 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 										ValidateFunc: validation.IntBetween(0, 64000),
 									},
 									"idle_timeout_in_minutes": {
-										Type:     pluginsdk.TypeInt,
-										Optional: true,
-										Default:  30,
-										ValidateFunc: func() pluginsdk.SchemaValidateFunc {
-											if !features.FourPointOhBeta() {
-												return validation.IntBetween(4, 120)
-											}
-											return validation.IntBetween(4, 100)
-										}(),
+										Type:         pluginsdk.TypeInt,
+										Optional:     true,
+										Default:      30,
+										ValidateFunc: validation.IntBetween(4, 100),
 									},
 									"managed_outbound_ip_count": {
 										Type:          pluginsdk.TypeInt,

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -468,13 +468,11 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"image_cleaner_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"image_cleaner_interval_hours": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
-				Default:      48,
 				ValidateFunc: validation.IntBetween(24, 2160),
 			},
 
@@ -1578,6 +1576,17 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			Sensitive:    true,
 			ValidateFunc: validation.StringLenBetween(8, 123),
 		}
+		resource.Schema["image_cleaner_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		}
+		resource.Schema["image_cleaner_interval_hours"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Default:      48,
+			ValidateFunc: validation.IntBetween(24, 2160),
+		}
 	}
 
 	return resource
@@ -1714,9 +1723,11 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	securityProfile.ImageCleaner = &managedclusters.ManagedClusterSecurityProfileImageCleaner{
-		Enabled:       utils.Bool(d.Get("image_cleaner_enabled").(bool)),
-		IntervalHours: utils.Int64(int64(d.Get("image_cleaner_interval_hours").(int))),
+	if d.Get("image_cleaner_enabled").(bool) {
+		securityProfile.ImageCleaner = &managedclusters.ManagedClusterSecurityProfileImageCleaner{
+			Enabled:       utils.Bool(d.Get("image_cleaner_enabled").(bool)),
+			IntervalHours: utils.Int64(int64(d.Get("image_cleaner_interval_hours").(int))),
+		}
 	}
 
 	azureKeyVaultKmsRaw := d.Get("key_management_service").([]interface{})

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1158,10 +1158,15 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 										ValidateFunc: validation.IntBetween(0, 64000),
 									},
 									"idle_timeout_in_minutes": {
-										Type:         pluginsdk.TypeInt,
-										Optional:     true,
-										Default:      30,
-										ValidateFunc: validation.IntBetween(4, 120),
+										Type:     pluginsdk.TypeInt,
+										Optional: true,
+										Default:  30,
+										ValidateFunc: func() pluginsdk.SchemaValidateFunc {
+											if !features.FourPointOhBeta() {
+												return validation.IntBetween(4, 120)
+											}
+											return validation.IntBetween(4, 100)
+										}(),
 									},
 									"managed_outbound_ip_count": {
 										Type:          pluginsdk.TypeInt,

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -735,7 +735,7 @@ A `load_balancer_profile` block supports the following:
 
 ~> **Note:** The fields `managed_outbound_ip_count`, `outbound_ip_address_ids` and `outbound_ip_prefix_ids` are mutually exclusive. Note that when specifying `outbound_ip_address_ids` ([azurerm_public_ip](/docs/providers/azurerm/r/public_ip.html)) the SKU must be `standard`.
 
-* `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `120` inclusive. Defaults to `30`.
+* `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `100` inclusive. Defaults to `30`.
 
 * `managed_outbound_ip_count` - (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be between `1` and `100` inclusive.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR contains the following changes for 4.0:

- Removes the default values for `image_cleaner_enabled` and `image_cleaner_interval_hours`, closes https://github.com/hashicorp/terraform-provider-azurerm/issues/19654
- Renames `automatic_channel_upgrade` - > `automatic_upgrade_channel` (to better align with the API)
- Renames `node_os_channel_upgrade` - > `node_os_upgrade_channel` (to better align with the API)
- Lowers the upper limit for the `idle_timeout_in_minutes` validation function

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


