### PR TITLE
`recovery_services` - Add new `recovery_service` block to the provider that supports `vm_backup_stop_protection_and_retain_data_on_destroy` and `purge_protected_items_from_vault_on_destroy`

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -60,5 +60,9 @@ func Default() UserFeatures {
 		PostgresqlFlexibleServer: PostgresqlFlexibleServerFeatures{
 			RestartServerOnConfigurationValueChange: true,
 		},
+		RecoveryService: RecoveryServiceFeatures{
+			VMBackupStopProtectionAndRetainDataOnDestroy: false,
+			PurgeProtectedItemsFromVaultOnDestroy:        false,
+		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -17,6 +17,7 @@ type UserFeatures struct {
 	ManagedDisk              ManagedDiskFeatures
 	Subscription             SubscriptionFeatures
 	PostgresqlFlexibleServer PostgresqlFlexibleServerFeatures
+	RecoveryService          RecoveryServiceFeatures
 }
 
 type CognitiveAccountFeatures struct {
@@ -84,4 +85,9 @@ type SubscriptionFeatures struct {
 
 type PostgresqlFlexibleServerFeatures struct {
 	RestartServerOnConfigurationValueChange bool
+}
+
+type RecoveryServiceFeatures struct {
+	VMBackupStopProtectionAndRetainDataOnDestroy bool
+	PurgeProtectedItemsFromVaultOnDestroy        bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -304,6 +304,26 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 				},
 			},
 		},
+
+		"recovery_service": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"vm_backup_stop_protection_and_retain_data_on_destroy": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"purge_protected_items_from_vault_on_destroy": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
 	}
 
 	// this is a temporary hack to enable us to gradually add provider blocks to test configurations
@@ -510,6 +530,19 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			subscriptionRaw := items[0].(map[string]interface{})
 			if v, ok := subscriptionRaw["restart_server_on_configuration_value_change"]; ok {
 				featuresMap.PostgresqlFlexibleServer.RestartServerOnConfigurationValueChange = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["recovery_service"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			recoveryServicesRaw := items[0].(map[string]interface{})
+			if v, ok := recoveryServicesRaw["vm_backup_stop_protection_and_retain_data_on_destroy"]; ok {
+				featuresMap.RecoveryService.VMBackupStopProtectionAndRetainDataOnDestroy = v.(bool)
+			}
+			if v, ok := recoveryServicesRaw["purge_protected_items_from_vault_on_destroy"]; ok {
+				featuresMap.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -75,6 +75,10 @@ func TestExpandFeatures(t *testing.T) {
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: true,
 				},
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:        false,
+				},
 			},
 		},
 		{
@@ -161,6 +165,12 @@ func TestExpandFeatures(t *testing.T) {
 							"scale_to_zero_before_deletion": true,
 						},
 					},
+					"recovery_service": []interface{}{
+						map[string]interface{}{
+							"vm_backup_stop_protection_and_retain_data_on_destroy": true,
+							"purge_protected_items_from_vault_on_destroy":          true,
+						},
+					},
 				},
 			},
 			Expected: features.UserFeatures{
@@ -217,6 +227,10 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: true,
+				},
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: true,
+					PurgeProtectedItemsFromVaultOnDestroy:        true,
 				},
 			},
 		},
@@ -304,6 +318,12 @@ func TestExpandFeatures(t *testing.T) {
 							"scale_to_zero_before_deletion": false,
 						},
 					},
+					"recovery_service": []interface{}{
+						map[string]interface{}{
+							"vm_backup_stop_protection_and_retain_data_on_destroy": false,
+							"purge_protected_items_from_vault_on_destroy":          false,
+						},
+					},
 				},
 			},
 			Expected: features.UserFeatures{
@@ -360,6 +380,10 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: false,
+				},
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:        false,
 				},
 			},
 		},
@@ -1345,6 +1369,76 @@ func TestExpandFeaturesPosgresqlFlexibleServer(t *testing.T) {
 			Expected: features.UserFeatures{
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.Subscription, testCase.Expected.Subscription) {
+			t.Fatalf("Expected %+v but got %+v", result.Subscription, testCase.Expected.Subscription)
+		}
+	}
+}
+
+func TestExpandFeaturesRecoveryService(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"recovery_service": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:        false,
+				},
+			},
+		},
+		{
+			Name: "Recovery Service Features Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"recovery_service": []interface{}{
+						map[string]interface{}{
+							"vm_backup_stop_protection_and_retain_data_on_destroy": true,
+							"purge_protected_items_from_vault_on_destroy":          true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: true,
+					PurgeProtectedItemsFromVaultOnDestroy:        true,
+				},
+			},
+		},
+		{
+			Name: "Recovery Service Features Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"recovery_service": []interface{}{
+						map[string]interface{}{
+							"vm_backup_stop_protection_and_retain_data_on_destroy": false,
+							"purge_protected_items_from_vault_on_destroy":          false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				RecoveryService: features.RecoveryServiceFeatures{
+					VMBackupStopProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:        false,
 				},
 			},
 		},

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -644,10 +644,6 @@ resource "azurerm_backup_protected_vm" "test" {
 
 func (r BackupProtectedVmResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_protected_vm" "import" {

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -232,6 +232,25 @@ func TestAccBackupProtectedVm_protectionStopped(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedVm_protectionStoppedOnDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
+	r := BackupProtectedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.protectionStoppedOnDestroy(data),
+		},
+	})
+}
+
 func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := protecteditems.ParseProtectedItemID(state.ID)
 	if err != nil {
@@ -248,10 +267,6 @@ func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.
 
 func (BackupProtectedVmResource) base(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d"
   location = "%s"
@@ -395,10 +410,6 @@ resource "azurerm_backup_policy_vm" "test" {
 
 func (BackupProtectedVmResource) baseWithoutVM(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d"
   location = "%s"
@@ -475,6 +486,10 @@ resource "azurerm_backup_policy_vm" "test" {
 
 func (r BackupProtectedVmResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -490,6 +505,10 @@ resource "azurerm_backup_protected_vm" "test" {
 
 func (r BackupProtectedVmResource) updateDiskExclusion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -506,10 +525,6 @@ resource "azurerm_backup_protected_vm" "test" {
 // For update backup policy id test
 func (BackupProtectedVmResource) basePolicyTest(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d-1"
   location = "%s"
@@ -572,6 +587,10 @@ resource "azurerm_managed_disk" "test" {
 // For update backup policy id test
 func (r BackupProtectedVmResource) withBasePolicy(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_policy_vm" "test_change_backup" {
@@ -594,6 +613,10 @@ resource "azurerm_backup_policy_vm" "test_change_backup" {
 // For update backup policy id test
 func (r BackupProtectedVmResource) linkFirstBackupPolicy(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -608,6 +631,10 @@ resource "azurerm_backup_protected_vm" "test" {
 // For update backup policy id test
 func (r BackupProtectedVmResource) linkSecondBackupPolicy(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -621,6 +648,10 @@ resource "azurerm_backup_protected_vm" "test" {
 
 func (r BackupProtectedVmResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "import" {
@@ -634,6 +665,10 @@ resource "azurerm_backup_protected_vm" "import" {
 
 func (r BackupProtectedVmResource) additionalVault(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_resource_group" "test2" {
@@ -669,6 +704,10 @@ resource "azurerm_backup_policy_vm" "test2" {
 
 func (r BackupProtectedVmResource) separateResourceGroups(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -732,5 +771,20 @@ resource "azurerm_backup_protected_vm" "test" {
   include_disk_luns = [0]
   protection_state  = "ProtectionStopped"
 }
+`, r.base(data))
+}
+
+func (r BackupProtectedVmResource) protectionStoppedOnDestroy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    recovery_service {
+      vm_backup_stop_protection_and_retain_data_on_destroy = true
+      purge_protected_items_from_vault_on_destroy          = true
+    }
+  }
+}
+
+%s
 `, r.base(data))
 }

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -587,10 +587,6 @@ resource "azurerm_managed_disk" "test" {
 // For update backup policy id test
 func (r BackupProtectedVmResource) withBasePolicy(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_policy_vm" "test_change_backup" {
@@ -704,10 +700,6 @@ resource "azurerm_backup_policy_vm" "test2" {
 
 func (r BackupProtectedVmResource) separateResourceGroups(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_protected_vm" "test" {

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -6,8 +6,6 @@ package recoveryservices
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems"
 	"log"
 	"strings"
 	"time"
@@ -20,7 +18,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-01-01/vaults"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupresourcevaultconfigs"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -61,10 +61,10 @@ provider "azurerm" {
     postgresql_flexible_server {
       restart_server_on_configuration_value_change = true
     }
-    
+
     recovery_service {
       retain_data_and_stop_protection_on_back_vm_destroy = true
-      purge_protected_items_from_vault_on_destroy = true
+      purge_protected_items_from_vault_on_destroy        = true
     }
 
     resource_group {

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -61,6 +61,11 @@ provider "azurerm" {
     postgresql_flexible_server {
       restart_server_on_configuration_value_change = true
     }
+    
+    recovery_service {
+      retain_data_and_stop_protection_on_back_vm_destroy = true
+      purge_protected_items_from_vault_on_destroy = true
+    }
 
     resource_group {
       prevent_deletion_if_contains_resources = true
@@ -106,6 +111,8 @@ The `features` block supports the following:
 * `log_analytics_workspace` - (Optional) A `log_analytics_workspace` block as defined below.
 
 * `managed_disk` - (Optional) A `managed_disk` block as defined below.
+
+* `recovery_service` - (Optional) A `recovery_service` block as defined below.
 
 * `resource_group` - (Optional) A `resource_group` block as defined below.
 
@@ -190,6 +197,14 @@ The `managed_disk` block supports the following:
 The `postgresql_flexible_server` block supports the following:
 
 * `restart_server_on_configuration_value_change` - (Optional) Should the `postgresql_flexible_server` restart after static server parameter change or removal? Defaults to `true`.
+
+---
+
+The `recovery_service` block supports the following:
+
+* `vm_backup_stop_protection_and_retain_data_on_destroy` - (Optional) Should we retain the data and stop protection instead of destroying the backup protected vm? Defaults to `false`.
+
+* `purge_protected_items_from_vault_on_destroy` - (Optional) Should we purge all protected items when destroying the vault. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds a new features block for recovery services. The two new fields are  `vm_backup_stop_protection_and_retain_data_on_destroy` and `purge_protected_items_from_vault_on_destroy`.

`vm_backup_stop_protection_and_retain_data_on_destroy` allows for data to be retained and protection to be stopped when destroying a `azurerm_backup_protected_vm`. 

`purge_protected_items_from_vault_on_destroy` - purges all protected items when destroying `azurerm_recovery_services_vault`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `recovery_services` - Add `recovery_service` block to the provider that supports `vm_backup_stop_protection_and_retain_data_on_destroy` and `purge_protected_items_from_vault_on_destroy`[GH-25515]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
