### PR TITLE
r/storage_account: defaulting the value for `dns_endpoint_type`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2116,7 +2116,14 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 			publicNetworkAccessEnabled = false
 		}
 		d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
-		d.Set("dns_endpoint_type", props.DNSEndpointType)
+
+		// DNSEndpointType is null when unconfigured - therefore default this to Standard
+		dnsEndpointType := storage.DNSEndpointTypeStandard
+		if props.DNSEndpointType != "" {
+			// TODO: when this is ported over to `hashicorp/go-azure-sdk` this should be able to become != nil
+			dnsEndpointType = props.DNSEndpointType
+		}
+		d.Set("dns_endpoint_type", dnsEndpointType)
 
 		if crossTenantReplication := props.AllowCrossTenantReplication; crossTenantReplication != nil {
 			d.Set("cross_tenant_replication_enabled", crossTenantReplication)


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

This field defaults to `null` if unset in the API response, therefore needs to be explicitly defaulted on our side

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/25364