### PR TITLE
azurerm_windows_web_app - prevent panic

### DIFF
--- a/internal/services/appservice/migration/windows_web_app_slot.go
+++ b/internal/services/appservice/migration/windows_web_app_slot.go
@@ -1803,9 +1803,15 @@ func (w WindowsWebAppSlotV0toV1) Schema() map[string]*pluginsdk.Schema {
 
 func (w WindowsWebAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		v, ok := rawState["service_plan_id"]
+		if !ok || v == nil {
+			return rawState, nil
+		}
+
 		oldId := rawState["service_plan_id"].(string)
 		// service_plan_id can be empty if it is not in a different Service Plan to the "parent" app
 		if oldId == "" {
+
 			return rawState, nil
 		}
 		parsedId, err := commonids.ParseAppServicePlanIDInsensitively(oldId)

--- a/internal/services/appservice/migration/windows_web_app_slot.go
+++ b/internal/services/appservice/migration/windows_web_app_slot.go
@@ -1811,7 +1811,6 @@ func (w WindowsWebAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		oldId := rawState["service_plan_id"].(string)
 		// service_plan_id can be empty if it is not in a different Service Plan to the "parent" app
 		if oldId == "" {
-
 			return rawState, nil
 		}
 		parsedId, err := commonids.ParseAppServicePlanIDInsensitively(oldId)


### PR DESCRIPTION
prevent:

github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/migration.(*WindowsWebAppSlotV0toV1).UpgradeFunc.WindowsWebAppSlotV0toV1.UpgradeFunc.func1({0x0?, 0x0?}, 0x0?, {0x0?, 0x0?})
github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/migration/windows_web_app_slot.go:1806 +0x14c
github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk.StateUpgrades.func1({0x1086a1678, 0x14002b51a40}, 0x0?, {0x10768bf60, 0x14001ca0480})
github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk/state_upgrades.go:55 +0x64
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).upgradeJSONState(0x140007833c8, {0x1086a1678, 0x14002b51a40}, 0xd?, 0x1066a23ce?, 0x14?)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/grpc_provider.go:485 +0x88
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).UpgradeResourceState(0x140007833c8, {0x1086a1678?, 0x14002b51950?}, 0x14002633d60)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/grpc_provider.go:361 +0x384
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).UpgradeResourceState(0x140011d12c0, {0x1086a1678?, 0x14002b51200?}, 0x14002a7cb90)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/tf5server/server.go:757 +0x1f8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_UpgradeResourceState_Handler({0x1082b6780?, 0x140011d12c0}, {0x1086a1678, 0x14002b51200}, 0x1400018bb20, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:395 +0x164
google.golang.org/grpc.(*Server).processUnaryRPC(0x140002f01e0, {0x1086c9180, 0x14001692680}, 0x14002b52ea0, 0x14001620b40, 0x10de9feb8, 0x0)