### PR TITLE
`azurerm_monitor_alert_prometheus_rule_group`: when `severity` property is set to `0`, it is skipped

### DIFF
--- a/internal/services/monitor/monitor_alert_prometheus_rule_group_resource.go
+++ b/internal/services/monitor/monitor_alert_prometheus_rule_group_resource.go
@@ -293,7 +293,7 @@ func (r AlertPrometheusRuleGroupResource) Create() sdk.ResourceFunc {
 			if _, ok := metadata.ResourceData.GetOk("interval"); ok {
 				properties.Properties.Interval = pointer.To(model.Interval)
 			}
-			properties.Properties.Rules = expandPrometheusRuleModel(model.Rule)
+			properties.Properties.Rules = expandPrometheusRuleModel(model.Rule, metadata.ResourceData)
 
 			if _, err := client.CreateOrUpdate(ctx, id, properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
@@ -344,7 +344,7 @@ func (r AlertPrometheusRuleGroupResource) Update() sdk.ResourceFunc {
 				properties.Properties.Interval = pointer.To(model.Interval)
 			}
 			if metadata.ResourceData.HasChange("rule") {
-				properties.Properties.Rules = expandPrometheusRuleModel(model.Rule)
+				properties.Properties.Rules = expandPrometheusRuleModel(model.Rule, metadata.ResourceData)
 			}
 			if metadata.ResourceData.HasChange("scopes") {
 				properties.Properties.Scopes = model.Scopes
@@ -422,10 +422,10 @@ func (r AlertPrometheusRuleGroupResource) Delete() sdk.ResourceFunc {
 	}
 }
 
-func expandPrometheusRuleModel(inputList []PrometheusRuleModel) []prometheusrulegroups.PrometheusRule {
+func expandPrometheusRuleModel(inputList []PrometheusRuleModel, d *schema.ResourceData) []prometheusrulegroups.PrometheusRule {
 	outputList := make([]prometheusrulegroups.PrometheusRule, 0)
 
-	for _, v := range inputList {
+	for i, v := range inputList {
 		output := prometheusrulegroups.PrometheusRule{
 			Enabled:    pointer.To(v.Enabled),
 			Expression: v.Expression,
@@ -435,8 +435,8 @@ func expandPrometheusRuleModel(inputList []PrometheusRuleModel) []prometheusrule
 		if v.Alert != "" {
 			output.Actions = expandPrometheusRuleGroupActionModel(v.Action)
 			output.Alert = pointer.To(v.Alert)
-			if v.Severity != 0 {
-				output.Severity = pointer.To(int64(v.Severity))
+			if v, ok := d.GetOk(fmt.Sprintf("rule.%d.severity", i)); ok {
+				output.Severity = pointer.To(int64(v.(int)))
 			}
 			output.Annotations = pointer.To(v.Annotations)
 			output.For = pointer.To(v.For)

--- a/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
+++ b/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
@@ -225,7 +225,7 @@ EOF
 histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service="billing-processing"}[5m])) by (job_type))
 EOF
     for        = "PT5M"
-    severity   = 2
+    severity   = 0
     action {
       action_group_id = azurerm_monitor_action_group.test.id
     }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When the `severity` property of type int is not specified, the API does not return a default value. The current [code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/monitor/monitor_alert_prometheus_rule_group_resource.go#L438) skips the setting of the 0 value, which means that the 0 value allowed to be set cannot be successfully configured. Therefore, this PR is submitted to fix #25399


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Test case `TestAccAlertsManagementPrometheusRuleGroup_update ` passed locally.

PASS: TestAccAlertsManagementPrometheusRuleGroup_update (1444.40s)

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MONITOR/124557?buildTab=tests&expandedTest=build%3A%28id%3A124557%29%2Cid%3A2000000003

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/b0e7d82e-994c-4629-b486-6acf6b20cfa8)

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25399


