### PR TITLE
New Resource: `azurerm_maintenance_assignment_dynamic_scope`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -182,6 +182,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		loadbalancer.Registration{},
 		loganalytics.Registration{},
 		machinelearning.Registration{},
+		maintenance.Registration{},
 		managedhsm.Registration{},
 		media.Registration{},
 		monitor.Registration{},

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -1,0 +1,405 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package maintenance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/maintenanceconfigurations"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type MaintenanceDynamicScopeResource struct{}
+
+type Tag struct {
+	Tag    string   `tfschema:"tag"`
+	Values []string `tfschema:"values"`
+}
+
+type Filter struct {
+	Locations      []string `tfschema:"locations"`
+	OsTypes        []string `tfschema:"os_types"`
+	ResourceGroups []string `tfschema:"resource_groups"`
+	ResourceTypes  []string `tfschema:"resource_types"`
+	Tags           []Tag    `tfschema:"tags"`
+	TagFilter      string   `tfschema:"tag_filter"`
+}
+
+type MaintenanceDynamicScopeModel struct {
+	MaintenanceConfigurationId string   `tfschema:"maintenance_configuration_id"`
+	Scope                      string   `tfschema:"subscription_id"`
+	Location                   string   `tfschema:"location"`
+	Filter                     []Filter `tfschema:"filter"`
+}
+
+var _ sdk.Resource = MaintenanceDynamicScopeResource{}
+
+func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"maintenance_configuration_id": {
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			ValidateFunc:     maintenanceconfigurations.ValidateMaintenanceConfigurationID,
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		"subscription_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateSubscriptionID,
+		},
+
+		"location": commonschema.Location(),
+
+		"filter": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"locations": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"os_types": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"resource_groups": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"resource_types": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"tags": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"tag": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+
+					"tag_filter": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(configurationassignments.TagOperatorsAny),
+							string(configurationassignments.TagOperatorsAll),
+						}, false),
+					},
+				},
+			},
+		},
+	}
+}
+
+func (MaintenanceDynamicScopeResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (MaintenanceDynamicScopeResource) ModelObject() interface{} {
+	return &MaintenanceDynamicScopeModel{}
+}
+
+func (MaintenanceDynamicScopeResource) ResourceType() string {
+	return "azurerm_maintenance_assignment_dynamic_scope"
+}
+
+func (r MaintenanceDynamicScopeResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Maintenance.ConfigurationAssignmentsClient
+
+			var model MaintenanceDynamicScopeModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			subscriptionId, err := commonids.ParseSubscriptionID(model.Scope)
+			if err != nil {
+				return err
+			}
+
+			maintenanceConfigurationId, err := maintenanceconfigurations.ParseMaintenanceConfigurationID(model.MaintenanceConfigurationId)
+			if err != nil {
+				return err
+			}
+
+			id := configurationassignments.NewScopedConfigurationAssignmentID(subscriptionId.ID(), maintenanceConfigurationId.MaintenanceConfigurationName)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
+			}
+
+			configurationAssignment := configurationassignments.ConfigurationAssignment{
+				Name:     pointer.To(id.ConfigurationAssignmentName),
+				Location: pointer.To(location.Normalize(model.Location)),
+				Properties: &configurationassignments.ConfigurationAssignmentProperties{
+					MaintenanceConfigurationId: pointer.To(maintenanceConfigurationId.ID()),
+					// test to see if required but I think it's for specific resources i.e vmss or vms
+					//ResourceId: pointer.To(subscriptionId.ID()),
+				},
+			}
+
+			if len(model.Filter) > 1 {
+				filter := model.Filter[0]
+				filterProperties := configurationassignments.ConfigurationAssignmentFilterProperties{}
+
+				if len(filter.Locations) > 0 {
+					filterProperties.Locations = pointer.To(filter.Locations)
+				}
+
+				if len(filter.OsTypes) > 0 {
+					filterProperties.OsTypes = pointer.To(filter.OsTypes)
+				}
+
+				if len(filter.ResourceGroups) > 0 {
+					filterProperties.ResourceGroups = pointer.To(filter.ResourceGroups)
+				}
+
+				if len(filter.ResourceTypes) > 0 {
+					filterProperties.ResourceTypes = pointer.To(filter.ResourceTypes)
+				}
+
+				if len(filter.Tags) > 0 || filter.TagFilter != "" {
+					tags := make(map[string][]string)
+					for _, tag := range filter.Tags {
+						tags[tag.Tag] = tag.Values
+					}
+
+					tagProperties := &configurationassignments.TagSettingsProperties{
+						FilterOperator: pointer.To(configurationassignments.TagOperators(filter.TagFilter)),
+						Tags:           pointer.To(tags),
+					}
+					filterProperties.TagSettings = tagProperties
+				}
+				configurationAssignment.Properties.Filter = pointer.To(filterProperties)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, configurationAssignment); err != nil {
+				return fmt.Errorf("creating %s: %v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (MaintenanceDynamicScopeResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Maintenance.ConfigurationAssignmentsClient
+
+			var state MaintenanceDynamicScopeModel
+			id, err := configurationassignments.ParseScopedConfigurationAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return err
+			}
+
+			subscriptionId, err := commonids.ParseSubscriptionID(id.Scope)
+			if err != nil {
+				return err
+			}
+
+			state.Scope = subscriptionId.ID()
+
+			if model := resp.Model; model != nil {
+				state.Location = location.NormalizeNilable(model.Location)
+
+				if properties := model.Properties; properties != nil {
+
+					if properties.MaintenanceConfigurationId != nil {
+						maintenanceConfigurationId, err := maintenanceconfigurations.ParseMaintenanceConfigurationIDInsensitively(pointer.From(properties.MaintenanceConfigurationId))
+						if err != nil {
+							return fmt.Errorf("parsing %q: %+v", pointer.From(properties.MaintenanceConfigurationId), err)
+						}
+						state.MaintenanceConfigurationId = maintenanceConfigurationId.ID()
+					}
+
+					if filter := properties.Filter; filter != nil {
+						filterProp := make([]Filter, 0)
+						tagsListProp := make([]Tag, 0)
+						tagFilterProp := ""
+						if tags := filter.TagSettings; tags != nil {
+							tagFilterProp = string(pointer.From(tags.FilterOperator))
+							for k, v := range pointer.From(tags.Tags) {
+								tagsListProp = append(tagsListProp, Tag{
+									Tag:    k,
+									Values: v,
+								})
+							}
+						}
+						filterProp = append(filterProp, Filter{
+							Locations:      pointer.From(filter.Locations),
+							OsTypes:        pointer.From(filter.OsTypes),
+							ResourceGroups: pointer.From(filter.ResourceGroups),
+							ResourceTypes:  pointer.From(filter.ResourceTypes),
+							Tags:           tagsListProp,
+							TagFilter:      tagFilterProp,
+						})
+						state.Filter = filterProp
+					}
+				}
+			}
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (MaintenanceDynamicScopeResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Maintenance.ConfigurationAssignmentsClient
+
+			id, err := configurationassignments.ParseScopedConfigurationAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model MaintenanceDynamicScopeModel
+			if err = metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			existing := resp.Model
+
+			if metadata.ResourceData.HasChange("maintenance_configuration_id") {
+				existing.Properties.MaintenanceConfigurationId = pointer.To(model.MaintenanceConfigurationId)
+			}
+
+			if metadata.ResourceData.HasChange("location") {
+				existing.Location = pointer.To(model.Location)
+			}
+
+			if metadata.ResourceData.HasChange("filter") {
+				if len(model.Filter) > 1 {
+					filter := model.Filter[0]
+					filterProperties := configurationassignments.ConfigurationAssignmentFilterProperties{}
+
+					if len(filter.Locations) > 0 {
+						filterProperties.Locations = pointer.To(filter.Locations)
+					}
+
+					if len(filter.OsTypes) > 0 {
+						filterProperties.OsTypes = pointer.To(filter.OsTypes)
+					}
+
+					if len(filter.ResourceGroups) > 0 {
+						filterProperties.ResourceGroups = pointer.To(filter.ResourceGroups)
+					}
+
+					if len(filter.ResourceTypes) > 0 {
+						filterProperties.ResourceTypes = pointer.To(filter.ResourceTypes)
+					}
+
+					if len(filter.Tags) > 0 || filter.TagFilter != "" {
+						tags := make(map[string][]string)
+						for _, tag := range filter.Tags {
+							tags[tag.Tag] = tag.Values
+						}
+
+						tagProperties := &configurationassignments.TagSettingsProperties{
+							FilterOperator: pointer.To(configurationassignments.TagOperators(filter.TagFilter)),
+							Tags:           pointer.To(tags),
+						}
+						filterProperties.TagSettings = tagProperties
+					}
+					existing.Properties.Filter = pointer.To(filterProperties)
+				} else {
+					existing.Properties.Filter = &configurationassignments.ConfigurationAssignmentFilterProperties{}
+				}
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, pointer.From(id), *existing); err != nil {
+				return fmt.Errorf("creating %s: %v", id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func (MaintenanceDynamicScopeResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 10 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Maintenance.ConfigurationAssignmentsClient
+
+			id, err := configurationassignments.ParseScopedConfigurationAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (MaintenanceDynamicScopeResource) IDValidationFunc() func(interface{}, string) ([]string, []error) {
+	return configurationassignments.ValidateConfigurationAssignmentID
+}

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -178,7 +178,6 @@ func (r MaintenanceDynamicScopeResource) Create() sdk.ResourceFunc {
 			}
 
 			configurationAssignment := configurationassignments.ConfigurationAssignment{
-				Name:     pointer.To(id.ConfigurationAssignmentName),
 				Location: pointer.To(location.Normalize(model.Location)),
 				Properties: &configurationassignments.ConfigurationAssignmentProperties{
 					MaintenanceConfigurationId: pointer.To(maintenanceConfigurationId.ID()),

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -81,7 +81,7 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 							ValidateFunc: validation.StringInSlice([]string{
 								"Linux",
 								"Windows",
-							}, false),
+							}, true),
 						},
 						AtLeastOneOf: []string{"filter.0.locations", "filter.0.os_types", "filter.0.resource_groups", "filter.0.resource_types", "filter.0.tags"},
 					},
@@ -101,7 +101,7 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 							ValidateFunc: validation.StringInSlice([]string{
 								"Microsoft.Compute/virtualMachines",
 								"Microsoft.HybridCompute/machines",
-							}, false),
+							}, true),
 						},
 						AtLeastOneOf: []string{"filter.0.locations", "filter.0.os_types", "filter.0.resource_groups", "filter.0.resource_types", "filter.0.tags"},
 					},
@@ -134,7 +134,7 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 						ValidateFunc: validation.StringInSlice([]string{
 							string(configurationassignments.TagOperatorsAny),
 							string(configurationassignments.TagOperatorsAll),
-						}, false),
+						}, true),
 						RequiredWith: []string{
 							"filter.0.tags",
 						},

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -173,16 +173,20 @@ func (r MaintenanceDynamicScopeResource) Create() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
-					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 				}
 			}
 
+			if !response.WasNotFound(resp.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
 			configurationAssignment := configurationassignments.ConfigurationAssignment{
+				Name:     pointer.To(maintenanceConfigurationId.MaintenanceConfigurationName),
 				Location: pointer.To(location.Normalize(model.Location)),
 				Properties: &configurationassignments.ConfigurationAssignmentProperties{
 					MaintenanceConfigurationId: pointer.To(maintenanceConfigurationId.ID()),
-					// test to see if required but I think it's for specific resources i.e vmss or vms
-					//ResourceId: pointer.To(subscriptionId.ID()),
+					ResourceId:                 pointer.To(subscriptionId.ID()),
 				},
 			}
 

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -60,9 +60,9 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 		},
 
 		"filter": {
-			Type:         pluginsdk.TypeList,
-			Required:     true,
-			MaxItems:     1,
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"locations": {

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -358,7 +358,9 @@ func (MaintenanceDynamicScopeResource) Update() sdk.ResourceFunc {
 						filterProperties.TagSettings = tagProperties
 					}
 
-					existing.Properties.Filter = pointer.To(filterProperties)
+					if pointer.To(filterProperties) != nil {
+						existing.Properties.Filter = pointer.To(filterProperties)
+					}
 				} else {
 					existing.Properties.Filter = &configurationassignments.ConfigurationAssignmentFilterProperties{}
 				}

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -108,11 +108,10 @@ func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clie
 
 func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	provider "azurerm" {
-		features {}
-	}
-
-	%[1]s
+provider "azurerm" {
+  features {}
+}
+%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   name                         = "acctest-ca%[2]d"
@@ -128,11 +127,11 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 
 func (r MaintenanceDynamicScopeResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	provider "azurerm" {
-		features {}
-	}
+provider "azurerm" {
+  features {}
+}
 
-	%[1]s
+%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   name                         = "acctest-complete-%[2]d"
@@ -140,7 +139,7 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 
   filter {
     locations       = ["%[3]s"]
-    os_types        = ["windows"]
+    os_types        = ["Windows"]
     resource_groups = [azurerm_resource_group.test.name]
     resource_types  = ["Microsoft.Compute/virtualMachines"]
     tag_filter      = "Any"
@@ -155,18 +154,14 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 
 func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	provider "azurerm" {
-		features {}
-	}
-
-	%[1]s
+%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "import" {
-	name                         = azurerm_maintenance_assignment_dynamic_scope.test.name
-	maintenance_configuration_id = azurerm_maintenance_assignment_dynamic_scope.test.maintenance_configuration_id
-	filter {
-	  locations = azurerm_maintenance_assignment_dynamic_scope.test.filter.0.locations
-	}
+  name                         = azurerm_maintenance_assignment_dynamic_scope.test.name
+  maintenance_configuration_id = azurerm_maintenance_assignment_dynamic_scope.test.maintenance_configuration_id
+  filter {
+    locations = azurerm_maintenance_assignment_dynamic_scope.test.filter.0.locations
+  }
 }
 `, r.basic(data))
 }

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -67,12 +67,12 @@ func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string 
 %s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
-
-  filter {
-	locations = []
-  }
+	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+	subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+  
+	filter {
+	  locations = []
+	}
 }
 `, r.template(data))
 }
@@ -84,9 +84,9 @@ func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
 	subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
-
+  
 	filter {
-		locations = []
+	  locations = []
 	}
 }
 `, r.basic(data))

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package maintenance_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type MaintenanceDynamicScopeResource struct{}
+
+func TestAccMaintenanceAssignmentDynamicScope_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_dynamic_scope", "test")
+	r := MaintenanceDynamicScopeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("location"),
+	})
+}
+
+func TestAccMaintenanceAssignmentDynamicScope_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_dynamic_scope", "test")
+	r := MaintenanceDynamicScopeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := configurationassignments.ParseScopedConfigurationAssignmentID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Maintenance.ConfigurationAssignmentsClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
+  location                     = azurerm_resource_group.test.location
+  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+  subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+}
+`, r.template(data))
+}
+
+func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
+	location                     = azurerm_resource_group.test.location
+	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+	subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+}
+`, r.basic(data))
+}
+
+func (MaintenanceDynamicScopeResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-maint-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_maintenance_configuration" "test" {
+  name                = "acctest-MC%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope               = "InGuestPatch"
+  in_guest_user_patch_mode = "User"
+
+  window {
+    start_date_time = formatdate("YYYY-MM-DD hh:mm", timestamp())
+    time_zone       = "Greenwich Standard Time"
+    recur_every     = "1Day"
+  }
+
+  install_patches {
+    reboot = "Always"
+
+    windows {
+      classifications_to_include = ["Critical"]
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -68,7 +68,7 @@ func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string 
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-  subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
   filter {
 	locations = []
@@ -83,7 +83,7 @@ func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-	subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+	subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
 	filter {
 		locations = []
@@ -106,10 +106,10 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_maintenance_configuration" "test" {
-  name                = "acctest-MC%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  scope               = "InGuestPatch"
+  name                     = "acctest-MC%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  scope                    = "InGuestPatch"
   in_guest_user_patch_mode = "User"
 
   window {

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -27,6 +27,70 @@ func TestAccMaintenanceAssignmentDynamicScope_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
+			),
+		},
+		data.ImportStep("location"),
+	})
+}
+
+func TestAccMaintenanceAssignmentDynamicScope_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_dynamic_scope", "test")
+	r := MaintenanceDynamicScopeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.#").HasValue("1"),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.os_types.0").HasValue("windows"),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
+				check.That(data.ResourceName).Key("filter.0.tag_filter").HasValue("Any"),
+				check.That(data.ResourceName).Key("filter.0.tags.0.tag").HasValue("foo"),
+				check.That(data.ResourceName).Key("filter.0.tags.0.values.0").HasValue("barbar"),
+			),
+		},
+		data.ImportStep("location"),
+	})
+}
+
+func TestAccMaintenanceAssignmentDynamicScope_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_dynamic_scope", "test")
+	r := MaintenanceDynamicScopeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
+			),
+		},
+		data.ImportStep("location"),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.#").HasValue("1"),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.os_types.0").HasValue("windows"),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
+				check.That(data.ResourceName).Key("filter.0.tag_filter").HasValue("Any"),
+				check.That(data.ResourceName).Key("filter.0.tags.0.tag").HasValue("foo"),
+				check.That(data.ResourceName).Key("filter.0.tags.0.values.0").HasValue("barbar"),
+			),
+		},
+		data.ImportStep("location"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
 		data.ImportStep("location"),
@@ -42,6 +106,8 @@ func TestAccMaintenanceAssignmentDynamicScope_requiresImport(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
@@ -49,12 +115,12 @@ func TestAccMaintenanceAssignmentDynamicScope_requiresImport(t *testing.T) {
 }
 
 func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := configurationassignments.ParseScopedConfigurationAssignmentID(state.ID)
+	id, err := configurationassignments.ParseConfigurationAssignmentID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Maintenance.ConfigurationAssignmentsClient.Get(ctx, *id)
+	resp, err := clients.Maintenance.ConfigurationAssignmentsClient.ForSubscriptionsGet(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
@@ -67,7 +133,7 @@ func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string 
 %[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-  name                         = "acctest-CA%[2]d"
+  name                         = "acctest-ca%[2]d"
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
   subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
@@ -79,12 +145,36 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 `, r.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
-func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
+func (r MaintenanceDynamicScopeResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-  name                         = "acctest-CA%[2]d"
+  name                         = "acctest-complete-%[2]d"
+  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+
+  filter {
+    locations       = ["%[3]s"]
+    os_types        = ["windows"]
+    resource_groups = [azurerm_resource_group.test.name]
+    resource_types  = ["Microsoft.Compute/virtualMachines"]
+    tag_filter      = "Any"
+    tags {
+      tag    = "foo"
+      values = ["barbar"]
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_maintenance_assignment_dynamic_scope" "import" {
+  name                         = "acctest-ca%[2]d"
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
   subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
@@ -126,7 +216,16 @@ resource "azurerm_maintenance_configuration" "test" {
 
     windows {
       classifications_to_include = ["Critical"]
+      kb_numbers_to_exclude      = []
+      kb_numbers_to_include      = []
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      window[0].start_date_time,
+      window[0].duration
+    ]
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -69,6 +69,10 @@ func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
   subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+
+  filter {
+	locations = []
+  }
 }
 `, r.template(data))
 }
@@ -80,6 +84,10 @@ func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
 	subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+
+	filter {
+		locations = []
+	}
 }
 `, r.basic(data))
 }

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -64,32 +64,35 @@ func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clie
 
 func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-	subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
-  
-	filter {
-	  locations = []
-	}
+  name                         = "acctest-CA%[2]d"
+  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+
+  filter {
+    locations      = ["%[3]s"]
+    resource_types = ["Microsoft.Compute/virtualMachines"]
+  }
 }
-`, r.template(data))
+`, r.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
 func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-	subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
-  
-	filter {
-	  locations = []
-	}
+  name                         = "acctest-CA%[2]d"
+  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
+
+  filter {
+    locations = ["%[3]s"]
+  }
 }
-`, r.basic(data))
+`, r.basic(data), data.RandomInteger, data.Locations.Primary)
 }
 
 func (MaintenanceDynamicScopeResource) template(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -67,7 +67,6 @@ func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string 
 %s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-  location                     = azurerm_resource_group.test.location
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
   subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 }
@@ -79,7 +78,6 @@ func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData
 %s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
-	location                     = azurerm_resource_group.test.location
 	maintenance_configuration_id = azurerm_maintenance_configuration.test.id
 	subscription_id            = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 }

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -27,11 +27,9 @@ func TestAccMaintenanceAssignmentDynamicScope_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
-		data.ImportStep("location"),
+		data.ImportStep(),
 	})
 }
 
@@ -44,16 +42,9 @@ func TestAccMaintenanceAssignmentDynamicScope_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.#").HasValue("1"),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.os_types.0").HasValue("windows"),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
-				check.That(data.ResourceName).Key("filter.0.tag_filter").HasValue("Any"),
-				check.That(data.ResourceName).Key("filter.0.tags.0.tag").HasValue("foo"),
-				check.That(data.ResourceName).Key("filter.0.tags.0.values.0").HasValue("barbar"),
 			),
 		},
-		data.ImportStep("location"),
+		data.ImportStep(),
 	})
 }
 
@@ -66,34 +57,23 @@ func TestAccMaintenanceAssignmentDynamicScope_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
-		data.ImportStep("location"),
+		data.ImportStep(),
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.#").HasValue("1"),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.os_types.0").HasValue("windows"),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
-				check.That(data.ResourceName).Key("filter.0.tag_filter").HasValue("Any"),
-				check.That(data.ResourceName).Key("filter.0.tags.0.tag").HasValue("foo"),
-				check.That(data.ResourceName).Key("filter.0.tags.0.values.0").HasValue("barbar"),
 			),
 		},
-		data.ImportStep("location"),
+		data.ImportStep(),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
-		data.ImportStep("location"),
+		data.ImportStep(),
 	})
 }
 
@@ -106,8 +86,6 @@ func TestAccMaintenanceAssignmentDynamicScope_requiresImport(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("filter.0.locations.0").HasValue(data.Locations.Primary),
-				check.That(data.ResourceName).Key("filter.0.resource_types.0").HasValue("Microsoft.Compute/virtualMachines"),
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
@@ -130,12 +108,15 @@ func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clie
 
 func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%[1]s
+	provider "azurerm" {
+		features {}
+	}
+
+	%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   name                         = "acctest-ca%[2]d"
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
   filter {
     locations      = ["%[3]s"]
@@ -147,12 +128,15 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 
 func (r MaintenanceDynamicScopeResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%[1]s
+	provider "azurerm" {
+		features {}
+	}
+
+	%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
   name                         = "acctest-complete-%[2]d"
   maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
 
   filter {
     locations       = ["%[3]s"]
@@ -171,28 +155,24 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
 
 func (r MaintenanceDynamicScopeResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%[1]s
+	provider "azurerm" {
+		features {}
+	}
+
+	%[1]s
 
 resource "azurerm_maintenance_assignment_dynamic_scope" "import" {
-  name                         = "acctest-ca%[2]d"
-  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
-  subscription_id              = format("/subscriptions/%%s", data.azurerm_client_config.current.subscription_id)
-
-  filter {
-    locations = ["%[3]s"]
-  }
+	name                         = azurerm_maintenance_assignment_dynamic_scope.test.name
+	maintenance_configuration_id = azurerm_maintenance_assignment_dynamic_scope.test.maintenance_configuration_id
+	filter {
+	  locations = azurerm_maintenance_assignment_dynamic_scope.test.filter.0.locations
+	}
 }
-`, r.basic(data), data.RandomInteger, data.Locations.Primary)
+`, r.basic(data))
 }
 
 func (MaintenanceDynamicScopeResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-maint-%[1]d"
   location = "%[2]s"

--- a/internal/services/maintenance/registration.go
+++ b/internal/services/maintenance/registration.go
@@ -10,7 +10,10 @@ import (
 
 type Registration struct{}
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var (
+	_ sdk.TypedServiceRegistration                   = Registration{}
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/maintenance"
@@ -23,6 +26,16 @@ func (r Registration) Name() string {
 func (r Registration) WebsiteCategories() []string {
 	return []string{
 		"Maintenance",
+	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		MaintenanceDynamicScopeResource{},
 	}
 }
 

--- a/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
+++ b/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
@@ -52,7 +52,6 @@ resource "azurerm_maintenance_configuration" "example" {
 resource "azurerm_maintenance_assignment_dynamic_scope" "example" {
   name                         = "example"
   maintenance_configuration_id = azurerm_maintenance_configuration.example.id
-  subscription_id              = "/subscription/00000000-0000-0000-0000-000000000000"
 
   filter {
     locations       = ["West Europe"]
@@ -76,13 +75,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Dynamic Maintenance Assignment. Changing this forces a new Dynamic Maintenance Assignment to be created.
 
-~> **Note:** As a result of how this resource is assigned at the subscription, the name should be unique for each assignment, otherwise you may receive an existing resource error.
-
-* `subscription_id` - (Required) The ID of the subscription to scope the dynamic scope to. Changing this forces a new Dynamic Maintenance Assignment to be created.
+~> **Note:** The `name` must be unique per subscription.
 
 * `filter` - (Required) A `filter` block as defined below.
-
-~> **Note:** You must specify at least one filter otherwise ARM returns a `internal server error`.
 
 ---
 

--- a/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
+++ b/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
@@ -1,0 +1,132 @@
+---
+subcategory: "Maintenance"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_maintenance_assignment_dynamic_scope"
+description: |-
+  Manages a Dynamic Maintenance Assignment
+---
+
+# azurerm_maintenance_assignment_dynamic_scope
+
+Manages a Dynamic Maintenance Assignment.
+
+~> **Note:** Only valid for `InGuestPatch` Maintenance Configuration Scopes.
+
+## Example Usage
+
+```hcl
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_maintenance_configuration" "example" {
+  name                     = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  scope                    = "InGuestPatch"
+  in_guest_user_patch_mode = "User"
+
+  window {
+    start_date_time = formatdate("YYYY-MM-DD hh:mm", timestamp())
+    time_zone       = "Greenwich Standard Time"
+    recur_every     = "1Day"
+  }
+
+  install_patches {
+    reboot = "Always"
+
+    windows {
+      classifications_to_include = ["Critical"]
+      kb_numbers_to_exclude      = []
+      kb_numbers_to_include      = []
+    }
+  }
+}
+
+resource "azurerm_maintenance_assignment_dynamic_scope" "example" {
+  name                         = "example"
+  maintenance_configuration_id = azurerm_maintenance_configuration.example.id
+  subscription_id              = "/subscription/00000000-0000-0000-0000-000000000000"
+
+  filter {
+    locations       = ["West Europe"]
+    os_types        = ["Windows"]
+    resource_groups = [azurerm_resource_group.example.name]
+    resource_types  = ["Microsoft.Compute/virtualMachines"]
+    tag_filter      = "Any"
+    tags {
+      tag    = "foo"
+      values = ["barbar"]
+    }
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `maintenance_configuration_id` - (Required) The ID of the Maintenance Configuration Resource. Changing this forces a new Dynamic Maintenance Assignment to be created.
+
+* `name` - (Required) The name which should be used for this Dynamic Maintenance Assignment. Changing this forces a new Dynamic Maintenance Assignment to be created.
+
+~> **Note:** As a result of how this resource is assigned at the subscription, the name should be unique for each assignment, otherwise you may receive an existing resource error.
+
+* `subscription_id` - (Required) The ID of the subscription to scope the dynamic scope to. Changing this forces a new Dynamic Maintenance Assignment to be created.
+
+* `filter` - (Required) A `filter` block as defined below.
+
+~> **Note:** You must specify at least one filter otherwise ARM returns a `internal server error`.
+
+---
+
+A `filter` block supports the following:
+
+* `locations` - (Optional) Specifies a list of locations to scope the query to.
+
+* `os_types` - (Optional) Specifies a list of allowed operating systems.
+
+* `resource_groups` - (Optional) Specifies a list of allowed resource groups.
+
+* `resource_types` - (Optional) Specifies a list of allowed resources.
+
+* `tag_filter` - (Optional) Filter VMs by `Any` or `All` specified tags.
+
+* `tags` - (Optional) A mapping of tags for the VM
+
+---
+
+A `tags` block supports the following:
+
+* `tag` - (Required) Specifies the tag to filter by.
+
+* `values` - (Required) Specifies a list of values the defined tag can have.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Dynamic Maintenance Assignment
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Dynamic Maintenance Assignment
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dynamic Maintenance Assignment
+* `update` - (Defaults to 30 minutes) Used when updating the Dynamic Maintenance Assignment
+* `delete` - (Defaults to 10 minutes) Used when deleting the Dynamic Maintenance Assignment
+
+## Import
+
+Dynamic Maintenance Assignments can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_maintenance_assignment_dynamic_scope.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Maintenance/configurationAssignments/assignmentName
+```

--- a/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
+++ b/website/docs/r/maintenance_assignment_dynamic_scope.html.markdown
@@ -91,7 +91,7 @@ A `filter` block supports the following:
 
 * `resource_types` - (Optional) Specifies a list of allowed resources.
 
-* `tag_filter` - (Optional) Filter VMs by `Any` or `All` specified tags.
+* `tag_filter` - (Optional) Filter VMs by `Any` or `All` specified tags. Defaults to `Any`.
 
 * `tags` - (Optional) A mapping of tags for the VM
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Adding support to configure dynamic scopes on maintenance configuration resources.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_maintenance_assignment_dynamic_scope` - support for assigning dynamic scopes on maintenance configurations


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24411, fixes #23336


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
