### PR TITLE
New resources: `azurerm_redis_cache_policy` and `azurerm_redis_cache_policy_assignment`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -198,6 +198,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		policy.Registration{},
 		privatednsresolver.Registration{},
 		recoveryservices.Registration{},
+		redis.Registration{},
 		redhatopenshift.Registration{},
 		resource.Registration{},
 		sentinel.Registration{},

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 type RedisCacheAccessPolicyAssignmentResource struct {
@@ -32,9 +33,10 @@ func (r RedisCacheAccessPolicyAssignmentResource) Arguments() map[string]*plugin
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 		"redis_cache_id": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: redis.ValidateRediID,
 		},
 		"access_policy_name": {
 			Type:     pluginsdk.TypeString,
@@ -47,6 +49,11 @@ func (r RedisCacheAccessPolicyAssignmentResource) Arguments() map[string]*plugin
 		"object_id_alias": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
+			ValidateFunc: validation.StringInSlice(
+				[]string{
+					"ServicePrincipal",
+					"UserMSI",
+				}, false),
 		},
 	}
 }
@@ -192,7 +199,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Read() sdk.ResourceFunc {
 
 func (r RedisCacheAccessPolicyAssignmentResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			var model RedisCacheAccessPolicyAssignmentResourceModel
 			if err := metadata.Decode(&model); err != nil {

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -122,7 +122,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Update() sdk.ResourceFunc {
 			}
 
 			updateInput := redis.RedisCacheAccessPolicyAssignment{
-				Name: existing.Model.Name,
+				Name: &id.AccessPolicyAssignmentName,
 				Properties: &redis.RedisCacheAccessPolicyAssignmentProperties{
 					AccessPolicyName: existing.Model.Properties.AccessPolicyName,
 					ObjectId:         existing.Model.Properties.ObjectId,
@@ -172,10 +172,9 @@ func (r RedisCacheAccessPolicyAssignmentResource) Read() sdk.ResourceFunc {
 
 			state := RedisCacheAccessPolicyAssignmentResourceModel{}
 
+			state.Name = id.AccessPolicyAssignmentName
+
 			if model := resp.Model; model != nil {
-				if model.Name != nil {
-					state.Name = *model.Name
-				}
 				state.RedisCacheID = redis.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName).ID()
 				if model.Properties != nil {
 					state.AccessPolicyName = model.Properties.AccessPolicyName

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -95,6 +95,15 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 			}
 			id := redis.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 
+			existing, err := client.AccessPolicyAssignmentGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
 			createInput := redis.RedisCacheAccessPolicyAssignment{
 				Name: &model.Name,
 				Properties: &redis.RedisCacheAccessPolicyAssignmentProperties{

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -28,8 +28,9 @@ type RedisCacheAccessPolicyAssignmentResourceModel struct {
 func (r RedisCacheAccessPolicyAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 		"redis_cache_id": {

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -91,7 +91,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 
 			redisId, err := redis.ParseRediID(model.RedisCacheID)
 			if err != nil {
-				return fmt.Errorf("parsing Redis Cache ID (%s): %+v", model.RedisCacheID, err)
+				return err
 			}
 			id := redis.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -1,0 +1,213 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type RedisCacheAccessPolicyAssignmentResource struct {
+}
+
+var _ sdk.ResourceWithUpdate = RedisCacheAccessPolicyAssignmentResource{}
+
+type RedisCacheAccessPolicyAssignmentResourceModel struct {
+	Name             string `tfschema:"name"`
+	RedisCacheID     string `tfschema:"redis_cache_id"`
+	AccessPolicyName string `tfschema:"access_policy_name"`
+	ObjectID         string `tfschema:"object_id"`
+	ObjectIDAlias    string `tfschema:"object_id_alias"`
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"redis_cache_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"access_policy_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"object_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"object_id_alias": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) ModelObject() interface{} {
+	return &RedisCacheAccessPolicyAssignmentResourceModel{}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) ResourceType() string {
+	return "azurerm_redis_cache_access_policy_assignment"
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return redis.ValidateAccessPolicyAssignmentID
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model RedisCacheAccessPolicyAssignmentResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.Redis.Redis
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			redisId, err := redis.ParseRediID(model.RedisCacheID)
+			if err != nil {
+				return fmt.Errorf("parsing Redis Cache ID (%s): %+v", model.RedisCacheID, err)
+			}
+			id := redis.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.AccessPolicyName)
+
+			createInput := redis.RedisCacheAccessPolicyAssignment{
+				Name: &model.Name,
+				Properties: &redis.RedisCacheAccessPolicyAssignmentProperties{
+					AccessPolicyName: model.AccessPolicyName,
+					ObjectId:         model.ObjectID,
+					ObjectIdAlias:    model.ObjectIDAlias,
+				},
+			}
+			if err := client.AccessPolicyAssignmentCreateUpdateThenPoll(ctx, id, createInput); err != nil {
+				return fmt.Errorf("failed to create Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Redis.Redis
+			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var state RedisCacheAccessPolicyAssignmentResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.AccessPolicyAssignmentGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading Redis Cache Access Policy Assignment %s: %v", id, err)
+			}
+
+			updateInput := redis.RedisCacheAccessPolicyAssignment{
+				Name: existing.Model.Name,
+				Properties: &redis.RedisCacheAccessPolicyAssignmentProperties{
+					AccessPolicyName: existing.Model.Properties.AccessPolicyName,
+					ObjectId:         existing.Model.Properties.ObjectId,
+					ObjectIdAlias:    existing.Model.Properties.ObjectIdAlias,
+				},
+			}
+
+			if metadata.ResourceData.HasChange("name") {
+				updateInput.Name = &state.Name
+			}
+			if metadata.ResourceData.HasChange("access_policy_name") {
+				updateInput.Properties.AccessPolicyName = state.AccessPolicyName
+			}
+			if metadata.ResourceData.HasChange("object_id") {
+				updateInput.Properties.ObjectId = state.ObjectID
+			}
+			if metadata.ResourceData.HasChange("object_id_alias") {
+				updateInput.Properties.ObjectIdAlias = state.ObjectIDAlias
+			}
+			if err := client.AccessPolicyAssignmentCreateUpdateThenPoll(ctx, *id, updateInput); err != nil {
+				return fmt.Errorf("failed to update Redis Cache Access Policy Assignment: %s: %+v", id.AccessPolicyAssignmentName, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			client := metadata.Client.Redis.Redis
+
+			resp, err := client.AccessPolicyAssignmentGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving Redis Cache Access Policy Assignment %s: %+v", *id, err)
+			}
+
+			state := RedisCacheAccessPolicyAssignmentResourceModel{}
+
+			if model := resp.Model; model != nil {
+				if model.Name != nil {
+					state.Name = *model.Name
+				}
+				state.RedisCacheID = redis.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName).ID()
+				if model.Properties != nil {
+					state.AccessPolicyName = model.Properties.AccessPolicyName
+					state.ObjectID = model.Properties.ObjectId
+					state.ObjectIDAlias = model.Properties.ObjectIdAlias
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model RedisCacheAccessPolicyAssignmentResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.Redis.Redis
+			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			if _, err := client.AccessPolicyAssignmentDelete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyAssignmentName, id.RedisName, id.ResourceGroupName, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -29,6 +29,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Arguments() map[string]*plugin
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 		"redis_cache_id": {
 			Type:     pluginsdk.TypeString,

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -171,7 +171,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Delete() sdk.ResourceFunc {
 			client := metadata.Client.Redis.Redis
 			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
 			if err != nil {
-				return fmt.Errorf("while parsing resource ID: %+v", err)
+				return err
 			}
 
 			if _, err := client.AccessPolicyAssignmentDelete(ctx, *id); err != nil {

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -81,7 +81,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("parsing Redis Cache ID (%s): %+v", model.RedisCacheID, err)
 			}
-			id := redis.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.AccessPolicyName)
+			id := redis.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 
 			createInput := redis.RedisCacheAccessPolicyAssignment{
 				Name: &model.Name,
@@ -122,7 +122,7 @@ func (r RedisCacheAccessPolicyAssignmentResource) Update() sdk.ResourceFunc {
 			}
 
 			updateInput := redis.RedisCacheAccessPolicyAssignment{
-				Name: &id.AccessPolicyAssignmentName,
+				Name: existing.Model.Name,
 				Properties: &redis.RedisCacheAccessPolicyAssignmentProperties{
 					AccessPolicyName: existing.Model.Properties.AccessPolicyName,
 					ObjectId:         existing.Model.Properties.ObjectId,
@@ -172,9 +172,10 @@ func (r RedisCacheAccessPolicyAssignmentResource) Read() sdk.ResourceFunc {
 
 			state := RedisCacheAccessPolicyAssignmentResourceModel{}
 
-			state.Name = id.AccessPolicyAssignmentName
-
 			if model := resp.Model; model != nil {
+				if model.Name != nil {
+					state.Name = *model.Name
+				}
 				state.RedisCacheID = redis.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName).ID()
 				if model.Properties != nil {
 					state.AccessPolicyName = model.Properties.AccessPolicyName

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -33,6 +33,40 @@ func TestAccRedisCacheAccessPolicyAssignment_basic(t *testing.T) {
 	})
 }
 
+func TestAccRedisCacheAccessPolicyAssignment_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
+	r := RedisCacheAccessPolicyAssignmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccRedisCacheAccessPolicyAssignment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
+	r := RedisCacheAccessPolicyAssignmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
 func (t RedisCacheAccessPolicyAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := redis.ParseAccessPolicyAssignmentID(state.ID)
 	if err != nil {
@@ -77,11 +111,64 @@ resource "azurerm_redis_cache" "test" {
 }
 
 resource "azurerm_redis_cache_access_policy_assignment" "test" {
-  name               = "acctestRedisAccessPolicyAssignmentName-%d"
+  name               = "acctestRedisAccessPolicyAssignmentTest"
   redis_cache_id     = azurerm_redis_cache.test.id
   access_policy_name = "Data Contributor"
   object_id          = data.azurerm_client_config.test.object_id
   object_id_alias    = "ServicePrincipal"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RedisCacheAccessPolicyAssignmentResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                          = "acctestRedis-%d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  capacity                      = 1
+  family                        = "C"
+  public_network_access_enabled = false
+  sku_name                      = "Basic"
+  enable_non_ssl_port           = true
+  minimum_tls_version           = "1.2"
+
+  redis_configuration {
+  }
+}
+
+resource "azurerm_redis_cache_access_policy_assignment" "test" {
+  name               = "acctestRedisAccessPolicyAssignmentTest"
+  redis_cache_id     = azurerm_redis_cache.test.id
+  access_policy_name = "Data Owner"
+  object_id          = data.azurerm_client_config.test.object_id
+  object_id_alias    = "ServicePrincipal"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r RedisCacheAccessPolicyAssignmentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_redis_cache_access_policy_assignment" "import" {
+  name               = azurerm_redis_cache_access_policy_assignment.test.name
+  redis_cache_id     = azurerm_redis_cache_access_policy_assignment.test.redis_cache_id
+  access_policy_name = azurerm_redis_cache_access_policy_assignment.test.access_policy_name
+  object_id          = azurerm_redis_cache_access_policy_assignment.test.object_id
+  object_id_alias    = azurerm_redis_cache_access_policy_assignment.test.object_id_alias
+}
+`, r.basic(data))
 }

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type RedisCacheAccessPolicyAssignmentResource struct{}
+
+func TestAccRedisCacheAccessPolicyAssignment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
+	r := RedisCacheAccessPolicyAssignmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t RedisCacheAccessPolicyAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := redis.ParseAccessPolicyAssignmentID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Redis.Redis.AccessPolicyAssignmentGet(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (RedisCacheAccessPolicyAssignmentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 1
+  family              = "C"
+  sku_name            = "Basic"
+  enable_non_ssl_port = true
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+}
+
+resource "azurerm_redis_cache_access_policy_assignment" "test" {
+  name = "acctestRedisAccessPolicyAssignmentName-%d"
+  redis_cache_id = azurerm_redis_cache.test.id
+  access_policy_name = "Data Contributor"
+  object_id = data.azurerm_client_config.test.object_id
+  object_id_alias = "ServicePrincipal"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -62,15 +62,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
+  name                          = "acctestRedis-%d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  capacity                      = 1
+  family                        = "C"
   public_network_access_enabled = false
-  sku_name            = "Basic"
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
+  sku_name                      = "Basic"
+  enable_non_ssl_port           = true
+  minimum_tls_version           = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -76,11 +76,11 @@ resource "azurerm_redis_cache" "test" {
 }
 
 resource "azurerm_redis_cache_access_policy_assignment" "test" {
-  name = "acctestRedisAccessPolicyAssignmentName-%d"
-  redis_cache_id = azurerm_redis_cache.test.id
+  name               = "acctestRedisAccessPolicyAssignmentName-%d"
+  redis_cache_id     = azurerm_redis_cache.test.id
   access_policy_name = "Data Contributor"
-  object_id = data.azurerm_client_config.test.object_id
-  object_id_alias = "ServicePrincipal"
+  object_id          = data.azurerm_client_config.test.object_id
+  object_id_alias    = "ServicePrincipal"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -33,26 +33,6 @@ func TestAccRedisCacheAccessPolicyAssignment_basic(t *testing.T) {
 	})
 }
 
-func TestAccRedisCacheAccessPolicyAssignment_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
-	r := RedisCacheAccessPolicyAssignmentResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.update(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-	})
-}
-
 func TestAccRedisCacheAccessPolicyAssignment_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
 	r := RedisCacheAccessPolicyAssignmentResource{}
@@ -114,45 +94,6 @@ resource "azurerm_redis_cache_access_policy_assignment" "test" {
   name               = "acctestRedisAccessPolicyAssignmentTest"
   redis_cache_id     = azurerm_redis_cache.test.id
   access_policy_name = "Data Contributor"
-  object_id          = data.azurerm_client_config.test.object_id
-  object_id_alias    = "ServicePrincipal"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
-func (RedisCacheAccessPolicyAssignmentResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_redis_cache" "test" {
-  name                          = "acctestRedis-%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  capacity                      = 1
-  family                        = "C"
-  public_network_access_enabled = false
-  sku_name                      = "Basic"
-  enable_non_ssl_port           = true
-  minimum_tls_version           = "1.2"
-
-  redis_configuration {
-  }
-}
-
-resource "azurerm_redis_cache_access_policy_assignment" "test" {
-  name               = "acctestRedisAccessPolicyAssignmentTest"
-  redis_cache_id     = azurerm_redis_cache.test.id
-  access_policy_name = "Data Owner"
   object_id          = data.azurerm_client_config.test.object_id
   object_id_alias    = "ServicePrincipal"
 }

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -76,15 +76,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                          = "acctestRedis-%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  capacity                      = 1
-  family                        = "C"
-  public_network_access_enabled = false
-  sku_name                      = "Basic"
-  enable_non_ssl_port           = true
-  minimum_tls_version           = "1.2"
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 1
+  family              = "C"
+  sku_name            = "Basic"
+  enable_non_ssl_port = true
+  minimum_tls_version = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -27,6 +27,7 @@ func (r RedisCacheAccessPolicyResource) Arguments() map[string]*pluginsdk.Schema
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"redis_cache_id": {
 			Type:         pluginsdk.TypeString,

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -75,6 +75,15 @@ func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
 			}
 			id := redis.NewAccessPolicyID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 
+			existing, err := client.AccessPolicyGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
 			policyTypeCustom := redis.AccessPolicyTypeCustom
 
 			createInput := redis.RedisCacheAccessPolicy{

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -29,9 +29,10 @@ func (r RedisCacheAccessPolicyResource) Arguments() map[string]*pluginsdk.Schema
 			Required: true,
 		},
 		"redis_cache_id": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: redis.ValidateRediID,
 		},
 		"permissions": {
 			Type:     pluginsdk.TypeString,
@@ -175,7 +176,7 @@ func (r RedisCacheAccessPolicyResource) Read() sdk.ResourceFunc {
 
 func (r RedisCacheAccessPolicyResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			var model RedisCacheAccessPolicyResourceModel
 			if err := metadata.Decode(&model); err != nil {

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -182,13 +182,13 @@ func (r RedisCacheAccessPolicyResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("decoding %+v", err)
 			}
 			client := metadata.Client.Redis.Redis
-			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
+			id, err := redis.ParseAccessPolicyID(metadata.ResourceData.Id())
 			if err != nil {
 				return fmt.Errorf("while parsing resource ID: %+v", err)
 			}
 
-			if _, err := client.AccessPolicyAssignmentDelete(ctx, *id); err != nil {
-				return fmt.Errorf("deleting Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyAssignmentName, id.RedisName, id.ResourceGroupName, err)
+			if _, err := client.AccessPolicyDelete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting Redis Cache Access Policy %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyName, id.RedisName, id.ResourceGroupName, err)
 			}
 
 			return nil

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -1,0 +1,197 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type RedisCacheAccessPolicyResource struct {
+}
+
+var _ sdk.ResourceWithUpdate = RedisCacheAccessPolicyResource{}
+
+type RedisCacheAccessPolicyResourceModel struct {
+	Name         string `tfschema:"name"`
+	RedisCacheID string `tfschema:"redis_cache_id"`
+	Permissions  string `tfschema:"permissions"`
+}
+
+func (r RedisCacheAccessPolicyResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"redis_cache_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"permissions": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r RedisCacheAccessPolicyResource) ModelObject() interface{} {
+	return &RedisCacheAccessPolicyResourceModel{}
+}
+
+func (r RedisCacheAccessPolicyResource) ResourceType() string {
+	return "azurerm_redis_cache_access_policy"
+}
+
+func (r RedisCacheAccessPolicyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return redis.ValidateAccessPolicyID
+}
+
+func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model RedisCacheAccessPolicyResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.Redis.Redis
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			redisId, err := redis.ParseRediID(model.RedisCacheID)
+			if err != nil {
+				return fmt.Errorf("parsing Redis Cache ID (%s): %+v", model.RedisCacheID, err)
+			}
+			id := redis.NewAccessPolicyID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
+
+			policyTypeCustom := redis.AccessPolicyTypeCustom
+
+			createInput := redis.RedisCacheAccessPolicy{
+				Name: &model.Name,
+				Properties: &redis.RedisCacheAccessPolicyProperties{
+					Permissions: model.Permissions,
+					Type:        &policyTypeCustom,
+				},
+			}
+			if err := client.AccessPolicyCreateUpdateThenPoll(ctx, id, createInput); err != nil {
+				return fmt.Errorf("failed to create Redis Cache Access Policy %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Redis.Redis
+			id, err := redis.ParseAccessPolicyID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var state RedisCacheAccessPolicyResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.AccessPolicyGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading Redis Cache Access Policy %s: %v", id.AccessPolicyName, err)
+			}
+
+			policyTypeCustom := redis.AccessPolicyTypeCustom
+
+			updateInput := redis.RedisCacheAccessPolicy{
+				Name: &id.AccessPolicyName,
+				Properties: &redis.RedisCacheAccessPolicyProperties{
+					Permissions: existing.Model.Properties.Permissions,
+					Type:        &policyTypeCustom,
+				},
+			}
+
+			if metadata.ResourceData.HasChange("name") {
+				updateInput.Name = &state.Name
+			}
+			if metadata.ResourceData.HasChange("permissions") {
+				updateInput.Properties.Permissions = state.Permissions
+			}
+			if err := client.AccessPolicyCreateUpdateThenPoll(ctx, *id, updateInput); err != nil {
+				return fmt.Errorf("failed to update Redis Cache Access Policy %s: %+v", id.AccessPolicyName, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := redis.ParseAccessPolicyID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			client := metadata.Client.Redis.Redis
+
+			resp, err := client.AccessPolicyGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving Redis Cache Access Policy %s: %+v", *id, err)
+			}
+
+			state := RedisCacheAccessPolicyResourceModel{}
+
+			if model := resp.Model; model != nil {
+				if model.Name != nil {
+					state.Name = *model.Name
+				}
+				state.RedisCacheID = redis.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName).ID()
+				if model.Properties != nil {
+					state.Permissions = model.Properties.Permissions
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model RedisCacheAccessPolicyResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+			client := metadata.Client.Redis.Redis
+			id, err := redis.ParseAccessPolicyAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			if _, err := client.AccessPolicyAssignmentDelete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyAssignmentName, id.RedisName, id.ResourceGroupName, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type RedisCacheAccessPolicyAssignmentResource struct{}
+type RedisCacheAccessPolicyResource struct{}
 
-func TestAccRedisCacheAccessPolicyAssignment_basic(t *testing.T) {
+func TestAccRedisCacheAccessPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
-	r := RedisCacheAccessPolicyAssignmentResource{}
+	r := RedisCacheAccessPolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -33,13 +33,13 @@ func TestAccRedisCacheAccessPolicyAssignment_basic(t *testing.T) {
 	})
 }
 
-func (t RedisCacheAccessPolicyAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := redis.ParseAccessPolicyAssignmentID(state.ID)
+func (t RedisCacheAccessPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := redis.ParseAccessPolicyID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Redis.Redis.AccessPolicyAssignmentGet(ctx, *id)
+	resp, err := clients.Redis.Redis.AccessPolicyGet(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
@@ -47,7 +47,7 @@ func (t RedisCacheAccessPolicyAssignmentResource) Exists(ctx context.Context, cl
 	return utils.Bool(resp.Model != nil), nil
 }
 
-func (RedisCacheAccessPolicyAssignmentResource) basic(data acceptance.TestData) string {
+func (RedisCacheAccessPolicyResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -76,12 +76,10 @@ resource "azurerm_redis_cache" "test" {
   }
 }
 
-resource "azurerm_redis_cache_access_policy_assignment" "test" {
-  name               = "acctestRedisAccessPolicyAssignmentName-%d"
-  redis_cache_id     = azurerm_redis_cache.test.id
-  access_policy_name = "Data Contributor"
-  object_id          = data.azurerm_client_config.test.object_id
-  object_id_alias    = "ServicePrincipal"
+resource "azurerm_redis_cache_access_policy" "test" {
+  name           = "acctestRedisAccessPolicy-%d"
+  redis_cache_id = azurerm_redis_cache.test.id
+  permissions    = "+@read +@connection +cluster|info"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -19,7 +19,7 @@ import (
 type RedisCacheAccessPolicyResource struct{}
 
 func TestAccRedisCacheAccessPolicy_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy_assignment", "test")
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy", "test")
 	r := RedisCacheAccessPolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -62,15 +62,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
+  name                          = "acctestRedis-%d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  capacity                      = 1
+  family                        = "C"
   public_network_access_enabled = false
-  sku_name            = "Basic"
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
+  sku_name                      = "Basic"
+  enable_non_ssl_port           = true
+  minimum_tls_version           = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -33,26 +33,6 @@ func TestAccRedisCacheAccessPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccRedisCacheAccessPolicy_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy", "test")
-	r := RedisCacheAccessPolicyResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.update(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-	})
-}
-
 func TestAccRedisCacheAccessPolicy_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy", "test")
 	r := RedisCacheAccessPolicyResource{}
@@ -128,41 +108,4 @@ resource "azurerm_redis_cache_access_policy" "import" {
   permissions    = azurerm_redis_cache_access_policy.test.permissions
 }
 `, r.basic(data))
-}
-
-func (RedisCacheAccessPolicyResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_redis_cache" "test" {
-  name                          = "acctestRedis-%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  capacity                      = 1
-  family                        = "C"
-  public_network_access_enabled = false
-  sku_name                      = "Basic"
-  enable_non_ssl_port           = true
-  minimum_tls_version           = "1.2"
-
-  redis_configuration {
-  }
-}
-
-resource "azurerm_redis_cache_access_policy" "test" {
-  name           = "acctestRedisAccessPolicy-test"
-  redis_cache_id = azurerm_redis_cache.test.id
-  permissions    = "+@read +@connection allkeys"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -111,7 +111,7 @@ resource "azurerm_redis_cache" "test" {
 }
 
 resource "azurerm_redis_cache_access_policy" "test" {
-  name           = "acctestRedisAccessPolicy-test"
+  name           = "acctestRedisAccessPolicytest"
   redis_cache_id = azurerm_redis_cache.test.id
   permissions    = "+@read +@connection +cluster|info allkeys"
 }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -79,7 +79,7 @@ resource "azurerm_redis_cache" "test" {
 resource "azurerm_redis_cache_access_policy" "test" {
   name           = "acctestRedisAccessPolicy-%d"
   redis_cache_id = azurerm_redis_cache.test.id
-  permissions    = "+@read +@connection +cluster|info"
+  permissions    = "+@read +@connection +cluster|info allkeys"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -76,15 +76,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                          = "acctestRedis-%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  capacity                      = 1
-  family                        = "C"
-  public_network_access_enabled = false
-  sku_name                      = "Basic"
-  enable_non_ssl_port           = true
-  minimum_tls_version           = "1.2"
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 1
+  family              = "C"
+  sku_name            = "Basic"
+  enable_non_ssl_port = true
+  minimum_tls_version = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -54,10 +54,10 @@ func resourceRedisCache() *pluginsdk.Resource {
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(90 * time.Minute),
+			Create: pluginsdk.DefaultTimeout(180 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(90 * time.Minute),
-			Delete: pluginsdk.DefaultTimeout(90 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(180 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(180 * time.Minute),
 		},
 
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/redis/registration.go
+++ b/internal/services/redis/registration.go
@@ -53,7 +53,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
-		RedisCacheAccessPolicyResource{},
+		RedisCacheAccessPolicyAssignmentResource{},
 		RedisCacheAccessPolicyResource{},
 	}
 }

--- a/internal/services/redis/registration.go
+++ b/internal/services/redis/registration.go
@@ -53,6 +53,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
-		RedisCacheAccessPolicyAssignmentResource{},
+		RedisCacheAccessPolicyResource{},
+		RedisCacheAccessPolicyResource{},
 	}
 }

--- a/internal/services/redis/registration.go
+++ b/internal/services/redis/registration.go
@@ -10,7 +10,10 @@ import (
 
 type Registration struct{}
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var (
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/redis"
@@ -41,5 +44,15 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_redis_cache":         resourceRedisCache(),
 		"azurerm_redis_firewall_rule": resourceRedisFirewallRule(),
 		"azurerm_redis_linked_server": resourceRedisLinkedServer(),
+	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		RedisCacheAccessPolicyAssignmentResource{},
 	}
 }

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -228,10 +228,10 @@ A `redis_configuration` block exports the following:
 
  The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 90 minutes) Used when creating the Redis Cache.
-* `update` - (Defaults to 90 minutes) Used when updating the Redis Cache.
+* `create` - (Defaults to 180 minutes) Used when creating the Redis Cache.
+* `update` - (Defaults to 180 minutes) Used when updating the Redis Cache.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache.
-* `delete` - (Defaults to 90 minutes) Used when deleting the Redis Cache.
+* `delete` - (Defaults to 180 minutes) Used when deleting the Redis Cache.
 
 ## Import
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -1,0 +1,72 @@
+---
+subcategory: "Redis"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_redis_cache_access_policy"
+description: |-
+  Manages a Redis Cache Access Policy.
+---
+
+# azurerm_redis_cache_access_policy
+
+Manages a Redis Cache Access Policy
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "East US"
+}
+
+resource "azurerm_redis_cache" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 1
+  family              = "P"
+  sku_name            = "Premium"
+  enable_non_ssl_port = false
+
+  redis_configuration {
+    maxmemory_reserved = 2
+    maxmemory_delta    = 2
+    maxmemory_policy   = "allkeys-lru"
+  }
+}
+
+resource "azurerm_redis_cache_access_policy" "example" {
+  name           = "example"
+  redis_cache_id = azurerm_redis_cache.example.id
+  permissions    = "+@read +@connection +cluster|info" 
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Redis Cache Access Policy.
+
+* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Redis.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 60 minutes) Used when creating the Redis Cache Access Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Redis Cache Access Policy.
+
+## Import
+
+Redis can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_redis_cache_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicies/policy1
+```

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -37,7 +37,7 @@ resource "azurerm_redis_cache" "example" {
 resource "azurerm_redis_cache_access_policy" "example" {
   name           = "example"
   redis_cache_id = azurerm_redis_cache.example.id
-  permissions    = "+@read +@connection +cluster|info" 
+  permissions    = "+@read +@connection +cluster|info"
 }
 ```
 
@@ -48,6 +48,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the Redis Cache Access Policy.
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
+
+* `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy.
 
 ## Attributes Reference
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Redis.
+* `id` - The ID of the Redis Cache Access Policy.
 
 ## Timeouts
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy to be created.
 
-* `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy.
+* `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy. Changing this forces a new Redis Cache Access Policy to be created.
 
 ## Attributes Reference
 
@@ -62,7 +62,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 5 minutes) Used when creating the Redis Cache Access Policy.
-* `update` - (Defaults to 5 minutes) Used when updating the Redis Cache Access Policy.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy.
 * `delete` - (Defaults to 5 minutes) Used when deleting the Redis Cache Access Policy.
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -71,5 +71,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Redis Cache Access Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_redis_cache_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicies/policy1
+terraform import azurerm_redis_cache_access_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicies/policy1
 ```

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -67,7 +67,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Redis can be imported using the `resource id`, e.g.
+Redis Cache Access Policy can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_redis_cache_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicies/policy1

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Redis Cache Access Policy.
 
-* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
+* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy to be created.
 
 * `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy.
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -61,9 +61,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the Redis Cache Access Policy.
+* `create` - (Defaults to 5 minutes) Used when creating the Redis Cache Access Policy.
+* `update` - (Defaults to 5 minutes) Used when updating the Redis Cache Access Policy.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy.
-* `delete` - (Defaults to 60 minutes) Used when deleting the Redis Cache Access Policy.
+* `delete` - (Defaults to 5 minutes) Used when deleting the Redis Cache Access Policy.
 
 ## Import
 

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_redis_cache_access_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Redis Cache Access Policy.
+* `name` - (Required) The name of the Redis Cache Access Policy. Changing this forces a new Redis Cache Access Policy to be created.
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy to be created.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -77,8 +77,8 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Redis can be imported using the `resource id`, e.g.
+Redis Cache Policy Assignment can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_redis_cache_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicyAssignments/assignment1
+terraform import azurerm_redis_cache_access_policy_assignment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicyAssignments/assignment1
 ```

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_redis_cache_access_policy_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Redis Cache Access Policy.
+* `name` - (Required) The name of the Redis Cache Access Policy Assignment.
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -1,0 +1,83 @@
+---
+subcategory: "Redis"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_redis_cache_access_policy_assignment"
+description: |-
+  Manages a Redis Cache Access Policy Assignment.
+---
+
+# azurerm_redis_cache_access_policy_assignment
+
+Manages a Redis Cache Access Policy Assignment
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "East US"
+}
+
+resource "azurerm_redis_cache" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 1
+  family              = "P"
+  sku_name            = "Premium"
+  enable_non_ssl_port = false
+
+  redis_configuration {
+    maxmemory_reserved = 2
+    maxmemory_delta    = 2
+    maxmemory_policy   = "allkeys-lru"
+  }
+}
+
+resource "azurerm_redis_cache_access_policy_assignment" "example" {
+  name               = "example"
+  redis_cache_id     = azurerm_redis_cache.example.id
+  access_policy_name = "Data Contributor"
+  object_id          = data.azurerm_client_config.test.object_id
+  object_id_alias    = "ServicePrincipal"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Redis Cache Access Policy.
+
+* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
+
+* `access_policy_name` - (Required) The name of the Access Policy to be assigned.
+
+* `object_id` - (Required) The principal ID to be assigned the Access Policy.
+
+* `object_id_alias` - (Required) The alias of the principal ID. Possible values are `ServicePrincipal` and `UserMSI`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Redis.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 60 minutes) Used when creating the Redis Cache Access Policy Assignment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy Assignment.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Redis Cache Access Policy Assignment.
+
+## Import
+
+Redis can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_redis_cache_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1/accessPolicyAssignments/assignment1
+```

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Redis Cache Access Policy Assignment.
 
-* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis to be created.
+* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
 * `access_policy_name` - (Required) The name of the Access Policy to be assigned.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_redis_cache_access_policy_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Redis Cache Access Policy Assignment.
+* `name` - (Required) The name of the Redis Cache Access Policy Assignment. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -71,6 +71,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Redis Cache Access Policy Assignment.
+* `update` - (Defaults to 5 minutes) Used when updating the Redis Cache Access Policy Assignment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy Assignment.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Redis Cache Access Policy Assignment.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -54,11 +54,11 @@ The following arguments are supported:
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
-* `access_policy_name` - (Required) The name of the Access Policy to be assigned.
+* `access_policy_name` - (Required) The name of the Access Policy to be assigned. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
-* `object_id` - (Required) The principal ID to be assigned the Access Policy.
+* `object_id` - (Required) The principal ID to be assigned the Access Policy. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
-* `object_id_alias` - (Required) The alias of the principal ID. Possible values are `ServicePrincipal` and `UserMSI`.
+* `object_id_alias` - (Required) The alias of the principal ID. Possible values are `ServicePrincipal` and `UserMSI`. Changing this forces a new Redis Cache Access Policy Assignment to be created.
 
 ## Attributes Reference
 
@@ -71,7 +71,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Redis Cache Access Policy Assignment.
-* `update` - (Defaults to 5 minutes) Used when updating the Redis Cache Access Policy Assignment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Access Policy Assignment.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Redis Cache Access Policy Assignment.
 

--- a/website/docs/r/redis_cache_access_policy_assignment.html.markdown
+++ b/website/docs/r/redis_cache_access_policy_assignment.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Redis.
+* `id` - The ID of the Redis Cache Access Policy Assignment.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adds 2 new resources:
`azurerm_redis_cache_access_policy`
`azurerm_redis_cache_access_policy_assignment`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/805046/e4c178de-4e55-47c3-b4e0-a23e717e3980)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New resource: `azurerm_redis_cache_access_policy` 
* New resource: `azurerm_redis_cache_access_policy_assignment` 
* `azurerm_redis_cache`: Up Create/Update/Delete default timeouts to 180 minutes

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] New Feature (ie adding a service, resource, or data source)


## Related Issue(s)
Fixes #24692


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
