### PR TITLE
`azurerm_cosmosdb_account` - deprecate `connection_strings` and rename `enable_*` properties

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_data_source.go
+++ b/internal/services/cosmos/cosmosdb_account_data_source.go
@@ -5,6 +5,7 @@ package cosmos
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"sort"
 	"time"
@@ -22,7 +23,7 @@ import (
 )
 
 func dataSourceCosmosDbAccount() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	dataSource := &pluginsdk.Resource{
 		Read: dataSourceCosmosDbAccountRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -56,14 +57,12 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_free_tier": {
+			"free_tier_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_automatic_failover": {
+			"automatic_failover_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
@@ -150,8 +149,7 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_multiple_write_locations": {
+			"multiple_write_locations_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
@@ -199,16 +197,6 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
-			},
-
-			"connection_strings": {
-				Type:      pluginsdk.TypeList,
-				Computed:  true,
-				Sensitive: true,
-				Elem: &pluginsdk.Schema{
-					Type:      pluginsdk.TypeString,
-					Sensitive: true,
-				},
 			},
 
 			"primary_sql_connection_string": {
@@ -260,6 +248,37 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		dataSource.Schema["connection_strings"] = &pluginsdk.Schema{
+			Type:      pluginsdk.TypeList,
+			Computed:  true,
+			Sensitive: true,
+			Elem: &pluginsdk.Schema{
+				Type:      pluginsdk.TypeString,
+				Sensitive: true,
+			},
+			Deprecated: "This property has been superseded by the primary and secondary connection strings for sql, mongodb and readonly and will be removed in v4.0 of the AzureRM provider",
+		}
+		dataSource.Schema["enable_free_tier"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "This property has been renamed to `free_tier_enabled` and will be removed in v4.0 of the AzureRM provider",
+		}
+		dataSource.Schema["enable_automatic_failover"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "This property has been renamed to `automatic_failover_enabled` and will be removed in v4.0 of the AzureRM provider",
+		}
+		dataSource.Schema["enable_multiple_write_locations"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "This property has been renamed to `multiple_write_locations_enabled` and will be removed in v4.0 of the AzureRM provider",
+		}
+
+	}
+
+	return dataSource
 }
 
 func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -293,8 +312,15 @@ func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("ip_range_filter", common.CosmosDBIpRulesToIpRangeFilterThreePointOh(props.IPRules))
 			d.Set("endpoint", props.DocumentEndpoint)
 			d.Set("is_virtual_network_filter_enabled", props.IsVirtualNetworkFilterEnabled)
-			d.Set("enable_free_tier", props.EnableFreeTier)
-			d.Set("enable_automatic_failover", props.EnableAutomaticFailover)
+			if !features.FourPointOhBeta() {
+				d.Set("enable_free_tier", props.EnableFreeTier)
+				d.Set("enable_automatic_failover", props.EnableAutomaticFailover)
+				d.Set("enable_multiple_write_locations", props.EnableMultipleWriteLocations)
+			}
+
+			d.Set("free_tier_enabled", props.EnableFreeTier)
+			d.Set("automatic_failover_enabled", props.EnableAutomaticFailover)
+			d.Set("multiple_write_locations_enabled", props.EnableMultipleWriteLocations)
 
 			if v := props.KeyVaultKeyUri; v != nil {
 				d.Set("key_vault_key_id", v)
@@ -368,8 +394,6 @@ func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 			if err := d.Set("write_endpoints", writeEndpoints); err != nil {
 				return fmt.Errorf("setting `write_endpoints`: %s", err)
 			}
-
-			d.Set("enable_multiple_write_locations", props.EnableMultipleWriteLocations)
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
@@ -417,7 +441,9 @@ func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 			}
 
-			d.Set("connection_strings", connStrings)
+			if !features.FourPointOhBeta() {
+				d.Set("connection_strings", connStrings)
+			}
 		}
 	}
 	return nil

--- a/internal/services/cosmos/cosmosdb_account_data_source.go
+++ b/internal/services/cosmos/cosmosdb_account_data_source.go
@@ -5,7 +5,6 @@ package cosmos
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"sort"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -893,12 +893,15 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	enableMultipleWriteLocations := d.Get("multiple_write_locations_enabled").(bool)
 
 	if !features.FourPointOhBeta() {
+		// nolint : staticcheck
 		if v, ok := d.GetOkExists("enable_automatic_failover"); ok {
 			enableAutomaticFailover = v.(bool)
 		}
+		// nolint : staticcheck
 		if v, ok := d.GetOkExists("multiple_write_locations_enabled"); ok {
 			enableMultipleWriteLocations = v.(bool)
 		}
+		// nolint : staticcheck
 		if v, ok := d.GetOkExists("enable_free_tier"); ok {
 			enableFreeTier = v.(bool)
 		}
@@ -1136,6 +1139,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		disableLocalAuthentication := pointer.To(d.Get("local_authentication_disabled").(bool))
 		enableAutomaticFailover := pointer.To(d.Get("automatic_failover_enabled").(bool))
 		if !features.FourPointOhBeta() {
+			// nolint : staticcheck
 			if v, ok := d.GetOkExists("enable_automatic_failover"); ok {
 				enableAutomaticFailover = pointer.To(v.(bool))
 			}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -242,12 +242,17 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				},
 			},
 
-			// TODO: 4.0 - set the default to Tls12
 			// per Microsoft's documentation, as of April 1 2023 the default minimal TLS version for all new accounts is 1.2
 			"minimal_tls_version": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: !features.FourPointOhBeta(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return string(cosmosdb.MinimalTlsVersionTlsOneTwo)
+				}(),
 				ValidateFunc: validation.StringInSlice(cosmosdb.PossibleValuesForMinimalTlsVersion(), false),
 			},
 
@@ -469,13 +474,6 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 					},
 				},
 				Set: resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash,
-			},
-
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_multiple_write_locations": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
 			},
 
 			"access_key_metadata_writes_enabled": {
@@ -770,7 +768,27 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				Type:      pluginsdk.TypeString,
 				Sensitive: true,
 			},
-			Deprecated: "This property has been superseded by the primary and secondary connection strings for sql, mongodb and readonly and will be removed in v4.0 of the provider",
+			Deprecated: "This property has been superseded by the primary and secondary connection strings for sql, mongodb and readonly and will be removed in v4.0 of the AzureRM provider",
+		}
+		resource.Schema["enable_multiple_write_locations"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "This property will be renamed to `multiple_write_locations_enabled` in v4.0 of the AzureRM Provider",
+		}
+		resource.Schema["enable_free_tier"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "This property will be renamed to `multiple_write_locations_enabled` in v4.0 of the AzureRM Provider",
+		}
+	}
+
+	if features.FourPointOh() {
+		resource.Schema["multiple_write_locations_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
 		}
 	}
 

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1140,7 +1140,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		enableAutomaticFailover := pointer.To(d.Get("automatic_failover_enabled").(bool))
 		if !features.FourPointOhBeta() {
 			// nolint : staticcheck
-			if v, ok := d.GetOkExists("enable_automatic_failover"); ok {
+			if v, ok := d.GetOkExists("enable_automatic_failover"); ok && v.(bool) {
 				enableAutomaticFailover = pointer.To(v.(bool))
 			}
 		}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -898,7 +898,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 			enableAutomaticFailover = v.(bool)
 		}
 		// nolint : staticcheck
-		if v, ok := d.GetOkExists("multiple_write_locations_enabled"); ok {
+		if v, ok := d.GetOkExists("enable_multiple_write_locations"); ok {
 			enableMultipleWriteLocations = v.(bool)
 		}
 		// nolint : staticcheck

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -837,7 +837,7 @@ func TestAccCosmosDBAccount_freeTier(t *testing.T) {
 			Config: r.freeTier(data, "GlobalDocumentDB", cosmosdb.DefaultConsistencyLevelEventual),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, cosmosdb.DefaultConsistencyLevelEventual, 1),
-				check.That(data.ResourceName).Key("enable_free_tier").HasValue("true"),
+				check.That(data.ResourceName).Key("free_tier_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -960,7 +960,7 @@ func TestAccCosmosDBAccount_vNetFilters(t *testing.T) {
 	})
 }
 
-// todo remove for 4.0
+// TODO 4.0 remove post 4.0
 func TestAccCosmosDBAccount_vNetFiltersThreePointOh(t *testing.T) {
 	if features.FourPointOhBeta() {
 		t.Skip("this test requires 3.0 mode")
@@ -1354,7 +1354,7 @@ func TestAccCosmosDBAccount_gremlinDatabasesToRestore(t *testing.T) {
 	})
 }
 
-// todo remove for 4.0
+// TODO 4.0 remove post 4.0
 func TestAccCosmosDBAccount_ipRangeFiltersThreePointOh(t *testing.T) {
 	if features.FourPointOhBeta() {
 		t.Skip("this test requires 3.0 mode")
@@ -1381,6 +1381,55 @@ func TestAccCosmosDBAccount_ipRangeFiltersThreePointOh(t *testing.T) {
 			Config: r.vNetFiltersThreePointOh(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCosmosDBAccount_supersededProperties(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("this test contains deprecated properties and can be removed post 4.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	// Limited regional availability
+	data.Locations.Primary = "westeurope"
+	data.Locations.Secondary = "northeurope"
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicMongoDB(data, cosmosdb.DefaultConsistencyLevelEventual),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, cosmosdb.DefaultConsistencyLevelEventual, 1),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.supersededProperties(data, cosmosdb.DefaultConsistencyLevelEventual),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, cosmosdb.DefaultConsistencyLevelEventual, 2),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCosmosDBAccount_supersededFreeTier(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("this test contains deprecated properties and can be removed post 4.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.supersededFreeTier(data, "GlobalDocumentDB", cosmosdb.DefaultConsistencyLevelEventual),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, cosmosdb.DefaultConsistencyLevelEventual, 1),
+				check.That(data.ResourceName).Key("enable_free_tier").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -1695,7 +1744,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -1753,7 +1802,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -1818,7 +1867,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -1867,7 +1916,7 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "%s"
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   consistency_policy {
     consistency_level       = "BoundedStaleness"
@@ -1911,7 +1960,7 @@ resource "azurerm_cosmosdb_account" "test" {
     name = "EnableMongo"
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   consistency_policy {
     consistency_level       = "BoundedStaleness"
@@ -1972,7 +2021,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -2037,7 +2086,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -2114,7 +2163,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -2186,7 +2235,7 @@ resource "azurerm_cosmosdb_account" "test" {
     id = azurerm_subnet.subnet2.id
   }
 
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
 
   geo_location {
     location          = azurerm_resource_group.test.location
@@ -2407,8 +2456,8 @@ resource "azurerm_cosmosdb_account" "test" {
     name = "EnableMongo"
   }
 
-  enable_multiple_write_locations = true
-  enable_automatic_failover       = true
+  multiple_write_locations_enabled = true
+  automatic_failover_enabled       = true
 
   consistency_policy {
     consistency_level = "%s"
@@ -2477,8 +2526,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -2518,8 +2567,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -2566,7 +2615,7 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "%s"
 
-  enable_free_tier = true
+  free_tier_enabled = true
 
   consistency_policy {
     consistency_level = "%s"
@@ -4509,8 +4558,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -4550,8 +4599,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -4591,8 +4640,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -4632,8 +4681,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
-  enable_multiple_write_locations = false
-  enable_automatic_failover       = false
+  multiple_write_locations_enabled = false
+  automatic_failover_enabled       = false
 
   consistency_policy {
     consistency_level       = "Eventual"
@@ -4733,7 +4782,7 @@ resource "azurerm_cosmosdb_account" "test" {
   virtual_network_rule {
     id = azurerm_subnet.subnet2.id
   }
-  enable_multiple_write_locations = true
+  multiple_write_locations_enabled = true
   geo_location {
     location          = azurerm_resource_group.test.location
     failover_priority = 0
@@ -4756,4 +4805,97 @@ resource "azurerm_cosmosdb_account" "test" {
   network_acl_bypass_for_azure_services = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
+}
+
+func (CosmosDBAccountResource) supersededProperties(data acceptance.TestData, consistency cosmosdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+variable "geo_location" {
+  type = list(object({
+    location          = string
+    failover_priority = string
+    zone_redundant    = bool
+  }))
+  default = [
+    {
+      location          = "%s"
+      failover_priority = 0
+      zone_redundant    = false
+    },
+    {
+      location          = "%s"
+      failover_priority = 1
+      zone_redundant    = true
+    }
+  ]
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "MongoDB"
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  enable_multiple_write_locations = true
+  enable_automatic_failover       = true
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  dynamic "geo_location" {
+    for_each = var.geo_location
+    content {
+      location          = geo_location.value.location
+      failover_priority = geo_location.value.failover_priority
+      zone_redundant    = geo_location.value.zone_redundant
+    }
+  }
+}
+`, data.Locations.Primary, data.Locations.Secondary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(consistency))
+}
+
+func (CosmosDBAccountResource) supersededFreeTier(data acceptance.TestData, kind cosmosdb.DatabaseAccountKind, consistency cosmosdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "%s"
+
+  enable_free_tier = true
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(kind), string(consistency))
 }

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -51,9 +51,9 @@ The following attributes are exported:
 
 * `ip_range_filter` - The current IP Filter for this CosmosDB account
 
-* `enable_free_tier` - If Free Tier pricing option is enabled for this CosmosDB Account. You can have up to one free tier Azure Cosmos DB account per Azure subscription.
+* `free_tier_enabled` - If Free Tier pricing option is enabled for this CosmosDB Account. You can have up to one free tier Azure Cosmos DB account per Azure subscription.
 
-* `enable_automatic_failover` - If automatic failover is enabled for this CosmosDB Account.
+* `automatic_failover_enabled` - If automatic failover is enabled for this CosmosDB Account.
 
 * `capabilities` - Capabilities enabled on this Cosmos DB account.
 
@@ -61,7 +61,7 @@ The following attributes are exported:
 
 * `virtual_network_rule` - Subnets that are allowed to access this CosmosDB account.
 
-* `enable_multiple_write_locations` - If multiple write locations are enabled for this Cosmos DB account.
+* `multiple_write_locations_enabled` - If multiple write locations are enabled for this Cosmos DB account.
 
 `consistency_policy` The current consistency Settings for this CosmosDB account with the following properties:
 
@@ -92,8 +92,6 @@ The following attributes are exported:
 * `primary_readonly_key` - The primary read-only Key for the CosmosDB account.
 
 * `secondary_readonly_key` - The secondary read-only key for the CosmosDB account.
-
-* `connection_strings` - A list of connection strings available for this CosmosDB account.
 
 * `primary_sql_connection_string` - The primary SQL connection string for the CosmosDB Account.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -142,11 +142,11 @@ The following arguments are supported:
 
 ~> **Note:** To enable the "Accept connections from within public Azure datacenters" behavior, you should add `0.0.0.0` to the list, see the [documentation](https://docs.microsoft.com/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-global-azure-datacenters-or-other-sources-within-azure) for more details.
 
-* `enable_free_tier` - (Optional) Enable the Free Tier pricing option for this Cosmos DB account. Defaults to `false`. Changing this forces a new resource to be created.
+* `free_tier_enabled` - (Optional) Enable the Free Tier pricing option for this Cosmos DB account. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `analytical_storage_enabled` - (Optional) Enable Analytical Storage option for this Cosmos DB account. Defaults to `false`. Enabling and then disabling analytical storage forces a new resource to be created.
 
-* `enable_automatic_failover` - (Optional) Enable automatic failover for this Cosmos DB account.
+* `automatic_failover_enabled` - (Optional) Enable automatic failover for this Cosmos DB account.
 
 * `partition_merge_enabled` - (Optional) Is partition merge on the Cosmos DB account enabled? Defaults to `false`.
 
@@ -164,7 +164,7 @@ The following arguments are supported:
 
 * `virtual_network_rule` - (Optional) Specifies a `virtual_network_rule` block as defined below, used to define which subnets are allowed to access this CosmosDB account.
 
-* `enable_multiple_write_locations` - (Optional) Enable multiple write locations for this Cosmos DB account.
+* `multiple_write_locations_enabled` - (Optional) Enable multiple write locations for this Cosmos DB account.
 
 * `access_key_metadata_writes_enabled` - (Optional) Is write operations on metadata resources (databases, containers, throughput) via account keys enabled? Defaults to `true`.
 
@@ -330,8 +330,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `primary_readonly_key` - The Primary read-only Key for the CosmosDB Account.
 
 * `secondary_readonly_key` - The Secondary read-only key for the CosmosDB Account.
-
-* `connection_strings` - A list of connection strings available for this CosmosDB account.
 
 * `primary_sql_connection_string` - Primary SQL connection string for the CosmosDB Account.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

* Deprecates and removes `connection_strings` in 4.0 -  closes https://github.com/hashicorp/terraform-provider-azurerm/issues/9621
* Sets `minimal_tls_version` to `1.2` in 4.0
* Deprecates and supersedes the following properties in the resource and data source:
    * `enable_multiple_write_locations` -> `multiple_write_locations_enabled` 
    * `enable_free_tier` -> `free_tier_enabled`
    * `enable_automatic_failover` -> `automatic_failover_enabled`

## Testing 

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/1ab76cc0-22ee-4946-8bb9-791e87653d2e)

Failing tests are flaky.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
