### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert_v2` - support `identity`

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-15-preview/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -20,28 +21,29 @@ import (
 )
 
 type ScheduledQueryRulesAlertV2Model struct {
-	Name                                  string                                    `tfschema:"name"`
-	ResourceGroupName                     string                                    `tfschema:"resource_group_name"`
-	Actions                               []ScheduledQueryRulesAlertV2ActionsModel  `tfschema:"action"`
-	AutoMitigate                          bool                                      `tfschema:"auto_mitigation_enabled"`
-	CheckWorkspaceAlertsStorageConfigured bool                                      `tfschema:"workspace_alerts_storage_enabled"`
-	Criteria                              []ScheduledQueryRulesAlertV2CriteriaModel `tfschema:"criteria"`
-	Description                           string                                    `tfschema:"description"`
-	DisplayName                           string                                    `tfschema:"display_name"`
-	Enabled                               bool                                      `tfschema:"enabled"`
-	EvaluationFrequency                   string                                    `tfschema:"evaluation_frequency"`
-	Location                              string                                    `tfschema:"location"`
-	MuteActionsDuration                   string                                    `tfschema:"mute_actions_after_alert_duration"`
-	OverrideQueryTimeRange                string                                    `tfschema:"query_time_range_override"`
-	Scopes                                []string                                  `tfschema:"scopes"`
-	Severity                              scheduledqueryrules.AlertSeverity         `tfschema:"severity"`
-	SkipQueryValidation                   bool                                      `tfschema:"skip_query_validation"`
-	Tags                                  map[string]string                         `tfschema:"tags"`
-	TargetResourceTypes                   []string                                  `tfschema:"target_resource_types"`
-	WindowSize                            string                                    `tfschema:"window_duration"`
-	CreatedWithApiVersion                 string                                    `tfschema:"created_with_api_version"`
-	IsLegacyLogAnalyticsRule              bool                                      `tfschema:"is_a_legacy_log_analytics_rule"`
-	IsWorkspaceAlertsStorageConfigured    bool                                      `tfschema:"is_workspace_alerts_storage_configured"`
+	Name                                  string                                     `tfschema:"name"`
+	ResourceGroupName                     string                                     `tfschema:"resource_group_name"`
+	Actions                               []ScheduledQueryRulesAlertV2ActionsModel   `tfschema:"action"`
+	AutoMitigate                          bool                                       `tfschema:"auto_mitigation_enabled"`
+	CheckWorkspaceAlertsStorageConfigured bool                                       `tfschema:"workspace_alerts_storage_enabled"`
+	Criteria                              []ScheduledQueryRulesAlertV2CriteriaModel  `tfschema:"criteria"`
+	Description                           string                                     `tfschema:"description"`
+	DisplayName                           string                                     `tfschema:"display_name"`
+	Enabled                               bool                                       `tfschema:"enabled"`
+	EvaluationFrequency                   string                                     `tfschema:"evaluation_frequency"`
+	Location                              string                                     `tfschema:"location"`
+	MuteActionsDuration                   string                                     `tfschema:"mute_actions_after_alert_duration"`
+	OverrideQueryTimeRange                string                                     `tfschema:"query_time_range_override"`
+	Scopes                                []string                                   `tfschema:"scopes"`
+	Severity                              scheduledqueryrules.AlertSeverity          `tfschema:"severity"`
+	SkipQueryValidation                   bool                                       `tfschema:"skip_query_validation"`
+	Tags                                  map[string]string                          `tfschema:"tags"`
+	TargetResourceTypes                   []string                                   `tfschema:"target_resource_types"`
+	WindowSize                            string                                     `tfschema:"window_duration"`
+	CreatedWithApiVersion                 string                                     `tfschema:"created_with_api_version"`
+	IsLegacyLogAnalyticsRule              bool                                       `tfschema:"is_a_legacy_log_analytics_rule"`
+	IsWorkspaceAlertsStorageConfigured    bool                                       `tfschema:"is_workspace_alerts_storage_configured"`
+	Identity                              []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
 }
 
 type ScheduledQueryRulesAlertV2ActionsModel struct {
@@ -374,6 +376,8 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 			Optional: true,
 		},
 
+		"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
+
 		"tags": commonschema.Tags(),
 
 		"target_resource_types": {
@@ -426,6 +430,12 @@ func (r ScheduledQueryRulesAlertV2Resource) Create() sdk.ResourceFunc {
 			if !response.WasNotFound(existing.HttpResponse) {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
+
+			ExpanededIdentity, err := identity.ExpandSystemOrUserAssignedMapFromModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding SystemOrUserAssigned Identity: %+v", err)
+			}
+
 			kind := scheduledqueryrules.KindLogAlert
 			properties := &scheduledqueryrules.ScheduledQueryRuleResource{
 				Kind:     &kind,
@@ -439,7 +449,8 @@ func (r ScheduledQueryRulesAlertV2Resource) Create() sdk.ResourceFunc {
 					SkipQueryValidation:                   &model.SkipQueryValidation,
 					TargetResourceTypes:                   &model.TargetResourceTypes,
 				},
-				Tags: &model.Tags,
+				Identity: ExpanededIdentity,
+				Tags:     &model.Tags,
 			}
 
 			properties.Properties.Actions = expandScheduledQueryRulesAlertV2ActionsModel(model.Actions)
@@ -584,6 +595,13 @@ func (r ScheduledQueryRulesAlertV2Resource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			if metadata.ResourceData.HasChange("identity") {
+				model.Identity, err = identity.ExpandSystemOrUserAssignedMapFromModel(resourceModel.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding SystemOrUserAssigned Identity: %+v", err)
+				}
+			}
+
 			if metadata.ResourceData.HasChange("tags") {
 				model.Tags = &resourceModel.Tags
 			}
@@ -622,10 +640,16 @@ func (r ScheduledQueryRulesAlertV2Resource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
+			flattenedIdentity, err := identity.FlattenSystemOrUserAssignedMapToModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("flattening SystemOrUserAssigned Identity: %+v", err)
+			}
+
 			state := ScheduledQueryRulesAlertV2Model{
 				Name:              id.ScheduledQueryRuleName,
 				ResourceGroupName: id.ResourceGroupName,
 				Location:          location.Normalize(model.Location),
+				Identity:          *flattenedIdentity,
 			}
 
 			properties := &model.Properties

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
@@ -89,6 +89,69 @@ func TestAccMonitorScheduledQueryRulesAlertV2_update(t *testing.T) {
 	})
 }
 
+func TestAccMonitorScheduledQueryRulesAlertV2_identitySystemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert_v2", "test")
+	r := MonitorScheduledQueryRulesAlertV2Resource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.identitySystemAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMonitorScheduledQueryRulesAlertV2_identityUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert_v2", "test")
+	r := MonitorScheduledQueryRulesAlertV2Resource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.identitySystemAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.identityUserAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsEmpty(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r MonitorScheduledQueryRulesAlertV2Resource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := scheduledqueryrules.ParseScheduledQueryRuleID(state.ID)
 	if err != nil {
@@ -128,6 +191,18 @@ resource "azurerm_monitor_action_group" "test" {
   name                = "acctest-mag-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   short_name          = "test mag"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_application_insights.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -294,6 +369,68 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
     key  = "value"
     key2 = "value2"
   }
+}
+`, template, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MonitorScheduledQueryRulesAlertV2Resource) identitySystemAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
+  name                 = "acctest-isqr-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = "%s"
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_application_insights.test.id]
+  severity             = 3
+  criteria {
+    query                   = <<-QUERY
+      requests
+	    | summarize CountByCountry=count() by client_CountryOrRegion
+	  QUERY
+    time_aggregation_method = "Count"
+    threshold               = 5.0
+    operator                = "Equal"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MonitorScheduledQueryRulesAlertV2Resource) identityUserAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
+  name                 = "acctest-isqr-%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = "%s"
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_application_insights.test.id]
+  severity             = 3
+  criteria {
+    query                   = <<-QUERY
+      requests
+	    | summarize CountByCountry=count() by client_CountryOrRegion
+	  QUERY
+    time_aggregation_method = "Count"
+    threshold               = 5.0
+    operator                = "Equal"
+  }
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+  depends_on = [azurerm_role_assignment.test]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

support `identity`

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 5 -run TestAccMonitorScheduledQueryRulesAlertV2_identity -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorScheduledQueryRulesAlertV2_identitySystemAssigned
=== PAUSE TestAccMonitorScheduledQueryRulesAlertV2_identitySystemAssigned
=== RUN   TestAccMonitorScheduledQueryRulesAlertV2_identityUpdate
=== PAUSE TestAccMonitorScheduledQueryRulesAlertV2_identityUpdate
=== CONT  TestAccMonitorScheduledQueryRulesAlertV2_identitySystemAssigned
=== CONT  TestAccMonitorScheduledQueryRulesAlertV2_identityUpdate
--- PASS: TestAccMonitorScheduledQueryRulesAlertV2_identitySystemAssigned (118.98s)
--- PASS: TestAccMonitorScheduledQueryRulesAlertV2_identityUpdate (199.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       199.047s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

`azurerm_monitor_scheduled_query_rules_alert_v2` - support `identity` property [GH-25365]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/25311, resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/23437, resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/23248


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
