### PR TITLE
`managed_hsm_role_*_ids`: use specific resource id to replace generic nested item id

### DIFF
--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource.go
@@ -105,7 +105,7 @@ func (m KeyVaultManagedHSMRoleAssignmentResource) Create() sdk.ResourceFunc {
 			locks.ByName(model.VaultBaseUrl, "azurerm_key_vault_managed_hardware_security_module")
 			defer locks.UnlockByName(model.VaultBaseUrl, "azurerm_key_vault_managed_hardware_security_module")
 
-			id, err := parse.NewNestedItemID(model.VaultBaseUrl, model.Scope, parse.RoleAssignmentType, model.Name)
+			id, err := parse.NewManagedHSMRoleAssignmentID(model.VaultBaseUrl, model.Scope, model.Name)
 			if err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func (m KeyVaultManagedHSMRoleAssignmentResource) Read() sdk.ResourceFunc {
 		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
 			client := meta.Client.ManagedHSMs.DataPlaneRoleAssignmentsClient
 
-			id, err := parse.NestedItemID(meta.ResourceData.Id())
+			id, err := parse.ManagedHSMRoleAssignmentID(meta.ResourceData.Id())
 			if err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func (m KeyVaultManagedHSMRoleAssignmentResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 10 * time.Minute,
 		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
-			id, err := parse.NestedItemID(meta.ResourceData.Id())
+			id, err := parse.ManagedHSMRoleAssignmentID(meta.ResourceData.Id())
 			if err != nil {
 				return err
 			}
@@ -197,5 +197,5 @@ func (m KeyVaultManagedHSMRoleAssignmentResource) Delete() sdk.ResourceFunc {
 }
 
 func (m KeyVaultManagedHSMRoleAssignmentResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
-	return validate.NestedItemId
+	return validate.ManagedHSMRoleAssignmentId
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
@@ -18,7 +18,7 @@ type KeyVaultManagedHSMRoleAssignmentResource struct{}
 
 // real test nested in TestAccKeyVaultManagedHardwareSecurityModule, only provide Exists logic here
 func (k KeyVaultManagedHSMRoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.NestedItemID(state.ID)
+	id, err := parse.ManagedHSMRoleAssignmentID(state.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_data_source.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_data_source.go
@@ -137,7 +137,7 @@ func (k KeyvaultMHSMRoleDefinitionDataSource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			id, err := parse.NewNestedItemID(model.VaultBaseUrl, roleDefinitionScope, parse.RoleDefinitionType, model.Name)
+			id, err := parse.NewManagedHSMRoleDefinitionID(model.VaultBaseUrl, roleDefinitionScope, model.Name)
 			if err != nil {
 				return err
 			}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
@@ -170,7 +170,7 @@ func (k KeyVaultMHSMRoleDefinitionResource) Create() sdk.ResourceFunc {
 			locks.ByName(model.VaultBaseUrl, "azurerm_key_vault_managed_hardware_security_module")
 			defer locks.UnlockByName(model.VaultBaseUrl, "azurerm_key_vault_managed_hardware_security_module")
 
-			id, err := parse.NewNestedItemID(model.VaultBaseUrl, roleDefinitionScope, parse.RoleDefinitionType, model.Name)
+			id, err := parse.NewManagedHSMRoleDefinitionID(model.VaultBaseUrl, roleDefinitionScope, model.Name)
 			if err != nil {
 				return err
 			}
@@ -207,7 +207,7 @@ func (k KeyVaultMHSMRoleDefinitionResource) Read() sdk.ResourceFunc {
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
 			// import has no model data but only id
-			id, err := parse.NestedItemID(meta.ResourceData.Id())
+			id, err := parse.ManagedHSMRoleDefinitionID(meta.ResourceData.Id())
 			if err != nil {
 				return err
 			}
@@ -258,7 +258,7 @@ func (k KeyVaultMHSMRoleDefinitionResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			id, err := parse.NewNestedItemID(model.VaultBaseUrl, roleDefinitionScope, parse.RoleDefinitionType, model.Name)
+			id, err := parse.NewManagedHSMRoleDefinitionID(model.VaultBaseUrl, roleDefinitionScope, model.Name)
 			if err != nil {
 				return err
 			}
@@ -297,7 +297,7 @@ func (k KeyVaultMHSMRoleDefinitionResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 10 * time.Minute,
 		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
-			id, err := parse.NestedItemID(meta.ResourceData.Id())
+			id, err := parse.ManagedHSMRoleDefinitionID(meta.ResourceData.Id())
 			if err != nil {
 				return err
 			}
@@ -314,7 +314,7 @@ func (k KeyVaultMHSMRoleDefinitionResource) Delete() sdk.ResourceFunc {
 }
 
 func (k KeyVaultMHSMRoleDefinitionResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
-	return validate.NestedItemId
+	return validate.ManagedHSMRoleDefinitionId
 }
 
 func expandKeyVaultMHSMRolePermissions(perms []Permission) *[]keyvault.Permission {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
@@ -19,7 +19,7 @@ type KeyVaultMHSMRoleDefinitionResource struct{}
 // real test nested in TestAccKeyVaultManagedHardwareSecurityModule, only provide Exists logic here
 func (k KeyVaultMHSMRoleDefinitionResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	baseURL := state.Attributes["vault_base_url"]
-	id, err := parse.NestedItemID(state.ID)
+	id, err := parse.ManagedHSMRoleDefinitionID(state.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/managedhsm/parse/managed_hsm_role_assignment_id.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_assignment_id.go
@@ -24,10 +24,6 @@ func NewManagedHSMRoleAssignmentID(hsmBaseUrl, scope string, name string) (*Mana
 	if err != nil || hsmBaseUrl == "" {
 		return nil, fmt.Errorf("parsing managedHSM nested itemID %q: %+v", hsmBaseUrl, err)
 	}
-	// (@jackofallops) - Log Analytics service adds the port number to the API returns, so we strip it here
-	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
-		keyVaultUrl.Host = hostParts[0]
-	}
 
 	return &ManagedHSMRoleAssignmentId{
 		VaultBaseUrl: keyVaultUrl.String(),

--- a/internal/services/managedhsm/parse/managed_hsm_role_assignment_id.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_assignment_id.go
@@ -1,0 +1,87 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ManagedHSMRoleAssignmentId{}
+
+type ManagedHSMRoleAssignmentId struct {
+	VaultBaseUrl string
+	Scope        string
+	Name         string
+}
+
+func NewManagedHSMRoleAssignmentID(hsmBaseUrl, scope string, name string) (*ManagedHSMRoleAssignmentId, error) {
+	keyVaultUrl, err := url.Parse(hsmBaseUrl)
+	if err != nil || hsmBaseUrl == "" {
+		return nil, fmt.Errorf("parsing managedHSM nested itemID %q: %+v", hsmBaseUrl, err)
+	}
+	// (@jackofallops) - Log Analytics service adds the port number to the API returns, so we strip it here
+	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
+		keyVaultUrl.Host = hostParts[0]
+	}
+
+	return &ManagedHSMRoleAssignmentId{
+		VaultBaseUrl: keyVaultUrl.String(),
+		Scope:        scope,
+		Name:         name,
+	}, nil
+}
+
+func (n ManagedHSMRoleAssignmentId) ID() string {
+	// example: https://tharvey-keyvault.managedhsm.azure.net///RoleAssignment/uuid-idshifds-fks
+	segments := []string{
+		strings.TrimSuffix(n.VaultBaseUrl, "/"),
+		n.Scope,
+		"RoleAssignment",
+		n.Name,
+	}
+	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
+}
+
+func (n ManagedHSMRoleAssignmentId) String() string {
+	return n.ID()
+}
+
+func ManagedHSMRoleAssignmentID(input string) (*ManagedHSMRoleAssignmentId, error) {
+	idURL, err := url.ParseRequestURI(input)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse Azure KeyVault Child Id: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	nameSep := strings.LastIndex(path, "/")
+	if nameSep <= 0 {
+		return nil, fmt.Errorf("no name speparate exist in %s", input)
+	}
+	scope, name := path[:nameSep], path[nameSep+1:]
+
+	typeSep := strings.LastIndex(scope, "/")
+	if typeSep <= 0 {
+		return nil, fmt.Errorf("no type speparate exist in %s", input)
+	}
+	scope, typ := scope[:typeSep], scope[typeSep+1:]
+	if typ != "RoleAssignment" {
+		return nil, fmt.Errorf("invalid type %s, must be 'RoleAssignment'", typ)
+	}
+
+	childId := ManagedHSMRoleAssignmentId{
+		VaultBaseUrl: fmt.Sprintf("%s://%s/", idURL.Scheme, idURL.Host),
+		Scope:        scope,
+		Name:         name,
+	}
+
+	return &childId, nil
+}

--- a/internal/services/managedhsm/parse/managed_hsm_role_assignment_id_test.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_assignment_id_test.go
@@ -37,7 +37,7 @@ func TestNewManagedHSMRoleAssignmentID(t *testing.T) {
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
 			Scope:           "/keys",
 			Name:            "test",
-			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net//keys/%s/test", mhsmType),
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net:443//keys/%s/test", mhsmType),
 			ExpectError:     false,
 		},
 	}

--- a/internal/services/managedhsm/parse/managed_hsm_role_assignment_id_test.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_assignment_id_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 )
 
-func TestNewMHSMNestedItemID(t *testing.T) {
-	mhsmType := RoleDefinitionType
+func TestNewManagedHSMRoleAssignmentID(t *testing.T) {
+	mhsmType := "RoleDefinition"
 	cases := []struct {
 		Scenario        string
 		keyVaultBaseUrl string
@@ -42,7 +42,7 @@ func TestNewMHSMNestedItemID(t *testing.T) {
 		},
 	}
 	for idx, tc := range cases {
-		id, err := NewNestedItemID(tc.keyVaultBaseUrl, tc.Scope, mhsmType, tc.Name)
+		id, err := NewManagedHSMRoleDefinitionID(tc.keyVaultBaseUrl, tc.Scope, tc.Name)
 		if err != nil {
 			if !tc.ExpectError {
 				t.Fatalf("Got error for New Resource ID '%s': %+v", tc.keyVaultBaseUrl, err)
@@ -56,11 +56,11 @@ func TestNewMHSMNestedItemID(t *testing.T) {
 	}
 }
 
-func TestParseMHSMNestedItemID(t *testing.T) {
-	typ := RoleDefinitionType
+func TestParseManagedHSMRoleAssignmentID(t *testing.T) {
+	typ := "RoleDefinition"
 	cases := []struct {
 		Input       string
-		Expected    NestedItemId
+		Expected    ManagedHSMRoleDefinitionId
 		ExpectError bool
 	}{
 		{
@@ -70,7 +70,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/test", typ),
 			ExpectError: true,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "test",
 				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Scope:        "/",
@@ -79,7 +79,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
 			ExpectError: true,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "bird",
 				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Scope:        "/",
@@ -88,7 +88,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
 			ExpectError: false,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "bird",
 				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Scope:        "/",
@@ -97,7 +97,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/world", typ),
 			ExpectError: false,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "world",
 				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Scope:        "/keys",
@@ -106,7 +106,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/fdf067c93bbb4b22bff4d8b7a9a56217", typ),
 			ExpectError: true,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "fdf067c93bbb4b22bff4d8b7a9a56217",
 				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Scope:        "/keys",
@@ -115,7 +115,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 		{
 			Input:       "https://kvhsm23030816100222.managedhsm.azure.net///RoleDefinition/862d4d5e-bf01-11ed-a49d-00155d61ee9e",
 			ExpectError: true,
-			Expected: NestedItemId{
+			Expected: ManagedHSMRoleDefinitionId{
 				Name:         "862d4d5e-bf01-11ed-a49d-00155d61ee9e",
 				VaultBaseUrl: "https://kvhsm23030816100222.managedhsm.azure.net/",
 				Scope:        "/",
@@ -124,7 +124,7 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 	}
 
 	for idx, tc := range cases {
-		secretId, err := NestedItemID(tc.Input)
+		roleId, err := ManagedHSMRoleDefinitionID(tc.Input)
 		if err != nil {
 			if tc.ExpectError {
 				continue
@@ -133,24 +133,24 @@ func TestParseMHSMNestedItemID(t *testing.T) {
 			t.Fatalf("Got error for ID '%s': %+v", tc.Input, err)
 		}
 
-		if secretId == nil {
+		if roleId == nil {
 			t.Fatalf("Expected a SecretID to be parsed for ID '%s', got nil.", tc.Input)
 		}
 
-		if tc.Expected.VaultBaseUrl != secretId.VaultBaseUrl {
-			t.Fatalf("Expected %d 'KeyVaultBaseUrl' to be '%s', got '%s' for ID '%s'", idx, tc.Expected.VaultBaseUrl, secretId.VaultBaseUrl, tc.Input)
+		if tc.Expected.VaultBaseUrl != roleId.VaultBaseUrl {
+			t.Fatalf("Expected %d 'KeyVaultBaseUrl' to be '%s', got '%s' for ID '%s'", idx, tc.Expected.VaultBaseUrl, roleId.VaultBaseUrl, tc.Input)
 		}
 
-		if tc.Expected.Name != secretId.Name {
-			t.Fatalf("Expected 'Name' to be '%s', got '%s' for ID '%s'", tc.Expected.Name, secretId.Name, tc.Input)
+		if tc.Expected.Name != roleId.Name {
+			t.Fatalf("Expected 'Name' to be '%s', got '%s' for ID '%s'", tc.Expected.Name, roleId.Name, tc.Input)
 		}
 
-		if tc.Expected.Scope != secretId.Scope {
-			t.Fatalf("Expected 'Scope' to be '%s', got '%s' for ID '%s'", tc.Expected.Scope, secretId.Scope, tc.Input)
+		if tc.Expected.Scope != roleId.Scope {
+			t.Fatalf("Expected 'Scope' to be '%s', got '%s' for ID '%s'", tc.Expected.Scope, roleId.Scope, tc.Input)
 		}
 
-		if tc.Input != secretId.ID() {
-			t.Fatalf("Expected 'ID()' to be '%s', got '%s'", tc.Input, secretId.ID())
+		if tc.Input != roleId.ID() {
+			t.Fatalf("Expected 'ID()' to be '%s', got '%s'", tc.Input, roleId.ID())
 		}
 	}
 }

--- a/internal/services/managedhsm/parse/managed_hsm_role_definition_id.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_definition_id.go
@@ -31,10 +31,6 @@ func NewManagedHSMRoleDefinitionID(hsmBaseUrl, scope string, name string) (*Mana
 	if err != nil || hsmBaseUrl == "" {
 		return nil, fmt.Errorf("parsing managedHSM nested itemID %q: %+v", hsmBaseUrl, err)
 	}
-	// (@jackofallops) - Log Analytics service adds the port number to the API returns, so we strip it here
-	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
-		keyVaultUrl.Host = hostParts[0]
-	}
 
 	return &ManagedHSMRoleDefinitionId{
 		VaultBaseUrl: keyVaultUrl.String(),

--- a/internal/services/managedhsm/parse/managed_hsm_role_definition_id.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_definition_id.go
@@ -11,25 +11,22 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
-var _ resourceids.Id = NestedItemId{}
-
-type MHSMResourceType string
+var _ resourceids.Id = ManagedHSMRoleDefinitionId{}
 
 const (
-	// TODO: this should be extended to support the other types of Nested Items available for a Managed HSM
+// TODO: this should be extended to support the other types of Nested Items available for a Managed HSM
 
-	RoleDefinitionType MHSMResourceType = "RoleDefinition"
-	RoleAssignmentType MHSMResourceType = "RoleAssignment"
+// RoleDefinitionType MHSMResourceType = "RoleDefinition"
+// RoleAssignmentType MHSMResourceType = "RoleAssignment"
 )
 
-type NestedItemId struct {
+type ManagedHSMRoleDefinitionId struct {
 	VaultBaseUrl string
 	Scope        string
-	Type         MHSMResourceType
 	Name         string
 }
 
-func NewNestedItemID(hsmBaseUrl, scope string, typ MHSMResourceType, name string) (*NestedItemId, error) {
+func NewManagedHSMRoleDefinitionID(hsmBaseUrl, scope string, name string) (*ManagedHSMRoleDefinitionId, error) {
 	keyVaultUrl, err := url.Parse(hsmBaseUrl)
 	if err != nil || hsmBaseUrl == "" {
 		return nil, fmt.Errorf("parsing managedHSM nested itemID %q: %+v", hsmBaseUrl, err)
@@ -39,33 +36,32 @@ func NewNestedItemID(hsmBaseUrl, scope string, typ MHSMResourceType, name string
 		keyVaultUrl.Host = hostParts[0]
 	}
 
-	return &NestedItemId{
+	return &ManagedHSMRoleDefinitionId{
 		VaultBaseUrl: keyVaultUrl.String(),
 		Scope:        scope,
-		Type:         typ,
 		Name:         name,
 	}, nil
 }
 
-func (n NestedItemId) ID() string {
+func (n ManagedHSMRoleDefinitionId) ID() string {
 	// example: https://tharvey-keyvault.managedhsm.azure.net///uuid-idshifds-fks
 	segments := []string{
 		strings.TrimSuffix(n.VaultBaseUrl, "/"),
 		n.Scope,
-		string(n.Type),
+		"RoleDefinition",
 		n.Name,
 	}
 	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
 }
 
-func (n NestedItemId) String() string {
+func (n ManagedHSMRoleDefinitionId) String() string {
 	return n.ID()
 }
 
-func NestedItemID(input string) (*NestedItemId, error) {
+func ManagedHSMRoleDefinitionID(input string) (*ManagedHSMRoleDefinitionId, error) {
 	idURL, err := url.ParseRequestURI(input)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse Azure KeyVault Child Id: %s", err)
+		return nil, fmt.Errorf("cannot parse Azure KeyVault Child Id: %s", err)
 	}
 
 	path := idURL.Path
@@ -84,11 +80,13 @@ func NestedItemID(input string) (*NestedItemId, error) {
 		return nil, fmt.Errorf("no type speparate exist in %s", input)
 	}
 	scope, typ := scope[:typeSep], scope[typeSep+1:]
+	if typ != "RoleDefinition" {
+		return nil, fmt.Errorf("invalid type %s, must be 'RoleDefinition'", typ)
+	}
 
-	childId := NestedItemId{
+	childId := ManagedHSMRoleDefinitionId{
 		VaultBaseUrl: fmt.Sprintf("%s://%s/", idURL.Scheme, idURL.Host),
 		Scope:        scope,
-		Type:         MHSMResourceType(typ),
 		Name:         name,
 	}
 

--- a/internal/services/managedhsm/parse/managed_hsm_role_definition_id_test.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_definition_id_test.go
@@ -37,7 +37,7 @@ func TestNewManagedHSMRoleDefinitionID(t *testing.T) {
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
 			Scope:           "/keys",
 			Name:            "test",
-			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net//keys/%s/test", mhsmType),
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net:443//keys/%s/test", mhsmType),
 			ExpectError:     false,
 		},
 	}

--- a/internal/services/managedhsm/parse/managed_hsm_role_definition_id_test.go
+++ b/internal/services/managedhsm/parse/managed_hsm_role_definition_id_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewManagedHSMRoleDefinitionID(t *testing.T) {
+	mhsmType := "RoleAssignment"
+	cases := []struct {
+		Scenario        string
+		keyVaultBaseUrl string
+		Expected        string
+		Scope           string
+		Name            string
+		ExpectError     bool
+	}{
+		{
+			Scenario:        "empty values",
+			keyVaultBaseUrl: "",
+			Expected:        "",
+			ExpectError:     true,
+		},
+		{
+			Scenario:        "valid, no port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net",
+			Scope:           "/",
+			Name:            "test",
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net///%s/test", mhsmType),
+			ExpectError:     false,
+		},
+		{
+			Scenario:        "valid, with port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
+			Scope:           "/keys",
+			Name:            "test",
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net//keys/%s/test", mhsmType),
+			ExpectError:     false,
+		},
+	}
+	for idx, tc := range cases {
+		id, err := NewManagedHSMRoleAssignmentID(tc.keyVaultBaseUrl, tc.Scope, tc.Name)
+		if err != nil {
+			if !tc.ExpectError {
+				t.Fatalf("Got error for New Resource ID '%s': %+v", tc.keyVaultBaseUrl, err)
+				return
+			}
+			continue
+		}
+		if id.ID() != tc.Expected {
+			t.Fatalf("Expected %d id for %q to be %q, got %q", idx, tc.keyVaultBaseUrl, tc.Expected, id)
+		}
+	}
+}
+
+func TestParseManagedHSMRoleDefinitionID(t *testing.T) {
+	typ := "RoleAssignment"
+	cases := []struct {
+		Input       string
+		Expected    ManagedHSMRoleDefinitionId
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/test", typ),
+			ExpectError: true,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "test",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
+			ExpectError: true,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "bird",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
+			ExpectError: false,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "bird",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/world", typ),
+			ExpectError: false,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "world",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/keys",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/fdf067c93bbb4b22bff4d8b7a9a56217", typ),
+			ExpectError: true,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "fdf067c93bbb4b22bff4d8b7a9a56217",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/keys",
+			},
+		},
+		{
+			Input:       "https://kvhsm23030816100222.managedhsm.azure.net///RoleAssignment/862d4d5e-bf01-11ed-a49d-00155d61ee9e",
+			ExpectError: true,
+			Expected: ManagedHSMRoleDefinitionId{
+				Name:         "862d4d5e-bf01-11ed-a49d-00155d61ee9e",
+				VaultBaseUrl: "https://kvhsm23030816100222.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+	}
+
+	for idx, tc := range cases {
+		roleId, err := ManagedHSMRoleAssignmentID(tc.Input)
+		if err != nil {
+			if tc.ExpectError {
+				continue
+			}
+
+			t.Fatalf("Got error for ID '%s': %+v", tc.Input, err)
+		}
+
+		if roleId == nil {
+			t.Fatalf("Expected a SecretID to be parsed for ID '%s', got nil.", tc.Input)
+		}
+
+		if tc.Expected.VaultBaseUrl != roleId.VaultBaseUrl {
+			t.Fatalf("Expected %d 'KeyVaultBaseUrl' to be '%s', got '%s' for ID '%s'", idx, tc.Expected.VaultBaseUrl, roleId.VaultBaseUrl, tc.Input)
+		}
+
+		if tc.Expected.Name != roleId.Name {
+			t.Fatalf("Expected 'Name' to be '%s', got '%s' for ID '%s'", tc.Expected.Name, roleId.Name, tc.Input)
+		}
+
+		if tc.Expected.Scope != roleId.Scope {
+			t.Fatalf("Expected 'Scope' to be '%s', got '%s' for ID '%s'", tc.Expected.Scope, roleId.Scope, tc.Input)
+		}
+
+		if tc.Input != roleId.ID() {
+			t.Fatalf("Expected 'ID()' to be '%s', got '%s'", tc.Input, roleId.ID())
+		}
+	}
+}

--- a/internal/services/managedhsm/validate/mhsm_role_assignment_id.go
+++ b/internal/services/managedhsm/validate/mhsm_role_assignment_id.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func ManagedHSMRoleAssignmentId(i interface{}, k string) (warnings []string, errors []error) {
+	if warnings, errors = validation.StringIsNotEmpty(i, k); len(errors) > 0 {
+		return warnings, errors
+	}
+
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %s to be a string", k))
+		return warnings, errors
+	}
+
+	if _, err := parse.ManagedHSMRoleAssignmentID(v); err != nil {
+		errors = append(errors, fmt.Errorf("parsing %q: %s", v, err))
+		return warnings, errors
+	}
+
+	return warnings, errors
+}

--- a/internal/services/managedhsm/validate/mhsm_role_assignment_id_test.go
+++ b/internal/services/managedhsm/validate/mhsm_role_assignment_id_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestMHSMNestedItemId(t *testing.T) {
+func TestManagedHSMRoleAssignmentId(t *testing.T) {
 	cases := []struct {
 		Input       string
 		ExpectError bool
@@ -17,36 +17,35 @@ func TestMHSMNestedItemId(t *testing.T) {
 			ExpectError: true,
 		},
 		{
-			Input:       "https://my-keyvault.managedhsm.azure.net///test",
-			ExpectError: false,
-		},
-		{
-			Input:       "https://my-keyvault.managedhsm.azure.net//keys/test",
-			ExpectError: false,
-		},
-
-		{
-			Input:       "https://my-keyvault.managedhsm.azure.net/certificates/hello/world",
+			Input:       "https://my-hsm.managedhsm.azure.net///test",
 			ExpectError: true,
 		},
 		{
-			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			Input:       "https://my-hsm.managedhsm.azure.net///RoleAssignment/test",
 			ExpectError: false,
 		},
 		{
-			Input:       "https://my-keyvault.managedhsm.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",
+			Input:       "https://my-hsm.managedhsm.azure.net//keys/RoleAssignment/1492",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net//keys/RoleAssignment/1492/suffix",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net///RoleDefinition/000-000",
 			ExpectError: true,
 		},
 	}
 
 	for _, tc := range cases {
-		warnings, err := NestedItemId(tc.Input, "example")
+		warnings, err := ManagedHSMRoleAssignmentId(tc.Input, "example")
 		if err != nil {
 			if !tc.ExpectError {
 				t.Fatalf("Got error for input %q: %+v", tc.Input, err)
 			}
 
-			return
+			continue
 		}
 
 		if tc.ExpectError && len(warnings) == 0 {

--- a/internal/services/managedhsm/validate/mhsm_role_definition_id.go
+++ b/internal/services/managedhsm/validate/mhsm_role_definition_id.go
@@ -10,18 +10,18 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-func NestedItemId(i interface{}, k string) (warnings []string, errors []error) {
+func ManagedHSMRoleDefinitionId(i interface{}, k string) (warnings []string, errors []error) {
 	if warnings, errors = validation.StringIsNotEmpty(i, k); len(errors) > 0 {
 		return warnings, errors
 	}
 
 	v, ok := i.(string)
 	if !ok {
-		errors = append(errors, fmt.Errorf("Expected %s to be a string!", k))
+		errors = append(errors, fmt.Errorf("expected %s to be a string", k))
 		return warnings, errors
 	}
 
-	if _, err := parse.NestedItemID(v); err != nil {
+	if _, err := parse.ManagedHSMRoleDefinitionID(v); err != nil {
 		errors = append(errors, fmt.Errorf("parsing %q: %s", v, err))
 		return warnings, errors
 	}

--- a/internal/services/managedhsm/validate/mhsm_role_definition_id_test.go
+++ b/internal/services/managedhsm/validate/mhsm_role_definition_id_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"testing"
+)
+
+func TestManagedHSMRoleDefinitionId(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net///test",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net///RoleDefinition/test",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net//keys/RoleDefinition/1492",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net//keys/RoleDefinition/1492/suffix",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-hsm.managedhsm.azure.net///RoleAssignment/000-000",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		warnings, err := ManagedHSMRoleDefinitionId(tc.Input, "example")
+		if err != nil {
+			if !tc.ExpectError {
+				t.Fatalf("Got error for input %q: %+v", tc.Input, err)
+			}
+
+			continue
+		}
+
+		if tc.ExpectError && len(warnings) == 0 {
+			t.Fatalf("Got no errors for input %q but expected some", tc.Input)
+		} else if !tc.ExpectError && len(warnings) > 0 {
+			t.Fatalf("Got %d errors for input %q when didn't expect any", len(warnings), tc.Input)
+		}
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Use specific resource ids for managed hsm role defitnition and role assignment instead of the origin generic id. **It contains a scope field in the middle of the current resource ID, So it's not supported to convert to a New Resource ID Type in this PR**.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_managed_hardware_security_module_role_definition` - update resource id with specific definition instead of generic ones
* `azurerm_key_vault_managed_hardware_security_module_role_assignment` - update resource id with specific definition instead of generic ones


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

