### PR TITLE
azurerm_windows_web_app - Correctly set "WEBSITE_NODE_DEFAULT_VERSION" during update

### DIFF
--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -909,7 +909,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
-			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
+			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
 				appSettingsProps := *appSettingsUpdate.Properties
 				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -877,8 +877,9 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				currentStack = sc.ApplicationStack[0].CurrentStack
 			}
 
+			shouldSaveAppSettings := false
 			if metadata.ResourceData.HasChanges("site_config", "app_settings") || servicePlanChange {
-				model.Properties.SiteConfig, err = sc.ExpandForUpdate(metadata, model.Properties.SiteConfig, state.AppSettings)
+				model.Properties.SiteConfig, shouldSaveAppSettings, err = sc.ExpandForUpdate(metadata, model.Properties.SiteConfig, state.AppSettings)
 				if err != nil {
 					return err
 				}
@@ -908,10 +909,15 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
-			if metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
+			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
 				appSettingsProps := *appSettingsUpdate.Properties
 				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
+				// (@apokalypt) - While parsing the node version, we remove it, so we need to set it back even if there is no change
+				// https://github.com/hashicorp/terraform-provider-azurerm/issues/25452
+				if state.SiteConfig[0].ApplicationStack[0].NodeVersion != "" {
+					appSettingsProps["WEBSITE_NODE_DEFAULT_VERSION"] = state.SiteConfig[0].ApplicationStack[0].NodeVersion
+				}
 				appSettingsUpdate.Properties = &appSettingsProps
 				if _, err := client.UpdateApplicationSettings(ctx, *id, *appSettingsUpdate); err != nil {
 					return fmt.Errorf("updating App Settings for Linux %s: %+v", *id, err)

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -843,8 +843,9 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 				currentStack = sc.ApplicationStack[0].CurrentStack
 			}
 
+			shouldSaveAppSettings := false
 			if metadata.ResourceData.HasChanges("site_config", "app_settings") {
-				model.Properties.SiteConfig, err = sc.ExpandForUpdate(metadata, model.Properties.SiteConfig, state.AppSettings)
+				model.Properties.SiteConfig, shouldSaveAppSettings, err = sc.ExpandForUpdate(metadata, model.Properties.SiteConfig, state.AppSettings)
 				if err != nil {
 					return err
 				}
@@ -896,10 +897,15 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			}
 
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
-			if metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
+			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
 				appSettingsProps := *appSettingsUpdate.Properties
 				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
+				// (@apokalypt) - While parsing the node version, we remove it, so we need to set it back even if there is no change
+				// https://github.com/hashicorp/terraform-provider-azurerm/issues/25452
+				if state.SiteConfig[0].ApplicationStack[0].NodeVersion != "" {
+					appSettingsProps["WEBSITE_NODE_DEFAULT_VERSION"] = state.SiteConfig[0].ApplicationStack[0].NodeVersion
+				}
 				appSettingsUpdate.Properties = &appSettingsProps
 				if _, err := client.UpdateApplicationSettingsSlot(ctx, *id, *appSettingsUpdate); err != nil {
 					return fmt.Errorf("updating App Settings for Windows %s: %+v", *id, err)

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -897,7 +897,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			}
 
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
-			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
+			if shouldSaveAppSettings || metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") || metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
 				appSettingsProps := *appSettingsUpdate.Properties
 				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Right now, the NodeJS environment variable can be unset during an update. This PR ensure that the version is correctly set if we need to update AppSettings for any reason


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_windows_web_app` -  avoid "WEBSITE_NODE_DEFAULT_VERSION" to be lost during update


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25452 
