### PR TITLE
refactor: using `New{Resource}ID` rather than instantiating the Resource ID types

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -489,11 +489,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("data_collection_rule_id", defaultDataCollectionRuleResourceId)
 
-			sharedKeyId := sharedKeyWorkspaces.WorkspaceId{
-				SubscriptionId:    id.SubscriptionId,
-				ResourceGroupName: id.ResourceGroupName,
-				WorkspaceName:     id.WorkspaceName,
-			}
+			sharedKeyId := sharedKeyWorkspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
 			sharedKeysResp, err := sharedKeyClient.SharedKeysGetSharedKeys(ctx, sharedKeyId)
 			if err != nil {
 				log.Printf("[ERROR] Unable to List Shared keys for Log Analytics workspaces %s: %+v", id.WorkspaceName, err)
@@ -529,11 +525,7 @@ func resourceLogAnalyticsWorkspaceDelete(d *pluginsdk.ResourceData, meta interfa
 	defer cancel()
 
 	id, err := workspaces.ParseWorkspaceID(d.Id())
-	sharedKeyId := sharedKeyWorkspaces.WorkspaceId{
-		SubscriptionId:    id.SubscriptionId,
-		ResourceGroupName: id.ResourceGroupName,
-		WorkspaceName:     id.WorkspaceName,
-	}
+	sharedKeyId := sharedKeyWorkspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
 	if err != nil {
 		return err
 	}

--- a/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_scale_set_test.go
+++ b/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_scale_set_test.go
@@ -4,6 +4,7 @@
 package parse
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"reflect"
 	"testing"
 
@@ -58,12 +59,8 @@ func TestMaintenanceAssignmentVirtualMachineScaleSetID(t *testing.T) {
 			Error: false,
 			Expect: &MaintenanceAssignmentVirtualMachineScaleSetId{
 				VirtualMachineScaleSetIdRaw: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resGroup1/providers/microsoft.compute/virtualMachineScaleSets/vmss1",
-				VirtualMachineScaleSetId: &commonids.VirtualMachineScaleSetId{
-					SubscriptionId:             "00000000-0000-0000-0000-000000000000",
-					ResourceGroupName:          "resGroup1",
-					VirtualMachineScaleSetName: "vmss1",
-				},
-				Name: "assign1",
+				VirtualMachineScaleSetId:    pointer.To(commonids.NewVirtualMachineScaleSetID("00000000-0000-0000-0000-000000000000", "resGroup1", "vmss1")),
+				Name:                        "assign1",
 			},
 		},
 		{

--- a/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_scale_set_test.go
+++ b/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_scale_set_test.go
@@ -4,10 +4,10 @@
 package parse
 
 import (
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 )
 

--- a/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_test.go
+++ b/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_test.go
@@ -4,6 +4,7 @@
 package parse
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"reflect"
 	"testing"
 
@@ -58,12 +59,8 @@ func TestMaintenanceAssignmentVirtualMachineID(t *testing.T) {
 			Error: false,
 			Expect: &MaintenanceAssignmentVirtualMachineId{
 				VirtualMachineIdRaw: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resGroup1/providers/microsoft.compute/virtualMachines/vm1",
-				VirtualMachineId: &commonids.VirtualMachineId{
-					SubscriptionId:     "00000000-0000-0000-0000-000000000000",
-					ResourceGroupName:  "resGroup1",
-					VirtualMachineName: "vm1",
-				},
-				Name: "assign1",
+				VirtualMachineId:    pointer.To(commonids.NewVirtualMachineID("00000000-0000-0000-0000-000000000000", "resGroup1", "vm1")),
+				Name:                "assign1",
 			},
 		},
 		{

--- a/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_test.go
+++ b/internal/services/maintenance/parse/maintenance_assignment_virtual_machine_test.go
@@ -4,10 +4,10 @@
 package parse
 
 import (
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 )
 

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -863,10 +863,8 @@ func ParseMonitorDiagnosticId(monitorId string) (*diagnosticsettings.ScopedDiagn
 		return nil, fmt.Errorf("expected the Monitor Diagnostics ID to be in the format `{resourceId}|{name}` but got %d segments", len(v))
 	}
 
-	identifier := diagnosticsettings.ScopedDiagnosticSettingId{
-		ResourceUri:           v[0],
-		DiagnosticSettingName: v[1],
-	}
+	// TODO: this can become a Composite Resource ID once https://github.com/hashicorp/go-azure-helpers/pull/208 is released
+	identifier := diagnosticsettings.NewScopedDiagnosticSettingID(v[0], v[1])
 	return &identifier, nil
 }
 

--- a/internal/services/network/parse/private_endpoint_application_security_group_association_id_test.go
+++ b/internal/services/network/parse/private_endpoint_application_security_group_association_id_test.go
@@ -52,16 +52,8 @@ func TestPrivateEndpointApplicationSecurityGroupAssociationID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/privateEndpoints/endpoints1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/applicationSecurityGroups/securityGroup1",
 			Error: false,
 			Expect: &PrivateEndpointApplicationSecurityGroupAssociationId{
-				ApplicationSecurityGroupId: applicationsecuritygroups.ApplicationSecurityGroupId{
-					ResourceGroupName:            "mygroup1",
-					SubscriptionId:               "00000000-0000-0000-0000-000000000000",
-					ApplicationSecurityGroupName: "securityGroup1",
-				},
-				PrivateEndpointId: privateendpoints.PrivateEndpointId{
-					ResourceGroupName:   "group1",
-					SubscriptionId:      "00000000-0000-0000-0000-000000000000",
-					PrivateEndpointName: "endpoints1",
-				},
+				ApplicationSecurityGroupId: applicationsecuritygroups.NewApplicationSecurityGroupID("00000000-0000-0000-0000-000000000000", "mygroup1", "securityGroup1"),
+				PrivateEndpointId:          privateendpoints.NewPrivateEndpointID("00000000-0000-0000-0000-000000000000", "group1", "endpoints1"),
 			},
 		},
 	}

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -367,11 +367,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	defer cancel()
 
 	id := vaults.NewVaultID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	cfgId := backupresourcevaultconfigs.VaultId{
-		SubscriptionId:    id.SubscriptionId,
-		ResourceGroupName: id.ResourceGroupName,
-		VaultName:         id.VaultName,
-	}
+	cfgId := backupresourcevaultconfigs.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
 
 	encryption, err := expandEncryption(d)
 	if err != nil {
@@ -575,9 +571,8 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	cfgId := backupresourcevaultconfigs.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
 
-	log.Printf("[DEBUG] Reading Recovery Service %s", id.String())
+	cfgId := backupresourcevaultconfigs.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
@@ -586,85 +581,85 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 			return nil
 		}
 
-		return fmt.Errorf("making Read request on Recovery Service %s: %+v", id.String(), err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-
-	if resp.Model == nil {
-		return fmt.Errorf("recovery Service Vault response %q : model is nil", id.ID())
-	}
-	model := resp.Model
 
 	d.Set("name", id.VaultName)
 	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("location", location.Normalize(model.Location))
 
-	if sku := model.Sku; sku != nil {
-		d.Set("sku", string(sku.Name))
-	}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
 
-	if prop := model.Properties; prop != nil {
-
-		immutability := vaults.ImmutabilityStateDisabled
-		if prop.SecuritySettings != nil && prop.SecuritySettings.ImmutabilitySettings != nil {
-			immutability = pointer.From(prop.SecuritySettings.ImmutabilitySettings.State)
+		if sku := model.Sku; sku != nil {
+			d.Set("sku", string(sku.Name))
 		}
-		d.Set("immutability", string(immutability))
 
-		d.Set("public_network_access_enabled", flattenRecoveryServicesVaultPublicNetworkAccess(model.Properties.PublicNetworkAccess))
+		if prop := model.Properties; prop != nil {
 
-		d.Set("monitoring", flattenRecoveryServicesVaultMonitorSettings(prop.MonitoringSettings))
+			immutability := vaults.ImmutabilityStateDisabled
+			if prop.SecuritySettings != nil && prop.SecuritySettings.ImmutabilitySettings != nil {
+				immutability = pointer.From(prop.SecuritySettings.ImmutabilitySettings.State)
+			}
+			d.Set("immutability", string(immutability))
 
-		storageModeType := vaults.StandardTierStorageRedundancyInvalid
-		crossRegionRestoreEnabled := false
-		if prop.RedundancySettings != nil {
-			storageModeType = pointer.From(prop.RedundancySettings.StandardTierStorageRedundancy)
-			if prop.RedundancySettings.CrossRegionRestore != nil {
-				crossRegionRestoreEnabled = *prop.RedundancySettings.CrossRegionRestore == vaults.CrossRegionRestoreEnabled
+			d.Set("public_network_access_enabled", flattenRecoveryServicesVaultPublicNetworkAccess(model.Properties.PublicNetworkAccess))
+
+			d.Set("monitoring", flattenRecoveryServicesVaultMonitorSettings(prop.MonitoringSettings))
+
+			storageModeType := vaults.StandardTierStorageRedundancyInvalid
+			crossRegionRestoreEnabled := false
+			if prop.RedundancySettings != nil {
+				storageModeType = pointer.From(prop.RedundancySettings.StandardTierStorageRedundancy)
+				if prop.RedundancySettings.CrossRegionRestore != nil {
+					crossRegionRestoreEnabled = *prop.RedundancySettings.CrossRegionRestore == vaults.CrossRegionRestoreEnabled
+				}
+			}
+			d.Set("cross_region_restore_enabled", crossRegionRestoreEnabled)
+			d.Set("storage_mode_type", string(storageModeType))
+		}
+
+		cfg, err := cfgsClient.Get(ctx, cfgId)
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %+v", cfgId, err)
+		}
+
+		softDeleteEnabled := false
+		if cfg.Model != nil && cfg.Model.Properties != nil && cfg.Model.Properties.SoftDeleteFeatureState != nil {
+			softDeleteEnabled = *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
+		}
+		d.Set("soft_delete_enabled", softDeleteEnabled)
+
+		flattenIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		if err := d.Set("identity", flattenIdentity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
+
+		encryption := flattenVaultEncryption(*model)
+		if encryption != nil {
+			d.Set("encryption", []interface{}{encryption})
+		}
+
+		vaultSettingsId := replicationvaultsetting.NewReplicationVaultSettingID(id.SubscriptionId, id.ResourceGroupName, id.VaultName, "default")
+		vaultSetting, err := vaultSettingsClient.Get(ctx, vaultSettingsId)
+		if err != nil {
+			return fmt.Errorf("reading Recovery Service Vault Setting %s: %+v", id.String(), err)
+		}
+
+		classicVmwareReplicationEnabled := false
+		if vaultSetting.Model != nil && vaultSetting.Model.Properties != nil {
+			if v := vaultSetting.Model.Properties.VMwareToAzureProviderType; v != nil {
+				classicVmwareReplicationEnabled = strings.EqualFold(*v, "vmware")
 			}
 		}
-		d.Set("cross_region_restore_enabled", crossRegionRestoreEnabled)
-		d.Set("storage_mode_type", string(storageModeType))
+		d.Set("classic_vmware_replication_enabled", classicVmwareReplicationEnabled)
+
+		return tags.FlattenAndSet(d, model.Tags)
 	}
 
-	cfg, err := cfgsClient.Get(ctx, cfgId)
-	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v", cfgId, err)
-	}
-
-	softDeleteEnabled := false
-	if cfg.Model != nil && cfg.Model.Properties != nil && cfg.Model.Properties.SoftDeleteFeatureState != nil {
-		softDeleteEnabled = *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
-	}
-	d.Set("soft_delete_enabled", softDeleteEnabled)
-
-	flattenIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-	if err := d.Set("identity", flattenIdentity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
-	encryption := flattenVaultEncryption(*model)
-	if encryption != nil {
-		d.Set("encryption", []interface{}{encryption})
-	}
-
-	vaultSettingsId := replicationvaultsetting.NewReplicationVaultSettingID(id.SubscriptionId, id.ResourceGroupName, id.VaultName, "default")
-	vaultSetting, err := vaultSettingsClient.Get(ctx, vaultSettingsId)
-	if err != nil {
-		return fmt.Errorf("reading Recovery Service Vault Setting %s: %+v", id.String(), err)
-	}
-
-	classicVmwareReplicationEnabled := false
-	if vaultSetting.Model != nil && vaultSetting.Model.Properties != nil {
-		if v := vaultSetting.Model.Properties.VMwareToAzureProviderType; v != nil {
-			classicVmwareReplicationEnabled = strings.EqualFold(*v, "vmware")
-		}
-	}
-	d.Set("classic_vmware_replication_enabled", classicVmwareReplicationEnabled)
-
-	return tags.FlattenAndSet(d, model.Tags)
+	return nil
 }
 
 func resourceRecoveryServicesVaultDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -718,10 +713,7 @@ func resourceRecoveryServicesVaultDelete(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	log.Printf("[DEBUG] Deleting Recovery Service  %s", id.String())
-
-	_, err = client.Delete(ctx, *id)
-	if err != nil {
+	if _, err = client.Delete(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -627,6 +627,7 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 		if cfg.Model != nil && cfg.Model.Properties != nil && cfg.Model.Properties.SoftDeleteFeatureState != nil {
 			softDeleteEnabled = *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
 		}
+
 		d.Set("soft_delete_enabled", softDeleteEnabled)
 
 		flattenIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)

--- a/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
+++ b/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
@@ -670,12 +670,7 @@ func (r ThreatIntelligenceIndicator) Read() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			workspaceId := workspaces.WorkspaceId{
-				SubscriptionId:    id.SubscriptionId,
-				ResourceGroupName: id.ResourceGroup,
-				WorkspaceName:     id.WorkspaceName,
-			}
-
+			workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)
 			resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.IndicatorName)
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -354,11 +354,8 @@ func (k ClusterResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("while reading data for cluster %q: %+v", id.ManagedClusterName, err)
 			}
 
-			nts, err := nodeTypeClient.ListByManagedClustersComplete(ctx, nodetype.ManagedClusterId{
-				SubscriptionId:     id.SubscriptionId,
-				ResourceGroupName:  id.ResourceGroupName,
-				ManagedClusterName: id.ManagedClusterName,
-			})
+			clusterId := nodetype.NewManagedClusterID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName)
+			nts, err := nodeTypeClient.ListByManagedClustersComplete(ctx, clusterId)
 			if err != nil {
 				return fmt.Errorf("while listing NodeTypes for cluster %q: +%v", id.ManagedClusterName, err)
 			}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

We should be using `example.NewExampleID(` rather than `example.ExampleId{` to instantiate Resource IDs

Whilst that might seem pedantic, it means that should a new field be added to `ExampleId` we'd get a compile-time failure when using the `New` function which would mean we'd identify the missing field, whereas instantiating the struct would mean these would get the default (empty) value - leading to incorrect details.

It's minor, but worthwhile from a consistency perspective
