### PR TITLE
`azurerm_nginx_deployment` dropped validation of SKU property.

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -94,19 +94,15 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"sku": {
-			// move to enum once this issue fixed: <https://github.com/Azure/azure-rest-api-specs/issues/20848>
-			// docs: <https://docs.nginx.com/nginx-for-azure/billing/overview/>
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice(
-				[]string{
-					"publicpreview_Monthly_gmz7xq9ge3py",
-					"standard_Monthly",
-				}, false),
+			// docs: <https://docs.nginx.com/nginxaas/azure/billing/overview/>
+			// we will not be forcing validation of SKU as there are internal SKUs
+			// used for testing and for F5 NGINX private offers
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 
-		// only one type of identity is supported.
 		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 		"managed_resource_group": {

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -63,7 +63,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `nginx_version` - NGINX version of the Nginx Deployment.
 
-* `sku` - Name of the SKU for this Nginx Deployment.
+* `sku` - (Required) Specifies the Nginx Deployment SKU. Possible values include `standard_Monthly`. Changing this forces a new resource to be created.
 
 * `automatic_upgrade_channel` - The automatic upgrade channel for this NGINX deployment.
 

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Nginx Deployment should exist. Changing this forces a new Nginx Deployment to be created.
 
-* `sku` - (Required) Specify the Name of Nginx deployment SKU. The possible value are `publicpreview_Monthly_gmz7xq9ge3py` and `standard_Monthly`. Changing this forces a new Nginx Deployment to be created.
+* `sku` - (Required) Specifies the Nginx Deployment SKU. Possible values include `standard_Monthly`. Changing this forces a new resource to be created.
 
 * `managed_resource_group` - (Optional) Specify the managed resource group to deploy VNet injection related network resources. Changing this forces a new Nginx Deployment to be created.
 
@@ -199,7 +199,7 @@ A `frontend_private` block supports the following:
 
 A `frontend_public` block supports the following:
 
-* `ip_address` - (Optional) Specifies a list of Public IP Resouce ID to this Nginx Deployment.
+* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this Nginx Deployment.
 
 ---
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

There is a requirement from engineering to have this be a plain string field to support test SKUs that are sensitive and should not be added to a enumerated list of SKUs in the provider. The documented supported SKUs are still the publically available SKUs so not docs change is needed.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

No changelog message is desired as we do not change support merely relaxed validation.

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

