### PR TITLE
`azurerm_mysql_flexible_server_active_directory_administrator` , `azurerm_mysql_flexible_server` - fix acctests failure

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_aad_administrator_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_aad_administrator_resource_test.go
@@ -130,7 +130,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     identity_ids = [azurerm_user_assigned_identity.test.id, azurerm_user_assigned_identity.test2.id]
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Ternary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r MySQLFlexibleServerAdministratorResource) basic(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -1234,7 +1234,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     geo_backup_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
   }
 }
-`, r.cmkTemplate(data), data.RandomInteger, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomInteger)
+`, r.cmkTemplate(data), data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (r MySqlFlexibleServerResource) identity(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -535,7 +535,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mysql-%d"
   location = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Ternary)
 }
 
 func (r MySqlFlexibleServerResource) basic(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -1114,7 +1114,7 @@ resource "azurerm_key_vault_key" "test" {
     azurerm_key_vault_access_policy.server,
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomString)
 }
 
 func (r MySqlFlexibleServerResource) withoutCustomerManagedKey(data acceptance.TestData) string {


### PR DESCRIPTION
## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The following tests fail with error "The location doesn't support High Availability Mode 1."

```
TestAccMySqlFlexibleServer_updateHA
TestAccDataSourceMySqlFlexibleServer_complete
TestAccMySqlFlexibleServer_complete
TestAccMySqlFlexibleServer_failover
TestAccMySqlFlexibleServer_completeUpdate
```

The following tests fail with error , "The requested size for resource is currently not available in this zone. Please try another zone or deploy to a different location"

```
TestAccMySQLFlexibleServerAdministrator_basic
TestAccMySQLFlexibleServerAdministrator_update
TestAccMySQLFlexibleServerAdministrator_requiresImport
TestAccMySqlFlexibleServer_enableGeoRedundantBackup
```
TC link: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MYSQL/121776?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildDeploymentsSection=false&expandBuildChangesSection=true

Update the test location to eastus2 to fix above acctests failure.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/382ff4dc-b61e-4495-978a-6d60e8755c8b)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/c259e286-006b-4c6c-98b3-5703118d029c)


