### PR TITLE
`network`: outputting the subnet name when the name is not `GatewaySubnet`

### DIFF
--- a/internal/services/network/validate/gateway_subnet.go
+++ b/internal/services/network/validate/gateway_subnet.go
@@ -24,7 +24,7 @@ func IsGatewaySubnet(i interface{}, k string) (warnings []string, errors []error
 	}
 
 	if !strings.EqualFold(id.SubnetName, "GatewaySubnet") {
-		errors = append(errors, fmt.Errorf("expected %s to reference a gateway subnet with name GatewaySubnet", k))
+		errors = append(errors, fmt.Errorf("expected %s to reference a gateway subnet with name GatewaySubnet but got %q", k, id.SubnetName))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR fixes an issue where the GatewaySubnet validation didn't output the name of the Subnet when validation failed - which can be misleading when interpolating from another value (particularly a value from within a Set) - as such outputting the name should make issues like #25483 clearer.

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/25483