### PR TITLE
``azurerm_windows_web_app`` - FIX node version reset to "0.12.1" during update

### DIFF
--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -644,19 +644,10 @@ func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, exist
 		expanded.AppCommandLine = pointer.To(s.AppCommandLine)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
-		if appSettings == nil {
-			appSettings = make(map[string]string)
-		}
-		appSettings["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(s.HealthCheckEvictionTime))
-	}
-
 	if len(s.ApplicationStack) == 1 {
 		winAppStack := s.ApplicationStack[0]
 
-		// (@apokalypt) If we are using node we need to always set the version since we remove it when we are parsing the web app
-		// https://github.com/hashicorp/terraform-provider-azurerm/issues/25452
-		if winAppStack.NodeVersion != "" {
+		if metadata.ResourceData.HasChange("site_config.0.application_stack.0.node_version") || winAppStack.NodeVersion != "" {
 			if appSettings == nil {
 				appSettings = make(map[string]string)
 			}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -911,9 +911,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
 				appSettingsProps := *appSettingsUpdate.Properties
-				if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
-					appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
-				}
+				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
 				appSettingsUpdate.Properties = &appSettingsProps
 				if _, err := client.UpdateApplicationSettings(ctx, *id, *appSettingsUpdate); err != nil {
 					return fmt.Errorf("updating App Settings for Linux %s: %+v", *id, err)

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -907,17 +907,6 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("setting Site Metadata for Current Stack on Windows %s: %+v", id, err)
 			}
 
-			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
-			if metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
-				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
-				appSettingsProps := *appSettingsUpdate.Properties
-				appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
-				appSettingsUpdate.Properties = &appSettingsProps
-				if _, err := client.UpdateApplicationSettings(ctx, *id, *appSettingsUpdate); err != nil {
-					return fmt.Errorf("updating App Settings for Linux %s: %+v", *id, err)
-				}
-			}
-
 			if metadata.ResourceData.HasChange("connection_string") {
 				connectionStringUpdate := helpers.ExpandConnectionStrings(state.ConnectionStrings)
 				if connectionStringUpdate.Properties == nil {

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -907,6 +907,19 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("setting Site Metadata for Current Stack on Windows %s: %+v", id, err)
 			}
 
+			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
+			if metadata.ResourceData.HasChanges("app_settings", "site_config") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
+				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(model.Properties.SiteConfig.AppSettings)
+				appSettingsProps := *appSettingsUpdate.Properties
+				if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
+					appSettingsProps["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = strconv.Itoa(int(state.SiteConfig[0].HealthCheckEvictionTime))
+				}
+				appSettingsUpdate.Properties = &appSettingsProps
+				if _, err := client.UpdateApplicationSettings(ctx, *id, *appSettingsUpdate); err != nil {
+					return fmt.Errorf("updating App Settings for Linux %s: %+v", *id, err)
+				}
+			}
+
 			if metadata.ResourceData.HasChange("connection_string") {
 				connectionStringUpdate := helpers.ExpandConnectionStrings(state.ConnectionStrings)
 				if connectionStringUpdate.Properties == nil {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1087,6 +1087,15 @@ func TestAccWindowsWebApp_withNode14(t *testing.T) {
 			),
 		},
 		data.ImportStep("site_credential.0.password"),
+		{
+			Config: r.nodeWithAppSettings(data, "~14"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~14"),
+			),
+			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
+		},
+		data.ImportStep("site_credential.0.password"),
 	})
 }
 
@@ -1102,6 +1111,15 @@ func TestAccWindowsWebApp_withNode18(t *testing.T) {
 			),
 		},
 		data.ImportStep("site_credential.0.password"),
+		{
+			Config: r.nodeWithAppSettings(data, "~18"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~18"),
+			),
+			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
+		},
+		data.ImportStep("site_credential.0.password"),
 	})
 }
 
@@ -1115,6 +1133,15 @@ func TestAccWindowsWebApp_withNode20(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
+		},
+		data.ImportStep("site_credential.0.password"),
+		{
+			Config: r.nodeWithAppSettings(data, "~20"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~20"),
+			),
+			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
 		},
 		data.ImportStep("site_credential.0.password"),
 	})
@@ -2717,6 +2744,34 @@ resource "azurerm_windows_web_app" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    application_stack {
+      node_version  = "%s"
+      current_stack = "node"
+    }
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, nodeVersion)
+}
+
+func (r WindowsWebAppResource) nodeWithAppSettings(data acceptance.TestData, nodeVersion string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  app_settings = {
+	"foo" = "bar"
+  }
 
   site_config {
     application_stack {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2767,7 +2767,7 @@ resource "azurerm_windows_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   app_settings = {
-	"foo" = "bar"
+    "foo" = "bar"
   }
 
   site_config {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1093,7 +1093,6 @@ func TestAccWindowsWebApp_withNode14(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~14"),
 			),
-			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
 		},
 		data.ImportStep("site_credential.0.password"),
 	})
@@ -1117,7 +1116,6 @@ func TestAccWindowsWebApp_withNode18(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~18"),
 			),
-			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
 		},
 		data.ImportStep("site_credential.0.password"),
 	})
@@ -1141,7 +1139,6 @@ func TestAccWindowsWebApp_withNode20(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("site_config.0.application_stack.0.node_version").HasValue("~20"),
 			),
-			ExpectNonEmptyPlan: true, // should only indicate that the app settings have changed
 		},
 		data.ImportStep("site_credential.0.password"),
 	})


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Right now, the NodeJS environment variable can be unset during an update. This PR ensure that the version is correctly set if we need to update AppSettings for any reason
I also remove the duplicate code to avoid patching/updating app settings two times


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

> Sorry but I could only run locally the tests... I've made some tests in our professional environment and it's correctly working but I will appreciate if someone can run them properly


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_windows_web_app` -  avoid "WEBSITE_NODE_DEFAULT_VERSION" to be lost during update


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25452 
