### PR TITLE
`azurerm_kubernetes_cluster` - fix panic caused by schema property only introduced in 4.0

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1761,11 +1761,12 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	autoUpgradeProfile := &managedclusters.ManagedClusterAutoUpgradeProfile{}
 
-	autoChannelUpgrade := d.Get("automatic_upgrade_channel").(string)
-	nodeOsChannelUpgrade := d.Get("node_os_upgrade_channel").(string)
-	if !features.FourPointOhBeta() {
-		autoChannelUpgrade = d.Get("automatic_channel_upgrade").(string)
-		nodeOsChannelUpgrade = d.Get("node_os_channel_upgrade").(string)
+	autoChannelUpgrade := d.Get("automatic_channel_upgrade").(string)
+	nodeOsChannelUpgrade := d.Get("node_os_channel_upgrade").(string)
+	if features.FourPointOhBeta() {
+		autoChannelUpgrade = d.Get("automatic_upgrade_channel").(string)
+		nodeOsChannelUpgrade = d.Get("node_os_upgrade_channel").(string)
+
 	}
 
 	// this check needs to be separate and gated since node_os_channel_upgrade is a preview feature

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1746,7 +1746,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	if d.Get("image_cleaner_enabled").(bool) {
+	if !features.FourPointOhBeta() || d.Get("image_cleaner_enabled").(bool) {
 		securityProfile.ImageCleaner = &managedclusters.ManagedClusterSecurityProfileImageCleaner{
 			Enabled:       utils.Bool(d.Get("image_cleaner_enabled").(bool)),
 			IntervalHours: utils.Int64(int64(d.Get("image_cleaner_interval_hours").(int))),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The property renames in https://github.com/hashicorp/terraform-provider-azurerm/pull/25296 cause a panic in the create. Switched the logic around for getting the channel upgrade properties to prevent a panic.

Also updated the image cleaner logic in the create to preserve the current behaviour and prevent import errors.

