### PR TITLE
`azurerm_data_protection_backup_instance_kubernetes_cluster` - fix protection error `ScenarioPluginInvalidWorkflowDataRequest` and `UserErrorKubernetesBackupExtensionUnhealthy`

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource.go
@@ -209,6 +209,15 @@ func (r DataProtectionBackupInstanceKubernatesClusterResource) Create() sdk.Reso
 						ResourceType:     pointer.To("Microsoft.ContainerService/managedClusters"),
 						ResourceUri:      pointer.To(aksId.ID()),
 					},
+					DataSourceSetInfo: &backupinstances.DatasourceSet{
+						DatasourceType:   pointer.To("Microsoft.ContainerService/managedClusters"),
+						ObjectType:       pointer.To("DatasourceSet"),
+						ResourceID:       aksId.ID(),
+						ResourceLocation: pointer.To(location.Normalize(model.Location)),
+						ResourceName:     pointer.To(aksId.ManagedClusterName),
+						ResourceType:     pointer.To("Microsoft.ContainerService/managedClusters"),
+						ResourceUri:      pointer.To(aksId.ID()),
+					},
 					FriendlyName: pointer.To(id.BackupInstanceName),
 					ObjectType:   "BackupInstance",
 					PolicyInfo: backupinstances.PolicyInfo{

--- a/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource_test.go
@@ -184,6 +184,24 @@ resource "azurerm_role_assignment" "test_cluster_msi_contributor_on_snap_rg" {
   principal_id         = azurerm_kubernetes_cluster.test.identity[0].principal_id
 }
 
+resource "azurerm_role_assignment" "test_vault_data_contributor_on_storage" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_vault_msi_snapshot_contributor_on_snap_rg" {
+  scope                = azurerm_resource_group.snap.id
+  role_definition_name = "Disk Snapshot Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_vault_data_operator_on_snap_rg" {
+  scope                = azurerm_resource_group.snap.id
+  role_definition_name = "Data Operator for Managed Disks"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
 resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "test" {
   name                = "acctest-paks-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -214,8 +232,17 @@ resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "test" {
       data_store_type = "OperationalStore"
     }
   }
-}
 
+  depends_on = [
+    azurerm_role_assignment.test_extension_and_storage_account_permission,
+    azurerm_role_assignment.test_vault_msi_read_on_cluster,
+    azurerm_role_assignment.test_vault_msi_read_on_snap_rg,
+    azurerm_role_assignment.test_cluster_msi_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_msi_snapshot_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_operator_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_contributor_on_storage,
+  ]
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
@@ -276,6 +303,12 @@ resource "azurerm_data_protection_backup_instance_kubernetes_cluster" "test" {
 
   depends_on = [
     azurerm_role_assignment.test_extension_and_storage_account_permission,
+    azurerm_role_assignment.test_vault_msi_read_on_cluster,
+    azurerm_role_assignment.test_vault_msi_read_on_snap_rg,
+    azurerm_role_assignment.test_cluster_msi_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_msi_snapshot_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_operator_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_contributor_on_storage,
   ]
 }
 `, template, data.RandomInteger)

--- a/website/docs/r/data_protection_backup_instance_kubernetes_cluster.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_kubernetes_cluster.html.markdown
@@ -109,6 +109,24 @@ resource "azurerm_role_assignment" "vault_msi_read_on_snap_rg" {
   principal_id         = azurerm_data_protection_backup_vault.example.identity[0].principal_id
 }
 
+resource "azurerm_role_assignment" "test_vault_msi_snapshot_contributor_on_snap_rg" {
+  scope                = azurerm_resource_group.snap.id
+  role_definition_name = "Disk Snapshot Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_vault_data_operator_on_snap_rg" {
+  scope                = azurerm_resource_group.snap.id
+  role_definition_name = "Data Operator for Managed Disks"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_vault_data_contributor_on_storage" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+
 resource "azurerm_role_assignment" "cluster_msi_contributor_on_snap_rg" {
   scope                = azurerm_resource_group.snap.id
   role_definition_name = "Contributor"
@@ -166,7 +184,13 @@ resource "azurerm_data_protection_backup_instance_kubernetes_cluster" "example" 
   }
 
   depends_on = [
-    azurerm_role_assignment.extension_and_storage_account_permission,
+    azurerm_role_assignment.test_extension_and_storage_account_permission,
+    azurerm_role_assignment.test_vault_msi_read_on_cluster,
+    azurerm_role_assignment.test_vault_msi_read_on_snap_rg,
+    azurerm_role_assignment.test_cluster_msi_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_msi_snapshot_contributor_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_operator_on_snap_rg,
+    azurerm_role_assignment.test_vault_data_contributor_on_storage,
   ]
 }
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

- Set `DataSourceSetInfo` information to fix protection error `ScenarioPluginInvalidWorkflowDataRequest` that exists even if the resource is created successfully.

- Add role assignment in test case and documentation to fix protection error `UserErrorKubernetesBackupExtensionUnhealthy`
that exists even though the resource is created successfully.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

PASS: TestAccDataProtectionBackupInstanceKubernatesCluster_complete (1391.95s)
PASS: TestAccDataProtectionBackupInstanceKubernatesCluster_basic (1693.22s)
PASS: TestAccDataProtectionBackupInstanceKubernatesCluster_requiresImport (2029.78s)

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/3f28924e-5add-49d5-a5df-c2ac9bda3208)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_data_protection_backup_instance_kubernetes_cluster` - fix protection error  `ScenarioPluginInvalidWorkflowDataRequest` and `UserErrorKubernetesBackupExtensionUnhealthy` [GH-25294]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25294 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
