### PR TITLE
New Resource: `azurerm_virtual_machine_automanage_configuration_assignment`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -40,7 +40,7 @@ service/authorization:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(client_config|federated_identity_credential|marketplace_role_assignment|pim_|role_|user_assigned_identity)((.|\n)*)###'
 
 service/automanage:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_automanage_configuration((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(automanage_configuration|virtual_machine_automanage_configuration_assignment)((.|\n)*)###'
 
 service/automation:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_automation_((.|\n)*)###'

--- a/internal/services/automanage/client/client.go
+++ b/internal/services/automanage/client/client.go
@@ -5,8 +5,8 @@ package client
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofilehciassignments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofiles"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"

--- a/internal/services/automanage/client/client.go
+++ b/internal/services/automanage/client/client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofilehciassignments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofiles"
@@ -14,6 +15,7 @@ import (
 type Client struct {
 	ConfigurationProfilesClient              *configurationprofiles.ConfigurationProfilesClient
 	ConfigurationProfileHCIAssignmentsClient *configurationprofilehciassignments.ConfigurationProfileHCIAssignmentsClient
+	ConfigurationProfileVMAssignmentsClient  *configurationprofileassignments.ConfigurationProfileAssignmentsClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -29,8 +31,15 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(configurationProfileHCIAssignmentsClient.Client, o.Authorizers.ResourceManager)
 
+	configurationProfileVMAssignmentsClient, err := configurationprofileassignments.NewConfigurationProfileAssignmentsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building ConfigurationProfilesHCIAssignments client: %+v", err)
+	}
+	o.Configure(configurationProfileVMAssignmentsClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
 		ConfigurationProfilesClient:              configurationProfilesClient,
 		ConfigurationProfileHCIAssignmentsClient: configurationProfileHCIAssignmentsClient,
+		ConfigurationProfileVMAssignmentsClient:  configurationProfileVMAssignmentsClient,
 	}, nil
 }

--- a/internal/services/automanage/registration.go
+++ b/internal/services/automanage/registration.go
@@ -50,5 +50,6 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		AutoManageConfigurationResource{},
+		VirtualMachineConfigurationAssignment{},
 	}
 }

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource.go
@@ -3,6 +3,8 @@ package automanage
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
@@ -10,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"time"
 )
 
 type VirtualMachineConfigurationAssignment struct {

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource.go
@@ -1,0 +1,164 @@
+package automanage
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofiles"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"time"
+)
+
+type VirtualMachineConfigurationAssignment struct {
+	VirtualMachineId string `tfschema:"virtual_machine_id"`
+	ConfigurationId  string `tfschema:"configuration_id"`
+}
+
+func (v VirtualMachineConfigurationAssignment) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"virtual_machine_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: configurationprofileassignments.ValidateVirtualMachineID,
+		},
+		"configuration_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: configurationprofiles.ValidateConfigurationProfileID,
+		},
+	}
+}
+
+func (v VirtualMachineConfigurationAssignment) Attributes() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (v VirtualMachineConfigurationAssignment) ModelObject() interface{} {
+	return &VirtualMachineConfigurationAssignment{}
+}
+
+func (v VirtualMachineConfigurationAssignment) ResourceType() string {
+	return "azurerm_virtual_machine_automanage_configuration_assignment"
+}
+
+func (v VirtualMachineConfigurationAssignment) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Automanage.ConfigurationProfileVMAssignmentsClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model VirtualMachineConfigurationAssignment
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vmId, err := configurationprofileassignments.ParseVirtualMachineID(model.VirtualMachineId)
+			if err != nil {
+				return err
+			}
+
+			configurationId, err := configurationprofiles.ParseConfigurationProfileID(model.ConfigurationId)
+			if err != nil {
+				return err
+			}
+
+			id := configurationprofileassignments.NewVirtualMachineProviders2ConfigurationProfileAssignmentID(subscriptionId, vmId.ResourceGroupName, vmId.VirtualMachineName, configurationId.ConfigurationProfileName)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(v.ResourceType(), id)
+			}
+
+			properties := configurationprofileassignments.ConfigurationProfileAssignment{
+				Name: &configurationId.ConfigurationProfileName,
+				Properties: &configurationprofileassignments.ConfigurationProfileAssignmentProperties{
+					ConfigurationProfile: pointer.To(configurationId.ID()),
+					TargetId:             pointer.To(vmId.ID()),
+				},
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (v VirtualMachineConfigurationAssignment) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Automanage.ConfigurationProfileVMAssignmentsClient
+			id, err := configurationprofileassignments.ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := VirtualMachineConfigurationAssignment{}
+
+			if model := resp.Model; model != nil {
+				configurationId, err := configurationprofiles.ParseConfigurationProfileID(*model.Properties.ConfigurationProfile)
+				if err != nil {
+					return err
+				}
+				state.ConfigurationId = configurationId.ID()
+
+				virtualMachineId, err := configurationprofileassignments.ParseVirtualMachineID(*model.Properties.TargetId)
+				if err != nil {
+					return err
+				}
+				state.VirtualMachineId = virtualMachineId.ID()
+			}
+
+			return metadata.Encode(state)
+		},
+	}
+}
+
+func (v VirtualMachineConfigurationAssignment) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Automanage.ConfigurationProfileVMAssignmentsClient
+
+			id, err := configurationprofileassignments.ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (v VirtualMachineConfigurationAssignment) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return configurationprofileassignments.ValidateVirtualMachineProviders2ConfigurationProfileAssignmentID
+}
+
+var _ sdk.Resource = &VirtualMachineConfigurationAssignment{}

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
@@ -1,0 +1,126 @@
+package automanage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type VirtualMachineConfigurationAssignmentResource struct{}
+
+func TestAccVirtualMachineConfigurationAssignment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
+	r := VirtualMachineConfigurationAssignmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r VirtualMachineConfigurationAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	client := clients.Automanage.ConfigurationProfileVMAssignmentsClient
+
+	id, err := configurationprofileassignments.ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r VirtualMachineConfigurationAssignmentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+	features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_automanage_configuration" "test" {
+  name                = "acctest-amcp-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_machine_automanage_configuration_assignment" "test" {
+	virtual_machine_id = azurerm_virtual_machine.test.id
+	configuration_id  = azurerm_virtual_machine_automanage_configuration_profile.test.id
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
@@ -66,7 +66,7 @@ func (r VirtualMachineConfigurationAssignmentResource) Exists(ctx context.Contex
 func (r VirtualMachineConfigurationAssignmentResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-	features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -132,9 +132,10 @@ resource "azurerm_automanage_configuration" "test" {
 }
 
 resource "azurerm_virtual_machine_automanage_configuration_assignment" "test" {
-	virtual_machine_id = azurerm_linux_virtual_machine.test.id
-	configuration_id   = azurerm_automanage_configuration.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  configuration_id   = azurerm_automanage_configuration.test.id
 }
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/README.md
@@ -1,0 +1,154 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments` Documentation
+
+The `configurationprofileassignments` SDK allows for interaction with the Azure Resource Manager Service `automanage` (API Version `2022-05-04`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments"
+```
+
+
+### Client Initialization
+
+```go
+client := configurationprofileassignments.NewConfigurationProfileAssignmentsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewVirtualMachineProviders2ConfigurationProfileAssignmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "configurationProfileAssignmentValue")
+
+payload := configurationprofileassignments.ConfigurationProfileAssignment{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewVirtualMachineProviders2ConfigurationProfileAssignmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "configurationProfileAssignmentValue")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.Get`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewVirtualMachineProviders2ConfigurationProfileAssignmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "configurationProfileAssignmentValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+read, err := client.List(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.ListByClusterName`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "clusterValue")
+
+read, err := client.ListByClusterName(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.ListByMachineName`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "machineValue")
+
+read, err := client.ListByMachineName(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+read, err := client.ListBySubscription(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConfigurationProfileAssignmentsClient.ListByVirtualMachines`
+
+```go
+ctx := context.TODO()
+id := configurationprofileassignments.NewVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue")
+
+read, err := client.ListByVirtualMachines(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/client.go
@@ -1,0 +1,26 @@
+package configurationprofileassignments
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConfigurationProfileAssignmentsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewConfigurationProfileAssignmentsClientWithBaseURI(sdkApi sdkEnv.Api) (*ConfigurationProfileAssignmentsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "configurationprofileassignments", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ConfigurationProfileAssignmentsClient: %+v", err)
+	}
+
+	return &ConfigurationProfileAssignmentsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_cluster.go
@@ -1,0 +1,125 @@
+package configurationprofileassignments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &ClusterId{}
+
+// ClusterId is a struct representing the Resource ID for a Cluster
+type ClusterId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ClusterName       string
+}
+
+// NewClusterID returns a new ClusterId struct
+func NewClusterID(subscriptionId string, resourceGroupName string, clusterName string) ClusterId {
+	return ClusterId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ClusterName:       clusterName,
+	}
+}
+
+// ParseClusterID parses 'input' into a ClusterId
+func ParseClusterID(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseClusterIDInsensitively parses 'input' case-insensitively into a ClusterId
+// note: this method should only be used for API response data and not user input
+func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ClusterName, ok = input.Parsed["clusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateClusterID checks that 'input' can be parsed as a Cluster ID
+func ValidateClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cluster ID
+func (id ClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AzureStackHCI/clusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cluster ID
+func (id ClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftAzureStackHCI", "Microsoft.AzureStackHCI", "Microsoft.AzureStackHCI"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterName", "clusterValue"),
+	}
+}
+
+// String returns a human-readable description of this Cluster ID
+func (id ClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cluster Name: %q", id.ClusterName),
+	}
+	return fmt.Sprintf("Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_machine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_machine.go
@@ -1,0 +1,125 @@
+package configurationprofileassignments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &MachineId{}
+
+// MachineId is a struct representing the Resource ID for a Machine
+type MachineId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	MachineName       string
+}
+
+// NewMachineID returns a new MachineId struct
+func NewMachineID(subscriptionId string, resourceGroupName string, machineName string) MachineId {
+	return MachineId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		MachineName:       machineName,
+	}
+}
+
+// ParseMachineID parses 'input' into a MachineId
+func ParseMachineID(input string) (*MachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseMachineIDInsensitively parses 'input' case-insensitively into a MachineId
+// note: this method should only be used for API response data and not user input
+func ParseMachineIDInsensitively(input string) (*MachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *MachineId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.MachineName, ok = input.Parsed["machineName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "machineName", input)
+	}
+
+	return nil
+}
+
+// ValidateMachineID checks that 'input' can be parsed as a Machine ID
+func ValidateMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Machine ID
+func (id MachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.HybridCompute/machines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.MachineName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Machine ID
+func (id MachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftHybridCompute", "Microsoft.HybridCompute", "Microsoft.HybridCompute"),
+		resourceids.StaticSegment("staticMachines", "machines", "machines"),
+		resourceids.UserSpecifiedSegment("machineName", "machineValue"),
+	}
+}
+
+// String returns a human-readable description of this Machine ID
+func (id MachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Machine Name: %q", id.MachineName),
+	}
+	return fmt.Sprintf("Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_virtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_virtualmachine.go
@@ -1,0 +1,125 @@
+package configurationprofileassignments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineId{}
+
+// VirtualMachineId is a struct representing the Resource ID for a Virtual Machine
+type VirtualMachineId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	VirtualMachineName string
+}
+
+// NewVirtualMachineID returns a new VirtualMachineId struct
+func NewVirtualMachineID(subscriptionId string, resourceGroupName string, virtualMachineName string) VirtualMachineId {
+	return VirtualMachineId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		VirtualMachineName: virtualMachineName,
+	}
+}
+
+// ParseVirtualMachineID parses 'input' into a VirtualMachineId
+func ParseVirtualMachineID(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineIDInsensitively parses 'input' case-insensitively into a VirtualMachineId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineIDInsensitively(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineName, ok = input.Parsed["virtualMachineName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineID checks that 'input' can be parsed as a Virtual Machine ID
+func ValidateVirtualMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine ID
+func (id VirtualMachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine ID
+func (id VirtualMachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("virtualMachineName", "virtualMachineValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine ID
+func (id VirtualMachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Name: %q", id.VirtualMachineName),
+	}
+	return fmt.Sprintf("Virtual Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_virtualmachineproviders2configurationprofileassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/id_virtualmachineproviders2configurationprofileassignment.go
@@ -1,0 +1,136 @@
+package configurationprofileassignments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineProviders2ConfigurationProfileAssignmentId{}
+
+// VirtualMachineProviders2ConfigurationProfileAssignmentId is a struct representing the Resource ID for a Virtual Machine Providers 2 Configuration Profile Assignment
+type VirtualMachineProviders2ConfigurationProfileAssignmentId struct {
+	SubscriptionId                     string
+	ResourceGroupName                  string
+	VirtualMachineName                 string
+	ConfigurationProfileAssignmentName string
+}
+
+// NewVirtualMachineProviders2ConfigurationProfileAssignmentID returns a new VirtualMachineProviders2ConfigurationProfileAssignmentId struct
+func NewVirtualMachineProviders2ConfigurationProfileAssignmentID(subscriptionId string, resourceGroupName string, virtualMachineName string, configurationProfileAssignmentName string) VirtualMachineProviders2ConfigurationProfileAssignmentId {
+	return VirtualMachineProviders2ConfigurationProfileAssignmentId{
+		SubscriptionId:                     subscriptionId,
+		ResourceGroupName:                  resourceGroupName,
+		VirtualMachineName:                 virtualMachineName,
+		ConfigurationProfileAssignmentName: configurationProfileAssignmentName,
+	}
+}
+
+// ParseVirtualMachineProviders2ConfigurationProfileAssignmentID parses 'input' into a VirtualMachineProviders2ConfigurationProfileAssignmentId
+func ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(input string) (*VirtualMachineProviders2ConfigurationProfileAssignmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineProviders2ConfigurationProfileAssignmentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineProviders2ConfigurationProfileAssignmentId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineProviders2ConfigurationProfileAssignmentIDInsensitively parses 'input' case-insensitively into a VirtualMachineProviders2ConfigurationProfileAssignmentId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineProviders2ConfigurationProfileAssignmentIDInsensitively(input string) (*VirtualMachineProviders2ConfigurationProfileAssignmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineProviders2ConfigurationProfileAssignmentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineProviders2ConfigurationProfileAssignmentId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineProviders2ConfigurationProfileAssignmentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineName, ok = input.Parsed["virtualMachineName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", input)
+	}
+
+	if id.ConfigurationProfileAssignmentName, ok = input.Parsed["configurationProfileAssignmentName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "configurationProfileAssignmentName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineProviders2ConfigurationProfileAssignmentID checks that 'input' can be parsed as a Virtual Machine Providers 2 Configuration Profile Assignment ID
+func ValidateVirtualMachineProviders2ConfigurationProfileAssignmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Providers 2 Configuration Profile Assignment ID
+func (id VirtualMachineProviders2ConfigurationProfileAssignmentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s/providers/Microsoft.AutoManage/configurationProfileAssignments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineName, id.ConfigurationProfileAssignmentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Providers 2 Configuration Profile Assignment ID
+func (id VirtualMachineProviders2ConfigurationProfileAssignmentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("virtualMachineName", "virtualMachineValue"),
+		resourceids.StaticSegment("staticProviders2", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftAutoManage", "Microsoft.AutoManage", "Microsoft.AutoManage"),
+		resourceids.StaticSegment("staticConfigurationProfileAssignments", "configurationProfileAssignments", "configurationProfileAssignments"),
+		resourceids.UserSpecifiedSegment("configurationProfileAssignmentName", "configurationProfileAssignmentValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Providers 2 Configuration Profile Assignment ID
+func (id VirtualMachineProviders2ConfigurationProfileAssignmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Name: %q", id.VirtualMachineName),
+		fmt.Sprintf("Configuration Profile Assignment Name: %q", id.ConfigurationProfileAssignmentName),
+	}
+	return fmt.Sprintf("Virtual Machine Providers 2 Configuration Profile Assignment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_createorupdate.go
@@ -1,0 +1,59 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignment
+}
+
+// CreateOrUpdate ...
+func (c ConfigurationProfileAssignmentsClient) CreateOrUpdate(ctx context.Context, id VirtualMachineProviders2ConfigurationProfileAssignmentId, input ConfigurationProfileAssignment) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignment
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_delete.go
@@ -1,0 +1,47 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c ConfigurationProfileAssignmentsClient) Delete(ctx context.Context, id VirtualMachineProviders2ConfigurationProfileAssignmentId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_get.go
@@ -1,0 +1,54 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignment
+}
+
+// Get ...
+func (c ConfigurationProfileAssignmentsClient) Get(ctx context.Context, id VirtualMachineProviders2ConfigurationProfileAssignmentId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignment
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_list.go
@@ -1,0 +1,56 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignmentList
+}
+
+// List ...
+func (c ConfigurationProfileAssignmentsClient) List(ctx context.Context, id commonids.ResourceGroupId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.AutoManage/configurationProfileAssignments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignmentList
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbyclustername.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbyclustername.go
@@ -1,0 +1,55 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByClusterNameOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignmentList
+}
+
+// ListByClusterName ...
+func (c ConfigurationProfileAssignmentsClient) ListByClusterName(ctx context.Context, id ClusterId) (result ListByClusterNameOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.AutoManage/configurationProfileAssignments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignmentList
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbymachinename.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbymachinename.go
@@ -1,0 +1,55 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByMachineNameOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignmentList
+}
+
+// ListByMachineName ...
+func (c ConfigurationProfileAssignmentsClient) ListByMachineName(ctx context.Context, id MachineId) (result ListByMachineNameOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.AutoManage/configurationProfileAssignments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignmentList
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbysubscription.go
@@ -1,0 +1,56 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignmentList
+}
+
+// ListBySubscription ...
+func (c ConfigurationProfileAssignmentsClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.AutoManage/configurationProfileAssignments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignmentList
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbyvirtualmachines.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/method_listbyvirtualmachines.go
@@ -1,0 +1,55 @@
+package configurationprofileassignments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByVirtualMachinesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConfigurationProfileAssignmentList
+}
+
+// ListByVirtualMachines ...
+func (c ConfigurationProfileAssignmentsClient) ListByVirtualMachines(ctx context.Context, id VirtualMachineId) (result ListByVirtualMachinesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.AutoManage/configurationProfileAssignments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConfigurationProfileAssignmentList
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignment.go
@@ -1,0 +1,17 @@
+package configurationprofileassignments
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConfigurationProfileAssignment struct {
+	Id         *string                                   `json:"id,omitempty"`
+	ManagedBy  *string                                   `json:"managedBy,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *ConfigurationProfileAssignmentProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                    `json:"systemData,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignmentlist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignmentlist.go
@@ -1,0 +1,8 @@
+package configurationprofileassignments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConfigurationProfileAssignmentList struct {
+	Value *[]ConfigurationProfileAssignment `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignmentproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/model_configurationprofileassignmentproperties.go
@@ -1,0 +1,10 @@
+package configurationprofileassignments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConfigurationProfileAssignmentProperties struct {
+	ConfigurationProfile *string `json:"configurationProfile,omitempty"`
+	Status               *string `json:"status,omitempty"`
+	TargetId             *string `json:"targetId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments/version.go
@@ -1,0 +1,12 @@
+package configurationprofileassignments
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-05-04"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/configurationprofileassignments/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,6 +232,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/role
 github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roleassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roledefinitions
 github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-05-01-preview/roledefinitions
+github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofileassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofilehciassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/automanage/2022-05-04/configurationprofiles
 github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook

--- a/website/docs/r/virtual_machine_automanage_configuration_assignment.html.markdown
+++ b/website/docs/r/virtual_machine_automanage_configuration_assignment.html.markdown
@@ -1,0 +1,118 @@
+---
+subcategory: "Automanage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_machine_automanage_configuration_assignment"
+description: |-
+  Manages a Virtual Machine Automanage Configuration Profile Assignment.
+---
+
+# azurerm_virtual_machine_automanage_configuration_assignment
+
+Manages a Virtual Machine Automanage Configuration Profile Assignment.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "westus"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "examplevnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "example" {
+  name                = "exampleni"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "example" {
+  name                            = "examplevm"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.example.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.example.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_automanage_configuration" "example" {
+  name                = "exampleconfig"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_virtual_machine_automanage_configuration_assignment" "example" {
+  virtual_machine_id = azurerm_linux_virtual_machine.example.id
+  configuration_id   = azurerm_automanage_configuration.example.id
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `virtual_machine_id` - (Required) The ARM resource ID of the Virtual Machine to assign the Automanage Configuration to. Changing this forces a new resource to be created.
+
+* `configuration_id` - (Required) The ARM resource ID of the Automanage Configuration to assign to the Virtual Machine. Changing this forces a new resource to be created.
+
+---
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Virtual Machine Automanage Configuration Profile Assignment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Automanage Configuration.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Automanage Configuration.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Automanage Configuration.
+
+## Import
+
+Virtual Machine Automanage Configuration Profile Assignment can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_machine_automanage_configuration_assignment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.AutoManage/configurationProfileAssignments/default
+```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

- New Resource: `azurerm_virtual_machine_automanage_configuration_assignment`
- Adding test cases for this resource
- Adding documentation for using this resource


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccVirtualMachineConfigurationAssignment_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_automanage.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/automanage #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccVirtualMachineConfigurationAssignment_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_automanage.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccVirtualMachineConfigurationAssignment_basic\E$ #gosetup
=== RUN   TestAccVirtualMachineConfigurationAssignment_basic
=== PAUSE TestAccVirtualMachineConfigurationAssignment_basic
=== CONT  TestAccVirtualMachineConfigurationAssignment_basic
--- PASS: TestAccVirtualMachineConfigurationAssignment_basic (338.49s)
PASS


Process finished with the exit code 0

GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccVirtualMachineConfigurationAssignment_requireImport_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_automanage.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/automanage #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___TestAccVirtualMachineConfigurationAssignment_requireImport_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_automanage.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccVirtualMachineConfigurationAssignment_requireImport\E$ #gosetup
=== RUN   TestAccVirtualMachineConfigurationAssignment_requireImport
=== PAUSE TestAccVirtualMachineConfigurationAssignment_requireImport
=== CONT  TestAccVirtualMachineConfigurationAssignment_requireImport
--- PASS: TestAccVirtualMachineConfigurationAssignment_requireImport (350.29s)
PASS


Process finished with the exit code 0
```

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* **New Resource**: `azurerm_virtual_machine_automanage_configuration_assignment` [GH-25480]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
