### PR TITLE
`azurerm_synapse_spark_pool` - added spark pool 3.4 support for Synapse

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -213,7 +213,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  "3.4",
+				Default:  "2.4", // TODO: make this field Required in 4.0 since the default value changes over time
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -213,12 +213,13 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  "2.4",
+				Default:  "3.4",
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",
 					"3.2",
 					"3.3",
+					"3.4",
 				}, false),
 			},
 

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -131,6 +131,14 @@ func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
 		},
 		// not returned by service
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.sparkVersion(data, "3.4"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
 	})
 }
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2` and `3.3`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. `2.4` and `3.1` have been deprecated.  On 8 July 2024, extended support for Apache Spark Pool `3.2` will end.  Defaults to latest: `3.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. `2.4` and `3.1` have been deprecated.  On 8 July 2024, extended support for Apache Spark Pool `3.2` will end.  Defaults to latest: `3.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
Created Issue for this: https://github.com/hashicorp/terraform-provider-azurerm/issues/25318

Updated `azurerm_synapse_spark_pool` resource to add support for `spark_pool_version 3.4`.  Also, updated the default version to be `3.4`, which is the latest version.