### PR TITLE
`public_ip_prefix` - add missing attributes to documentation

### DIFF
--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -31,8 +31,8 @@ output "public_ip_prefix" {
 
 ## Attributes Reference
 
-* `name` - The name of the Public IP prefix resource.
-* `resource_group_name` - The name of the resource group in which to create the public IP.
+* `id` - The ID of the Public IP Prefix.
+* `ip_prefix` - The Public IP address range, in CIDR notation.
 * `location` - The supported Azure location where the resource exists.
 * `sku` - The SKU of the Public IP Prefix.
 * `prefix_length` - The number of bits of the prefix.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_public_ip_prefix` was missing the `id` and `ip_prefix` attributes. It also included `name` and `resource_group_name` in attributes, even though they are already required arguments.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”