### PR TITLE
`azurerm_stack_hci_cluster` - change `client_id` to `optional`

### DIFF
--- a/internal/services/azurestackhci/stack_hci_cluster_resource.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource.go
@@ -58,7 +58,7 @@ func resourceArmStackHCICluster() *pluginsdk.Resource {
 
 			"client_id": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IsUUID,
 			},

--- a/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -37,6 +37,24 @@ func TestAccStackHCICluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccStackHCICluster_basicWithoutClientId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithoutClientId(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cloud_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("service_endpoint").IsNotEmpty(),
+				check.That(data.ResourceName).Key("resource_provider_object_id").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStackHCICluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
 	r := StackHCIClusterResource{}
@@ -176,6 +194,20 @@ func (r StackHCIClusterResource) Exists(ctx context.Context, client *clients.Cli
 	}
 
 	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r StackHCIClusterResource) basicWithoutClientId(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stack_hci_cluster" "test" {
+  name                = "acctest-StackHCICluster-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+}
+`, template, data.RandomInteger)
 }
 
 func (r StackHCIClusterResource) basic(data acceptance.TestData) string {

--- a/website/docs/r/stack_hci_cluster.html.markdown
+++ b/website/docs/r/stack_hci_cluster.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Azure Stack HCI Cluster should exist. Changing this forces a new resource to be created.
 
-* `client_id` - (Optional) The Client ID of the Azure Active Directory which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
+* `client_id` - (Optional) The Client ID of the Azure Active Directory Application which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/stack_hci_cluster.html.markdown
+++ b/website/docs/r/stack_hci_cluster.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Azure Stack HCI Cluster should exist. Changing this forces a new resource to be created.
 
-* `client_id` - (Required) The Client ID of the Azure Active Directory which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
+* `client_id` - (Optional) The Client ID of the Azure Active Directory which is used by the Azure Stack HCI Cluster. Changing this forces a new resource to be created.
 
 * `identity` - (Optional) An `identity` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

change `client_id` to `optional`, as by test it is not required.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/azurestackhci -parallel 5 -run TestAccStackHCICluster_basicW -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStackHCICluster_basicWithoutClientId
=== PAUSE TestAccStackHCICluster_basicWithoutClientId
=== CONT  TestAccStackHCICluster_basicWithoutClientId
--- PASS: TestAccStackHCICluster_basicWithoutClientId (195.65s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/azurestackhci 195.667s
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_stack_hci_cluster` - change `client_id` to `optional` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
