### PR TITLE
`storage`: refactoring the Account Cache, Encryption Scopes and the Test Assertions to use `hashicorp/go-azure-sdk` rather than `Azure/azure-sdk-for-go`

### DIFF
--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -1059,7 +1059,7 @@ func resourceVirtualMachineDeleteVhd(ctx context.Context, storageClient *intStor
 		DeleteSnapshots: false,
 	}
 	if _, err := blobsClient.Delete(ctx, id.ContainerName, id.BlobName, input); err != nil {
-		return fmt.Errorf("deleting Blob %q (Container %q / Account %q / Resource Group %q): %s", id.BlobName, id.ContainerName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("deleting Blob %q (Container %q in %s): %+v", id.BlobName, id.ContainerName, id.AccountId, err)
 	}
 
 	return nil

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -984,7 +984,7 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 			}
 
 			if osDisk.Vhd != nil {
-				if err = resourceVirtualMachineDeleteVhd(ctx, storageClient, osDisk.Vhd); err != nil {
+				if err = resourceVirtualMachineDeleteVhd(ctx, storageClient, id.SubscriptionId, osDisk.Vhd); err != nil {
 					return fmt.Errorf("deleting OS Disk VHD: %+v", err)
 				}
 			} else if osDisk.ManagedDisk != nil {
@@ -1009,7 +1009,7 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 				}
 
 				if disk.Vhd != nil {
-					if err = resourceVirtualMachineDeleteVhd(ctx, storageClient, disk.Vhd); err != nil {
+					if err = resourceVirtualMachineDeleteVhd(ctx, storageClient, id.SubscriptionId, disk.Vhd); err != nil {
 						return fmt.Errorf("deleting Data Disk VHD: %+v", err)
 					}
 				} else if disk.ManagedDisk != nil {
@@ -1024,7 +1024,7 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceVirtualMachineDeleteVhd(ctx context.Context, storageClient *intStor.Client, vhd *compute.VirtualHardDisk) error {
+func resourceVirtualMachineDeleteVhd(ctx context.Context, storageClient *intStor.Client, subscriptionId string, vhd *compute.VirtualHardDisk) error {
 	if vhd == nil {
 		return fmt.Errorf("`vhd` was nil`")
 	}
@@ -1038,7 +1038,7 @@ func resourceVirtualMachineDeleteVhd(ctx context.Context, storageClient *intStor
 		return fmt.Errorf("parsing %q: %s", uri, err)
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %s", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}

--- a/internal/services/legacy/virtual_machine_resource_test.go
+++ b/internal/services/legacy/virtual_machine_resource_test.go
@@ -246,7 +246,7 @@ func (VirtualMachineResource) unmanagedDiskExistsInContainer(blobName string, sh
 		accountName := state.Attributes["storage_account_name"]
 		containerName := state.Attributes["name"]
 
-		account, err := clients.Storage.FindAccount(ctx, accountName)
+		account, err := clients.Storage.FindAccount(ctx, clients.Account.SubscriptionId, accountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %s", accountName, blobName, containerName, err)
 		}

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
@@ -313,7 +313,7 @@ func (r MachineLearningDataStoreBlobStorage) Read() sdk.ResourceFunc {
 			if storageAccount == nil {
 				return fmt.Errorf("Unable to locate Storage Account %q!", *data.AccountName)
 			}
-			containerId := commonids.NewStorageContainerID(subscriptionId, storageAccount.ResourceGroup, *data.AccountName, *data.ContainerName)
+			containerId := commonids.NewStorageContainerID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, *data.AccountName, *data.ContainerName)
 			model.StorageContainerID = containerId.ID()
 
 			model.IsDefault = *data.IsDefault

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
@@ -306,7 +306,7 @@ func (r MachineLearningDataStoreBlobStorage) Read() sdk.ResourceFunc {
 			}
 			model.ServiceDataAuthIdentity = serviceDataAuth
 
-			storageAccount, err := storageClient.FindAccount(ctx, *data.AccountName)
+			storageAccount, err := storageClient.FindAccount(ctx, subscriptionId, *data.AccountName)
 			if err != nil {
 				return fmt.Errorf("retrieving Account %q for Container %q: %s", *data.AccountName, *data.ContainerName, err)
 			}

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
@@ -313,7 +313,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Read() sdk.ResourceFunc {
 			}
 			model.ServiceDataIdentity = serviceDataIdentity
 
-			storageAccount, err := storageClient.FindAccount(ctx, data.AccountName)
+			storageAccount, err := storageClient.FindAccount(ctx, subscriptionId, data.AccountName)
 			if err != nil {
 				return fmt.Errorf("retrieving Account %q for Data Lake Gen2 File System %q: %s", data.AccountName, data.Filesystem, err)
 			}

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
@@ -320,7 +320,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Read() sdk.ResourceFunc {
 			if storageAccount == nil {
 				return fmt.Errorf("Unable to locate Storage Account %q!", data.AccountName)
 			}
-			containerId := commonids.NewStorageContainerID(subscriptionId, storageAccount.ResourceGroup, data.AccountName, data.Filesystem)
+			containerId := commonids.NewStorageContainerID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, data.AccountName, data.Filesystem)
 			model.StorageContainerID = containerId.ID()
 
 			model.IsDefault = *data.IsDefault

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
@@ -303,7 +303,7 @@ func (r MachineLearningDataStoreFileShare) Read() sdk.ResourceFunc {
 			}
 			model.ServiceDataIdentity = serviceDataIdentity
 
-			storageAccount, err := storageClient.FindAccount(ctx, data.AccountName)
+			storageAccount, err := storageClient.FindAccount(ctx, subscriptionId, data.AccountName)
 			if err != nil {
 				return fmt.Errorf("retrieving Account %q for Share %q: %s", data.AccountName, data.FileShareName, err)
 			}

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
@@ -310,7 +310,7 @@ func (r MachineLearningDataStoreFileShare) Read() sdk.ResourceFunc {
 			if storageAccount == nil {
 				return fmt.Errorf("Unable to locate Storage Account %q!", data.AccountName)
 			}
-			fileShareId := storageparse.NewStorageShareResourceManagerID(subscriptionId, storageAccount.ResourceGroup, data.AccountName, "default", data.FileShareName)
+			fileShareId := storageparse.NewStorageShareResourceManagerID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, data.AccountName, "default", data.FileShareName)
 			model.StorageFileShareID = fileShareId.ID()
 
 			model.IsDefault = *data.IsDefault

--- a/internal/services/storage/client/client.go
+++ b/internal/services/storage/client/client.go
@@ -20,17 +20,20 @@ import (
 var StorageDomainSuffix *string
 
 type Client struct {
-	AccountsClient           *storage.AccountsClient
-	BlobServicesClient       *storage.BlobServicesClient
-	EncryptionScopesClient   *storage.EncryptionScopesClient
-	FileServicesClient       *storage.FileServicesClient
+	StorageDomainSuffix string
+
+	// NOTE: These SDK clients use `hashicorp/go-azure-sdk` and should be used going forwards
+	ResourceManager          *storage_v2023_01_01.Client
 	SyncCloudEndpointsClient *cloudendpointresource.CloudEndpointResourceClient
 	SyncGroupsClient         *syncgroupresource.SyncGroupResourceClient
 	SyncServiceClient        *storagesyncservicesresource.StorageSyncServicesResourceClient
 
-	ResourceManager *storage_v2023_01_01.Client
-
-	StorageDomainSuffix string
+	// NOTE: these SDK clients use the legacy `Azure/azure-sdk-for-go` and should no longer be used
+	// for new functionality - please instead use the `hashicorp/go-azure-sdk` clients above.
+	AccountsClient         *storage.AccountsClient
+	BlobServicesClient     *storage.BlobServicesClient
+	EncryptionScopesClient *storage.EncryptionScopesClient
+	FileServicesClient     *storage.FileServicesClient
 
 	authorizerForAad auth.Authorizer
 }

--- a/internal/services/storage/client/client.go
+++ b/internal/services/storage/client/client.go
@@ -30,10 +30,9 @@ type Client struct {
 
 	// NOTE: these SDK clients use the legacy `Azure/azure-sdk-for-go` and should no longer be used
 	// for new functionality - please instead use the `hashicorp/go-azure-sdk` clients above.
-	AccountsClient         *storage.AccountsClient
-	BlobServicesClient     *storage.BlobServicesClient
-	EncryptionScopesClient *storage.EncryptionScopesClient
-	FileServicesClient     *storage.FileServicesClient
+	AccountsClient     *storage.AccountsClient
+	BlobServicesClient *storage.BlobServicesClient
+	FileServicesClient *storage.FileServicesClient
 
 	authorizerForAad auth.Authorizer
 }
@@ -52,9 +51,6 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 
 	blobServicesClient := storage.NewBlobServicesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&blobServicesClient.Client, o.ResourceManagerAuthorizer)
-
-	encryptionScopesClient := storage.NewEncryptionScopesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&encryptionScopesClient.Client, o.ResourceManagerAuthorizer)
 
 	fileServicesClient := storage.NewFileServicesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&fileServicesClient.Client, o.ResourceManagerAuthorizer)
@@ -89,7 +85,6 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	client := Client{
 		AccountsClient:           &accountsClient,
 		BlobServicesClient:       &blobServicesClient,
-		EncryptionScopesClient:   &encryptionScopesClient,
 		FileServicesClient:       &fileServicesClient,
 		ResourceManager:          resourceManager,
 		SyncCloudEndpointsClient: syncCloudEndpointsClient,

--- a/internal/services/storage/client/data_plane.go
+++ b/internal/services/storage/client/data_plane.go
@@ -56,7 +56,7 @@ func (c Client) configureDataPlane(ctx context.Context, clientName string, baseC
 			return fmt.Errorf("retrieving Storage Account Key: %s", err)
 		}
 
-		storageAuth, err := auth.NewSharedKeyAuthorizer(account.name, *accountKey, operation.sharedKeyAuthenticationType)
+		storageAuth, err := auth.NewSharedKeyAuthorizer(account.StorageAccountId.StorageAccountName, *accountKey, operation.sharedKeyAuthenticationType)
 		if err != nil {
 			return fmt.Errorf("building Shared Key Authorizer for %s client: %+v", clientName, err)
 		}

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -32,7 +32,7 @@ const (
 )
 
 type accountDetails struct {
-	ID commonids.StorageAccountId
+	StorageAccountId commonids.StorageAccountId
 
 	Kind          storage.Kind
 	Sku           *storage.Sku
@@ -186,11 +186,11 @@ func populateAccountDetails(accountName string, props storage.Account) (*account
 	}
 
 	return &accountDetails{
-		name:          accountName,
-		ID:            *id,
-		Kind:          props.Kind,
-		Sku:           props.Sku,
-		ResourceGroup: id.ResourceGroupName,
-		Properties:    props.AccountProperties,
+		name:             accountName,
+		StorageAccountId: *id,
+		Kind:             props.Kind,
+		Sku:              props.Sku,
+		ResourceGroup:    id.ResourceGroupName,
+		Properties:       props.AccountProperties,
 	}, nil
 }

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -33,20 +33,30 @@ const (
 )
 
 type accountDetails struct {
-	Kind storage.Kind
-
-	// TODO: migrate to using IsHnsEnabled
-	Properties *storage.AccountProperties
-	// IsHnsEnabled     bool
-
+	Kind             storage.Kind
+	IsHnsEnabled     bool
 	StorageAccountId commonids.StorageAccountId
 
 	accountKey *string
 
-	primaryBlobEndpoint  *string
-	primaryDfsEndpoint   *string
-	primaryFileEndpoint  *string
+	// primaryBlobEndpoint is the Primary Blob Endpoint for the Data Plane API for this Storage Account
+	// e.g. `https://{account}.blob.core.windows.net`
+	primaryBlobEndpoint *string
+
+	// primaryDfsEndpoint is the Primary Dfs Endpoint for the Data Plane API for this Storage Account
+	// e.g. `https://sale.dfs.core.windows.net`
+	primaryDfsEndpoint *string
+
+	// primaryFileEndpoint is the Primary File Endpoint for the Data Plane API for this Storage Account
+	// e.g. `https://{account}.file.core.windows.net`
+	primaryFileEndpoint *string
+
+	// primaryQueueEndpoint is the Primary Queue Endpoint for the Data Plane API for this Storage Account
+	// e.g. `https://{account}.queue.core.windows.net`
 	primaryQueueEndpoint *string
+
+	// primaryTableEndpoint is the Primary Table Endpoint for the Data Plane API for this Storage Account
+	// e.g. `https://{account}.table.core.windows.net`
 	primaryTableEndpoint *string
 }
 
@@ -183,30 +193,30 @@ func populateAccountDetails(accountName string, props storage.Account) (*account
 		Kind:             props.Kind,
 	}
 
-	if props.AccountProperties != nil && props.AccountProperties.PrimaryEndpoints != nil {
-		if props.AccountProperties.PrimaryEndpoints.Blob != nil {
-			endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Blob, "/")
-			account.primaryBlobEndpoint = pointer.To(endpoint)
-		}
+	if props.AccountProperties != nil {
+		account.IsHnsEnabled = pointer.From(props.AccountProperties.IsHnsEnabled)
 
-		if props.AccountProperties.PrimaryEndpoints.Dfs != nil {
-			endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Dfs, "/")
-			account.primaryDfsEndpoint = pointer.To(endpoint)
-		}
-
-		if props.AccountProperties.PrimaryEndpoints.File != nil {
-			endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.File, "/")
-			account.primaryFileEndpoint = pointer.To(endpoint)
-		}
-
-		if props.AccountProperties.PrimaryEndpoints.Queue != nil {
-			endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Queue, "/")
-			account.primaryQueueEndpoint = pointer.To(endpoint)
-		}
-
-		if props.AccountProperties.PrimaryEndpoints.Table != nil {
-			endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Table, "/")
-			account.primaryTableEndpoint = pointer.To(endpoint)
+		if props.AccountProperties.PrimaryEndpoints != nil {
+			if props.AccountProperties.PrimaryEndpoints.Blob != nil {
+				endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Blob, "/")
+				account.primaryBlobEndpoint = pointer.To(endpoint)
+			}
+			if props.AccountProperties.PrimaryEndpoints.Dfs != nil {
+				endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Dfs, "/")
+				account.primaryDfsEndpoint = pointer.To(endpoint)
+			}
+			if props.AccountProperties.PrimaryEndpoints.File != nil {
+				endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.File, "/")
+				account.primaryFileEndpoint = pointer.To(endpoint)
+			}
+			if props.AccountProperties.PrimaryEndpoints.Queue != nil {
+				endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Queue, "/")
+				account.primaryQueueEndpoint = pointer.To(endpoint)
+			}
+			if props.AccountProperties.PrimaryEndpoints.Table != nil {
+				endpoint := strings.TrimSuffix(*props.AccountProperties.PrimaryEndpoints.Table, "/")
+				account.primaryTableEndpoint = pointer.To(endpoint)
+			}
 		}
 	}
 

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -32,7 +32,8 @@ const (
 )
 
 type accountDetails struct {
-	ID            string
+	ID commonids.StorageAccountId
+
 	Kind          storage.Kind
 	Sku           *storage.Sku
 	ResourceGroup string
@@ -186,7 +187,7 @@ func populateAccountDetails(accountName string, props storage.Account) (*account
 
 	return &accountDetails{
 		name:          accountName,
-		ID:            accountId,
+		ID:            *id,
 		Kind:          props.Kind,
 		Sku:           props.Sku,
 		ResourceGroup: id.ResourceGroupName,

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -189,31 +189,36 @@ func populateAccountDetails(accountId commonids.StorageAccountId, account storag
 		StorageAccountId: accountId,
 	}
 
-	if props := account.Properties; props != nil {
-		out.IsHnsEnabled = pointer.From(props.IsHnsEnabled)
+	if account.Properties == nil {
+		return nil, fmt.Errorf("populating details for %s: `model.Properties` was nil", accountId)
+	}
+	if account.Properties.PrimaryEndpoints == nil {
+		return nil, fmt.Errorf("populating details for %s: `model.Properties.PrimaryEndpoints` was nil", accountId)
+	}
 
-		if endpoints := props.PrimaryEndpoints; endpoints != nil {
-			if endpoints.Blob != nil {
-				endpoint := strings.TrimSuffix(*endpoints.Blob, "/")
-				out.primaryBlobEndpoint = pointer.To(endpoint)
-			}
-			if endpoints.Dfs != nil {
-				endpoint := strings.TrimSuffix(*endpoints.Dfs, "/")
-				out.primaryDfsEndpoint = pointer.To(endpoint)
-			}
-			if endpoints.File != nil {
-				endpoint := strings.TrimSuffix(*endpoints.File, "/")
-				out.primaryFileEndpoint = pointer.To(endpoint)
-			}
-			if endpoints.Queue != nil {
-				endpoint := strings.TrimSuffix(*endpoints.Queue, "/")
-				out.primaryQueueEndpoint = pointer.To(endpoint)
-			}
-			if endpoints.Table != nil {
-				endpoint := strings.TrimSuffix(*endpoints.Table, "/")
-				out.primaryTableEndpoint = pointer.To(endpoint)
-			}
-		}
+	props := *account.Properties
+	out.IsHnsEnabled = pointer.From(props.IsHnsEnabled)
+
+	endpoints := *props.PrimaryEndpoints
+	if endpoints.Blob != nil {
+		endpoint := strings.TrimSuffix(*endpoints.Blob, "/")
+		out.primaryBlobEndpoint = pointer.To(endpoint)
+	}
+	if endpoints.Dfs != nil {
+		endpoint := strings.TrimSuffix(*endpoints.Dfs, "/")
+		out.primaryDfsEndpoint = pointer.To(endpoint)
+	}
+	if endpoints.File != nil {
+		endpoint := strings.TrimSuffix(*endpoints.File, "/")
+		out.primaryFileEndpoint = pointer.To(endpoint)
+	}
+	if endpoints.Queue != nil {
+		endpoint := strings.TrimSuffix(*endpoints.Queue, "/")
+		out.primaryQueueEndpoint = pointer.To(endpoint)
+	}
+	if endpoints.Table != nil {
+		endpoint := strings.TrimSuffix(*endpoints.Table, "/")
+		out.primaryTableEndpoint = pointer.To(endpoint)
 	}
 
 	return &out, nil

--- a/internal/services/storage/storage_account_customer_managed_key_resource_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -159,6 +160,9 @@ func TestAccStorageAccountCustomerManagedKey_userAssignedIdentityWithFederatedId
 }
 
 func (r StorageAccountCustomerManagedKeyResource) accountHasDefaultSettings(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
 	accountId, err := commonids.ParseStorageAccountID(state.Attributes["id"])
 	if err != nil {
 		return err

--- a/internal/services/storage/storage_account_customer_managed_key_resource_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_test.go
@@ -186,7 +186,7 @@ func (r StorageAccountCustomerManagedKeyResource) accountHasDefaultSettings(ctx 
 				}
 
 				if encryption.KeySource != nil && *encryption.KeySource != storageaccounts.KeySourceMicrosoftPointStorage {
-					return fmt.Errorf("%q should be %q", encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointStorage))
+					return fmt.Errorf("%q should be %q", *encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointStorage))
 				}
 			} else {
 				return fmt.Errorf("storage account encryption properties not found")
@@ -219,7 +219,7 @@ func (r StorageAccountCustomerManagedKeyResource) Exists(ctx context.Context, cl
 					return utils.Bool(true), nil
 				}
 
-				return nil, fmt.Errorf("%q should be %q", encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointKeyvault))
+				return nil, fmt.Errorf("%q should be %q", *encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointKeyvault))
 			}
 		}
 	}

--- a/internal/services/storage/storage_account_customer_managed_key_resource_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_test.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -163,31 +164,33 @@ func (r StorageAccountCustomerManagedKeyResource) accountHasDefaultSettings(ctx 
 		return err
 	}
 
-	resp, err := client.Storage.AccountsClient.GetProperties(ctx, accountId.ResourceGroupName, accountId.StorageAccountName, "")
+	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *accountId, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
 		return fmt.Errorf("Bad: Get on storageServiceClient: %+v", err)
 	}
 
-	if utils.ResponseWasNotFound(resp.Response) {
+	if response.WasNotFound(resp.HttpResponse) {
 		return fmt.Errorf("Bad: %s does not exist", accountId)
 	}
 
-	if props := resp.AccountProperties; props != nil {
-		if encryption := props.Encryption; encryption != nil {
-			if services := encryption.Services; services != nil {
-				if !*services.Blob.Enabled {
-					return fmt.Errorf("enable_blob_encryption not set to default")
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if encryption := props.Encryption; encryption != nil {
+				if services := encryption.Services; services != nil {
+					if !*services.Blob.Enabled {
+						return fmt.Errorf("enable_blob_encryption not set to default")
+					}
+					if !*services.File.Enabled {
+						return fmt.Errorf("enable_file_encryption not set to default")
+					}
 				}
-				if !*services.File.Enabled {
-					return fmt.Errorf("enable_file_encryption not set to default")
-				}
-			}
 
-			if encryption.KeySource != storage.KeySourceMicrosoftStorage {
-				return fmt.Errorf("%q should be %q", encryption.KeySource, string(storage.KeySourceMicrosoftStorage))
+				if encryption.KeySource != nil && *encryption.KeySource != storageaccounts.KeySourceMicrosoftPointStorage {
+					return fmt.Errorf("%q should be %q", encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointStorage))
+				}
+			} else {
+				return fmt.Errorf("storage account encryption properties not found")
 			}
-		} else {
-			return fmt.Errorf("storage account encryption properties not found")
 		}
 	}
 
@@ -200,25 +203,25 @@ func (r StorageAccountCustomerManagedKeyResource) Exists(ctx context.Context, cl
 		return nil, err
 	}
 
-	resp, err := client.Storage.AccountsClient.GetProperties(ctx, accountId.ResourceGroupName, accountId.StorageAccountName, "")
+	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *accountId, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+
 		return nil, fmt.Errorf("Bad: Get on storageServiceClient: %+v", err)
 	}
 
-	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
-	}
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if encryption := props.Encryption; encryption != nil {
+				if encryption.KeySource != nil && *encryption.KeySource == storageaccounts.KeySourceMicrosoftPointKeyvault {
+					return utils.Bool(true), nil
+				}
 
-	if resp.AccountProperties == nil {
-		return nil, fmt.Errorf("storage account encryption properties not found")
-	}
-	props := *resp.AccountProperties
-	if encryption := props.Encryption; encryption != nil {
-		if encryption.KeySource == storage.KeySourceMicrosoftKeyvault {
-			return utils.Bool(true), nil
+				return nil, fmt.Errorf("%q should be %q", encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointKeyvault))
+			}
 		}
-
-		return nil, fmt.Errorf("%q should be %q", encryption.KeySource, string(storage.KeySourceMicrosoftKeyvault))
 	}
 
 	return utils.Bool(false), nil

--- a/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -186,27 +189,26 @@ func (r StorageAccountNetworkRulesResource) Exists(ctx context.Context, client *
 		return nil, err
 	}
 
-	resp, err := client.Storage.AccountsClient.GetProperties(ctx, id.ResourceGroupName, id.StorageAccountName, "")
+	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if resp.AccountProperties == nil {
-		return utils.Bool(false), nil
-	}
-
-	rule := resp.AccountProperties.NetworkRuleSet
-	if rule == nil {
-		return utils.Bool(false), nil
-	}
-
-	if (rule.IPRules != nil && len(*rule.IPRules) != 0) ||
-		(rule.VirtualNetworkRules != nil && len(*rule.VirtualNetworkRules) != 0) ||
-		rule.Bypass != "AzureServices" || rule.DefaultAction != "Allow" {
-		return utils.Bool(true), nil
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if acls := props.NetworkAcls; acls != nil {
+				hasIPRules := acls.IPRules != nil && len(*acls.IPRules) > 0
+				usesNonDefaultAction := acls.DefaultAction != storageaccounts.DefaultActionAllow
+				usesNonDefaultBypass := acls.Bypass != nil && *acls.Bypass != storageaccounts.BypassAzureServices
+				hasVirtualNetworkRules := acls.VirtualNetworkRules != nil && len(*acls.VirtualNetworkRules) > 0
+				if hasIPRules || usesNonDefaultAction || usesNonDefaultBypass || hasVirtualNetworkRules {
+					return pointer.To(true), nil
+				}
+			}
+		}
 	}
 
 	return utils.Bool(false), nil

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	azautorest "github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1551,7 +1551,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	if err := storageClient.AddToCache(id.StorageAccountName, account); err != nil {
+	if err := storageClient.AddToCache(id, account); err != nil {
 		return fmt.Errorf("populating cache for %s: %+v", id, err)
 	}
 
@@ -2425,7 +2425,7 @@ func resourceStorageAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// remove this from the cache
-	storageClient.RemoveAccountFromCache(id.StorageAccountName)
+	storageClient.RemoveAccountFromCache(*id)
 
 	return nil
 }

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
+	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	azautorest "github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -148,8 +148,8 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"Standard",
-					"Premium",
+					string(storage.SkuTierStandard),
+					string(storage.SkuTierPremium),
 				}, false),
 			},
 
@@ -1277,7 +1277,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 
 				if d.Get("access_tier") != "" {
-					if accountKind := d.Get("account_kind").(string); !slices.Contains(storageKindsSupportsSkuTier, storage.Kind(accountKind)) {
+					if accountKind := storage.Kind(d.Get("account_kind").(string)); !slices.Contains(storageKindsSupportsSkuTier, accountKind) {
 						return fmt.Errorf("`access_tier` is only available for accounts of kind: %v", storageKindsSupportsSkuTier)
 					}
 				}
@@ -1329,7 +1329,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return tf.ImportAsExistsError("azurerm_storage_account", id.ID())
 	}
 
-	accountKind := d.Get("account_kind").(string)
+	accountKind := storage.Kind(d.Get("account_kind").(string))
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 	enableHTTPSTrafficOnly := d.Get("enable_https_traffic_only").(bool)
@@ -1347,7 +1347,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 	dnsEndpointType := d.Get("dns_endpoint_type").(string)
 
-	accountTier := d.Get("account_tier").(string)
+	accountTier := storage.SkuTier(d.Get("account_tier").(string))
 	replicationType := d.Get("account_replication_type").(string)
 	storageType := fmt.Sprintf("%s_%s", accountTier, replicationType)
 
@@ -1358,7 +1358,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			Name: storage.SkuName(storageType),
 		},
 		Tags: tags.Expand(t),
-		Kind: storage.Kind(accountKind),
+		Kind: accountKind,
 		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
 			PublicNetworkAccess:          publicNetworkAccess,
 			EnableHTTPSTrafficOnly:       &enableHTTPSTrafficOnly,
@@ -1416,14 +1416,14 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// BlobStorage does not support ZRS
-	if accountKind == string(storage.KindBlobStorage) {
+	if accountKind == storage.KindBlobStorage {
 		if string(parameters.Sku.Name) == string(storage.SkuNameStandardZRS) {
 			return fmt.Errorf("a `account_replication_type` of `ZRS` isn't supported for Blob Storage accounts")
 		}
 	}
 
 	accessTier, ok := d.GetOk("access_tier")
-	if slices.Contains(storageKindsSupportsSkuTier, storage.Kind(accountKind)) {
+	if slices.Contains(storageKindsSupportsSkuTier, accountKind) {
 		if !ok {
 			// default to "Hot"
 			accessTier = string(storage.AccessTierHot)
@@ -1433,15 +1433,15 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("`access_tier` is only available for accounts of kind: %v", storageKindsSupportsSkuTier)
 	}
 
-	if isHnsEnabled && !slices.Contains(storageKindsSupportHns, storage.Kind(accountKind)) {
+	if isHnsEnabled && !slices.Contains(storageKindsSupportHns, accountKind) {
 		return fmt.Errorf("`is_hns_enabled` can only be used with account of kinds: %v", storageKindsSupportHns)
 	}
 
 	// NFSv3 is supported for standard general-purpose v2 storage accounts and for premium block blob storage accounts.
 	// (https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to#step-5-create-and-configure-a-storage-account)
 	if nfsV3Enabled &&
-		!((accountTier == string(storage.SkuTierPremium) && accountKind == string(storage.KindBlockBlobStorage)) ||
-			(accountTier == string(storage.SkuTierStandard) && accountKind == string(storage.KindStorageV2))) {
+		!((accountTier == storage.SkuTierPremium && accountKind == storage.KindBlockBlobStorage) ||
+			(accountTier == storage.SkuTierStandard && accountKind == storage.KindStorageV2)) {
 		return fmt.Errorf("`nfsv3_enabled` can only be used with account tier `Standard` and account kind `StorageV2`, or account tier `Premium` and account kind `BlockBlobStorage`")
 	}
 	if nfsV3Enabled && !isHnsEnabled {
@@ -1449,7 +1449,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// AccountTier must be Premium for FileStorage
-	if accountKind == string(storage.KindFileStorage) {
+	if accountKind == storage.KindFileStorage {
 		if string(parameters.Sku.Tier) == string(storage.SkuNameStandardLRS) {
 			return fmt.Errorf("a `account_tier` of `Standard` is not supported for FileStorage accounts")
 		}
@@ -1472,7 +1472,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// for encryption of blob, file, table and queue
 	var encryption *storage.Encryption
 	if v, ok := d.GetOk("customer_managed_key"); ok {
-		if accountTier != string(storage.AccessTierPremium) && accountKind != string(storage.KindStorageV2) {
+		if accountTier != storage.SkuTierPremium && accountKind != storage.KindStorageV2 {
 			return fmt.Errorf("customer managed key can only be used with account kind `StorageV2` or account tier `Premium`")
 		}
 		if storageAccountIdentity.Type != storage.IdentityTypeUserAssigned && storageAccountIdentity.Type != storage.IdentityTypeSystemAssignedUserAssigned {
@@ -1491,7 +1491,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	queueEncryptionKeyType := d.Get("queue_encryption_key_type").(string)
 	tableEncryptionKeyType := d.Get("table_encryption_key_type").(string)
 
-	if accountKind != string(storage.KindStorageV2) {
+	if accountKind != storage.KindStorageV2 {
 		if queueEncryptionKeyType == string(storage.KeyTypeAccount) {
 			return fmt.Errorf("`queue_encryption_key_type = \"Account\"` can only be used with account kind `StorageV2`")
 		}
@@ -1525,8 +1525,8 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	infrastructureEncryption := d.Get("infrastructure_encryption_enabled").(bool)
 
 	if infrastructureEncryption {
-		if !((accountTier == string(storage.SkuTierPremium) && (accountKind == string(storage.KindBlockBlobStorage)) || accountKind == string(storage.KindFileStorage)) ||
-			(accountKind == string(storage.KindStorageV2))) {
+		if !((accountTier == storage.SkuTierPremium && (accountKind == storage.KindBlockBlobStorage) || accountKind == storage.KindFileStorage) ||
+			(accountKind == storage.KindStorageV2)) {
 			return fmt.Errorf("`infrastructure_encryption_enabled` can only be used with account kind `StorageV2`, or account tier `Premium` and account kind is one of `BlockBlobStorage` or `FileStorage`")
 		}
 		encryption.RequireInfrastructureEncryption = &infrastructureEncryption
@@ -1555,7 +1555,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("populating cache for %s: %+v", id, err)
 	}
 
-	supportLevel := resolveStorageAccountServiceSupportLevel(storage.Kind(accountKind), storage.SkuTier(accountTier))
+	supportLevel := resolveStorageAccountServiceSupportLevel(accountKind, accountTier)
 
 	if val, ok := d.GetOk("blob_properties"); ok {
 		if !supportLevel.supportBlob {
@@ -1563,7 +1563,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		blobClient := meta.(*clients.Client).Storage.BlobServicesClient
 
-		blobProperties, err := expandBlobProperties(storage.Kind(accountKind), val.([]interface{}))
+		blobProperties, err := expandBlobProperties(accountKind, val.([]interface{}))
 		if err != nil {
 			return err
 		}
@@ -1630,7 +1630,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		shareProperties := expandShareProperties(val.([]interface{}))
 
 		// The API complains if any multichannel info is sent on non premium fileshares. Even if multichannel is set to false
-		if accountTier != string(storage.SkuTierPremium) && shareProperties.FileServicePropertiesProperties != nil && shareProperties.FileServicePropertiesProperties.ProtocolSettings != nil {
+		if accountTier != storage.SkuTierPremium && shareProperties.FileServicePropertiesProperties != nil && shareProperties.FileServicePropertiesProperties.ProtocolSettings != nil {
 			// Error if the user has tried to enable multichannel on a standard tier storage account
 			smb := shareProperties.FileServicePropertiesProperties.ProtocolSettings.Smb
 			if smb != nil && smb.Multichannel != nil {
@@ -1693,12 +1693,12 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	locks.ByName(id.StorageAccountName, storageAccountResourceName)
 	defer locks.UnlockByName(id.StorageAccountName, storageAccountResourceName)
 
-	accountTier := d.Get("account_tier").(string)
+	accountTier := storage.SkuTier(d.Get("account_tier").(string))
 	replicationType := d.Get("account_replication_type").(string)
 	storageType := fmt.Sprintf("%s_%s", accountTier, replicationType)
-	accountKind := d.Get("account_kind").(string)
+	accountKind := storage.Kind(d.Get("account_kind").(string))
 
-	if accountKind == string(storage.KindBlobStorage) || accountKind == string(storage.KindStorage) {
+	if accountKind == storage.KindBlobStorage || accountKind == storage.KindStorage {
 		if storageType == string(storage.SkuNameStandardZRS) {
 			return fmt.Errorf("an `account_replication_type` of `ZRS` isn't supported for Blob Storage accounts")
 		}
@@ -1781,7 +1781,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("account_kind") {
-		params.Kind = storage.Kind(accountKind)
+		params.Kind = accountKind
 	}
 
 	if d.HasChange("access_tier") {
@@ -1932,7 +1932,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// Followings are updates to the sub-services
-	supportLevel := resolveStorageAccountServiceSupportLevel(storage.Kind(accountKind), storage.SkuTier(accountTier))
+	supportLevel := resolveStorageAccountServiceSupportLevel(accountKind, accountTier)
 
 	if d.HasChange("blob_properties") {
 		if !supportLevel.supportBlob {
@@ -1940,7 +1940,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		blobClient := meta.(*clients.Client).Storage.BlobServicesClient
-		blobProperties, err := expandBlobProperties(storage.Kind(accountKind), d.Get("blob_properties").([]interface{}))
+		blobProperties, err := expandBlobProperties(accountKind, d.Get("blob_properties").([]interface{}))
 		if err != nil {
 			return err
 		}
@@ -1992,7 +1992,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 		shareProperties := expandShareProperties(d.Get("share_properties").([]interface{}))
 		// The API complains if any multichannel info is sent on non premium fileshares. Even if multichannel is set to false
-		if accountTier != string(storage.SkuTierPremium) {
+		if accountTier != storage.SkuTierPremium {
 			// Error if the user has tried to enable multichannel on a standard tier storage account
 			if shareProperties.FileServicePropertiesProperties.ProtocolSettings.Smb.Multichannel != nil && shareProperties.FileServicePropertiesProperties.ProtocolSettings.Smb.Multichannel.Enabled != nil {
 				if *shareProperties.FileServicePropertiesProperties.ProtocolSettings.Smb.Multichannel.Enabled {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -11,7 +11,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -1614,9 +1616,9 @@ func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Clie
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Storage.AccountsClient.GetProperties(ctx, id.ResourceGroupName, id.StorageAccountName, "")
+	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
@@ -1629,7 +1631,7 @@ func (r StorageAccountResource) Destroy(ctx context.Context, client *clients.Cli
 	if err != nil {
 		return nil, err
 	}
-	if _, err := client.Storage.AccountsClient.Delete(ctx, id.ResourceGroupName, id.StorageAccountName); err != nil {
+	if _, err := client.Storage.ResourceManager.StorageAccounts.Delete(ctx, *id); err != nil {
 		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 	return utils.Bool(true), nil

--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -75,6 +75,7 @@ func dataSourceStorageBlob() *pluginsdk.Resource {
 
 func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -82,7 +83,7 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	containerName := d.Get("storage_container_name").(string)
 	name := d.Get("name").(string)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %v", accountName, name, containerName, err)
 	}

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -169,6 +169,7 @@ func resourceStorageBlob() *pluginsdk.Resource {
 
 func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -176,7 +177,7 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	containerName := d.Get("storage_container_name").(string)
 	name := d.Get("name").(string)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Blob %q (Container %q): %v", accountName, name, containerName, err)
 	}
@@ -250,6 +251,7 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -258,7 +260,7 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("parsing %q: %v", d.Id(), err)
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %v", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}
@@ -323,6 +325,7 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -331,7 +334,7 @@ func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		return fmt.Errorf("parsing %q: %v", d.Id(), err)
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %v", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}
@@ -394,6 +397,7 @@ func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 func resourceStorageBlobDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -402,7 +406,7 @@ func resourceStorageBlobDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("parsing %q: %v", d.Id(), err)
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %s", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -495,7 +495,7 @@ func (r StorageBlobResource) Exists(ctx context.Context, client *clients.Client,
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func (r StorageBlobResource) Destroy(ctx context.Context, client *clients.Client
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %+v", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}
@@ -562,7 +562,7 @@ func (r StorageBlobResource) blobMatchesContent(kind blobs.BlobType, expectedCon
 		containerName := state.Attributes["storage_container_name"]
 		accountName := state.Attributes["storage_account_name"]
 
-		account, err := clients.Storage.FindAccount(ctx, accountName)
+		account, err := clients.Storage.FindAccount(ctx, clients.Account.SubscriptionId, accountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 		}

--- a/internal/services/storage/storage_container_data_source.go
+++ b/internal/services/storage/storage_container_data_source.go
@@ -63,13 +63,14 @@ func dataSourceStorageContainer() *pluginsdk.Resource {
 
 func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	containerName := d.Get("name").(string)
 	accountName := d.Get("storage_account_name").(string)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Container %q: %v", accountName, containerName, err)
 	}

--- a/internal/services/storage/storage_container_data_source.go
+++ b/internal/services/storage/storage_container_data_source.go
@@ -117,7 +117,7 @@ func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{})
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
 
-	resourceManagerId := commonids.NewStorageContainerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, containerName)
+	resourceManagerId := commonids.NewStorageContainerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, containerName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_container_data_source.go
+++ b/internal/services/storage/storage_container_data_source.go
@@ -117,11 +117,7 @@ func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{})
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
 
-	storageAccountId, err := commonids.ParseStorageAccountIDInsensitively(account.ID)
-	if err != nil {
-		return err
-	}
-	resourceManagerId := commonids.NewStorageContainerID(storageAccountId.SubscriptionId, storageAccountId.ResourceGroupName, storageAccountId.StorageAccountName, containerName)
+	resourceManagerId := commonids.NewStorageContainerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, containerName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -216,7 +216,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -95,6 +95,7 @@ func resourceStorageContainer() *pluginsdk.Resource {
 
 func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -106,7 +107,7 @@ func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{})
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Container %q: %v", accountName, containerName, err)
 	}
@@ -158,6 +159,7 @@ func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{})
 
 func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -166,7 +168,7 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Container %q: %v", id.AccountId.AccountName, id.ContainerName, err)
 	}
@@ -216,6 +218,7 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -224,7 +227,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Container %q: %v", id.AccountId.AccountName, id.ContainerName, err)
 	}
@@ -269,6 +272,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 func resourceStorageContainerDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -277,7 +281,7 @@ func resourceStorageContainerDelete(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Container %q: %v", id.AccountId.AccountName, id.ContainerName, err)
 	}

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -245,7 +245,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("retrieving %s: %v", id, err)
 	}
 	if props == nil {
-		log.Printf("[DEBUG] Container %q was not found in Account %q / Resource Group %q - assuming removed & removing from state", id.ContainerName, id.AccountId.AccountName, account.ResourceGroup)
+		log.Printf("[DEBUG] Container %q was not found in %s - assuming removed & removing from state", id.ContainerName, id.AccountId)
 		d.SetId("")
 		return nil
 	}
@@ -262,7 +262,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
 
-	resourceManagerId := commonids.NewStorageContainerID(subscriptionId, account.ResourceGroup, id.AccountId.AccountName, id.ContainerName)
+	resourceManagerId := commonids.NewStorageContainerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, id.ContainerName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -207,7 +207,7 @@ func (r StorageContainerResource) Exists(ctx context.Context, client *clients.Cl
 
 	prop, err := containersClient.Get(ctx, id.ContainerName)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Container %q (Account %q / Resource Group %q): %+v", id.ContainerName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving Container %q in %s: %+v", id.ContainerName, id.AccountId, err)
 	}
 
 	return utils.Bool(prop != nil), nil
@@ -233,7 +233,7 @@ func (r StorageContainerResource) Destroy(ctx context.Context, client *clients.C
 	}
 
 	if err = containersClient.Delete(ctx, id.ContainerName); err != nil {
-		return nil, fmt.Errorf("deleting Container %q (Account %q / Resource Group %q): %+v", id.ContainerName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("deleting Container %q in %s: %+v", id.ContainerName, id.AccountId, err)
 	}
 
 	return utils.Bool(true), nil

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -192,7 +192,7 @@ func (r StorageContainerResource) Exists(ctx context.Context, client *clients.Cl
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Container %q: %+v", id.AccountId.AccountName, id.ContainerName, err)
 	}
@@ -219,7 +219,7 @@ func (r StorageContainerResource) Destroy(ctx context.Context, client *clients.C
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Container %q: %+v", id.AccountId.AccountName, id.ContainerName, err)
 	}

--- a/internal/services/storage/storage_containers_data_source.go
+++ b/internal/services/storage/storage_containers_data_source.go
@@ -89,6 +89,7 @@ func (r storageContainersDataSource) Read() sdk.ResourceFunc {
 
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			blobContainersClient := metadata.Client.Storage.ResourceManager.BlobContainers
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			var plan storageContainersDataSourceModel
 			if err := metadata.Decode(&plan); err != nil {
@@ -100,7 +101,7 @@ func (r storageContainersDataSource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			account, err := metadata.Client.Storage.FindAccount(ctx, id.StorageAccountName)
+			account, err := metadata.Client.Storage.FindAccount(ctx, subscriptionId, id.StorageAccountName)
 			if err != nil {
 				return fmt.Errorf("retrieving Storage Account %q: %v", id.StorageAccountName, err)
 			}

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -53,7 +53,7 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("unable to locate Storage Account: %q", id.AccountId.AccountName)
 			}
 
-			d.Set("storage_account_id", account.ID)
+			d.Set("storage_account_id", account.ID.ID())
 
 			return []*pluginsdk.ResourceData{d}, nil
 		}),

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -38,6 +38,7 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 			return err
 		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
 			storageClient := meta.(*clients.Client).Storage
+			subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 
 			id, err := filesystems.ParseFileSystemID(d.Id(), storageClient.StorageDomainSuffix)
 			if err != nil {
@@ -45,7 +46,7 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 			}
 
 			// we then need to look up the Storage Account ID
-			account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+			account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 			if err != nil {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("retrieving Account %q for Data Lake Gen2 File System %q: %s", id.AccountId.AccountName, id.FileSystemName, err)
 			}
@@ -132,6 +133,7 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 
 func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -144,7 +146,7 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	// Confirm the storage account exists and retrieve its properties
-	account, err := storageClient.FindAccount(ctx, accountResourceManagerId.StorageAccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountResourceManagerId.StorageAccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", accountResourceManagerId.StorageAccountName, filesystemName, err)
 	}
@@ -244,6 +246,7 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta
 
 func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -253,7 +256,7 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}
@@ -325,6 +328,7 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta
 
 func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -334,7 +338,7 @@ func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta i
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}
@@ -398,6 +402,7 @@ func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta i
 
 func resourceStorageDataLakeGen2FileSystemDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -407,7 +412,7 @@ func resourceStorageDataLakeGen2FileSystemDelete(d *pluginsdk.ResourceData, meta
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -53,7 +53,7 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("unable to locate Storage Account: %q", id.AccountId.AccountName)
 			}
 
-			d.Set("storage_account_id", account.ID.ID())
+			d.Set("storage_account_id", account.StorageAccountId.ID())
 
 			return []*pluginsdk.ResourceData{d}, nil
 		}),

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -153,7 +153,7 @@ func (r StorageDataLakeGen2FileSystemResource) Exists(ctx context.Context, clien
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId, id.FileSystemName, err)
 	}
@@ -183,7 +183,7 @@ func (r StorageDataLakeGen2FileSystemResource) Destroy(ctx context.Context, clie
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId, id.FileSystemName, err)
 	}

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -35,6 +35,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 			_, err := paths.ParsePathID(id, storageDomainSuffix)
 			return err
 		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+			subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 			ctx, cancel := context.WithTimeout(ctx, d.Timeout(pluginsdk.TimeoutRead))
 			defer cancel()
 
@@ -46,7 +47,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 			}
 
 			// Retrieve the storage account
-			account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+			account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 			if err != nil {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("retrieving Account %q for Data Lake Gen2 Path %q in File System %q: %s", id.AccountId.AccountName, id.Path, id.FileSystemName, err)
 			}
@@ -155,6 +156,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 
 func resourceStorageDataLakeGen2PathCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -168,7 +170,7 @@ func resourceStorageDataLakeGen2PathCreate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	// Confirm the storage account exists and retrieve its properties
-	account, err := storageClient.FindAccount(ctx, accountResourceManagerId.StorageAccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountResourceManagerId.StorageAccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", accountResourceManagerId.StorageAccountName, filesystemName, err)
 	}
@@ -263,6 +265,7 @@ func resourceStorageDataLakeGen2PathCreate(d *pluginsdk.ResourceData, meta inter
 
 func resourceStorageDataLakeGen2PathUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -272,7 +275,7 @@ func resourceStorageDataLakeGen2PathUpdate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}
@@ -326,6 +329,7 @@ func resourceStorageDataLakeGen2PathUpdate(d *pluginsdk.ResourceData, meta inter
 
 func resourceStorageDataLakeGen2PathRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -335,7 +339,7 @@ func resourceStorageDataLakeGen2PathRead(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}
@@ -389,6 +393,7 @@ func resourceStorageDataLakeGen2PathRead(d *pluginsdk.ResourceData, meta interfa
 
 func resourceStorageDataLakeGen2PathDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -398,7 +403,7 @@ func resourceStorageDataLakeGen2PathDelete(d *pluginsdk.ResourceData, meta inter
 	}
 
 	// Retrieve the storage account properties
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Data Lake Gen2 Filesystem %q: %v", id.AccountId.AccountName, id.FileSystemName, err)
 	}

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -64,7 +64,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("retrieving File System %q for Data Lake Gen2 Path %q in Account %q: %s", id.FileSystemName, id.Path, id.AccountId.AccountName, err)
 			}
 
-			d.Set("storage_account_id", account.ID)
+			d.Set("storage_account_id", account.ID.ID())
 			d.Set("filesystem_name", id.FileSystemName)
 
 			return []*pluginsdk.ResourceData{d}, nil

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -64,7 +64,7 @@ func resourceStorageDataLakeGen2Path() *pluginsdk.Resource {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("retrieving File System %q for Data Lake Gen2 Path %q in Account %q: %s", id.FileSystemName, id.Path, id.AccountId.AccountName, err)
 			}
 
-			d.Set("storage_account_id", account.ID.ID())
+			d.Set("storage_account_id", account.StorageAccountId.ID())
 			d.Set("filesystem_name", id.FileSystemName)
 
 			return []*pluginsdk.ResourceData{d}, nil

--- a/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
@@ -137,7 +137,7 @@ func (r StorageDataLakeGen2PathResource) Exists(ctx context.Context, client *cli
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId, id.FileSystemName, err)
 	}

--- a/internal/services/storage/storage_encryption_scope_data_source.go
+++ b/internal/services/storage/storage_encryption_scope_data_source.go
@@ -5,15 +5,16 @@ package storage
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceStorageEncryptionScope() *pluginsdk.Resource {
@@ -51,7 +52,7 @@ func dataSourceStorageEncryptionScope() *pluginsdk.Resource {
 }
 
 func dataSourceStorageEncryptionScopeRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Storage.EncryptionScopesClient
+	client := meta.(*clients.Client).Storage.ResourceManager.EncryptionScopes
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -61,9 +62,9 @@ func dataSourceStorageEncryptionScopeRead(d *pluginsdk.ResourceData, meta interf
 	}
 
 	id := encryptionscopes.NewEncryptionScopeID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.StorageAccountName, d.Get("name").(string))
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.StorageAccountName, id.EncryptionScopeName)
+	resp, err := client.Get(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 
@@ -72,15 +73,16 @@ func dataSourceStorageEncryptionScopeRead(d *pluginsdk.ResourceData, meta interf
 
 	d.SetId(id.ID())
 
-	if props := resp.EncryptionScopeProperties; props != nil {
-		d.Set("source", flattenEncryptionScopeSource(props.Source))
-		var keyId string
-		if kv := props.KeyVaultProperties; kv != nil {
-			if kv.KeyURI != nil {
-				keyId = *kv.KeyURI
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			keyVaultKeyUri := ""
+			if props.KeyVaultProperties != nil && props.KeyVaultProperties.KeyUri != nil {
+				keyVaultKeyUri = *props.KeyVaultProperties.KeyUri
 			}
+			d.Set("key_vault_key_id", keyVaultKeyUri)
+
+			d.Set("source", string(pointer.From(props.Source)))
 		}
-		d.Set("key_vault_key_id", keyId)
 	}
 
 	return nil

--- a/internal/services/storage/storage_encryption_scope_data_source.go
+++ b/internal/services/storage/storage_encryption_scope_data_source.go
@@ -5,9 +5,9 @@ package storage
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes"

--- a/internal/services/storage/storage_encryption_scope_resource_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_test.go
@@ -6,10 +6,8 @@ package storage_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/encryptionscopes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -189,14 +187,14 @@ func (t StorageEncryptionScopeResource) Exists(ctx context.Context, clients *cli
 		return nil, err
 	}
 
-	resp, err := clients.Storage.EncryptionScopesClient.Get(ctx, id.ResourceGroupName, id.StorageAccountName, id.EncryptionScopeName)
+	resp, err := clients.Storage.ResourceManager.EncryptionScopes.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	enabled := false
-	if resp.EncryptionScopeProperties != nil {
-		enabled = strings.EqualFold(string(resp.EncryptionScopeProperties.State), string(storage.EncryptionScopeStateEnabled))
+	if model := resp.Model; model != nil && model.Properties != nil && model.Properties.State != nil {
+		enabled = *model.Properties.State == encryptionscopes.EncryptionScopeStateEnabled
 	}
 
 	return utils.Bool(enabled), nil

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -201,7 +201,7 @@ func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("setting `metadata`: %s", err)
 	}
 
-	resourceManagerId := parse.NewStorageQueueResourceManagerID(subscriptionId, account.ResourceGroup, id.AccountId.AccountName, "default", id.QueueName)
+	resourceManagerId := parse.NewStorageQueueResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, "default", id.QueueName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -72,6 +72,7 @@ func resourceStorageQueue() *pluginsdk.Resource {
 
 func resourceStorageQueueCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -81,7 +82,7 @@ func resourceStorageQueueCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Queue %q: %v", accountName, queueName, err)
 	}
@@ -127,6 +128,7 @@ func resourceStorageQueueCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -138,7 +140,7 @@ func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
 	}
@@ -160,6 +162,7 @@ func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -168,7 +171,7 @@ func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
 	}
@@ -208,6 +211,7 @@ func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 func resourceStorageQueueDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -216,7 +220,7 @@ func resourceStorageQueueDelete(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Queue %q: %s", id.AccountId.AccountName, id.QueueName, err)
 	}

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -160,7 +160,6 @@ func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/storage/storage_queue_resource_test.go
+++ b/internal/services/storage/storage_queue_resource_test.go
@@ -90,7 +90,7 @@ func (r StorageQueueResource) Exists(ctx context.Context, client *clients.Client
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId.AccountName, id.QueueName, err)
 	}

--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -85,13 +85,14 @@ func dataSourceStorageShare() *pluginsdk.Resource {
 
 func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	shareName := d.Get("name").(string)
 	accountName := d.Get("storage_account_name").(string)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Share %q: %s", accountName, shareName, err)
 	}

--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
@@ -140,11 +139,7 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("setting `metadata`: %v", err)
 	}
 
-	storageAccountId, err := commonids.ParseStorageAccountIDInsensitively(account.ID)
-	if err != nil {
-		return err
-	}
-	resourceManagerId := parse.NewStorageShareResourceManagerID(storageAccountId.SubscriptionId, storageAccountId.ResourceGroupName, storageAccountId.StorageAccountName, "default", shareName)
+	resourceManagerId := parse.NewStorageShareResourceManagerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, "default", shareName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -139,7 +139,7 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("setting `metadata`: %v", err)
 	}
 
-	resourceManagerId := parse.NewStorageShareResourceManagerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, "default", shareName)
+	resourceManagerId := parse.NewStorageShareResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", shareName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_share_directory_resource.go
+++ b/internal/services/storage/storage_share_directory_resource.go
@@ -90,9 +90,10 @@ func resourceStorageShareDirectory() *pluginsdk.Resource {
 }
 
 func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	directoryName := d.Get("name").(string)
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
@@ -106,11 +107,12 @@ func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interfa
 			return err
 		}
 	} else {
+
 		// TODO: this is needed until `share_name` / `storage_account_name` are removed in favor of `storage_share_id` in v4.0
 		// we will retrieve the storage account twice but this will make it easier to refactor later
 		storageAccountName := d.Get("storage_account_name").(string)
 
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccount(ctx, subscriptionId, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %v", storageAccountName, err)
 		}
@@ -137,7 +139,7 @@ func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("determining storage share ID")
 	}
 
-	account, err := storageClient.FindAccount(ctx, storageShareId.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, storageShareId.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Directory %q (Share %q): %v", storageShareId.AccountId.AccountName, directoryName, storageShareId.ShareName, err)
 	}
@@ -196,9 +198,10 @@ func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interfa
 }
 
 func resourceStorageShareDirectoryUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := directories.ParseDirectoryID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
@@ -208,7 +211,7 @@ func resourceStorageShareDirectoryUpdate(d *pluginsdk.ResourceData, meta interfa
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Directory %q (Share %q): %v", id.AccountId.AccountName, id.DirectoryPath, id.ShareName, err)
 	}
@@ -229,16 +232,17 @@ func resourceStorageShareDirectoryUpdate(d *pluginsdk.ResourceData, meta interfa
 }
 
 func resourceStorageShareDirectoryRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := directories.ParseDirectoryID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Directory %q (Share %q): %v", id.AccountId.AccountName, id.DirectoryPath, id.ShareName, err)
 	}
@@ -285,16 +289,17 @@ func resourceStorageShareDirectoryRead(d *pluginsdk.ResourceData, meta interface
 }
 
 func resourceStorageShareDirectoryDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := directories.ParseDirectoryID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Directory %q (Share %q): %v", id.AccountId.AccountName, id.DirectoryPath, id.ShareName, err)
 	}

--- a/internal/services/storage/storage_share_directory_resource_test.go
+++ b/internal/services/storage/storage_share_directory_resource_test.go
@@ -194,14 +194,14 @@ func (r StorageShareDirectoryResource) Exists(ctx context.Context, client *clien
 	}
 	dirClient, err := client.Storage.FileShareDirectoriesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return nil, fmt.Errorf("building File Share client for Storage Account %q (Resource Group %q): %+v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("building File Share client for %s: %+v", account.StorageAccountId, err)
 	}
 	resp, err := dirClient.Get(ctx, id.ShareName, id.DirectoryPath)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retrieving Storage Share %q (File Share %q / Account %q / Resource Group %q): %s", id.DirectoryPath, id.ShareName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving Storage Share %q (File Share %q in %s): %+v", id.DirectoryPath, id.ShareName, account.StorageAccountId, err)
 	}
 	return utils.Bool(true), nil
 }

--- a/internal/services/storage/storage_share_directory_resource_test.go
+++ b/internal/services/storage/storage_share_directory_resource_test.go
@@ -185,7 +185,7 @@ func (r StorageShareDirectoryResource) Exists(ctx context.Context, client *clien
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Directory %q (Share %q): %s", id.AccountId.AccountName, id.DirectoryPath, id.ShareName, err)
 	}

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -107,9 +107,10 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 }
 
 func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	storageShareId, err := shares.ParseShareID(d.Get("storage_share_id").(string), storageClient.StorageDomainSuffix)
 	if err != nil {
@@ -119,7 +120,7 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	fileName := d.Get("name").(string)
 	path := d.Get("path").(string)
 
-	account, err := storageClient.FindAccount(ctx, storageShareId.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, storageShareId.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for File %q (Share %q): %v", storageShareId.AccountId.AccountName, fileName, storageShareId.ShareName, err)
 	}
@@ -196,16 +197,17 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 }
 
 func resourceStorageShareFileUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := files.ParseFileID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for %s: %v", id.AccountId.AccountName, id, err)
 	}
@@ -247,16 +249,17 @@ func resourceStorageShareFileUpdate(d *pluginsdk.ResourceData, meta interface{})
 }
 
 func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := files.ParseFileID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for File %q (Share %q): %s", id.AccountId.AccountName, id.FileName, id.ShareName, err)
 	}
@@ -300,16 +303,17 @@ func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourceStorageShareFileDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := files.ParseFileID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for File %q (Share %q): %v", id.AccountId.AccountName, id.FileName, id.ShareName, err)
 	}

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -319,7 +319,7 @@ func resourceStorageShareFileDelete(d *pluginsdk.ResourceData, meta interface{})
 
 	client, err := storageClient.FileShareFilesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return fmt.Errorf("building File Share File Client for Storage Account %q (Resource Group %q): %v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building File Share File Client for %s: %v", account.StorageAccountId, err)
 	}
 
 	if _, err = client.Delete(ctx, id.ShareName, id.DirectoryPath, id.FileName); err != nil {

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -158,7 +158,7 @@ func (StorageShareFileResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, err
 	}
 
-	account, err := clients.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := clients.Storage.FindAccount(ctx, clients.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for File %q (Share %q): %s", id.AccountId.AccountName, id.FileName, id.ShareName, err)
 	}

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -174,7 +174,7 @@ func (StorageShareFileResource) Exists(ctx context.Context, clients *clients.Cli
 	resp, err := client.GetProperties(ctx, id.ShareName, id.DirectoryPath, id.FileName)
 	if err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {
-			return nil, fmt.Errorf("checking for presence of existing File %q (File Share %q / Storage Account %q / Resource Group %q): %s", id.FileName, id.ShareName, id.AccountId.AccountName, account.ResourceGroup, err)
+			return nil, fmt.Errorf("checking for presence of existing File %q (File Share %q in %s): %+v", id.FileName, id.ShareName, account.StorageAccountId, err)
 		}
 	}
 

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -285,7 +285,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("flattening `metadata`: %+v", err)
 	}
 
-	resourceManagerId := parse.NewStorageShareResourceManagerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, "default", id.ShareName)
+	resourceManagerId := parse.NewStorageShareResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", id.ShareName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -252,7 +252,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 	// The files API does not support bearer tokens (@manicminer, 2024-02-15)
 	client, err := storageClient.FileSharesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
 	if err != nil {
-		return fmt.Errorf("building File Share Client for Storage Account %q (Resource Group %q): %v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	props, err := client.Get(ctx, id.ShareName)
@@ -260,7 +260,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 	if props == nil {
-		log.Printf("[DEBUG] File Share %q was not found in Account %q / Resource Group %q - assuming removed & removing from state", id.ShareName, id.AccountId.AccountName, account.ResourceGroup)
+		log.Printf("[DEBUG] File Share %q was not found in %s - assuming removed & removing from state", id.ShareName, account.StorageAccountId)
 		d.SetId("")
 		return nil
 	}
@@ -312,7 +312,7 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	// The files API does not support bearer tokens (@manicminer, 2024-02-15)
 	client, err := storageClient.FileSharesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
 	if err != nil {
-		return fmt.Errorf("building File Share Client for Storage Account %q (Resource Group %q): %v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	if d.HasChange("quota") {
@@ -387,7 +387,7 @@ func resourceStorageShareDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	// The files API does not support bearer tokens (@manicminer, 2024-02-15)
 	client, err := storageClient.FileSharesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
 	if err != nil {
-		return fmt.Errorf("building File Share Client for Storage Account %q (Resource Group %q): %v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	if err = client.Delete(ctx, id.ShareName); err != nil {

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
@@ -286,11 +285,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("flattening `metadata`: %+v", err)
 	}
 
-	storageAccountId, err := commonids.ParseStorageAccountIDInsensitively(account.ID)
-	if err != nil {
-		return err
-	}
-	resourceManagerId := parse.NewStorageShareResourceManagerID(storageAccountId.SubscriptionId, storageAccountId.ResourceGroupName, storageAccountId.StorageAccountName, "default", id.ShareName)
+	resourceManagerId := parse.NewStorageShareResourceManagerID(account.ID.SubscriptionId, account.ID.ResourceGroupName, account.ID.StorageAccountName, "default", id.ShareName)
 	d.Set("resource_manager_id", resourceManagerId.ID())
 
 	return nil

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -276,7 +276,7 @@ func (r StorageShareResource) Exists(ctx context.Context, client *clients.Client
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Share %q: %+v", id.AccountId.AccountName, id.ShareName, err)
 	}
@@ -303,7 +303,7 @@ func (r StorageShareResource) Destroy(ctx context.Context, client *clients.Clien
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Share %q: %+v", id.AccountId.AccountName, id.ShareName, err)
 	}

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -286,12 +286,12 @@ func (r StorageShareResource) Exists(ctx context.Context, client *clients.Client
 
 	sharesClient, err := client.Storage.FileSharesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return nil, fmt.Errorf("building File Share Client for Storage Account %q (Resource Group %q): %+v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	props, err := sharesClient.Get(ctx, id.ShareName)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving File Share %q (Account %q / Resource Group %q): %+v", id.ShareName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving File Share %q in %s: %+v", id.ShareName, account.StorageAccountId, err)
 	}
 
 	return utils.Bool(props != nil), nil
@@ -313,10 +313,10 @@ func (r StorageShareResource) Destroy(ctx context.Context, client *clients.Clien
 
 	sharesClient, err := client.Storage.FileSharesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return nil, fmt.Errorf("building File Share Client for Storage Account %q (Resource Group %q): %+v", id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
 	}
 	if err := sharesClient.Delete(ctx, id.ShareName); err != nil {
-		return nil, fmt.Errorf("deleting File Share %q (Account %q / Resource Group %q): %+v", id.ShareName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("deleting File Share %q in %s: %+v", id.ShareName, account.StorageAccountId, err)
 	}
 
 	return utils.Bool(true), nil

--- a/internal/services/storage/storage_table_entities_data_source.go
+++ b/internal/services/storage/storage_table_entities_data_source.go
@@ -125,7 +125,7 @@ func (k storageTableEntitiesDataSource) Read() sdk.ResourceFunc {
 
 			client, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 			if err != nil {
-				return fmt.Errorf("building Table Entity Client for Storage Account %q (Resource Group %q): %s", model.StorageAccountName, account.ResourceGroup, err)
+				return fmt.Errorf("building Table Entity Client for %s: %+v", account.StorageAccountId, err)
 			}
 
 			input := entities.QueryEntitiesInput{
@@ -142,7 +142,7 @@ func (k storageTableEntitiesDataSource) Read() sdk.ResourceFunc {
 
 			result, err := client.Query(ctx, model.TableName, input)
 			if err != nil {
-				return fmt.Errorf("retrieving Entities (Filter %q) (Table %q / Storage Account %q / Resource Group %q): %s", model.Filter, model.TableName, model.StorageAccountName, account.ResourceGroup, err)
+				return fmt.Errorf("retrieving Entities (Filter %q) (Table %q in %s): %+v", model.Filter, model.TableName, account.StorageAccountId, err)
 			}
 
 			var flattenedEntities []TableEntityDataSourceModel

--- a/internal/services/storage/storage_table_entities_data_source.go
+++ b/internal/services/storage/storage_table_entities_data_source.go
@@ -115,7 +115,7 @@ func (k storageTableEntitiesDataSource) Read() sdk.ResourceFunc {
 
 			storageClient := metadata.Client.Storage
 
-			account, err := storageClient.FindAccount(ctx, model.StorageAccountName)
+			account, err := storageClient.FindAccount(ctx, metadata.Client.Account.SubscriptionId, model.StorageAccountName)
 			if err != nil {
 				return fmt.Errorf("retrieving Account %q for Table %q: %s", model.StorageAccountName, model.TableName, err)
 			}

--- a/internal/services/storage/storage_table_entity_data_source.go
+++ b/internal/services/storage/storage_table_entity_data_source.go
@@ -81,7 +81,7 @@ func dataSourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{
 
 	dataPlaneClient, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return fmt.Errorf("building Table Entity Client for Storage Account %q (Resource Group %q): %v", accountName, account.ResourceGroup, err)
+		return fmt.Errorf("building Table Entity Client for %s: %v", accountName, account.StorageAccountId, err)
 	}
 
 	endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeTable)

--- a/internal/services/storage/storage_table_entity_data_source.go
+++ b/internal/services/storage/storage_table_entity_data_source.go
@@ -62,16 +62,17 @@ func dataSourceStorageTableEntity() *pluginsdk.Resource {
 }
 
 func dataSourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	accountName := d.Get("storage_account_name").(string)
 	tableName := d.Get("table_name").(string)
 	partitionKey := d.Get("partition_key").(string)
 	rowKey := d.Get("row_key").(string)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Table %q: %v", accountName, tableName, err)
 	}
@@ -81,7 +82,7 @@ func dataSourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{
 
 	dataPlaneClient, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return fmt.Errorf("building Table Entity Client for %s: %v", accountName, account.StorageAccountId, err)
+		return fmt.Errorf("building Table Entity Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeTable)

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -99,9 +99,10 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 }
 
 func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	partitionKey := d.Get("partition_key").(string)
 	rowKey := d.Get("row_key").(string)
@@ -118,7 +119,7 @@ func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{
 		// we will retrieve the storage account twice but this will make it easier to refactor later
 		storageAccountName := d.Get("storage_account_name").(string)
 
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccount(ctx, subscriptionId, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %v", storageAccountName, err)
 		}
@@ -145,7 +146,7 @@ func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{
 		return fmt.Errorf("determining storage table ID")
 	}
 
-	account, err := storageClient.FindAccount(ctx, storageTableId.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, storageTableId.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Table %q: %v", storageTableId.AccountId.AccountName, storageTableId.TableName, err)
 	}
@@ -197,9 +198,10 @@ func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{
 }
 
 func resourceStorageTableEntityUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := entities.ParseEntityID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
@@ -208,7 +210,7 @@ func resourceStorageTableEntityUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	storageTableId := tables.NewTableID(id.AccountId, id.TableName)
 
-	account, err := storageClient.FindAccount(ctx, storageTableId.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, storageTableId.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Table %q: %v", storageTableId.AccountId.AccountName, storageTableId.TableName, err)
 	}
@@ -239,16 +241,17 @@ func resourceStorageTableEntityUpdate(d *pluginsdk.ResourceData, meta interface{
 }
 
 func resourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := entities.ParseEntityID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Table %q: %s", id.AccountId.AccountName, id.TableName, err)
 	}
@@ -290,16 +293,17 @@ func resourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{})
 }
 
 func resourceStorageTableEntityDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	id, err := entities.ParseEntityID(d.Id(), storageClient.StorageDomainSuffix)
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Table %q: %s", id.AccountId.AccountName, id.TableName, err)
 	}

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -262,7 +262,7 @@ func resourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{})
 
 	client, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return fmt.Errorf("building Table Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building Table Entity Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	input := entities.GetEntityInput{
@@ -309,7 +309,7 @@ func resourceStorageTableEntityDelete(d *pluginsdk.ResourceData, meta interface{
 
 	client, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
-		return fmt.Errorf("building Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountId.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("building Entity Client for %s: %+v", account.StorageAccountId, err)
 	}
 
 	input := entities.DeleteEntityInput{

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -182,7 +182,7 @@ func (r StorageTableEntityResource) Exists(ctx context.Context, client *clients.
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Table %q: %+v", id.AccountId.AccountName, id.TableName, err)
 	}

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -205,7 +205,7 @@ func (r StorageTableEntityResource) Exists(ctx context.Context, client *clients.
 		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retrieving Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %+v", id.PartitionKey, id.RowKey, id.TableName, id.AccountId.AccountName, account.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving Entity (Partition Key %q / Row Key %q) (Table %q in %s): %+v", id.PartitionKey, id.RowKey, id.TableName, account.StorageAccountId, err)
 	}
 	return utils.Bool(true), nil
 }

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -102,16 +102,17 @@ func resourceStorageTable() *pluginsdk.Resource {
 }
 
 func resourceStorageTableCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	storageClient := meta.(*clients.Client).Storage
 
 	tableName := d.Get("name").(string)
 	accountName := d.Get("storage_account_name").(string)
 	aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 	acls := expandStorageTableACLs(aclsRaw)
 
-	account, err := storageClient.FindAccount(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q for Table %q: %s", accountName, tableName, err)
 	}
@@ -167,6 +168,7 @@ func resourceStorageTableCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -175,7 +177,7 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Table %q: %v", id.AccountId.AccountName, id.TableName, err)
 	}
@@ -223,6 +225,7 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 func resourceStorageTableDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -231,7 +234,7 @@ func resourceStorageTableDelete(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Table %q: %v", id.AccountId.AccountName, id.TableName, err)
 	}
@@ -253,6 +256,7 @@ func resourceStorageTableDelete(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -261,7 +265,7 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Storage Account %q for Table %q: %v", id.AccountId.AccountName, id.TableName, err)
 	}

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -87,7 +87,7 @@ func (r StorageTableResource) Exists(ctx context.Context, client *clients.Client
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Table %q: %+v", id.AccountId.AccountName, id.TableName, err)
 	}
@@ -107,7 +107,7 @@ func (r StorageTableResource) Destroy(ctx context.Context, client *clients.Clien
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, id.AccountId.AccountName)
+	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Table %q: %+v", id.AccountId.AccountName, id.TableName, err)
 	}


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR refactors the majority of the `Storage` Service Package over to using `hashicorp/go-azure-sdk` rather than `Azure/azure-sdk-for-go`. Whilst this is mostly removing the technical debt of the legacy Azure SDK - switching to use `hashicorp/go-azure-sdk` also means that fields which are marked as Optional in the Azure API Definitions means that these are correctly output as Optional in the SDK, which is not the case in `Azure/azure-sdk-for-go`.

Whilst I looked into doing this change in this PR, this intentionally _does not_ refactor the `azurerm_storage_account` data source/resource or `azurerm_storage_account_network_rules` resource due to the size of the changeset - but that should be done in a follow-up PR.