### PR TITLE
[BUG:] `azurerm_mssql_elasticpool`/`azurerm_mssql_database` - update the behavior of the `enclave_type` field.

### DIFF
--- a/internal/services/mssql/helper/database.go
+++ b/internal/services/mssql/helper/database.go
@@ -108,7 +108,7 @@ func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *datab
 						}
 
 						if partnerDatabase.Id != nil && partnerDatabase.Properties != nil && partnerDatabase.Properties.PreferredEnclaveType != nil {
-							if primaryEnclaveType != "" && databases.AlwaysEncryptedEnclaveType(primaryEnclaveType) == *partnerDatabase.Properties.PreferredEnclaveType {
+							if primaryEnclaveType != "" && primaryEnclaveType == *partnerDatabase.Properties.PreferredEnclaveType {
 								log.Printf("[INFO] Found Partner %s", partnerDatabaseId)
 								partnerDatabases = append(partnerDatabases, *partnerDatabase)
 							} else {

--- a/internal/services/mssql/helper/database.go
+++ b/internal/services/mssql/helper/database.go
@@ -20,7 +20,7 @@ import (
 // FindDatabaseReplicationPartners looks for partner databases having one of the specified replication roles, by
 // reading any replication links then attempting to discover and match the corresponding server/database resources for
 // the other end of the link.
-func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *databases.DatabasesClient, replicationLinksClient *sql.ReplicationLinksClient, resourcesClient *resources.Client, id commonids.SqlDatabaseId, primaryEnclaveType databases.AlwaysEncryptedEnclaveType, rolesToFind []sql.ReplicationRole) ([]databases.Database, error) {
+func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *databases.DatabasesClient, replicationLinksClient *sql.ReplicationLinksClient, resourcesClient *resources.Client, id commonids.SqlDatabaseId, primaryEnclaveType string, rolesToFind []sql.ReplicationRole) ([]databases.Database, error) {
 	var partnerDatabases []databases.Database
 
 	matchesRole := func(role sql.ReplicationRole) bool {
@@ -108,11 +108,11 @@ func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *datab
 						}
 
 						if partnerDatabase.Id != nil && partnerDatabase.Properties != nil && partnerDatabase.Properties.PreferredEnclaveType != nil {
-							if primaryEnclaveType == *partnerDatabase.Properties.PreferredEnclaveType {
+							if primaryEnclaveType != "" && databases.AlwaysEncryptedEnclaveType(primaryEnclaveType) == *partnerDatabase.Properties.PreferredEnclaveType {
 								log.Printf("[INFO] Found Partner %s", partnerDatabaseId)
 								partnerDatabases = append(partnerDatabases, *partnerDatabase)
 							} else {
-								log.Printf("[INFO] Mismatch of possible Partner Database based on enclave type (%s vs %s) for %s", string(primaryEnclaveType), string(*partnerDatabase.Properties.PreferredEnclaveType), id)
+								log.Printf("[INFO] Mismatch of possible Partner Database based on enclave type (%q vs %q) for %s", primaryEnclaveType, string(*partnerDatabase.Properties.PreferredEnclaveType), id)
 							}
 						}
 					}

--- a/internal/services/mssql/helper/database.go
+++ b/internal/services/mssql/helper/database.go
@@ -20,7 +20,7 @@ import (
 // FindDatabaseReplicationPartners looks for partner databases having one of the specified replication roles, by
 // reading any replication links then attempting to discover and match the corresponding server/database resources for
 // the other end of the link.
-func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *databases.DatabasesClient, replicationLinksClient *sql.ReplicationLinksClient, resourcesClient *resources.Client, id commonids.SqlDatabaseId, primaryEnclaveType string, rolesToFind []sql.ReplicationRole) ([]databases.Database, error) {
+func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *databases.DatabasesClient, replicationLinksClient *sql.ReplicationLinksClient, resourcesClient *resources.Client, id commonids.SqlDatabaseId, primaryEnclaveType databases.AlwaysEncryptedEnclaveType, rolesToFind []sql.ReplicationRole) ([]databases.Database, error) {
 	var partnerDatabases []databases.Database
 
 	matchesRole := func(role sql.ReplicationRole) bool {

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -308,7 +308,7 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	// NOTE: The 'PreferredEnclaveType' field cannot be passed to the APIs Create if the 'sku_name' is a DW or DC-series SKU...
 	if !strings.HasPrefix(strings.ToLower(skuName), "dw") && !strings.Contains(strings.ToLower(skuName), "_dc_") && enclaveType != "" {
-		input.Properties.PreferredEnclaveType = pointer.To(databases.AlwaysEncryptedEnclaveType(enclaveType))
+		input.Properties.PreferredEnclaveType = pointer.To(enclaveType)
 	}
 
 	createMode := d.Get("create_mode").(string)
@@ -711,7 +711,7 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		// The 'PreferredEnclaveType' field cannot be passed to the APIs Update if the
 		// 'sku_name' is a DW or DC-series SKU...
 		if !strings.HasPrefix(strings.ToLower(skuName), "dw") && !strings.Contains(strings.ToLower(skuName), "_dc_") && enclaveType != "" {
-			props.PreferredEnclaveType = pointer.To(databases.AlwaysEncryptedEnclaveType(enclaveType))
+			props.PreferredEnclaveType = pointer.To(enclaveType)
 		} else {
 			props.PreferredEnclaveType = nil
 		}

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -214,9 +214,7 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	locks.ByID(id.ID())
 	defer locks.UnlockByID(id.ID())
 
-	// PER THE SERVICE TEAM: If the config doesn’t specify any value for the 'enclave_type'
-	// field it shouldn’t be passed as part of the ARM API request for database or
-	// elastic pool, as it is an optional parameter and not a required one.
+	// NOTE: The service default is actually nil/empty which indicates enclave is disabled. the value `Default` is NOT the default.
 	var enclaveType databases.AlwaysEncryptedEnclaveType
 	if v, ok := d.GetOk("enclave_type"); ok && v.(string) != "" {
 		enclaveType = databases.AlwaysEncryptedEnclaveType(v.(string))

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -113,9 +113,7 @@ func resourceMsSqlDatabaseImporter(ctx context.Context, d *pluginsdk.ResourceDat
 		return nil, err
 	}
 
-	// PER THE SERVICE TEAM: If the config doesn’t specify any value for the 'enclave_type'
-	// field it shouldn’t be passed as part of the ARM API request for database or
-	// elastic pool, as it is an optional parameter and not a required one.
+	// NOTE: The service default is actually nil/empty which indicates enclave is disabled. the value `Default` is NOT the default.
 	var enclaveType databases.AlwaysEncryptedEnclaveType
 	if v, ok := d.GetOk("enclave_type"); ok && v.(string) != "" {
 		enclaveType = databases.AlwaysEncryptedEnclaveType(v.(string))

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -90,7 +90,7 @@ func TestAccMsSqlDatabase_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("license_type").HasValue("LicenseIncluded"),
 				check.That(data.ResourceName).Key("max_size_gb").HasValue("2"),
-				check.That(data.ResourceName).Key("enclave_type").IsEmpty(),
+				check.That(data.ResourceName).Key("enclave_type").HasValue("Default"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.ENV").HasValue("Staging"),
 			),
@@ -1076,6 +1076,7 @@ resource "azurerm_mssql_database" "test" {
   license_type = "LicenseIncluded"
   max_size_gb  = 2
   sku_name     = "GP_Gen5_2"
+  enclave_type = "Default"
 
   storage_account_type = "Zone"
 

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -844,12 +844,13 @@ func TestAccMsSqlDatabase_enclaveType(t *testing.T) {
 }
 
 func TestAccMsSqlDatabase_enclaveTypeUpdate(t *testing.T) {
+	// NOTE: Once the enclave_type field has be set it cannot be changed...
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MsSqlDatabaseResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.enclaveType(data, ""),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("enclave_type").IsEmpty(),
@@ -865,10 +866,18 @@ func TestAccMsSqlDatabase_enclaveTypeUpdate(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.enclaveType(data, ""),
+			Config: r.enclaveType(data, `  enclave_type = "Default"`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enclave_type").IsEmpty(),
+				check.That(data.ResourceName).Key("enclave_type").HasValue("Default"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.enclaveType(data, `  enclave_type = "VBS"`),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enclave_type").HasValue("VBS"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -267,9 +267,7 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 		},
 	}
 
-	// PER THE SERVICE TEAM: If the config doesn’t specify any value for the 'enclave_type'
-	// field it shouldn’t be passed as part of the ARM API request for database or
-	// elastic pool, as it is an optional parameter and not a required one.
+	// NOTE: The service default is actually nil/empty which indicates enclave is disabled. the value `Default` is NOT the default.
 	if v, ok := d.GetOk("enclave_type"); ok && v.(string) != "" {
 		elasticPool.Properties.PreferredEnclaveType = pointer.To(elasticpools.AlwaysEncryptedEnclaveType(v.(string)))
 	}

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -369,6 +369,7 @@ func TestAccMsSqlElasticPool_vCoreToStandardDTU(t *testing.T) {
 }
 
 func TestAccMsSqlElasticPool_enclaveTypeUpdate(t *testing.T) {
+	// NOTE: Once the enclave_type has be set it cannot be removed...
 	data := acceptance.BuildTestData(t, "azurerm_mssql_elasticpool", "test")
 	r := MsSqlElasticPoolResource{}
 
@@ -390,10 +391,18 @@ func TestAccMsSqlElasticPool_enclaveTypeUpdate(t *testing.T) {
 		},
 		data.ImportStep("max_size_gb"),
 		{
-			Config: r.basicDTU(data, ""),
+			Config: r.basicDTU(data, `enclave_type = "Default"`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enclave_type").IsEmpty(),
+				check.That(data.ResourceName).Key("enclave_type").HasValue("Default"),
+			),
+		},
+		data.ImportStep("max_size_gb"),
+		{
+			Config: r.basicDTU(data, `enclave_type = "VBS"`),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enclave_type").HasValue("VBS"),
 			),
 		},
 		data.ImportStep("max_size_gb"),

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -190,11 +190,13 @@ The following arguments are supported:
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified in the configuration file (e.g., the default) enclaves are not enabled on the database. Once enabled, by specifying `Default` or `VBS`, removing the `enclave_type` field from the configuration file will force the creation of a new resource. Possible values are `Default` or `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified (e.g., the default) enclaves are not enabled on the database. <!-- TODO: Uncomment in 4.0: Once enabled (e.g., by specifying `Default` or `VBS`) removing the `enclave_type` field from the configuration file will force the creation of a new resource.--> Possible values are `Default` or `VBS`.
 
 -> **NOTE:** `enclave_type` is currently not supported for DW (e.g, DataWarehouse) and DC-series SKUs.
 
 -> **NOTE:** Geo Replicated and Failover databases must have the same `enclave_type`.
+
+~> **NOTE:** The default value for the `enclave_type` field is unset not `Default`.
 
 * `geo_backup_enabled` - (Optional) A boolean that specifies if the Geo Backup Policy is enabled. Defaults to `true`.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -190,7 +190,7 @@ The following arguments are supported:
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the database. Possible value `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the database. Possible values are `Default` or `VBS`.
 
 ~> **NOTE:** `enclave_type` is currently not supported for DW (e.g, DataWarehouse) and DC-series SKUs.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -190,7 +190,7 @@ The following arguments are supported:
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the database. Possible values are `Default` or `VBS`. Removing `enclave_type` from the configuration file after it has been set will cause a new resource to be created.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified in the configuration file (e.g., the default) enclaves are not enabled on the database. Once enabled, by specifying `Default` or `VBS`, removing the `enclave_type` field from the configuration file will force the creation of a new resource. Possible values are `Default` or `VBS`.
 
 -> **NOTE:** `enclave_type` is currently not supported for DW (e.g, DataWarehouse) and DC-series SKUs.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -190,11 +190,11 @@ The following arguments are supported:
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the database. Possible values are `Default` or `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the database. Possible values are `Default` or `VBS`. Removing `enclave_type` from the configuration file after it has been set will cause a new resource to be created.
 
-~> **NOTE:** `enclave_type` is currently not supported for DW (e.g, DataWarehouse) and DC-series SKUs.
+-> **NOTE:** `enclave_type` is currently not supported for DW (e.g, DataWarehouse) and DC-series SKUs.
 
-~> **NOTE:** Geo Replicated and Failover databases must have the same `enclave_type`.
+-> **NOTE:** Geo Replicated and Failover databases must have the same `enclave_type`.
 
 * `geo_backup_enabled` - (Optional) A boolean that specifies if the Geo Backup Policy is enabled. Defaults to `true`.
 
@@ -236,7 +236,7 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) Specifies the name of the SKU used by the database. For example, `GP_S_Gen5_2`,`HS_Gen4_1`,`BC_Gen5_2`, `ElasticPool`, `Basic`,`S0`, `P2` ,`DW100c`, `DS100`. Changing this from the HyperScale service tier to another service tier will create a new resource.
 
-~> **NOTE:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. When changing the `sku_name` of a database having one or more secondary databases, this resource will first update any secondary databases as necessary. In such cases it's recommended to use the same `sku_name` in your configuration for all related databases, as not doing so may cause an unresolvable diff during subsequent plans.
+-> **NOTE:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. When changing the `sku_name` of a database having one or more secondary databases, this resource will first update any secondary databases as necessary. In such cases it's recommended to use the same `sku_name` in your configuration for all related databases, as not doing so may cause an unresolvable diff during subsequent plans.
 
 * `storage_account_type` - (Optional) Specifies the storage account type used to store backups for this database. Possible values are `Geo`, `GeoZone`, `Local` and `Zone`. Defaults to `Geo`.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -73,11 +73,11 @@ The following arguments are supported:
 
 -> **NOTE:** One of either `max_size_gb` or `max_size_bytes` must be specified.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. Possible values are `Default` or `VBS`. Removing `enclave_type` from the configuration file after it has been set will cause a new resource to be created.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified in the configuration file (e.g., the default) enclaves are not enabled on the elastic pool. Once enabled, by specifying `Default` or `VBS`, removing the `enclave_type` field from the configuration file will force the creation of a new resource. Possible values are `Default` or `VBS`.
 
-~> **NOTE:** All databases that are added to the elastic pool must have the same `enclave_type` as the elastic pool.
+-> **NOTE:** All databases that are added to the elastic pool must have the same `enclave_type` as the elastic pool.
 
-~> **NOTE:** `enclave_type` is not supported for DC-series SKUs.
+-> **NOTE:** `enclave_type` is not supported for DC-series SKUs.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 -> **NOTE:** One of either `max_size_gb` or `max_size_bytes` must be specified.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. Possible value `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. Possible values are `Default` or `VBS`.
 
 ~> **NOTE:** All databases that are added to the elastic pool must have the same `enclave_type` as the elastic pool.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -73,11 +73,13 @@ The following arguments are supported:
 
 -> **NOTE:** One of either `max_size_gb` or `max_size_bytes` must be specified.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified in the configuration file (e.g., the default) enclaves are not enabled on the elastic pool. Once enabled, by specifying `Default` or `VBS`, removing the `enclave_type` field from the configuration file will force the creation of a new resource. Possible values are `Default` or `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. When `enclave_type` is not specified (e.g., the default) enclaves are not enabled on the elastic pool. <!-- TODO: Uncomment in 4.0: Once enabled (e.g., by specifying `Default` or `VBS`) removing the `enclave_type` field from the configuration file will force the creation of a new resource.--> Possible values are `Default` or `VBS`.
 
 -> **NOTE:** All databases that are added to the elastic pool must have the same `enclave_type` as the elastic pool.
 
 -> **NOTE:** `enclave_type` is not supported for DC-series SKUs.
+
+~> **NOTE:** The default value for `enclave_type` field is unset not `Default`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 -> **NOTE:** One of either `max_size_gb` or `max_size_bytes` must be specified.
 
-* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. Possible values are `Default` or `VBS`.
+* `enclave_type` - (Optional) Specifies the type of enclave to be used by the elastic pool. Possible values are `Default` or `VBS`. Removing `enclave_type` from the configuration file after it has been set will cause a new resource to be created.
 
 ~> **NOTE:** All databases that are added to the elastic pool must have the same `enclave_type` as the elastic pool.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

The current implementation of the `enclave_type` field is incorrect, currently if the field is excluded from the configuration file Terraform always sets the value to `Default`. The way the feature should have been implemented is if the `enclave_type` field is not specified in the configuration file it shouldn’t be passed as part of the ARM API request for databases/elastic pools.

Each of the below `enclaveType` values have specific meaning and in case nothing is specified we shouldn’t pass that parameter to the ARM API request:

- `Default`: enable default enclave functionality on the database, which can be VBS if capacity is available and no enclave if capacity is not available.
- `VBS`: enable VBS enclave on the database.

Passing `preferredEnclaveType: Default` to the ARM API when the field does not exist in the configuration file is causing a lot of customer support cases as the `enclave` is getting enabled in their databases/elastic pools without their knowledge. This causes end users to get an error when they attempt to add a newly created database to a pre-existing elastic pool, which doesn’t have an `enclave` type defined.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Test Results

<img width="396" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/20408400/612f533f-381e-4e85-89aa-44a7f357cfd5">

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_mssql_elasticpool` - update the behavior of the `enclave_type` field.
* `azurerm_mssql_database` - update the behavior of the `enclave_type` field.

<!-- What type of PR is this? -->
- [X] Bug Fix