### PR TITLE
`azurerm_sentinel_data_connector_threat_intelligence`, `azurerm_sentinel_data_connector_threat_intelligence_taxii`: fix time parsing error

### DIFF
--- a/internal/services/sentinel/azuresdkhacks/models.go
+++ b/internal/services/sentinel/azuresdkhacks/models.go
@@ -15,6 +15,8 @@ import (
 
 // TODO 4.0 check if this can be removed
 // Hacking the SDK model, together with the Create and Get method for working around issue: https://github.com/Azure/azure-rest-api-specs/issues/21487
+// The left issue is `PollingFrequency` is not consistent. The API returns 0, 1, 2, but the SDK expects the string value.
+// tracked on https://github.com/Azure/azure-rest-api-specs/issues/21487
 
 type DataConnectorModel struct {
 	autorest.Response `json:"-"`
@@ -446,7 +448,8 @@ func (t *Time) UnmarshalJSON(data []byte) (err error) {
 	// Firstly, try to parse the date time via RFC3339, which is the expected format defined by Swagger.
 	// However, since the service issue (#21487), it currently doesn't return in this format.
 	// In order not to break the code once the service fix it, we keep this try at first.
-	if time, err := time.Parse(time.RFC3339, string(data)); err == nil {
+	layout := fmt.Sprintf(`"%s"`, time.RFC3339)
+	if time, err := time.Parse(layout, string(data)); err == nil {
 		t.Time = time
 		return nil
 	}

--- a/internal/services/sentinel/sentinel_data_connector.go
+++ b/internal/services/sentinel/sentinel_data_connector.go
@@ -64,8 +64,6 @@ func assertDataConnectorKind(dc securityinsight.BasicDataConnector, expectKind s
 		kind = securityinsight.DataConnectorKindAzureSecurityCenter
 	case securityinsight.MCASDataConnector:
 		kind = securityinsight.DataConnectorKindMicrosoftCloudAppSecurity
-	case securityinsight.TIDataConnector:
-		kind = securityinsight.DataConnectorKindThreatIntelligence
 	case securityinsight.MTPDataConnector:
 		kind = securityinsight.DataConnectorKindMicrosoftThreatProtection
 	case securityinsight.IoTDataConnector:
@@ -88,8 +86,12 @@ func assertDataConnectorKind(dc securityinsight.BasicDataConnector, expectKind s
 		kind = securityinsight.DataConnectorKindMicrosoftDefenderAdvancedThreatProtection
 	case securityinsight.AwsS3DataConnector:
 		kind = securityinsight.DataConnectorKindAmazonWebServicesS3
+	case securityinsight.TiTaxiiDataConnector:
+		kind = securityinsight.DataConnectorKindThreatIntelligenceTaxii
 	case azuresdkhacks.TiTaxiiDataConnector:
 		kind = securityinsight.DataConnectorKindThreatIntelligenceTaxii
+	case securityinsight.TIDataConnector:
+		kind = securityinsight.DataConnectorKindThreatIntelligence
 	case azuresdkhacks.TIDataConnector:
 		kind = securityinsight.DataConnectorKindThreatIntelligence
 	}

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -69,7 +69,7 @@ func resourceSentinelDataConnectorThreatIntelligence() *pluginsdk.Resource {
 }
 
 func resourceSentinelDataConnectorThreatIntelligenceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := azuresdkhacks.DataConnectorsClient{BaseClient: meta.(*clients.Client).Sentinel.DataConnectorsClient.BaseClient}
+	client := meta.(*clients.Client).Sentinel.DataConnectorsClient
 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -101,11 +101,11 @@ func resourceSentinelDataConnectorThreatIntelligenceCreateUpdate(d *pluginsdk.Re
 
 	lookbackDate, _ := time.Parse(time.RFC3339, d.Get("lookback_date").(string))
 
-	param := azuresdkhacks.TIDataConnector{
+	param := securityinsight.TIDataConnector{
 		Name: &name,
-		TIDataConnectorProperties: &azuresdkhacks.TIDataConnectorProperties{
+		TIDataConnectorProperties: &securityinsight.TIDataConnectorProperties{
 			TenantID: &tenantId,
-			TipLookbackPeriod: &azuresdkhacks.Time{
+			TipLookbackPeriod: &date.Time{
 				Time: lookbackDate,
 			},
 			DataTypes: &securityinsight.TIDataConnectorDataTypes{
@@ -127,7 +127,7 @@ func resourceSentinelDataConnectorThreatIntelligenceCreateUpdate(d *pluginsdk.Re
 }
 
 func resourceSentinelDataConnectorThreatIntelligenceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := azuresdkhacks.DataConnectorsClient{BaseClient: meta.(*clients.Client).Sentinel.DataConnectorsClient.BaseClient}
+	client := meta.(*clients.Client).Sentinel.DataConnectorsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -148,7 +148,7 @@ func resourceSentinelDataConnectorThreatIntelligenceRead(d *pluginsdk.ResourceDa
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	dc, ok := resp.Value.(azuresdkhacks.TIDataConnector)
+	dc, ok := resp.Value.(securityinsight.TIDataConnector)
 	if !ok {
 		return fmt.Errorf("%s was not a Threat Intelligence Data Connector", id)
 	}

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -65,7 +64,7 @@ func TestAccAzureRMSentinelDataConnectorThreatIntelligence_requiresImport(t *tes
 }
 
 func (r SentinelDataConnectorThreatIntelligenceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	client := azuresdkhacks.DataConnectorsClient{BaseClient: clients.Sentinel.DataConnectorsClient.BaseClient}
+	client := clients.Sentinel.DataConnectorsClient
 
 	id, err := parse.DataConnectorID(state.ID)
 	if err != nil {


### PR DESCRIPTION
<!--  All Submissions -->
The returned date/time format has been changed. There is no need to use "patched" sdk

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="371" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/f9f5dc9c-c705-4f00-ac1c-7eb557c08eb0">

```
❯❯ tftest sentinel TestAccDataConnectorThreatIntelligenceTAXII            
=== RUN   TestAccDataConnectorThreatIntelligenceTAXII_basic
=== PAUSE TestAccDataConnectorThreatIntelligenceTAXII_basic
=== RUN   TestAccDataConnectorThreatIntelligenceTAXII_complete
=== PAUSE TestAccDataConnectorThreatIntelligenceTAXII_complete
=== RUN   TestAccDataConnectorThreatIntelligenceTAXII_update
=== PAUSE TestAccDataConnectorThreatIntelligenceTAXII_update
=== RUN   TestAccDataConnectorThreatIntelligenceTAXII_requiresImport
=== PAUSE TestAccDataConnectorThreatIntelligenceTAXII_requiresImport
=== CONT  TestAccDataConnectorThreatIntelligenceTAXII_basic
=== CONT  TestAccDataConnectorThreatIntelligenceTAXII_update
=== CONT  TestAccDataConnectorThreatIntelligenceTAXII_complete
=== CONT  TestAccDataConnectorThreatIntelligenceTAXII_requiresImport
--- PASS: TestAccDataConnectorThreatIntelligenceTAXII_requiresImport (238.11s)
--- PASS: TestAccDataConnectorThreatIntelligenceTAXII_basic (262.23s)
--- PASS: TestAccDataConnectorThreatIntelligenceTAXII_complete (271.44s)
--- PASS: TestAccDataConnectorThreatIntelligenceTAXII_update (385.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel	385.675s
```

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_sentinel_data_connector_threat_intelligence` -  fix tiplookback time parsing error
* `azurerm_sentinel_data_connector_threat_intelligence_taxii` - fix taxii tiplookback time parsing error
* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
fixes #25409

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
