### PR TITLE
`azurerm_storage_account` - Extend the support level of `(blob|queue|share)_properties` for `Storage` kind

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -70,14 +70,14 @@ func resolveStorageAccountServiceSupportLevel(kind storage.Kind, tier storage.Sk
 	supportBlob := kind != storage.KindFileStorage
 
 	// Queue is only supported for Storage and StorageV2, in Standard sku tier.
-	supportQueue := tier == storage.SkuTierStandard && kind == storage.KindStorageV2
+	supportQueue := tier == storage.SkuTierStandard && slices.Contains([]storage.Kind{storage.KindStorage, storage.KindStorageV2}, kind)
 
 	// File share is only supported for StorageV2 and FileStorage.
 	// See: https://docs.microsoft.com/en-us/azure/storage/files/storage-files-planning#management-concepts
 	// Per test, the StorageV2 with Premium sku tier also doesn't support file share.
-	supportShare := kind == storage.KindFileStorage || (kind == storage.KindStorageV2 && tier != storage.SkuTierPremium)
+	supportShare := kind == storage.KindFileStorage || (slices.Contains([]storage.Kind{storage.KindStorage, storage.KindStorageV2}, kind) && tier != storage.SkuTierPremium)
 
-	// Static Website is only supported for StorageV2 and BlockBlobStorage
+	// Static Website is only supported for StorageV2 (not for Storage(v1)) and BlockBlobStorage
 	supportStaticWebSite := kind == storage.KindStorageV2 || kind == storage.KindBlockBlobStorage
 
 	return storageAccountServiceSupportLevel{

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `queue_properties` - (Optional) A `queue_properties` block as defined below.
 
-~> **NOTE:** `queue_properties` can only be set for `Standard` (`account_tier`) `StorageV2` (`account_kind`) Storage Accounts.
+~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `StorageV2` Storage Accounts.
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 
 * `share_properties` - (Optional) A `share_properties` block as defined below.
 
-~> **NOTE:** `share_properties` can only be set for `Standard` (`account_tier`) `StorageV2` (`account_kind`) or `Premium` (`account_tier`) `FileStorage` (`account_kind`) Storage Accounts.
+~> **NOTE:** `share_properties` can only be configured when either `account_tier` is `Standard` and `account_kind` is `StorageV2` - or when `account_tier` is `Premium` and `account_kind` is `FileStorage`.
 
 * `network_rules` - (Optional) A `network_rules` block as documented below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `queue_properties` - (Optional) A `queue_properties` block as defined below.
 
-~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `StorageV2` Storage Accounts.
+~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `StorageV2`.
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 
 * `share_properties` - (Optional) A `share_properties` block as defined below.
 
-~> **NOTE:** `share_properties` can only be configured when either `account_tier` is `Standard` and `account_kind` is `Storage(V2)` - or when `account_tier` is `Premium` and `account_kind` is `FileStorage`.
+~> **NOTE:** `share_properties` can only be configured when either `account_tier` is `Standard` and `account_kind` is either `Storage` or `StorageV2` - or when `account_tier` is `Premium` and `account_kind` is `FileStorage`.
 
 * `network_rules` - (Optional) A `network_rules` block as documented below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `queue_properties` - (Optional) A `queue_properties` block as defined below.
 
-~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `StorageV2`.
+~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `Storage(V2)`.
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 
@@ -144,7 +144,7 @@ The following arguments are supported:
 
 * `share_properties` - (Optional) A `share_properties` block as defined below.
 
-~> **NOTE:** `share_properties` can only be configured when either `account_tier` is `Standard` and `account_kind` is `StorageV2` - or when `account_tier` is `Premium` and `account_kind` is `FileStorage`.
+~> **NOTE:** `share_properties` can only be configured when either `account_tier` is `Standard` and `account_kind` is `Storage(V2)` - or when `account_tier` is `Premium` and `account_kind` is `FileStorage`.
 
 * `network_rules` - (Optional) A `network_rules` block as documented below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `queue_properties` - (Optional) A `queue_properties` block as defined below.
 
-~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to `Storage(V2)`.
+~> **NOTE:** `queue_properties` can only be configured when `account_tier` is set to `Standard` and `account_kind` is set to either `Storage` or `StorageV2`.
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -136,13 +136,15 @@ The following arguments are supported:
 
 * `queue_properties` - (Optional) A `queue_properties` block as defined below.
 
-~> **NOTE:** `queue_properties` cannot be set when the `account_kind` is set to `BlobStorage`
+~> **NOTE:** `queue_properties` can only be set for `Standard` (`account_tier`) `StorageV2` (`account_kind`) Storage Accounts.
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 
 ~> **NOTE:** `static_website` can only be set when the `account_kind` is set to `StorageV2` or `BlockBlobStorage`.
 
 * `share_properties` - (Optional) A `share_properties` block as defined below.
+
+~> **NOTE:** `share_properties` can only be set for `Standard` (`account_tier`) `StorageV2` (`account_kind`) or `Premium` (`account_tier`) `FileStorage` (`account_kind`) Storage Accounts.
 
 * `network_rules` - (Optional) A `network_rules` block as documented below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

~Update document of `azurerm_storage_account` for the viable combinations for `(queue|share)_properties`~

`azurerm_storage_account` - Extend the support level of `(blob|queue|share)_properties` for `Storage` kind

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm on  storage_tier_kind_doc via 🐹 v1.22.1
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_StorageV1_'
=== RUN   TestAccStorageAccount_StorageV1_blobProperties
=== PAUSE TestAccStorageAccount_StorageV1_blobProperties
=== RUN   TestAccStorageAccount_StorageV1_queueProperties
=== PAUSE TestAccStorageAccount_StorageV1_queueProperties
=== RUN   TestAccStorageAccount_StorageV1_shareProperties
=== PAUSE TestAccStorageAccount_StorageV1_shareProperties
=== CONT  TestAccStorageAccount_StorageV1_blobProperties
=== CONT  TestAccStorageAccount_StorageV1_shareProperties
=== CONT  TestAccStorageAccount_StorageV1_queueProperties
--- PASS: TestAccStorageAccount_StorageV1_blobProperties (143.56s)
--- PASS: TestAccStorageAccount_StorageV1_queueProperties (158.50s)
--- PASS: TestAccStorageAccount_StorageV1_shareProperties (159.78s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       159.808s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - Extend the support level of `(blob|queue|share)_properties` for `Storage` kind [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25422


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
