### PR TITLE
fix: typo, Lodbalancer -> Load Balancer

### DIFF
--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -60,13 +60,13 @@ The following arguments are supported:
 
 The `tunnel_interface` block supports the following:
 
-* `identifier` - (Required) The unique identifier of this Gateway Lodbalancer Tunnel Interface.
+* `identifier` - (Required) The unique identifier of this Gateway Load Balancer Tunnel Interface.
 
-* `type` - (Required) The traffic type of this Gateway Lodbalancer Tunnel Interface. Possible values are `None`, `Internal` and `External`.
+* `type` - (Required) The traffic type of this Gateway Load Balancer Tunnel Interface. Possible values are `None`, `Internal` and `External`.
 
-* `protocol` - (Required) The protocol used for this Gateway Lodbalancer Tunnel Interface. Possible values are `None`, `Native` and `VXLAN`.
+* `protocol` - (Required) The protocol used for this Gateway Load Balancer Tunnel Interface. Possible values are `None`, `Native` and `VXLAN`.
 
-* `port` - (Required) The port number that this Gateway Lodbalancer Tunnel Interface listens to.
+* `port` - (Required) The port number that this Gateway Load Balancer Tunnel Interface listens to.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

`Lodbalancer` should be `Load Balancer`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”