### PR TITLE
`azurerm_cost_anomaly_alert` - Add start and end date parameters

### DIFF
--- a/internal/services/costmanagement/anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/anomaly_alert_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -81,6 +82,9 @@ resource "azurerm_cost_anomaly_alert" "test" {
 }
 
 func (AnomalyAlertResource) completeConfig(data acceptance.TestData) string {
+	start := time.Now().AddDate(0, 0, 1).UTC().Format("2006-01-02T00:00:00Z")
+	end := time.Now().AddDate(0, 0, 2).UTC().Format("2006-01-02T00:00:00Z")
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -95,8 +99,10 @@ resource "azurerm_cost_anomaly_alert" "test" {
   email_subject   = "Hi"
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
   message         = "Cost anomaly complete test"
+  start_date      = "%s"
+  end_date        = "%s"
 }
-`, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.RandomInteger, start, end)
 }
 
 func (r AnomalyAlertResource) requiresImportConfig(data acceptance.TestData) string {

--- a/website/docs/r/cost_anomaly_alert.html.markdown
+++ b/website/docs/r/cost_anomaly_alert.html.markdown
@@ -21,6 +21,8 @@ resource "azurerm_cost_anomaly_alert" "example" {
   subscription_id = "/subscriptions/00000000-0000-0000-0000-000000000000"
   email_subject   = "My Test Anomaly Alert"
   email_addresses = ["example@test.net"]
+  start_date      = "2023-01-02T00:00:00Z"
+  end_date        = "2023-02-02T00:00:00Z"
 }
 ```
 
@@ -38,7 +40,9 @@ The following arguments are supported:
 
 * `email_subject` - (Required) The email subject of the Cost Anomaly Alerts. Maximum length of the subject is 70.
 
+* `start_date` - (Optional) The start date and time of the Scheduled Action (UTC). When not supplied defaults to the current date and time. Changing this forces a new resource to be created.
 
+* `end_date` - (Optional) The end date and time of the Scheduled Action (UTC). When not supplied defaults to the current date and time plus 365 days. Note you cannot set and end date more than 365 days in the future. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/cost_anomaly_alert.html.markdown
+++ b/website/docs/r/cost_anomaly_alert.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `start_date` - (Optional) The start date and time of the Scheduled Action (UTC). When not supplied defaults to the current date and time. Changing this forces a new resource to be created.
 
-* `end_date` - (Optional) The end date and time of the Scheduled Action (UTC). When not supplied defaults to the current date and time plus 365 days. Note you cannot set and end date more than 365 days in the future. Changing this forces a new resource to be created.
+* `end_date` - (Optional) The end date and time of the Scheduled Action (UTC). When not supplied defaults to the current date and time plus 365 days. Note you cannot set an end date more than 365 days in the future. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes #25004

- Added `start_date` and `end_date` as optional parameters for the `azurerm_cost_anomaly_alert` resource.
- Updated logic used for end date calculation to add 365 days to current date instead of 1 year to fix issues occurring on leap years. The golang time package's [AddDate function](https://pkg.go.dev/time#Time.AddDate) normalizes dates. This meant that adding 1 year to February 29th becomes March 1 of the following year which is longer than the max end date of 1 year in the future.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


```
=== RUN   TestAccResourceAnomalyAlert_update
=== PAUSE TestAccResourceAnomalyAlert_update
=== CONT  TestAccResourceAnomalyAlert_update
--- PASS: TestAccResourceAnomalyAlert_update (98.98s)

=== RUN   TestAccResourceAnomalyAlert_complete
=== PAUSE TestAccResourceAnomalyAlert_complete
=== CONT  TestAccResourceAnomalyAlert_complete
--- PASS: TestAccResourceAnomalyAlert_complete (78.29s)

=== RUN   TestAccResourceAnomalyAlert_requiresImport
=== PAUSE TestAccResourceAnomalyAlert_requiresImport
=== CONT  TestAccResourceAnomalyAlert_requiresImport
--- PASS: TestAccResourceAnomalyAlert_requiresImport (44.24s)

PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement        
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cost_anomaly_alert` - Add start and end date parameters


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25004


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
