### PR TITLE
deprecations - update deprecation messages to specify removal in v4.0 of the Provider

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1574,7 +1574,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				string(managedclusters.UpgradeChannelStable),
 				string(managedclusters.UpgradeChannelNodeNegativeimage),
 			}, false),
-			Deprecated: features.DeprecatedInFourPointOh("The property `automatic_channel_upgrade` will be renamed to `automatic_upgrade_channel` in v4.0"),
+			Deprecated: features.DeprecatedInFourPointOh("The property `automatic_channel_upgrade` will be renamed to `automatic_upgrade_channel` in v4.0 of the AzureRM Provider."),
 		}
 		resource.Schema["node_os_channel_upgrade"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
@@ -1585,7 +1585,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
 				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
 			}, false),
-			Deprecated: features.DeprecatedInFourPointOh("The property `node_os_channel_upgrade` will be renamed to `node_os_upgrade_channel` in v4.0"),
+			Deprecated: features.DeprecatedInFourPointOh("The property `node_os_channel_upgrade` will be renamed to `node_os_upgrade_channel` in v4.0 of the AzureRM Provider."),
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1574,6 +1574,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				string(managedclusters.UpgradeChannelStable),
 				string(managedclusters.UpgradeChannelNodeNegativeimage),
 			}, false),
+			Deprecated: features.DeprecatedInFourPointOh("The property `automatic_channel_upgrade` will be renamed to `automatic_upgrade_channel` in v4.0"),
 		}
 		resource.Schema["node_os_channel_upgrade"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
@@ -1584,6 +1585,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
 				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
 			}, false),
+			Deprecated: features.DeprecatedInFourPointOh("The property `node_os_channel_upgrade` will be renamed to `node_os_upgrade_channel` in v4.0"),
 		}
 	}
 

--- a/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
@@ -35,7 +35,7 @@ func resourceDataFactoryIntegrationRuntimeManaged() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The resource 'azurerm_data_factory_integration_runtime_managed' has been superseded by the 'azurerm_data_factory_integration_runtime_azure_ssis'.",
+		DeprecationMessage: "The resource 'azurerm_data_factory_integration_runtime_managed' has been superseded by the 'azurerm_data_factory_integration_runtime_azure_ssis' resource and will be removed in v4.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_access_policy_resource.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_access_policy_resource.go
@@ -31,6 +31,8 @@ func resourceIoTTimeSeriesInsightsAccessPolicy() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_access_policy` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_event_source_eventhub.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_event_source_eventhub.go
@@ -34,6 +34,8 @@ func resourceIoTTimeSeriesInsightsEventSourceEventhub() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_event_source_eventhub` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_event_source_iothub.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_event_source_iothub.go
@@ -34,6 +34,8 @@ func resourceIoTTimeSeriesInsightsEventSourceIoTHub() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_event_source_iothub` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
@@ -33,6 +33,8 @@ func resourceIoTTimeSeriesInsightsGen2Environment() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_gen2_environment` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource.go
@@ -34,6 +34,8 @@ func resourceIoTTimeSeriesInsightsReferenceDataSet() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_reference_data_set` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_standard_environment_resource.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_standard_environment_resource.go
@@ -36,6 +36,8 @@ func resourceIoTTimeSeriesInsightsStandardEnvironment() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "Azure Time Series Insight will be retired on 2025-03-31. As a result the `azurerm_iot_time_series_insights_standard_environment` resource has been deprecated and will be removed in v4.0 of the AzureRM Provider.",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/registration.go
+++ b/internal/services/media/registration.go
@@ -16,7 +16,7 @@ var (
 )
 
 const (
-	azureMediaRetirementMessage = "Azure Media Services will be retired June 30th, 2024. Please see https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement"
+	azureMediaRetirementMessage = "Azure Media Services will be retired June 30th, 2024. Please see https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement. This resource is deprecated and will be removed in v4.0 of the AzureRM Provider."
 )
 
 func (r Registration) AssociatedGitHubLabel() string {

--- a/internal/services/resource/template_deployment_resource.go
+++ b/internal/services/resource/template_deployment_resource.go
@@ -43,7 +43,7 @@ func resourceTemplateDeployment() *pluginsdk.Resource {
 			0: migration.TemplateDeploymentV0ToV1{},
 		}),
 
-		DeprecationMessage: "The resource 'azurerm_template_deployment' has been superseded by the 'azurerm_resource_group_template_deployment' resource.",
+		DeprecationMessage: "The resource 'azurerm_template_deployment' has been superseded by the 'azurerm_resource_group_template_deployment' resource and will be removed in v4.0 of the AzureRM Provider.",
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- updates the deprecation messages of several resources to specify the removal of them in 4.0
- adds deprecation messages for the IoT Time Series Insights Resources. Closes  #15960
- adds deprecation messages for renamed properties in the kubernetes resource using the `DeprecatedInFourPointOh` function


