### PR TITLE
`azurerm_kubernetes_cluster` - Fix error when update `outbound_type` in `network_profile` nested block

### DIFF
--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -392,28 +392,6 @@ func TestAccKubernetesCluster_outboundTypeLoadBalancer(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_outboundTypeUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
-	r := KubernetesClusterResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.managedNatGatewayConfig(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.outboundTypeLoadBalancerConfig(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccKubernetesCluster_natGatewayProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2208,7 +2208,14 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		if key := "network_profile.0.outbound_type"; d.HasChange(key) {
-			existing.Model.Properties.NetworkProfile.OutboundType = pointer.To(managedclusters.OutboundType(d.Get(key).(string)))
+			outboundType := managedclusters.OutboundType(d.Get(key).(string))
+			existing.Model.Properties.NetworkProfile.OutboundType = pointer.To(outboundType)
+			if outboundType != managedclusters.OutboundTypeLoadBalancer {
+				existing.Model.Properties.NetworkProfile.LoadBalancerProfile = nil
+			}
+			if outboundType != managedclusters.OutboundTypeManagedNATGateway && outboundType != managedclusters.OutboundTypeUserAssignedNATGateway {
+				existing.Model.Properties.NetworkProfile.NatGatewayProfile = nil
+			}
 		}
 	}
 	if d.HasChange("service_mesh_profile") {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -363,19 +363,19 @@ resource "azurerm_subnet" "pod_subnet" {
     name = "aks-delegation"
 
     service_delegation {
-        actions = [
-            "Microsoft.Network/virtualNetworks/subnets/join/action",
-          ]
-        name    = "Microsoft.ContainerService/managedClusters"
-      }
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+      name = "Microsoft.ContainerService/managedClusters"
+    }
   }
 }
 
 resource "azurerm_subnet" "firewall_subnet" {
-  name = "AzureFirewallSubnet"
-  resource_group_name = azurerm_resource_group.test.name
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes = ["172.0.35.0/26"]
+  address_prefixes     = ["172.0.35.0/26"]
 }
 
 resource "azurerm_public_ip" "fw" {
@@ -390,8 +390,8 @@ resource "azurerm_firewall" "test" {
   name                = "firewall"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name = "AZFW_VNet"
-  sku_tier = "Standard"
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -436,21 +436,21 @@ resource "azurerm_route_table" "test" {
   resource_group_name           = azurerm_resource_group.test.name
   disable_bgp_route_propagation = false
   route {
-    name = "internal"
+    name           = "internal"
     address_prefix = azurerm_virtual_network.test.address_space[0]
-    next_hop_type = "VnetLocal"
+    next_hop_type  = "VnetLocal"
   }
   route {
-    name = "internet"
-    address_prefix = "0.0.0.0/0"
-    next_hop_type = "VirtualAppliance"
+    name                   = "internet"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = azurerm_firewall.test.ip_configuration[0].private_ip_address
   }
 }
 
 resource "azurerm_subnet_route_table_association" "node_subnet" {
   route_table_id = azurerm_route_table.test.id
-  subnet_id = azurerm_subnet.node_subnet.id
+  subnet_id      = azurerm_subnet.node_subnet.id
 }
   `, data.RandomInteger, data.Locations.Primary)
 }
@@ -467,14 +467,14 @@ resource "azurerm_kubernetes_cluster" "test" {
   kubernetes_version  = "1.29"
 
   default_node_pool {
-    name                   = "default"
-    node_count             = 1
-    vm_size                = "Standard_DS2_v2"
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
     upgrade_settings {
       max_surge = %q
     }
-    vnet_subnet_id 		   = azurerm_subnet.node_subnet.id
-    pod_subnet_id 		   = azurerm_subnet.pod_subnet.id
+    vnet_subnet_id = azurerm_subnet.node_subnet.id
+    pod_subnet_id  = azurerm_subnet.pod_subnet.id
   }
 
   identity {
@@ -482,7 +482,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   network_profile {
     network_plugin = "azure"
-	outbound_type = %q
+    outbound_type  = %q
   }
 }
   `, r.vnetWithNetworkProfileInfra(data), data.RandomInteger, data.RandomInteger, "10%", outboundType)

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -212,15 +212,15 @@ func TestAccKubernetesCluster_updateNetworkProfileOutboundType(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.networkProfileWithOutboundType(data, "userDefinedRouting"),
-		},
-		data.ImportStep(),
-		{
 			Config: r.networkProfileWithOutboundType(data, "userAssignedNATGateway"),
 		},
 		data.ImportStep(),
 		{
 			Config: r.networkProfileWithOutboundType(data, "userDefinedRouting"),
+		},
+		data.ImportStep(),
+		{
+			Config: r.networkProfileWithOutboundType(data, "userAssignedNATGateway"),
 		},
 		data.ImportStep(),
 		{

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -328,7 +328,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion)
 }
 
-func (KubernetesClusterResource) vnetWithRoutetable(data acceptance.TestData) string {
+func (KubernetesClusterResource) vnetWithNetworkProfileInfra(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -485,7 +485,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 	outbound_type = %q
   }
 }
-  `, r.vnetWithRoutetable(data), data.RandomInteger, data.RandomInteger, "10%", outboundType)
+  `, r.vnetWithNetworkProfileInfra(data), data.RandomInteger, data.RandomInteger, "10%", outboundType)
 }
 
 func (KubernetesClusterResource) dedicatedHost(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -208,15 +208,23 @@ func TestAccKubernetesCluster_updateNetworkProfileOutboundType(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.networkProfile(data, "loadBalancer"),
+			Config: r.networkProfileWithOutboundType(data, "loadBalancer"),
 		},
 		data.ImportStep(),
 		{
-			Config: r.networkProfile(data, "userDefinedRouting"),
+			Config: r.networkProfileWithOutboundType(data, "userDefinedRouting"),
 		},
 		data.ImportStep(),
 		{
-			Config: r.networkProfile(data, "loadBalancer"),
+			Config: r.networkProfileWithOutboundType(data, "userAssignedNATGateway"),
+		},
+		data.ImportStep(),
+		{
+			Config: r.networkProfileWithOutboundType(data, "userDefinedRouting"),
+		},
+		data.ImportStep(),
+		{
+			Config: r.networkProfileWithOutboundType(data, "loadBalancer"),
 		},
 		data.ImportStep(),
 	})
@@ -363,11 +371,81 @@ resource "azurerm_subnet" "pod_subnet" {
   }
 }
 
+resource "azurerm_subnet" "firewall_subnet" {
+  name = "AzureFirewallSubnet"
+  resource_group_name = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes = ["172.0.35.0/26"]
+}
+
+resource "azurerm_public_ip" "fw" {
+  name                = "fw-pip"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "firewall"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name = "AZFW_VNet"
+  sku_tier = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.firewall_subnet.id
+    public_ip_address_id = azurerm_public_ip.fw.id
+  }
+}
+
+resource "azurerm_public_ip" "nat_gw" {
+  name                = "nat-gw"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_nat_gateway" "test" {
+  name                = "test"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard"
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "test" {
+  nat_gateway_id       = azurerm_nat_gateway.test.id
+  public_ip_address_id = azurerm_public_ip.nat_gw.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "pod" {
+  subnet_id      = azurerm_subnet.pod_subnet.id
+  nat_gateway_id = azurerm_nat_gateway.test.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "node" {
+  subnet_id      = azurerm_subnet.node_subnet.id
+  nat_gateway_id = azurerm_nat_gateway.test.id
+}
+
 resource "azurerm_route_table" "test" {
   name                          = "test"
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
   disable_bgp_route_propagation = false
+  route {
+    name = "internal"
+    address_prefix = azurerm_virtual_network.test.address_space[0]
+    next_hop_type = "VnetLocal"
+  }
+  route {
+    name = "internet"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type = "VirtualAppliance"
+    next_hop_in_ip_address = azurerm_firewall.test.ip_configuration[0].private_ip_address
+  }
 }
 
 resource "azurerm_subnet_route_table_association" "node_subnet" {
@@ -377,7 +455,7 @@ resource "azurerm_subnet_route_table_association" "node_subnet" {
   `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r KubernetesClusterResource) networkProfile(data acceptance.TestData, outboundType string) string {
+func (r KubernetesClusterResource) networkProfileWithOutboundType(data acceptance.TestData, outboundType string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -392,8 +470,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     name                   = "default"
     node_count             = 1
     vm_size                = "Standard_DS2_v2"
+    upgrade_settings {
+      max_surge = %q
+    }
     vnet_subnet_id 		   = azurerm_subnet.node_subnet.id
-    pod_subnet_id 		   = azurerm_subnet.pod-subnet.id
+    pod_subnet_id 		   = azurerm_subnet.pod_subnet.id
   }
 
   identity {
@@ -404,7 +485,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 	outbound_type = %q
   }
 }
-  `, r.vnetWithRoutetable(data), data.RandomInteger, data.RandomInteger, outboundType)
+  `, r.vnetWithRoutetable(data), data.RandomInteger, data.RandomInteger, "10%", outboundType)
 }
 
 func (KubernetesClusterResource) dedicatedHost(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This pr fixed the error when trying to update `outbound_type` from `loadBalancer` to `userDefinedRouting` or `userAssignedNATGateway`. The original implementation won't erase load balance profile when the `outbound_type` is no longer `loadBalancer`, this mixed-state would be considered as invalid config by the service side. This pr will set the corresponding sub-profile to `nil` when the `outbound_type` has been changed. It should fix issue #25499 and #16712.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

A new test has been added.

=== RUN   TestAccKubernetesCluster_updateNetworkProfileOutboundType
=== PAUSE TestAccKubernetesCluster_updateNetworkProfileOutboundType
=== CONT  TestAccKubernetesCluster_updateNetworkProfileOutboundType
--- PASS: TestAccKubernetesCluster_updateNetworkProfileOutboundType (2786.31s)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [*] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25499, fixes #16712


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
