### PR TITLE
`compute` - update several resources to use `go-azure-sdk`

### DIFF
--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/skus"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservations"
@@ -32,47 +32,48 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 type Client struct {
 	// TODO: move the Compute client to using Meta Clients where possible
 	// TODO: @tombuildsstuff: investigate _if_ that's possible given Compute uses a myriad of API Versions
-	AvailabilitySetsClient           *availabilitysets.AvailabilitySetsClient
-	CapacityReservationsClient       *capacityreservations.CapacityReservationsClient
-	CapacityReservationGroupsClient  *capacityreservationgroups.CapacityReservationGroupsClient
-	DedicatedHostsClient             *dedicatedhosts.DedicatedHostsClient
-	DedicatedHostGroupsClient        *dedicatedhostgroups.DedicatedHostGroupsClient
-	DisksClient                      *disks.DisksClient
-	DiskAccessClient                 *diskaccesses.DiskAccessesClient
-	DiskEncryptionSetsClient         *diskencryptionsets.DiskEncryptionSetsClient
-	GalleriesClient                  *galleries.GalleriesClient
-	GalleryApplicationsClient        *galleryapplications.GalleryApplicationsClient
-	GalleryApplicationVersionsClient *galleryapplicationversions.GalleryApplicationVersionsClient
-	GalleryImagesClient              *galleryimages.GalleryImagesClient
-	GalleryImageVersionsClient       *galleryimageversions.GalleryImageVersionsClient
-	GallerySharingUpdateClient       *gallerysharingupdate.GallerySharingUpdateClient
-	ImagesClient                     *images.ImagesClient
-	MarketplaceAgreementsClient      *agreements.AgreementsClient
-	ProximityPlacementGroupsClient   *proximityplacementgroups.ProximityPlacementGroupsClient
-	SkusClient                       *skus.SkusClient
-	SSHPublicKeysClient              *sshpublickeys.SshPublicKeysClient
-	SnapshotsClient                  *snapshots.SnapshotsClient
-	VirtualMachinesClient            *virtualmachines.VirtualMachinesClient
-	VirtualMachineRunCommandsClient  *virtualmachineruncommands.VirtualMachineRunCommandsClient
-	VirtualMachineScaleSetsClient    *virtualmachinescalesets.VirtualMachineScaleSetsClient
-	VMExtensionImageClient           *compute.VirtualMachineExtensionImagesClient
-	VMExtensionClient                *compute.VirtualMachineExtensionsClient
-	VMScaleSetClient                 *compute.VirtualMachineScaleSetsClient
-	VMScaleSetExtensionsClient       *compute.VirtualMachineScaleSetExtensionsClient
-	VMScaleSetRollingUpgradesClient  *compute.VirtualMachineScaleSetRollingUpgradesClient
-	VMScaleSetVMsClient              *compute.VirtualMachineScaleSetVMsClient
-	VMClient                         *compute.VirtualMachinesClient
-	VMImageClient                    *virtualmachineimages.VirtualMachineImagesClient
+	AvailabilitySetsClient                      *availabilitysets.AvailabilitySetsClient
+	CapacityReservationsClient                  *capacityreservations.CapacityReservationsClient
+	CapacityReservationGroupsClient             *capacityreservationgroups.CapacityReservationGroupsClient
+	DedicatedHostsClient                        *dedicatedhosts.DedicatedHostsClient
+	DedicatedHostGroupsClient                   *dedicatedhostgroups.DedicatedHostGroupsClient
+	DisksClient                                 *disks.DisksClient
+	DiskAccessClient                            *diskaccesses.DiskAccessesClient
+	DiskEncryptionSetsClient                    *diskencryptionsets.DiskEncryptionSetsClient
+	GalleriesClient                             *galleries.GalleriesClient
+	GalleryApplicationsClient                   *galleryapplications.GalleryApplicationsClient
+	GalleryApplicationVersionsClient            *galleryapplicationversions.GalleryApplicationVersionsClient
+	GalleryImagesClient                         *galleryimages.GalleryImagesClient
+	GalleryImageVersionsClient                  *galleryimageversions.GalleryImageVersionsClient
+	GallerySharingUpdateClient                  *gallerysharingupdate.GallerySharingUpdateClient
+	ImagesClient                                *images.ImagesClient
+	MarketplaceAgreementsClient                 *agreements.AgreementsClient
+	ProximityPlacementGroupsClient              *proximityplacementgroups.ProximityPlacementGroupsClient
+	SkusClient                                  *skus.SkusClient
+	SSHPublicKeysClient                         *sshpublickeys.SshPublicKeysClient
+	SnapshotsClient                             *snapshots.SnapshotsClient
+	VirtualMachinesClient                       *virtualmachines.VirtualMachinesClient
+	VirtualMachineRunCommandsClient             *virtualmachineruncommands.VirtualMachineRunCommandsClient
+	VirtualMachineScaleSetsClient               *virtualmachinescalesets.VirtualMachineScaleSetsClient
+	VirtualMachineScaleSetRollingUpgradesClient *virtualmachinescalesetrollingupgrades.VirtualMachineScaleSetRollingUpgradesClient
+	VirtualMachineScaleSetVMsClient             *virtualmachinescalesetvms.VirtualMachineScaleSetVMsClient
+	VMExtensionImageClient                      *compute.VirtualMachineExtensionImagesClient
+	VMExtensionClient                           *compute.VirtualMachineExtensionsClient
+	VMScaleSetClient                            *compute.VirtualMachineScaleSetsClient
+	VMScaleSetExtensionsClient                  *compute.VirtualMachineScaleSetExtensionsClient
+	VMClient                                    *compute.VirtualMachinesClient
+	VMImageClient                               *virtualmachineimages.VirtualMachineImagesClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -205,17 +206,29 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(virtualMachinesClient.Client, o.Authorizers.ResourceManager)
 
+	virtualMachineRunCommandsClient, err := virtualmachineruncommands.NewVirtualMachineRunCommandsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building VirtualMachineRunCommands client: %+v", err)
+	}
+	o.Configure(virtualMachineRunCommandsClient.Client, o.Authorizers.ResourceManager)
+
+	virtualMachineScaleSetRollingUpgradesClient, err := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetRollingUpgradesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building VirtualMachineScaleSetRollingUpgrades client: %+v", err)
+	}
+	o.Configure(virtualMachineScaleSetRollingUpgradesClient.Client, o.Authorizers.ResourceManager)
+
 	virtualMachineScaleSetsClient, err := virtualmachinescalesets.NewVirtualMachineScaleSetsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building VirtualMachineScaleSets client: %+v", err)
 	}
 	o.Configure(virtualMachineScaleSetsClient.Client, o.Authorizers.ResourceManager)
 
-	virtualMachineRunCommandsClient, err := virtualmachineruncommands.NewVirtualMachineRunCommandsClientWithBaseURI(o.Environment.ResourceManager)
+	virtualMachineScaleSetVMsClient, err := virtualmachinescalesetvms.NewVirtualMachineScaleSetVMsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
-		return nil, fmt.Errorf("building VirtualMachineRunCommands client: %+v", err)
+		return nil, fmt.Errorf("building VirtualMachineScaleSetsVMs client: %+v", err)
 	}
-	o.Configure(virtualMachineRunCommandsClient.Client, o.Authorizers.ResourceManager)
+	o.Configure(virtualMachineScaleSetVMsClient.Client, o.Authorizers.ResourceManager)
 
 	vmExtensionImageClient := compute.NewVirtualMachineExtensionImagesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vmExtensionImageClient.Client, o.ResourceManagerAuthorizer)
@@ -235,82 +248,81 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	vmScaleSetExtensionsClient := compute.NewVirtualMachineScaleSetExtensionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vmScaleSetExtensionsClient.Client, o.ResourceManagerAuthorizer)
 
-	vmScaleSetRollingUpgradesClient := compute.NewVirtualMachineScaleSetRollingUpgradesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&vmScaleSetRollingUpgradesClient.Client, o.ResourceManagerAuthorizer)
-
-	vmScaleSetVMsClient := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&vmScaleSetVMsClient.Client, o.ResourceManagerAuthorizer)
-
 	vmClient := compute.NewVirtualMachinesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vmClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		AvailabilitySetsClient:           availabilitySetsClient,
-		CapacityReservationsClient:       capacityReservationsClient,
-		CapacityReservationGroupsClient:  capacityReservationGroupsClient,
-		DedicatedHostsClient:             dedicatedHostsClient,
-		DedicatedHostGroupsClient:        dedicatedHostGroupsClient,
-		DisksClient:                      disksClient,
-		DiskAccessClient:                 diskAccessClient,
-		DiskEncryptionSetsClient:         diskEncryptionSetsClient,
-		GalleriesClient:                  galleriesClient,
-		GalleryApplicationsClient:        galleryApplicationsClient,
-		GalleryApplicationVersionsClient: galleryApplicationVersionsClient,
-		GalleryImagesClient:              galleryImagesClient,
-		GalleryImageVersionsClient:       galleryImageVersionsClient,
-		GallerySharingUpdateClient:       gallerySharingUpdateClient,
-		ImagesClient:                     imagesClient,
-		MarketplaceAgreementsClient:      marketplaceAgreementsClient,
-		ProximityPlacementGroupsClient:   proximityPlacementGroupsClient,
-		SkusClient:                       skusClient,
-		SSHPublicKeysClient:              sshPublicKeysClient,
-		SnapshotsClient:                  snapshotsClient,
-		VirtualMachinesClient:            virtualMachinesClient,
-		VirtualMachineRunCommandsClient:  virtualMachineRunCommandsClient,
-		VirtualMachineScaleSetsClient:    virtualMachineScaleSetsClient,
-		VMExtensionImageClient:           &vmExtensionImageClient,
-		VMExtensionClient:                &vmExtensionClient,
-		VMScaleSetClient:                 &vmScaleSetClient,
-		VMScaleSetExtensionsClient:       &vmScaleSetExtensionsClient,
-		VMScaleSetRollingUpgradesClient:  &vmScaleSetRollingUpgradesClient,
-		VMScaleSetVMsClient:              &vmScaleSetVMsClient,
-		VMImageClient:                    vmImageClient,
+		AvailabilitySetsClient:                      availabilitySetsClient,
+		CapacityReservationsClient:                  capacityReservationsClient,
+		CapacityReservationGroupsClient:             capacityReservationGroupsClient,
+		DedicatedHostsClient:                        dedicatedHostsClient,
+		DedicatedHostGroupsClient:                   dedicatedHostGroupsClient,
+		DisksClient:                                 disksClient,
+		DiskAccessClient:                            diskAccessClient,
+		DiskEncryptionSetsClient:                    diskEncryptionSetsClient,
+		GalleriesClient:                             galleriesClient,
+		GalleryApplicationsClient:                   galleryApplicationsClient,
+		GalleryApplicationVersionsClient:            galleryApplicationVersionsClient,
+		GalleryImagesClient:                         galleryImagesClient,
+		GalleryImageVersionsClient:                  galleryImageVersionsClient,
+		GallerySharingUpdateClient:                  gallerySharingUpdateClient,
+		ImagesClient:                                imagesClient,
+		MarketplaceAgreementsClient:                 marketplaceAgreementsClient,
+		ProximityPlacementGroupsClient:              proximityPlacementGroupsClient,
+		SkusClient:                                  skusClient,
+		SSHPublicKeysClient:                         sshPublicKeysClient,
+		SnapshotsClient:                             snapshotsClient,
+		VirtualMachinesClient:                       virtualMachinesClient,
+		VirtualMachineRunCommandsClient:             virtualMachineRunCommandsClient,
+		VirtualMachineScaleSetsClient:               virtualMachineScaleSetsClient,
+		VirtualMachineScaleSetRollingUpgradesClient: virtualMachineScaleSetRollingUpgradesClient,
+		VirtualMachineScaleSetVMsClient:             virtualMachineScaleSetVMsClient,
+		VMExtensionImageClient:                      &vmExtensionImageClient,
+		VMExtensionClient:                           &vmExtensionClient,
+		VMScaleSetClient:                            &vmScaleSetClient,
+		VMScaleSetExtensionsClient:                  &vmScaleSetExtensionsClient,
+		VMImageClient:                               vmImageClient,
 
 		// NOTE: use `VirtualMachinesClient` instead
 		VMClient: &vmClient,
 	}, nil
 }
 
-func (c *Client) CancelRollingUpgradesBeforeDeletion(ctx context.Context, id commonids.VirtualMachineScaleSetId) error {
-	resp, err := c.VMScaleSetRollingUpgradesClient.GetLatest(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+func (c *Client) CancelRollingUpgradesBeforeDeletion(ctx context.Context, id virtualmachinescalesets.VirtualMachineScaleSetId) error {
+	virtualMachineScaleSetId := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+
+	resp, err := c.VirtualMachineScaleSetRollingUpgradesClient.GetLatest(ctx, virtualMachineScaleSetId)
 	if err != nil {
 		// No rolling upgrades are running so skipping attempt to cancel them before deletion
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return nil
 		}
 		return fmt.Errorf("retrieving rolling updates for %s: %+v", id, err)
 	}
 
-	var upgradeStatus compute.RollingUpgradeStatusCode
-	if status := resp.RunningStatus; status != nil {
-		upgradeStatus = status.Code
+	var upgradeStatus virtualmachinescalesetrollingupgrades.RollingUpgradeStatusCode
+	if model := resp.Model; model != nil && model.Properties != nil {
+		if status := model.Properties.RunningStatus; status != nil {
+			upgradeStatus = pointer.From(status.Code)
+		}
 	}
 
 	// If lastest rolling upgrade is marked as completed, skip cancellation
-	if upgradeStatus == compute.RollingUpgradeStatusCodeCompleted {
+	if upgradeStatus == virtualmachinescalesetrollingupgrades.RollingUpgradeStatusCodeCompleted {
 		return nil
 	}
 
-	future, err := c.VMScaleSetRollingUpgradesClient.Cancel(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+	future, err := c.VirtualMachineScaleSetRollingUpgradesClient.Cancel(ctx, virtualMachineScaleSetId)
 	if err != nil {
 		// If there is no rolling upgrade the API will throw a 409/No rolling upgrade to cancel
 		// we don't error out in this case
-		if response.WasConflict(future.Response()) {
+		if response.WasConflict(future.HttpResponse) {
 			return nil
 		}
 		return fmt.Errorf("cancelling rolling upgrades for %s: %+v", id, err)
 	}
-	if err := future.WaitForCompletionRef(ctx, c.VMScaleSetExtensionsClient.Client); err != nil {
+
+	if err := future.Poller.PollUntilDone(ctx); err != nil {
 		return fmt.Errorf("waiting for cancelling of rolling upgrades for %s: %+v", id, err)
 	}
 

--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -289,6 +289,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 }
 
 func (c *Client) CancelRollingUpgradesBeforeDeletion(ctx context.Context, id virtualmachinescalesets.VirtualMachineScaleSetId) error {
+	// TODO replace with commonid once https://github.com/hashicorp/pandora/issues/4017 has been merged
 	virtualMachineScaleSetId := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
 
 	resp, err := c.VirtualMachineScaleSetRollingUpgradesClient.GetLatest(ctx, virtualMachineScaleSetId)

--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -63,6 +64,7 @@ type Client struct {
 	SnapshotsClient                  *snapshots.SnapshotsClient
 	VirtualMachinesClient            *virtualmachines.VirtualMachinesClient
 	VirtualMachineRunCommandsClient  *virtualmachineruncommands.VirtualMachineRunCommandsClient
+	VirtualMachineScaleSetsClient    *virtualmachinescalesets.VirtualMachineScaleSetsClient
 	VMExtensionImageClient           *compute.VirtualMachineExtensionImagesClient
 	VMExtensionClient                *compute.VirtualMachineExtensionsClient
 	VMScaleSetClient                 *compute.VirtualMachineScaleSetsClient
@@ -203,6 +205,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(virtualMachinesClient.Client, o.Authorizers.ResourceManager)
 
+	virtualMachineScaleSetsClient, err := virtualmachinescalesets.NewVirtualMachineScaleSetsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building VirtualMachineScaleSets client: %+v", err)
+	}
+	o.Configure(virtualMachineScaleSetsClient.Client, o.Authorizers.ResourceManager)
+
 	virtualMachineRunCommandsClient, err := virtualmachineruncommands.NewVirtualMachineRunCommandsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building VirtualMachineRunCommands client: %+v", err)
@@ -259,6 +267,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		SnapshotsClient:                  snapshotsClient,
 		VirtualMachinesClient:            virtualMachinesClient,
 		VirtualMachineRunCommandsClient:  virtualMachineRunCommandsClient,
+		VirtualMachineScaleSetsClient:    virtualMachineScaleSetsClient,
 		VMExtensionImageClient:           &vmExtensionImageClient,
 		VMExtensionClient:                &vmExtensionClient,
 		VMScaleSetClient:                 &vmScaleSetClient,

--- a/internal/services/compute/edge_zone.go
+++ b/internal/services/compute/edge_zone.go
@@ -5,17 +5,18 @@ package compute
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
-func expandEdgeZone(input string) *compute.ExtendedLocation {
+func expandEdgeZone(input string) *virtualmachines.Model {
 	normalized := edgezones.Normalize(input)
 	if normalized == "" {
 		return nil
 	}
 
-	return &compute.ExtendedLocation{
+	return &virtualmachines.Model{
 		Name: utils.String(normalized),
 		Type: compute.ExtendedLocationTypesEdgeZone,
 	}

--- a/internal/services/compute/edge_zone.go
+++ b/internal/services/compute/edge_zone.go
@@ -5,28 +5,24 @@ package compute
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
-func expandEdgeZone(input string) *virtualmachines.Model {
+func expandEdgeZone(input string) *edgezones.Model {
 	normalized := edgezones.Normalize(input)
 	if normalized == "" {
 		return nil
 	}
 
-	return &virtualmachines.Model{
-		Name: utils.String(normalized),
-		Type: compute.ExtendedLocationTypesEdgeZone,
+	return &edgezones.Model{
+		Name: normalized,
 	}
 }
 
-func flattenEdgeZone(input *compute.ExtendedLocation) string {
-	if input == nil || input.Type != compute.ExtendedLocationTypesEdgeZone || input.Name == nil {
+func flattenEdgeZone(input *edgezones.Model) string {
+	if input == nil || input.Name == "" {
 		return ""
 	}
-	return edgezones.NormalizeNilable(input.Name)
+	return edgezones.Normalize(input.Name)
 }
 
 func expandManagedDiskEdgeZone(input string) *edgezones.Model {

--- a/internal/services/compute/helpers.go
+++ b/internal/services/compute/helpers.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"sort"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryimageversions"
@@ -12,12 +13,12 @@ import (
 	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
-func expandIDsToSubResources(input []interface{}) *[]compute.SubResource {
-	ids := make([]compute.SubResource, 0)
+func expandIDsToSubResources(input []interface{}) *[]virtualmachinescalesets.SubResource {
+	ids := make([]virtualmachinescalesets.SubResource, 0)
 
 	for _, v := range input {
-		ids = append(ids, compute.SubResource{
-			ID: utils.String(v.(string)),
+		ids = append(ids, virtualmachinescalesets.SubResource{
+			Id: utils.String(v.(string)),
 		})
 	}
 

--- a/internal/services/compute/helpers.go
+++ b/internal/services/compute/helpers.go
@@ -4,13 +4,12 @@
 package compute
 
 import (
-	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"sort"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryimageversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func expandIDsToSubResources(input []interface{}) *[]virtualmachinescalesets.SubResource {
@@ -18,42 +17,42 @@ func expandIDsToSubResources(input []interface{}) *[]virtualmachinescalesets.Sub
 
 	for _, v := range input {
 		ids = append(ids, virtualmachinescalesets.SubResource{
-			Id: utils.String(v.(string)),
+			Id: pointer.To(v.(string)),
 		})
 	}
 
 	return &ids
 }
 
-func flattenSubResourcesToIDs(input *[]compute.SubResource) []interface{} {
+func flattenSubResourcesToIDs(input *[]virtualmachinescalesets.SubResource) []interface{} {
 	ids := make([]interface{}, 0)
 	if input == nil {
 		return ids
 	}
 
 	for _, v := range *input {
-		if v.ID == nil {
+		if v.Id == nil {
 			continue
 		}
 
-		ids = append(ids, *v.ID)
+		ids = append(ids, *v.Id)
 	}
 
 	return ids
 }
 
-func flattenSubResourcesToStringIDs(input *[]compute.SubResource) []string {
+func flattenSubResourcesToStringIDs(input *[]virtualmachinescalesets.SubResource) []string {
 	ids := make([]string, 0)
 	if input == nil {
 		return ids
 	}
 
 	for _, v := range *input {
-		if v.ID == nil {
+		if v.Id == nil {
 			continue
 		}
 
-		ids = append(ids, *v.ID)
+		ids = append(ids, *v.Id)
 	}
 
 	return ids

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1021,7 +1021,8 @@ func resourceLinuxVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("secure_boot_enabled", secureBootEnabled)
 			d.Set("virtual_machine_id", props.VMId)
 
-			d.Set("user_data", props.UserData)
+			// userData is not returned by the API
+			d.Set("user_data", d.Get("user_data").(string))
 
 			connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, props)
 			d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -485,7 +485,7 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 
 	sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
-	sshKeys := ExpandSSHKeys(sshKeysRaw)
+	sshKeys := expandSSHKeys(sshKeysRaw)
 
 	params := virtualmachines.VirtualMachine{
 		Name:             pointer.To(id.VirtualMachineName),
@@ -910,7 +910,7 @@ func resourceLinuxVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 					d.Set("provision_vm_agent", config.ProvisionVMAgent)
 					d.Set("vm_agent_platform_updates_enabled", config.EnableVMAgentPlatformUpdates)
 
-					flattenedSSHKeys, err := FlattenSSHKeys(config.Ssh)
+					flattenedSSHKeys, err := flattenSSHKeys(config.Ssh)
 					if err != nil {
 						return fmt.Errorf("flattening `admin_ssh_key`: %+v", err)
 					}
@@ -1061,7 +1061,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving InstanceView for Linux %s: %+v", id, err)
 	}
 
-	shouldTurnBackOn := virtualMachineShouldBeStarted(*instanceView.Model)
+	shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView.Model)
 	hasEphemeralOSDisk := false
 	if model := existing.Model; model != nil && model.Properties != nil {
 		if storage := model.Properties.StorageProfile; storage != nil {

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -352,14 +352,14 @@ func TestAccLinuxVirtualMachine_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("user_data"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("user_data"),
 	})
 }
 

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -352,14 +352,14 @@ func TestAccLinuxVirtualMachine_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("user_data"),
+		data.ImportStep(),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("user_data"),
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/compute/linux_virtual_machine_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LinuxVirtualMachineResource struct{}
@@ -24,10 +24,10 @@ func (t LinuxVirtualMachineResource) Exists(ctx context.Context, clients *client
 
 	resp, err := clients.Compute.VirtualMachinesClient.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Compute Linux Virtual Machine %q", id)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LinuxVirtualMachineResource) templateBasePublicKey() string {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -5,12 +5,17 @@ package compute
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
@@ -22,14 +27,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/base64"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
@@ -42,7 +45,7 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := commonids.ParseVirtualMachineScaleSetID(id)
 			return err
-		}, importVirtualMachineScaleSet(compute.OperatingSystemTypesLinux, "azurerm_linux_virtual_machine_scale_set")),
+		}, importVirtualMachineScaleSet(virtualmachinescalesets.OperatingSystemTypesLinux, "azurerm_linux_virtual_machine_scale_set")),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(time.Minute * 60),
@@ -59,33 +62,32 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 }
 
 func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := commonids.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	exists, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	exists, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if !utils.ResponseWasNotFound(exists.Response) {
+		if !response.WasNotFound(exists.HttpResponse) {
 			return fmt.Errorf("checking for existing Linux %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(exists.Response) {
+	if !response.WasNotFound(exists.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_linux_virtual_machine_scale_set", *exists.ID)
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	t := d.Get("tags").(map[string]interface{})
 
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := ExpandVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
 
 	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
-	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+	bootDiagnostics := expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 
 	dataDisksRaw := d.Get("data_disk").([]interface{})
 	ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
@@ -94,7 +96,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("expanding `data_disk`: %+v", err)
 	}
 
-	identity, err := expandVirtualMachineScaleSetIdentity(d.Get("identity").([]interface{}))
+	identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
@@ -106,26 +108,26 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	}
 
 	osDiskRaw := d.Get("os_disk").([]interface{})
-	osDisk, err := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, compute.OperatingSystemTypesLinux)
+	osDisk, err := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, virtualmachinescalesets.OperatingSystemTypesLinux)
 	if err != nil {
 		return fmt.Errorf("expanding `os_disk`: %+v", err)
 	}
 	securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
 
 	planRaw := d.Get("plan").([]interface{})
-	plan := expandPlan(planRaw)
+	plan := expandPlanVMSS(planRaw)
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 
 	sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
-	sshKeys := ExpandSSHKeys(sshKeysRaw)
+	sshKeys := expandSSHKeys(sshKeysRaw)
 
 	provisionVMAgent := d.Get("provision_vm_agent").(bool)
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	healthProbeId := d.Get("health_probe_id").(string)
-	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	upgradeMode := virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
 	automaticOSUpgradePolicy := ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticOSUpgradePolicyRaw)
 	rollingUpgradePolicyRaw := d.Get("rolling_upgrade_policy").([]interface{})
@@ -134,22 +136,22 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	canHaveAutomaticOsUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	canHaveAutomaticOsUpgradePolicy := upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic || upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if !canHaveAutomaticOsUpgradePolicy && len(automaticOSUpgradePolicyRaw) > 0 {
 		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic` or `Rolling`")
 	}
 
-	shouldHaveRollingUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	shouldHaveRollingUpgradePolicy := upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic || upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if !shouldHaveRollingUpgradePolicy && len(rollingUpgradePolicyRaw) > 0 {
 		return fmt.Errorf("a `rolling_upgrade_policy` block cannot be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
-	shouldHaveRollingUpgradePolicy = upgradeMode == compute.UpgradeModeRolling
+	shouldHaveRollingUpgradePolicy = upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if shouldHaveRollingUpgradePolicy && len(rollingUpgradePolicyRaw) == 0 {
 		return fmt.Errorf("a `rolling_upgrade_policy` block must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
 
 	secretsRaw := d.Get("secret").([]interface{})
-	secrets := expandLinuxSecrets(secretsRaw)
+	secrets := expandLinuxSecretsVMSS(secretsRaw)
 
 	var computerNamePrefix string
 	if v, ok := d.GetOk("computer_name_prefix"); ok && len(v.(string)) > 0 {
@@ -163,31 +165,31 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	}
 
 	disablePasswordAuthentication := d.Get("disable_password_authentication").(bool)
-	networkProfile := &compute.VirtualMachineScaleSetNetworkProfile{
+	networkProfile := &virtualmachinescalesets.VirtualMachineScaleSetNetworkProfile{
 		NetworkInterfaceConfigurations: networkInterfaces,
 	}
 	if healthProbeId != "" {
-		networkProfile.HealthProbe = &compute.APIEntityReference{
-			ID: utils.String(healthProbeId),
+		networkProfile.HealthProbe = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(healthProbeId),
 		}
 	}
 
-	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
-	upgradePolicy := compute.UpgradePolicy{
-		Mode:                     upgradeMode,
+	priority := virtualmachinescalesets.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	upgradePolicy := virtualmachinescalesets.UpgradePolicy{
+		Mode:                     pointer.To(upgradeMode),
 		AutomaticOSUpgradePolicy: automaticOSUpgradePolicy,
 		RollingUpgradePolicy:     rollingUpgradePolicy,
 	}
 
-	virtualMachineProfile := compute.VirtualMachineScaleSetVMProfile{
-		Priority: priority,
-		OsProfile: &compute.VirtualMachineScaleSetOSProfile{
-			AdminUsername:      utils.String(d.Get("admin_username").(string)),
-			ComputerNamePrefix: utils.String(computerNamePrefix),
-			LinuxConfiguration: &compute.LinuxConfiguration{
-				DisablePasswordAuthentication: utils.Bool(disablePasswordAuthentication),
-				ProvisionVMAgent:              utils.Bool(provisionVMAgent),
-				SSH: &compute.SSHConfiguration{
+	virtualMachineProfile := virtualmachinescalesets.VirtualMachineScaleSetVMProfile{
+		Priority: pointer.To(priority),
+		OsProfile: &virtualmachinescalesets.VirtualMachineScaleSetOSProfile{
+			AdminUsername:      pointer.To(d.Get("admin_username").(string)),
+			ComputerNamePrefix: pointer.To(computerNamePrefix),
+			LinuxConfiguration: &virtualmachinescalesets.LinuxConfiguration{
+				DisablePasswordAuthentication: pointer.To(disablePasswordAuthentication),
+				ProvisionVMAgent:              pointer.To(provisionVMAgent),
+				Ssh: &virtualmachinescalesets.SshConfiguration{
 					PublicKeys: &sshKeys,
 				},
 			},
@@ -195,7 +197,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		},
 		DiagnosticsProfile: bootDiagnostics,
 		NetworkProfile:     networkProfile,
-		StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{
+		StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetStorageProfile{
 			ImageReference: sourceImageReference,
 			OsDisk:         osDisk,
 			DataDisks:      dataDisks,
@@ -204,14 +206,14 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 
 	if !features.FourPointOhBeta() {
 		if galleryApplications := expandVirtualMachineScaleSetGalleryApplications(d.Get("gallery_applications").([]interface{})); galleryApplications != nil {
-			virtualMachineProfile.ApplicationProfile = &compute.ApplicationProfile{
+			virtualMachineProfile.ApplicationProfile = &virtualmachinescalesets.ApplicationProfile{
 				GalleryApplications: galleryApplications,
 			}
 		}
 	}
 
 	if galleryApplications := expandVirtualMachineScaleSetGalleryApplication(d.Get("gallery_application").([]interface{})); galleryApplications != nil {
-		virtualMachineProfile.ApplicationProfile = &compute.ApplicationProfile{
+		virtualMachineProfile.ApplicationProfile = &virtualmachinescalesets.ApplicationProfile{
 			GalleryApplications: galleryApplications,
 		}
 	}
@@ -220,9 +222,9 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		if d.Get("single_placement_group").(bool) {
 			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
 		}
-		virtualMachineProfile.CapacityReservation = &compute.CapacityReservationProfile{
-			CapacityReservationGroup: &compute.SubResource{
-				ID: utils.String(v.(string)),
+		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(v.(string)),
 			},
 		}
 	}
@@ -242,60 +244,60 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 
 		if !features.FourPointOhBeta() {
 			if !pluginsdk.IsExplicitlyNullInConfig(d, "extension_operations_enabled") {
-				virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(v)
+				virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(v)
 			}
 		} else {
-			virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(v)
+			virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(v)
 		}
 	}
 
 	if v, ok := d.GetOk("extensions_time_budget"); ok {
 		if virtualMachineProfile.ExtensionProfile == nil {
-			virtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+			virtualMachineProfile.ExtensionProfile = &virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile{}
 		}
-		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(v.(string))
+		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(v.(string))
 	}
 
 	// otherwise the service return the error:
 	// Rolling Upgrade mode is not supported for this Virtual Machine Scale Set because a health probe or health extension was not provided.
-	if upgradeMode == compute.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
+	if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
 		return fmt.Errorf("`health_probe_id` must be set or a health extension must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
 
 	if adminPassword, ok := d.GetOk("admin_password"); ok {
-		virtualMachineProfile.OsProfile.AdminPassword = utils.String(adminPassword.(string))
+		virtualMachineProfile.OsProfile.AdminPassword = pointer.To(adminPassword.(string))
 	}
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
-		if priority != compute.VirtualMachinePriorityTypesSpot {
+		if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		virtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(v),
+		virtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+			MaxPrice: pointer.To(v),
 		}
 	}
 
 	if v, ok := d.GetOk("custom_data"); ok {
-		virtualMachineProfile.OsProfile.CustomData = utils.String(v.(string))
+		virtualMachineProfile.OsProfile.CustomData = pointer.To(v.(string))
 	}
 
 	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
 		if encryptionAtHostEnabled.(bool) {
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
-		virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
-			EncryptionAtHost: utils.Bool(encryptionAtHostEnabled.(bool)),
+		virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{
+			EncryptionAtHost: pointer.To(encryptionAtHostEnabled.(bool)),
 		}
 	}
 
 	secureBootEnabled := d.Get("secure_boot_enabled").(bool)
 	vtpmEnabled := d.Get("vtpm_enabled").(bool)
 	if securityEncryptionType != "" {
-		if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
+		if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
 			return fmt.Errorf("`secure_boot_enabled` must be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 		}
 		if !vtpmEnabled {
@@ -303,41 +305,41 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		}
 
 		if virtualMachineProfile.SecurityProfile == nil {
-			virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 		}
-		virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesConfidentialVM
+		virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesConfidentialVM)
 
 		if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-			virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+			virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 		}
-		virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
-		virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+		virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
+		virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 	} else {
 		if secureBootEnabled {
 			if virtualMachineProfile.SecurityProfile == nil {
-				virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+				virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 			}
 			if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-				virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+				virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 			}
-			virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
+			virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+			virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
 		}
 
 		if vtpmEnabled {
 			if virtualMachineProfile.SecurityProfile == nil {
-				virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+				virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 			}
 			if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-				virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+				virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 			}
-			virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+			virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+			virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 		}
 	}
 
 	if v, ok := d.GetOk("user_data"); ok {
-		virtualMachineProfile.UserData = utils.String(v.(string))
+		virtualMachineProfile.UserData = pointer.To(v.(string))
 	}
 
 	// Azure API: "Authentication using either SSH or by user name and password must be enabled in Linux profile."
@@ -346,22 +348,22 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	}
 
 	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
-		if virtualMachineProfile.Priority != compute.VirtualMachinePriorityTypesSpot {
+		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("an `eviction_policy` can only be specified when `priority` is set to `Spot`")
 		}
-		virtualMachineProfile.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string))
-	} else if priority == compute.VirtualMachinePriorityTypesSpot {
+		virtualMachineProfile.EvictionPolicy = pointer.To(virtualmachinescalesets.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string)))
+	} else if priority == virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 		return fmt.Errorf("an `eviction_policy` must be specified when `priority` is set to `Spot`")
 	}
 
-	scaleInPolicy := &compute.ScaleInPolicy{
-		Rules:         &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(string(compute.VirtualMachineScaleSetScaleInRulesDefault))},
-		ForceDeletion: utils.Bool(false),
+	scaleInPolicy := &virtualmachinescalesets.ScaleInPolicy{
+		Rules:         &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault))},
+		ForceDeletion: pointer.To(false),
 	}
 
 	if !features.FourPointOhBeta() {
 		if v, ok := d.GetOk("scale_in_policy"); ok {
-			scaleInPolicy.Rules = &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(v.(string))}
+			scaleInPolicy.Rules = &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(v.(string))}
 		}
 
 		if v, ok := d.GetOk("terminate_notification"); ok {
@@ -382,44 +384,44 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
 	automaticRepairsPolicy := ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
 
-	props := compute.VirtualMachineScaleSet{
+	props := virtualmachinescalesets.VirtualMachineScaleSet{
 		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
-		Location:         utils.String(location),
-		Sku: &compute.Sku{
-			Name:     utils.String(d.Get("sku").(string)),
+		Location:         location,
+		Sku: &virtualmachinescalesets.Sku{
+			Name:     pointer.To(d.Get("sku").(string)),
 			Capacity: utils.Int64(int64(d.Get("instances").(int))),
 
 			// doesn't appear this can be set to anything else, even Promo machines are Standard
-			Tier: utils.String("Standard"),
+			Tier: pointer.To("Standard"),
 		},
-		Identity: identity,
+		Identity: identityExpanded,
 		Plan:     plan,
-		Tags:     tags.Expand(t),
-		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetProperties{
 			AdditionalCapabilities:                 additionalCapabilities,
 			AutomaticRepairsPolicy:                 automaticRepairsPolicy,
-			DoNotRunExtensionsOnOverprovisionedVMs: utils.Bool(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
-			Overprovision:                          utils.Bool(d.Get("overprovision").(bool)),
-			SinglePlacementGroup:                   utils.Bool(d.Get("single_placement_group").(bool)),
+			DoNotRunExtensionsOnOverprovisionedVMs: pointer.To(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
+			Overprovision:                          pointer.To(d.Get("overprovision").(bool)),
+			SinglePlacementGroup:                   pointer.To(d.Get("single_placement_group").(bool)),
 			VirtualMachineProfile:                  &virtualMachineProfile,
 			UpgradePolicy:                          &upgradePolicy,
 			// OrchestrationMode needs to be hardcoded to Uniform, for the
 			// standard VMSS resource, since virtualMachineProfile is now supported
 			// in both VMSS and Orchestrated VMSS...
-			OrchestrationMode: compute.OrchestrationModeUniform,
+			OrchestrationMode: pointer.To(virtualmachinescalesets.OrchestrationModeUniform),
 			ScaleInPolicy:     scaleInPolicy,
 		},
 	}
 
 	if v, ok := d.GetOk("host_group_id"); ok {
-		props.VirtualMachineScaleSetProperties.HostGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		props.Properties.HostGroup = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	spotRestoreRaw := d.Get("spot_restore").([]interface{})
 	if spotRestorePolicy := ExpandVirtualMachineScaleSetSpotRestorePolicy(spotRestoreRaw); spotRestorePolicy != nil {
-		props.SpotRestorePolicy = spotRestorePolicy
+		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
 	if len(zones) > 0 {
@@ -427,12 +429,12 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk("platform_fault_domain_count"); ok {
-		props.VirtualMachineScaleSetProperties.PlatformFaultDomainCount = utils.Int32(int32(v.(int)))
+		props.Properties.PlatformFaultDomainCount = utils.Int32(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
-		props.VirtualMachineScaleSetProperties.ProximityPlacementGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		props.Properties.ProximityPlacementGroup = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
@@ -441,18 +443,12 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 			return fmt.Errorf("`zone_balance` can only be set to `true` when zones are specified")
 		}
 
-		props.VirtualMachineScaleSetProperties.ZoneBalance = utils.Bool(v.(bool))
+		props.Properties.ZoneBalance = pointer.To(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Linux %s", id)
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, props)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Linux %s: %+v", id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for Linux %s to be created..", id)
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Linux %s: %+v", id, err)
 	}
 	log.Printf("[DEBUG] %s was created", id)
 
@@ -462,11 +458,11 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 }
 
 func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -475,52 +471,55 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 
 	// retrieve
 	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
-	if existing.VirtualMachineScaleSetProperties == nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving Linux %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving Linux %s: `properties` was nil", id)
 	}
-	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+	if existing.Model.Properties.VirtualMachineProfile == nil {
 		return fmt.Errorf("retrieving Linux %s: `properties.virtualMachineProfile` was nil", id)
 	}
-	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile == nil {
+	if existing.Model.Properties.VirtualMachineProfile.StorageProfile == nil {
 		return fmt.Errorf("retrieving Linux %s: `properties.virtualMachineProfile,storageProfile` was nil", id)
 	}
 
-	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
-		VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
+	updateProps := virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{
+		VirtualMachineProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateVMProfile{
 			// if an image reference has been configured previously (it has to be), we would better to include that in this
 			// update request to avoid some circumstances that the API will complain ImageReference is null
 			// issue tracking: https://github.com/Azure/azure-rest-api-specs/issues/10322
-			StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
-				ImageReference: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference,
+			StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{
+				ImageReference: existing.Model.Properties.VirtualMachineProfile.StorageProfile.ImageReference,
 			},
 		},
 		// if an upgrade policy's been configured previously (which it will have) it must be threaded through
 		// this doesn't matter for Manual - but breaks when updating anything on a Automatic and Rolling Mode Scale Set
-		UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+		UpgradePolicy: existing.Model.Properties.UpgradePolicy,
 	}
-	update := compute.VirtualMachineScaleSetUpdate{}
+	update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{}
 
 	// first try and pull this from existing vm, which covers no changes being made to this block
 	automaticOSUpgradeIsEnabled := false
-	if policy := existing.VirtualMachineScaleSetProperties.UpgradePolicy; policy != nil {
+	if policy := existing.Model.Properties.UpgradePolicy; policy != nil {
 		if policy.AutomaticOSUpgradePolicy != nil && policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade != nil {
 			automaticOSUpgradeIsEnabled = *policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
 		}
 	}
 
 	if d.HasChange("automatic_os_upgrade_policy") || d.HasChange("rolling_upgrade_policy") {
-		upgradePolicy := compute.UpgradePolicy{}
-		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
-			upgradePolicy = compute.UpgradePolicy{
-				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+		upgradePolicy := virtualmachinescalesets.UpgradePolicy{}
+		if existing.Model.Properties.UpgradePolicy == nil {
+			upgradePolicy = virtualmachinescalesets.UpgradePolicy{
+				Mode: virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string)),
 			}
 		} else {
-			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
-			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+			upgradePolicy = *existing.Model.Properties.UpgradePolicy
+			upgradePolicy.Mode = virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {
@@ -545,14 +544,14 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		updateProps.UpgradePolicy = &upgradePolicy
 	}
 
-	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	priority := virtualmachinescalesets.VirtualMachinePriorityTypes(d.Get("priority").(string))
 	if d.HasChange("max_bid_price") {
-		if priority != compute.VirtualMachinePriorityTypesSpot {
+		if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		updateProps.VirtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(d.Get("max_bid_price").(float64)),
+		updateProps.VirtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+			MaxPrice: pointer.To(d.Get("max_bid_price").(float64)),
 		}
 	}
 
@@ -561,29 +560,29 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		if singlePlacementGroup {
 			return fmt.Errorf("%q can not be set to %q once it has been set to %q", "single_placement_group", "true", "false")
 		}
-		updateProps.SinglePlacementGroup = utils.Bool(singlePlacementGroup)
+		updateProps.SinglePlacementGroup = pointer.To(singlePlacementGroup)
 	}
 
 	if d.HasChange("admin_ssh_key") || d.HasChange("custom_data") || d.HasChange("disable_password_authentication") || d.HasChange("provision_vm_agent") || d.HasChange("secret") {
-		osProfile := compute.VirtualMachineScaleSetUpdateOSProfile{}
+		osProfile := virtualmachinescalesets.VirtualMachineScaleSetUpdateOSProfile{}
 
 		if d.HasChange("admin_ssh_key") || d.HasChange("disable_password_authentication") || d.HasChange("provision_vm_agent") {
-			linuxConfig := compute.LinuxConfiguration{}
+			linuxConfig := virtualmachinescalesets.LinuxConfiguration{}
 
 			if d.HasChange("admin_ssh_key") {
 				sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
-				sshKeys := ExpandSSHKeys(sshKeysRaw)
-				linuxConfig.SSH = &compute.SSHConfiguration{
+				sshKeys := expandSSHKeys(sshKeysRaw)
+				linuxConfig.Ssh = &virtualmachinescalesets.SshConfiguration{
 					PublicKeys: &sshKeys,
 				}
 			}
 
 			if d.HasChange("disable_password_authentication") {
-				linuxConfig.DisablePasswordAuthentication = utils.Bool(d.Get("disable_password_authentication").(bool))
+				linuxConfig.DisablePasswordAuthentication = pointer.To(d.Get("disable_password_authentication").(bool))
 			}
 
 			if d.HasChange("provision_vm_agent") {
-				linuxConfig.ProvisionVMAgent = utils.Bool(d.Get("provision_vm_agent").(bool))
+				linuxConfig.ProvisionVMAgent = pointer.To(d.Get("provision_vm_agent").(bool))
 			}
 
 			osProfile.LinuxConfiguration = &linuxConfig
@@ -595,13 +594,13 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			// customData can only be sent if it's a base64 encoded string,
 			// so it's not possible to remove this without tainting the resource
 			if v, ok := d.GetOk("custom_data"); ok {
-				osProfile.CustomData = utils.String(v.(string))
+				osProfile.CustomData = pointer.To(v.(string))
 			}
 		}
 
 		if d.HasChange("secret") {
 			secretsRaw := d.Get("secret").([]interface{})
-			osProfile.Secrets = expandLinuxSecrets(secretsRaw)
+			osProfile.Secrets = expandLinuxSecretsVMSS(secretsRaw)
 		}
 
 		updateProps.VirtualMachineProfile.OsProfile = &osProfile
@@ -611,7 +610,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		updateInstances = true
 
 		if updateProps.VirtualMachineProfile.StorageProfile == nil {
-			updateProps.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetUpdateStorageProfile{}
+			updateProps.VirtualMachineProfile.StorageProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{}
 		}
 
 		if d.HasChange("data_disk") {
@@ -634,15 +633,15 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 
 			// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurerm/issues/8273
-			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.Model.Properties.VirtualMachineProfile.StorageProfile.DataDisks
 			updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
-			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &compute.VirtualMachineScaleSetUpdateOSDisk{
-				Caching:                 existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
-				WriteAcceleratorEnabled: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
-				DiskSizeGB:              existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
-				Image:                   existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
-				VhdContainers:           existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
-				ManagedDisk:             existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &virtualmachinescalesets.VirtualMachineScaleSetUpdateOSDisk{
+				Caching:                 existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
+				WriteAcceleratorEnabled: existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
+				DiskSizeGB:              existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
+				Image:                   existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
+				VhdContainers:           existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
+				ManagedDisk:             existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
 			}
 		}
 	}
@@ -654,14 +653,14 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			return fmt.Errorf("expanding `network_interface`: %+v", err)
 		}
 
-		updateProps.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetUpdateNetworkProfile{
+		updateProps.VirtualMachineProfile.NetworkProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkProfile{
 			NetworkInterfaceConfigurations: networkInterfaces,
 		}
 
 		healthProbeId := d.Get("health_probe_id").(string)
 		if healthProbeId != "" {
-			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &compute.APIEntityReference{
-				ID: utils.String(healthProbeId),
+			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &virtualmachinescalesets.ApiEntityReference{
+				Id: pointer.To(healthProbeId),
 			}
 		}
 	}
@@ -675,12 +674,12 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 
 	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
 		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
-		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = utils.Bool(v)
+		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = pointer.To(v)
 	}
 
 	if d.HasChange("overprovision") {
 		v := d.Get("overprovision").(bool)
-		updateProps.Overprovision = utils.Bool(v)
+		updateProps.Overprovision = pointer.To(v)
 	}
 
 	if d.HasChange("scale_in") {
@@ -691,11 +690,11 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 
 	if !features.FourPointOhBeta() {
 		if d.HasChange("scale_in_policy") {
-			updateScaleInPolicy := &compute.ScaleInPolicy{}
+			updateScaleInPolicy := &virtualmachinescalesets.ScaleInPolicy{}
 
 			if d.HasChange("scale_in_policy") {
 				scaleInPolicy := d.Get("scale_in_policy").(string)
-				updateScaleInPolicy.Rules = &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)}
+				updateScaleInPolicy.Rules = &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(scaleInPolicy)}
 			}
 
 			updateProps.ScaleInPolicy = updateScaleInPolicy
@@ -716,13 +715,13 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		if d.Get("encryption_at_host_enabled").(bool) {
 			osDiskRaw := d.Get("os_disk").([]interface{})
 			securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
-		updateProps.VirtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
-			EncryptionAtHost: utils.Bool(d.Get("encryption_at_host_enabled").(bool)),
+		updateProps.VirtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{
+			EncryptionAtHost: pointer.To(d.Get("encryption_at_host_enabled").(bool)),
 		}
 	}
 
@@ -754,7 +753,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		if d.HasChange("sku") {
 			updateInstances = true
 
-			sku.Name = utils.String(d.Get("sku").(string))
+			sku.Name = pointer.To(d.Get("sku").(string))
 		}
 
 		if d.HasChange("instances") {
@@ -772,7 +771,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			return err
 		}
 		updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
-		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(d.Get("extensions_time_budget").(string))
 	}
 
 	if d.HasChange("tags") {
@@ -781,7 +780,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 
 	if d.HasChange("user_data") {
 		updateInstances = true
-		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data").(string))
+		updateProps.VirtualMachineProfile.UserData = pointer.To(d.Get("user_data").(string))
 	}
 
 	update.VirtualMachineScaleSetUpdateProperties = &updateProps
@@ -794,7 +793,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		Client:                       meta.(*clients.Client).Compute,
 		Existing:                     existing,
 		ID:                           id,
-		OSType:                       compute.OperatingSystemTypesLinux,
+		OSType:                       virtualmachinescalesets.OperatingSystemTypesLinux,
 	}
 
 	if err := metaData.performUpdate(ctx, update); err != nil {
@@ -815,9 +814,9 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 	}
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Linux %s - removing from state!", id)
 			d.SetId("")
 			return nil
@@ -885,7 +884,7 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 	d.Set("scale_in", FlattenVirtualMachineScaleSetScaleInPolicy(props.ScaleInPolicy))
 
 	if !features.FourPointOhBeta() {
-		rule := string(compute.VirtualMachineScaleSetScaleInRulesDefault)
+		rule := string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault)
 
 		if props.ScaleInPolicy != nil {
 			if rules := props.ScaleInPolicy.Rules; rules != nil && len(*rules) > 0 {
@@ -930,7 +929,7 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 
 		// the service just return empty when this is not assigned when provisioned
 		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
-		priority := compute.VirtualMachinePriorityTypesRegular
+		priority := virtualmachinescalesets.VirtualMachinePriorityTypesRegular
 		if profile.Priority != "" {
 			priority = profile.Priority
 		}
@@ -1082,9 +1081,9 @@ func resourceLinuxVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta i
 	}
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return nil
 		}
 
@@ -1107,7 +1106,7 @@ func resourceLinuxVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta i
 		resp.Sku.Capacity = utils.Int64(int64(0))
 
 		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
-		update := compute.VirtualMachineScaleSetUpdate{
+		update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
 			Sku: resp.Sku,
 		}
 		future, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update)
@@ -1251,8 +1250,8 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachineEvictionPolicyTypesDeallocate),
-				string(compute.VirtualMachineEvictionPolicyTypesDelete),
+				string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDeallocate),
+				string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDelete),
 			}, false),
 		},
 
@@ -1324,10 +1323,10 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
-			Default:  string(compute.VirtualMachinePriorityTypesRegular),
+			Default:  string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachinePriorityTypesRegular),
-				string(compute.VirtualMachinePriorityTypesSpot),
+				string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
+				string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot),
 			}, false),
 		},
 
@@ -1386,17 +1385,17 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 
 		"source_image_reference": sourceImageReferenceSchema(false),
 
-		"tags": tags.Schema(),
+		"tags": commonschema.Tags(),
 
 		"upgrade_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
-			Default:  string(compute.UpgradeModeManual),
+			Default:  string(virtualmachinescalesets.UpgradeModeManual),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.UpgradeModeAutomatic),
-				string(compute.UpgradeModeManual),
-				string(compute.UpgradeModeRolling),
+				string(virtualmachinescalesets.UpgradeModeAutomatic),
+				string(virtualmachinescalesets.UpgradeModeManual),
+				string(virtualmachinescalesets.UpgradeModeRolling),
 			}, false),
 		},
 
@@ -1443,9 +1442,9 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 			Computed: !features.FourPointOhBeta(),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachineScaleSetScaleInRulesDefault),
-				string(compute.VirtualMachineScaleSetScaleInRulesNewestVM),
-				string(compute.VirtualMachineScaleSetScaleInRulesOldestVM),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesNewestVM),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesOldestVM),
 			}, false),
 			Deprecated:    "`scale_in_policy` will be removed in favour of the `scale_in` code block in version 4.0 of the AzureRM Provider.",
 			ConflictsWith: []string{"scale_in"},

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -1045,7 +1045,9 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 				d.Set("vtpm_enabled", vtpmEnabled)
 				d.Set("secure_boot_enabled", secureBootEnabled)
-				d.Set("user_data", profile.UserData)
+
+				// userData is not returned by the API
+				d.Set("user_data", d.Get("user_data").(string))
 			}
 
 			if policy := props.UpgradePolicy; policy != nil {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -468,10 +468,9 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	updateInstances := false
-
-	// retrieve
-	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	options := virtualmachinescalesets.DefaultGetOperationOptions()
+	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+	existing, err := client.Get(ctx, *id, options)
 	if err != nil {
 		return fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
@@ -812,8 +811,9 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	options := virtualmachinescalesets.DefaultGetOperationOptions()
+	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, *id, options)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Linux %s - removing from state!", id)
@@ -1045,9 +1045,7 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 				d.Set("vtpm_enabled", vtpmEnabled)
 				d.Set("secure_boot_enabled", secureBootEnabled)
-
-				// userData is not returned by the API
-				d.Set("user_data", d.Get("user_data").(string))
+				d.Set("user_data", profile.UserData)
 			}
 
 			if policy := props.UpgradePolicy; policy != nil {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -814,7 +814,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.T)
 						Properties: &updateProps,
 					}
 
-					if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
+					if err := client.UpdateThenPoll(ctx2, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 						return fmt.Errorf("updating %s: %+v", *id, err)
 					}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -167,7 +167,6 @@ func TestAccLinuxVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
-			"user_data",
 		),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
@@ -177,7 +176,6 @@ func TestAccLinuxVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
-			"user_data",
 		),
 		{
 			// removed
@@ -188,7 +186,6 @@ func TestAccLinuxVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
-			"user_data",
 		),
 	})
 }
@@ -788,7 +785,9 @@ func TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.T)
 
 					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
 					defer cancel()
-					existing, err := client.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+					options := virtualmachinescalesets.DefaultGetOperationOptions()
+					options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+					existing, err := client.Get(ctx2, *id, options)
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
@@ -785,7 +786,9 @@ func TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.T)
 						return err
 					}
 
-					existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+					defer cancel()
+					existing, err := client.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func TestAccLinuxVirtualMachineScaleSet_otherBootDiagnostics(t *testing.T) {
@@ -779,40 +778,40 @@ func TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.T)
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					// This function manually updates the value for the image sku which triggers rolling upgrades
 					// and simulates the scenario where rolling upgrades are running when we try to delete a VMSS
-					client := clients.Compute.VMScaleSetClient
+					client := clients.Compute.VirtualMachineScaleSetsClient
 
-					id, err := commonids.ParseVirtualMachineScaleSetID(state.Attributes["id"])
+					id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.Attributes["id"])
 					if err != nil {
 						return err
 					}
 
-					existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+					existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}
 
-					existingImageReference := existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference
+					existingImageReference := existing.Model.Properties.VirtualMachineProfile.StorageProfile.ImageReference
 
-					imageReference := compute.ImageReference{
+					imageReference := virtualmachinescalesets.ImageReference{
 						Publisher: existingImageReference.Publisher,
 						Offer:     existingImageReference.Offer,
 						Sku:       pointer.To("22_04-lts"),
 						Version:   existingImageReference.Version,
 					}
 
-					updateProps := compute.VirtualMachineScaleSetUpdateProperties{
-						VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
-							StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
+					updateProps := virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{
+						VirtualMachineProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateVMProfile{
+							StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{
 								ImageReference: &imageReference,
 							},
 						},
-						UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+						UpgradePolicy: existing.Model.Properties.UpgradePolicy,
 					}
-					update := compute.VirtualMachineScaleSetUpdate{
-						VirtualMachineScaleSetUpdateProperties: &updateProps,
+					update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
+						Properties: &updateProps,
 					}
 
-					if _, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update); err != nil {
+					if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 						return fmt.Errorf("updating %s: %+v", *id, err)
 					}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -169,7 +169,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherUserData(t *testing.T) {
 			"user_data",
 		),
 		{
-			Config: r.otherUserData(data, "Goodbye Wolrd"),
+			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -7,27 +7,27 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LinuxVirtualMachineScaleSetResource struct{}
 
 func (r LinuxVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	resp, err := clients.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LinuxVirtualMachineScaleSetResource) templatePublicKey() string {

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -909,7 +909,8 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		// Shutdown
 		if shouldShutDown {
 			log.Printf("[DEBUG] Shutting Down %s", virtualMachineId)
-			options := virtualmachines.PowerOffOperationOptions{SkipShutdown: pointer.To(false)}
+			options := virtualmachines.DefaultPowerOffOperationOptions()
+			options.SkipShutdown = pointer.To(false)
 			if err := virtualMachinesClient.PowerOffThenPoll(ctx, *virtualMachineId, options); err != nil {
 				return fmt.Errorf("sending Power Off to %s: %+v", virtualMachineId, err)
 

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -31,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceManagedDisk() *pluginsdk.Resource {
@@ -622,7 +622,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	onDemandBurstingEnabled := d.Get("on_demand_bursting_enabled").(bool)
 	shouldShutDown := false
 	shouldDetach := false
-	expandedDisk := compute.DataDisk{}
+	expandedDisk := virtualmachines.DataDisk{}
 
 	id, err := commonids.ParseManagedDiskID(d.Id())
 	if err != nil {
@@ -826,31 +826,30 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	// if we are attached to a VM we bring down the VM as necessary for the operations which are not allowed while it's online
 	if shouldShutDown {
-		virtualMachine, err := commonids.ParseVirtualMachineID(*disk.Model.ManagedBy)
+		virtualMachineId, err := virtualmachines.ParseVirtualMachineID(*disk.Model.ManagedBy)
 		if err != nil {
 			return fmt.Errorf("parsing VMID %q for disk attachment: %+v", *disk.Model.ManagedBy, err)
 		}
 		// check instanceView State
-		vmClient := meta.(*clients.Client).Compute.VMClient
 
 		locks.ByName(name, VirtualMachineResourceName)
 		defer locks.UnlockByName(name, VirtualMachineResourceName)
 
-		vm, err := vmClient.Get(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName, "")
+		vm, err := virtualMachinesClient.Get(ctx, *virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 		if err != nil {
-			return fmt.Errorf("retrieving %s: %+v", virtualMachine, err)
+			return fmt.Errorf("retrieving %s: %+v", virtualMachineId, err)
 		}
 
-		instanceView, err := vmClient.InstanceView(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName)
+		instanceView, err := virtualMachinesClient.InstanceView(ctx, *virtualMachineId)
 		if err != nil {
-			return fmt.Errorf("retrieving InstanceView for V%s: %+v", virtualMachine, err)
+			return fmt.Errorf("retrieving InstanceView for %s: %+v", virtualMachineId, err)
 		}
 
-		shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView)
+		shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView.Model)
 		shouldDeallocate := true
 
-		if instanceView.Statuses != nil {
-			for _, status := range *instanceView.Statuses {
+		if instanceView.Model != nil && instanceView.Model.Statuses != nil {
+			for _, status := range *instanceView.Model.Statuses {
 				if status.Code == nil {
 					continue
 				}
@@ -880,68 +879,53 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 		// Detach
 		if shouldDetach {
-			dataDisks := make([]compute.DataDisk, 0)
-			if vm.StorageProfile != nil && vm.StorageProfile.DataDisks != nil {
-				for _, dataDisk := range *vm.StorageProfile.DataDisks {
+			dataDisks := make([]virtualmachines.DataDisk, 0)
+			if vmModel := vm.Model; vmModel != nil && vmModel.Properties != nil && vmModel.Properties.StorageProfile != nil && vmModel.Properties.StorageProfile.DataDisks != nil {
+				for _, dataDisk := range *vmModel.Properties.StorageProfile.DataDisks {
 					// since this field isn't (and shouldn't be) case-sensitive; we're deliberately not using `strings.EqualFold`
 					if dataDisk.Name != nil && *dataDisk.Name != id.DiskName {
 						dataDisks = append(dataDisks, dataDisk)
 					} else {
-						if dataDisk.Caching != compute.CachingTypesNone {
+						if dataDisk.Caching != nil && *dataDisk.Caching != virtualmachines.CachingTypesNone {
 							return fmt.Errorf("`disk_size_gb` can't be increased above 4095GB when `caching` is set to anything other than `None`")
 						}
 						expandedDisk = dataDisk
 					}
 				}
 
-				vm.StorageProfile.DataDisks = &dataDisks
+				vmModel.Properties.StorageProfile.DataDisks = &dataDisks
 
 				// fixes #2485
-				vm.Identity = nil
+				vmModel.Identity = nil
 				// fixes #1600
-				vm.Resources = nil
+				vmModel.Resources = nil
 
-				future, err := vmClient.CreateOrUpdate(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName, vm)
-				if err != nil {
-					return fmt.Errorf("removing Disk %q from Virtual Machine %q : %+v", id.DiskName, virtualMachine.String(), err)
-				}
-
-				if err = future.WaitForCompletionRef(ctx, vmClient.Client); err != nil {
-					return fmt.Errorf("waiting for Disk %q to be removed from Virtual Machine %q : %+v", id.DiskName, virtualMachine.String(), err)
+				if err := virtualMachinesClient.CreateOrUpdateThenPoll(ctx, *virtualMachineId, *vm.Model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+					return fmt.Errorf("removing Disk %q from %s : %+v", id.DiskName, virtualMachineId, err)
 				}
 			}
 		}
 
 		// Shutdown
 		if shouldShutDown {
-			log.Printf("[DEBUG] Shutting Down %s", virtualMachine)
-			forceShutdown := false
-			future, err := vmClient.PowerOff(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName, utils.Bool(forceShutdown))
-			if err != nil {
-				return fmt.Errorf("sending Power Off to %s: %+v", virtualMachine, err)
+			log.Printf("[DEBUG] Shutting Down %s", virtualMachineId)
+			options := virtualmachines.PowerOffOperationOptions{SkipShutdown: pointer.To(false)}
+			if err := virtualMachinesClient.PowerOffThenPoll(ctx, *virtualMachineId, options); err != nil {
+				return fmt.Errorf("sending Power Off to %s: %+v", virtualMachineId, err)
+
 			}
 
-			if err := future.WaitForCompletionRef(ctx, vmClient.Client); err != nil {
-				return fmt.Errorf("waiting for Power Off of %s: %+v", virtualMachine, err)
-			}
-
-			log.Printf("[DEBUG] Shut Down %s", virtualMachine)
+			log.Printf("[DEBUG] Shut Down %s", virtualMachineId)
 		}
 
 		// De-allocate
 		if shouldDeallocate {
-			log.Printf("[DEBUG] Deallocating %s.", virtualMachine)
+			log.Printf("[DEBUG] Deallocating %s.", virtualMachineId)
 			// Upgrading to 2021-07-01 exposed a new hibernate paramater to the Deallocate method
-			deAllocFuture, err := vmClient.Deallocate(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName, utils.Bool(false))
-			if err != nil {
-				return fmt.Errorf("Deallocating to %s: %+v", virtualMachine, err)
+			if err := virtualMachinesClient.DeallocateThenPoll(ctx, *virtualMachineId, virtualmachines.DefaultDeallocateOperationOptions()); err != nil {
+				return fmt.Errorf("Deallocating to %s: %+v", virtualMachineId, err)
 			}
-
-			if err := deAllocFuture.WaitForCompletionRef(ctx, vmClient.Client); err != nil {
-				return fmt.Errorf("waiting for Deallocation of %s: %+v", virtualMachine, err)
-			}
-
-			log.Printf("[DEBUG] Deallocated %s", virtualMachine)
+			log.Printf("[DEBUG] Deallocated %s", virtualMachineId)
 		}
 
 		// Update Disk
@@ -951,44 +935,33 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		// Reattach DataDisk
-		if shouldDetach && vm.StorageProfile != nil {
-			disks := *vm.StorageProfile.DataDisks
+		if shouldDetach && vm.Model.Properties.StorageProfile != nil {
+			disks := *vm.Model.Properties.StorageProfile.DataDisks
 
-			expandedDisk.DiskSizeGB = pointer.To(int32(pointer.From(diskUpdate.Properties.DiskSizeGB)))
+			expandedDisk.DiskSizeGB = diskUpdate.Properties.DiskSizeGB
 			disks = append(disks, expandedDisk)
 
-			vm.StorageProfile.DataDisks = &disks
+			vm.Model.Properties.StorageProfile.DataDisks = &disks
 
 			// fixes #2485
-			vm.Identity = nil
+			vm.Model.Identity = nil
 			// fixes #1600
-			vm.Resources = nil
+			vm.Model.Resources = nil
 
 			// if there's too many disks we get a 409 back with:
 			//   `The maximum number of data disks allowed to be attached to a VM of this size is 1.`
 			// which we're intentionally not wrapping, since the errors good.
-			future, err := vmClient.CreateOrUpdate(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName, vm)
-			if err != nil {
-				return fmt.Errorf("updating Virtual Machine %q to reattach Disk %q: %+v", virtualMachine.String(), name, err)
-			}
-
-			if err = future.WaitForCompletionRef(ctx, vmClient.Client); err != nil {
-				return fmt.Errorf("waiting for Virtual Machine %q to finish reattaching Disk %q: %+v", virtualMachine.String(), name, err)
+			if err := virtualMachinesClient.CreateOrUpdateThenPoll(ctx, *virtualMachineId, *vm.Model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+				return fmt.Errorf("updating %s to reattach Disk %q: %+v", virtualMachineId, name, err)
 			}
 		}
 
 		if shouldTurnBackOn && (shouldShutDown || shouldDeallocate) {
-			log.Printf("[DEBUG] Starting %s", virtualMachine)
-			future, err := vmClient.Start(ctx, virtualMachine.ResourceGroupName, virtualMachine.VirtualMachineName)
-			if err != nil {
-				return fmt.Errorf("starting %s: %+v", virtualMachine, err)
+			log.Printf("[DEBUG] Starting %s", virtualMachineId)
+			if err := virtualMachinesClient.StartThenPoll(ctx, *virtualMachineId); err != nil {
+				return fmt.Errorf("starting %s: %+v", virtualMachineId, err)
 			}
-
-			if err := future.WaitForCompletionRef(ctx, vmClient.Client); err != nil {
-				return fmt.Errorf("waiting for start of %s %+v", virtualMachine, err)
-			}
-
-			log.Printf("[DEBUG] Started %s", virtualMachine)
+			log.Printf("[DEBUG] Started %s", virtualMachineId)
 		}
 	} else { // otherwise, just update it
 		err := client.UpdateThenPoll(ctx, *id, diskUpdate)

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -2697,7 +2697,10 @@ func (ManagedDiskResource) checkLinuxVirtualMachineWasNotRestarted(ctx context.C
 	subscriptionId := commonids.NewSubscriptionID(client.Account.SubscriptionId)
 	opts := activitylogs.DefaultListOperationOptions()
 	opts.Filter = pointer.To(filter)
-	logs, err := activityLogsClient.ListComplete(ctx, subscriptionId, opts)
+
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	logs, err := activityLogsClient.ListComplete(ctx2, subscriptionId, opts)
 	if err != nil {
 		return fmt.Errorf("retrieving activity logs for Virtual Machine %q: %+v", state.ID, err)
 	}

--- a/internal/services/compute/network_interface.go
+++ b/internal/services/compute/network_interface.go
@@ -5,8 +5,8 @@ package compute
 
 import (
 	"context"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"

--- a/internal/services/compute/network_interface.go
+++ b/internal/services/compute/network_interface.go
@@ -5,10 +5,10 @@ package compute
 
 import (
 	"context"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
@@ -29,7 +29,7 @@ type connectionInfo struct {
 
 // retrieveConnectionInformation retrieves all of the Public and Private IP Addresses assigned to a Virtual Machine
 // nolint: deadcode unused
-func retrieveConnectionInformation(ctx context.Context, nicsClient *network.InterfacesClient, pipsClient *network.PublicIPAddressesClient, input *compute.VirtualMachineProperties) connectionInfo {
+func retrieveConnectionInformation(ctx context.Context, nicsClient *network.InterfacesClient, pipsClient *network.PublicIPAddressesClient, input *virtualmachines.VirtualMachineProperties) connectionInfo {
 	if input == nil || input.NetworkProfile == nil || input.NetworkProfile.NetworkInterfaces == nil {
 		return connectionInfo{}
 	}
@@ -39,11 +39,11 @@ func retrieveConnectionInformation(ctx context.Context, nicsClient *network.Inte
 
 	if input != nil && input.NetworkProfile != nil && input.NetworkProfile.NetworkInterfaces != nil {
 		for _, v := range *input.NetworkProfile.NetworkInterfaces {
-			if v.ID == nil {
+			if v.Id == nil {
 				continue
 			}
 
-			nic := retrieveIPAddressesForNIC(ctx, nicsClient, pipsClient, *v.ID)
+			nic := retrieveIPAddressesForNIC(ctx, nicsClient, pipsClient, *v.Id)
 			if nic == nil {
 				continue
 			}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1812,11 +1812,11 @@ func FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(input *[]virtualm
 	}
 
 	results := make([]interface{}, 0)
-	var networkSecurityGroupId string
-	var enableAcceleratedNetworking, enableIPForwarding, primary bool
-	var dnsServers []interface{}
-	var ipConfigurations []interface{}
 	for _, v := range *input {
+		var networkSecurityGroupId string
+		var enableAcceleratedNetworking, enableIPForwarding, primary bool
+		var dnsServers []interface{}
+		var ipConfigurations []interface{}
 		if props := v.Properties; props != nil {
 			if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
 				networkSecurityGroupId = *props.NetworkSecurityGroup.Id

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -4,11 +4,14 @@
 package compute
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/applicationsecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
@@ -728,7 +731,7 @@ func OrchestratedVirtualMachineScaleSetPriorityMixPolicySchema() *pluginsdk.Sche
 	}
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetOSProfile(input *compute.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetOSProfile(input *virtualmachinescalesets.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -883,19 +886,19 @@ func validatePasswordComplexity(input interface{}, key string, min int, max int)
 	return warnings, errors
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input []interface{}) *compute.AdditionalCapabilities {
-	capabilities := compute.AdditionalCapabilities{}
+func ExpandOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input []interface{}) *virtualmachinescalesets.AdditionalCapabilities {
+	capabilities := virtualmachinescalesets.AdditionalCapabilities{}
 
 	if len(input) > 0 {
 		raw := input[0].(map[string]interface{})
 
-		capabilities.UltraSSDEnabled = utils.Bool(raw["ultra_ssd_enabled"].(bool))
+		capabilities.UltraSSDEnabled = pointer.To(raw["ultra_ssd_enabled"].(bool))
 	}
 
 	return &capabilities
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input *compute.AdditionalCapabilities) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input *virtualmachinescalesets.AdditionalCapabilities) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -913,43 +916,43 @@ func FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input *comp
 	}
 }
 
-func expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(input map[string]interface{}, customData string) *compute.VirtualMachineScaleSetOSProfile {
-	osProfile := compute.VirtualMachineScaleSetOSProfile{}
-	winConfig := compute.WindowsConfiguration{}
-	patchSettings := compute.PatchSettings{}
+func expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(input map[string]interface{}, customData string) *virtualmachinescalesets.VirtualMachineScaleSetOSProfile {
+	osProfile := virtualmachinescalesets.VirtualMachineScaleSetOSProfile{}
+	winConfig := virtualmachinescalesets.WindowsConfiguration{}
+	patchSettings := virtualmachinescalesets.PatchSettings{}
 
 	if len(input) > 0 {
-		osProfile.CustomData = utils.String(customData)
-		osProfile.AdminUsername = utils.String(input["admin_username"].(string))
-		osProfile.AdminPassword = utils.String(input["admin_password"].(string))
+		osProfile.CustomData = pointer.To(customData)
+		osProfile.AdminUsername = pointer.To(input["admin_username"].(string))
+		osProfile.AdminPassword = pointer.To(input["admin_password"].(string))
 
 		if computerPrefix := input["computer_name_prefix"].(string); computerPrefix != "" {
-			osProfile.ComputerNamePrefix = utils.String(computerPrefix)
+			osProfile.ComputerNamePrefix = pointer.To(computerPrefix)
 		}
 
 		if secrets := input["secret"].([]interface{}); len(secrets) > 0 {
-			osProfile.Secrets = expandWindowsSecrets(secrets)
+			osProfile.Secrets = expandWindowsSecretsVMSS(secrets)
 		}
 
 		if additionalUnattendContents := input["additional_unattend_content"].([]interface{}); len(additionalUnattendContents) > 0 {
 			winConfig.AdditionalUnattendContent = expandWindowsConfigurationAdditionalUnattendContent(input["additional_unattend_content"].([]interface{}))
 		}
-		winConfig.EnableAutomaticUpdates = utils.Bool(input["enable_automatic_updates"].(bool))
-		winConfig.ProvisionVMAgent = utils.Bool(input["provision_vm_agent"].(bool))
+		winConfig.EnableAutomaticUpdates = pointer.To(input["enable_automatic_updates"].(bool))
+		winConfig.ProvisionVMAgent = pointer.To(input["provision_vm_agent"].(bool))
 		winRmListenersRaw := input["winrm_listener"].(*pluginsdk.Set).List()
-		winConfig.WinRM = expandWinRMListener(winRmListenersRaw)
+		winConfig.WinRM = expandWinRMListenerVMSS(winRmListenersRaw)
 
 		// Automatic VM Guest Patching and Hotpatching settings
-		patchSettings.AssessmentMode = compute.WindowsPatchAssessmentMode(input["patch_assessment_mode"].(string))
-		patchSettings.PatchMode = compute.WindowsVMGuestPatchMode(input["patch_mode"].(string))
-		patchSettings.EnableHotpatching = utils.Bool(input["hotpatching_enabled"].(bool))
+		patchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.WindowsPatchAssessmentMode(input["patch_assessment_mode"].(string)))
+		patchSettings.PatchMode = pointer.To(virtualmachinescalesets.WindowsVMGuestPatchMode(input["patch_mode"].(string)))
+		patchSettings.EnableHotpatching = pointer.To(input["hotpatching_enabled"].(bool))
 		winConfig.PatchSettings = &patchSettings
 
 		// due to a change in RP behavor, it will now throw and error if we pass an empty
 		// string add check to only include it if it is actually defined in the config file
 		timeZone := input["timezone"].(string)
 		if timeZone != "" {
-			winConfig.TimeZone = utils.String(timeZone)
+			winConfig.TimeZone = pointer.To(timeZone)
 		}
 	}
 
@@ -958,40 +961,40 @@ func expandOrchestratedVirtualMachineScaleSetOsProfileWithWindowsConfiguration(i
 	return &osProfile
 }
 
-func expandOrchestratedVirtualMachineScaleSetOsProfileWithLinuxConfiguration(input map[string]interface{}, customData string) *compute.VirtualMachineScaleSetOSProfile {
-	osProfile := compute.VirtualMachineScaleSetOSProfile{}
-	linConfig := compute.LinuxConfiguration{}
-	patchSettings := compute.LinuxPatchSettings{}
+func expandOrchestratedVirtualMachineScaleSetOsProfileWithLinuxConfiguration(input map[string]interface{}, customData string) *virtualmachinescalesets.VirtualMachineScaleSetOSProfile {
+	osProfile := virtualmachinescalesets.VirtualMachineScaleSetOSProfile{}
+	linConfig := virtualmachinescalesets.LinuxConfiguration{}
+	patchSettings := virtualmachinescalesets.LinuxPatchSettings{}
 
 	if len(input) > 0 {
-		osProfile.CustomData = utils.String(customData)
-		osProfile.AdminUsername = utils.String(input["admin_username"].(string))
+		osProfile.CustomData = pointer.To(customData)
+		osProfile.AdminUsername = pointer.To(input["admin_username"].(string))
 
 		if adminPassword := input["admin_password"].(string); adminPassword != "" {
-			osProfile.AdminPassword = utils.String(adminPassword)
+			osProfile.AdminPassword = pointer.To(adminPassword)
 		}
 
 		if computerPrefix := input["computer_name_prefix"].(string); computerPrefix != "" {
-			osProfile.ComputerNamePrefix = utils.String(computerPrefix)
+			osProfile.ComputerNamePrefix = pointer.To(computerPrefix)
 		}
 
 		if secrets := input["secret"].([]interface{}); len(secrets) > 0 {
-			osProfile.Secrets = expandLinuxSecrets(secrets)
+			osProfile.Secrets = expandLinuxSecretsVMSS(secrets)
 		}
 
-		if sshPublicKeys := ExpandSSHKeys(input["admin_ssh_key"].(*pluginsdk.Set).List()); len(sshPublicKeys) > 0 {
-			if linConfig.SSH == nil {
-				linConfig.SSH = &compute.SSHConfiguration{}
+		if sshPublicKeys := expandSSHKeysVMSS(input["admin_ssh_key"].(*pluginsdk.Set).List()); len(sshPublicKeys) > 0 {
+			if linConfig.Ssh == nil {
+				linConfig.Ssh = &virtualmachinescalesets.SshConfiguration{}
 			}
-			linConfig.SSH.PublicKeys = &sshPublicKeys
+			linConfig.Ssh.PublicKeys = &sshPublicKeys
 		}
 
-		linConfig.DisablePasswordAuthentication = utils.Bool(input["disable_password_authentication"].(bool))
-		linConfig.ProvisionVMAgent = utils.Bool(input["provision_vm_agent"].(bool))
+		linConfig.DisablePasswordAuthentication = pointer.To(input["disable_password_authentication"].(bool))
+		linConfig.ProvisionVMAgent = pointer.To(input["provision_vm_agent"].(bool))
 
 		// Automatic VM Guest Patching
-		patchSettings.AssessmentMode = compute.LinuxPatchAssessmentMode(input["patch_assessment_mode"].(string))
-		patchSettings.PatchMode = compute.LinuxVMGuestPatchMode(input["patch_mode"].(string))
+		patchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.LinuxPatchAssessmentMode(input["patch_assessment_mode"].(string)))
+		patchSettings.PatchMode = pointer.To(virtualmachinescalesets.LinuxVMGuestPatchMode(input["patch_mode"].(string)))
 		linConfig.PatchSettings = &patchSettings
 	}
 
@@ -1000,34 +1003,34 @@ func expandOrchestratedVirtualMachineScaleSetOsProfileWithLinuxConfiguration(inp
 	return &osProfile
 }
 
-func expandWindowsConfigurationAdditionalUnattendContent(input []interface{}) *[]compute.AdditionalUnattendContent {
-	output := make([]compute.AdditionalUnattendContent, 0)
+func expandWindowsConfigurationAdditionalUnattendContent(input []interface{}) *[]virtualmachinescalesets.AdditionalUnattendContent {
+	output := make([]virtualmachinescalesets.AdditionalUnattendContent, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
-		output = append(output, compute.AdditionalUnattendContent{
-			SettingName: compute.SettingNames(raw["setting"].(string)),
-			Content:     utils.String(raw["content"].(string)),
+		output = append(output, virtualmachinescalesets.AdditionalUnattendContent{
+			SettingName: pointer.To(virtualmachinescalesets.SettingNames(raw["setting"].(string))),
+			Content:     pointer.To(raw["content"].(string)),
 
 			// no other possible values
-			PassName:      compute.PassNamesOobeSystem,
-			ComponentName: compute.ComponentNamesMicrosoftWindowsShellSetup,
+			PassName:      pointer.To(virtualmachinescalesets.PassNamesOobeSystem),
+			ComponentName: pointer.To(virtualmachinescalesets.ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup),
 		})
 	}
 
 	return &output
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compute.VirtualMachineScaleSetNetworkConfiguration, error) {
-	output := make([]compute.VirtualMachineScaleSetNetworkConfiguration, 0)
+func ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration, error) {
+	output := make([]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
 		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
 
-		ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0)
+		ipConfigurations := make([]virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration, 0)
 		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
 		for _, configV := range ipConfigurationsRaw {
 			configRaw := configV.(map[string]interface{})
@@ -1039,22 +1042,22 @@ func ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(input []interface{
 			ipConfigurations = append(ipConfigurations, *ipConfiguration)
 		}
 
-		config := compute.VirtualMachineScaleSetNetworkConfiguration{
-			Name: utils.String(raw["name"].(string)),
-			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
-					DNSServers: dnsServers,
+		config := virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration{
+			Name: raw["name"].(string),
+			Properties: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationProperties{
+				DnsSettings: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationDnsSettings{
+					DnsServers: dnsServers,
 				},
-				EnableAcceleratedNetworking: utils.Bool(raw["enable_accelerated_networking"].(bool)),
-				EnableIPForwarding:          utils.Bool(raw["enable_ip_forwarding"].(bool)),
-				IPConfigurations:            &ipConfigurations,
-				Primary:                     utils.Bool(raw["primary"].(bool)),
+				EnableAcceleratedNetworking: pointer.To(raw["enable_accelerated_networking"].(bool)),
+				EnableIPForwarding:          pointer.To(raw["enable_ip_forwarding"].(bool)),
+				IPConfigurations:            ipConfigurations,
+				Primary:                     pointer.To(raw["primary"].(bool)),
 			},
 		}
 
 		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
-			config.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
-				ID: utils.String(nsgId),
+			config.Properties.NetworkSecurityGroup = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(nsgId),
 			}
 		}
 
@@ -1064,7 +1067,7 @@ func ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(input []interface{
 	return &output, nil
 }
 
-func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*compute.VirtualMachineScaleSetIPConfiguration, error) {
+func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration, error) {
 	applicationGatewayBackendAddressPoolIdsRaw := raw["application_gateway_backend_address_pool_ids"].(*pluginsdk.Set).List()
 	applicationGatewayBackendAddressPoolIds := expandIDsToSubResources(applicationGatewayBackendAddressPoolIdsRaw)
 
@@ -1075,16 +1078,16 @@ func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]inte
 	loadBalancerBackendAddressPoolIds := expandIDsToSubResources(loadBalancerBackendAddressPoolIdsRaw)
 
 	primary := raw["primary"].(bool)
-	version := compute.IPVersion(raw["version"].(string))
-	if primary && version == compute.IPVersionIPv6 {
+	version := virtualmachinescalesets.IPVersion(raw["version"].(string))
+	if primary && version == virtualmachinescalesets.IPVersionIPvSix {
 		return nil, fmt.Errorf("an IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary")
 	}
 
-	ipConfiguration := compute.VirtualMachineScaleSetIPConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-			Primary:                               utils.Bool(primary),
-			PrivateIPAddressVersion:               version,
+	ipConfiguration := virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration{
+		Name: raw["name"].(string),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetIPConfigurationProperties{
+			Primary:                               pointer.To(primary),
+			PrivateIPAddressVersion:               pointer.To(version),
 			ApplicationGatewayBackendAddressPools: applicationGatewayBackendAddressPoolIds,
 			ApplicationSecurityGroups:             applicationSecurityGroupIds,
 			LoadBalancerBackendAddressPools:       loadBalancerBackendAddressPoolIds,
@@ -1093,8 +1096,8 @@ func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]inte
 	}
 
 	if subnetId := raw["subnet_id"].(string); subnetId != "" {
-		ipConfiguration.VirtualMachineScaleSetIPConfigurationProperties.Subnet = &compute.APIEntityReference{
-			ID: utils.String(subnetId),
+		ipConfiguration.Properties.Subnet = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(subnetId),
 		}
 	}
 
@@ -1102,44 +1105,44 @@ func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]inte
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
-		ipConfiguration.VirtualMachineScaleSetIPConfigurationProperties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
 	}
 
 	return &ipConfiguration, nil
 }
 
-func expandOrchestratedVirtualMachineScaleSetPublicIPAddress(raw map[string]interface{}) *compute.VirtualMachineScaleSetPublicIPAddressConfiguration {
+func expandOrchestratedVirtualMachineScaleSetPublicIPAddress(raw map[string]interface{}) *virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration {
 	ipTagsRaw := raw["ip_tag"].([]interface{})
-	ipTags := make([]compute.VirtualMachineScaleSetIPTag, 0)
+	ipTags := make([]virtualmachinescalesets.VirtualMachineScaleSetIPTag, 0)
 	for _, ipTagV := range ipTagsRaw {
 		ipTagRaw := ipTagV.(map[string]interface{})
-		ipTags = append(ipTags, compute.VirtualMachineScaleSetIPTag{
-			Tag:       utils.String(ipTagRaw["tag"].(string)),
-			IPTagType: utils.String(ipTagRaw["type"].(string)),
+		ipTags = append(ipTags, virtualmachinescalesets.VirtualMachineScaleSetIPTag{
+			Tag:       pointer.To(ipTagRaw["tag"].(string)),
+			IPTagType: pointer.To(ipTagRaw["type"].(string)),
 		})
 	}
 
-	publicIPAddressConfig := compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetPublicIPAddressConfigurationProperties: &compute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
+	publicIPAddressConfig := virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration{
+		Name: raw["name"].(string),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
 			IPTags: &ipTags,
 		},
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &compute.VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings{
-			DomainNameLabel: utils.String(domainNameLabel),
+		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.DNSSettings = dns
+		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.IdleTimeoutInMinutes = utils.Int32(int32(raw["idle_timeout_in_minutes"].(int)))
+		publicIPAddressConfig.Properties.IdleTimeoutInMinutes = pointer.To(int64(raw["idle_timeout_in_minutes"].(int)))
 	}
 
 	if publicIPPrefixID := raw["public_ip_prefix_id"].(string); publicIPPrefixID != "" {
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.PublicIPPrefix = &compute.SubResource{
-			ID: utils.String(publicIPPrefixID),
+		publicIPAddressConfig.Properties.PublicIPPrefix = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(publicIPPrefixID),
 		}
 	}
 
@@ -1149,21 +1152,21 @@ func expandOrchestratedVirtualMachineScaleSetPublicIPAddress(raw map[string]inte
 	}
 
 	if version := raw["version"].(string); version != "" {
-		publicIPAddressConfig.PublicIPAddressVersion = compute.IPVersion(version)
+		publicIPAddressConfig.Properties.PublicIPAddressVersion = pointer.To(virtualmachinescalesets.IPVersion(version))
 	}
 
 	return &publicIPAddressConfig
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
-	output := make([]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, 0)
+func ExpandOrchestratedVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[]virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
+	output := make([]virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
 		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
 
-		ipConfigurations := make([]compute.VirtualMachineScaleSetUpdateIPConfiguration, 0)
+		ipConfigurations := make([]virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration, 0)
 		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
 		for _, configV := range ipConfigurationsRaw {
 			configRaw := configV.(map[string]interface{})
@@ -1175,22 +1178,22 @@ func ExpandOrchestratedVirtualMachineScaleSetNetworkInterfaceUpdate(input []inte
 			ipConfigurations = append(ipConfigurations, *ipConfiguration)
 		}
 
-		config := compute.VirtualMachineScaleSetUpdateNetworkConfiguration{
-			Name: utils.String(raw["name"].(string)),
-			VirtualMachineScaleSetUpdateNetworkConfigurationProperties: &compute.VirtualMachineScaleSetUpdateNetworkConfigurationProperties{
-				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
-					DNSServers: dnsServers,
+		config := virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration{
+			Name: pointer.To(raw["name"].(string)),
+			Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfigurationProperties{
+				DnsSettings: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationDnsSettings{
+					DnsServers: dnsServers,
 				},
-				EnableAcceleratedNetworking: utils.Bool(raw["enable_accelerated_networking"].(bool)),
-				EnableIPForwarding:          utils.Bool(raw["enable_ip_forwarding"].(bool)),
+				EnableAcceleratedNetworking: pointer.To(raw["enable_accelerated_networking"].(bool)),
+				EnableIPForwarding:          pointer.To(raw["enable_ip_forwarding"].(bool)),
 				IPConfigurations:            &ipConfigurations,
-				Primary:                     utils.Bool(raw["primary"].(bool)),
+				Primary:                     pointer.To(raw["primary"].(bool)),
 			},
 		}
 
 		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
-			config.VirtualMachineScaleSetUpdateNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
-				ID: utils.String(nsgId),
+			config.Properties.NetworkSecurityGroup = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(nsgId),
 			}
 		}
 
@@ -1200,7 +1203,7 @@ func ExpandOrchestratedVirtualMachineScaleSetNetworkInterfaceUpdate(input []inte
 	return &output, nil
 }
 
-func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{}) (*compute.VirtualMachineScaleSetUpdateIPConfiguration, error) {
+func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{}) (*virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration, error) {
 	applicationGatewayBackendAddressPoolIdsRaw := raw["application_gateway_backend_address_pool_ids"].(*pluginsdk.Set).List()
 	applicationGatewayBackendAddressPoolIds := expandIDsToSubResources(applicationGatewayBackendAddressPoolIdsRaw)
 
@@ -1211,17 +1214,17 @@ func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[strin
 	loadBalancerBackendAddressPoolIds := expandIDsToSubResources(loadBalancerBackendAddressPoolIdsRaw)
 
 	primary := raw["primary"].(bool)
-	version := compute.IPVersion(raw["version"].(string))
+	version := virtualmachinescalesets.IPVersion(raw["version"].(string))
 
-	if primary && version == compute.IPVersionIPv6 {
+	if primary && version == virtualmachinescalesets.IPVersionIPvSix {
 		return nil, fmt.Errorf("an IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary")
 	}
 
-	ipConfiguration := compute.VirtualMachineScaleSetUpdateIPConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetUpdateIPConfigurationProperties: &compute.VirtualMachineScaleSetUpdateIPConfigurationProperties{
-			Primary:                               utils.Bool(primary),
-			PrivateIPAddressVersion:               version,
+	ipConfiguration := virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration{
+		Name: pointer.To(raw["name"].(string)),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfigurationProperties{
+			Primary:                               pointer.To(primary),
+			PrivateIPAddressVersion:               pointer.To(version),
 			ApplicationGatewayBackendAddressPools: applicationGatewayBackendAddressPoolIds,
 			ApplicationSecurityGroups:             applicationSecurityGroupIds,
 			LoadBalancerBackendAddressPools:       loadBalancerBackendAddressPoolIds,
@@ -1230,8 +1233,8 @@ func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[strin
 	}
 
 	if subnetId := raw["subnet_id"].(string); subnetId != "" {
-		ipConfiguration.VirtualMachineScaleSetUpdateIPConfigurationProperties.Subnet = &compute.APIEntityReference{
-			ID: utils.String(subnetId),
+		ipConfiguration.Properties.Subnet = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(subnetId),
 		}
 	}
 
@@ -1239,59 +1242,59 @@ func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[strin
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
-		ipConfiguration.VirtualMachineScaleSetUpdateIPConfigurationProperties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
 	}
 
 	return &ipConfiguration, nil
 }
 
-func expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{}) *compute.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration {
-	publicIPAddressConfig := compute.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties: &compute.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties{},
+func expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{}) *virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration {
+	publicIPAddressConfig := virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration{
+		Name:       pointer.To(raw["name"].(string)),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties{},
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &compute.VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings{
-			DomainNameLabel: utils.String(domainNameLabel),
+		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.DNSSettings = dns
+		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
-		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.IdleTimeoutInMinutes = utils.Int32(int32(raw["idle_timeout_in_minutes"].(int)))
+		publicIPAddressConfig.Properties.IdleTimeoutInMinutes = pointer.To(int64(raw["idle_timeout_in_minutes"].(int)))
 	}
 
 	return &publicIPAddressConfig
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled bool) (*[]compute.VirtualMachineScaleSetDataDisk, error) {
-	disks := make([]compute.VirtualMachineScaleSetDataDisk, 0)
+func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled bool) (*[]virtualmachinescalesets.VirtualMachineScaleSetDataDisk, error) {
+	disks := make([]virtualmachinescalesets.VirtualMachineScaleSetDataDisk, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
-		storageAccountType := compute.StorageAccountTypes(raw["storage_account_type"].(string))
-		disk := compute.VirtualMachineScaleSetDataDisk{
-			Caching: compute.CachingTypes(raw["caching"].(string)),
-			ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-				StorageAccountType: storageAccountType,
+		storageAccountType := virtualmachinescalesets.StorageAccountTypes(raw["storage_account_type"].(string))
+		disk := virtualmachinescalesets.VirtualMachineScaleSetDataDisk{
+			Caching: pointer.To(virtualmachinescalesets.CachingTypes(raw["caching"].(string))),
+			ManagedDisk: &virtualmachinescalesets.VirtualMachineScaleSetManagedDiskParameters{
+				StorageAccountType: pointer.To(storageAccountType),
 			},
-			WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
-			CreateOption:            compute.DiskCreateOptionTypes(raw["create_option"].(string)),
+			WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
+			CreateOption:            virtualmachinescalesets.DiskCreateOptionTypes(raw["create_option"].(string)),
 		}
 
 		if dataDiskSize := raw["disk_size_gb"].(int); dataDiskSize > 0 {
-			disk.DiskSizeGB = utils.Int32(int32(dataDiskSize))
+			disk.DiskSizeGB = pointer.To(int64(dataDiskSize))
 		}
 
 		if lun := raw["lun"].(int); lun >= 0 {
-			disk.Lun = utils.Int32(int32(lun))
+			disk.Lun = int64(lun)
 		}
 
 		if id := raw["disk_encryption_set_id"].(string); id != "" {
-			disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-				ID: utils.String(id),
+			disk.ManagedDisk.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(id),
 			}
 		}
 
@@ -1300,13 +1303,13 @@ func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultra
 			iops = diskIops.(int)
 		}
 
-		if iops > 0 && !ultraSSDEnabled && storageAccountType != compute.StorageAccountTypesPremiumV2LRS {
+		if iops > 0 && !ultraSSDEnabled && storageAccountType != virtualmachinescalesets.StorageAccountTypesPremiumVTwoLRS {
 			return nil, fmt.Errorf("`ultra_ssd_disk_iops_read_write` can only be set when `storage_account_type` is set to `PremiumV2_LRS` or `UltraSSD_LRS`")
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if iops > 0 {
-			disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
+			disk.DiskIOPSReadWrite = pointer.To(int64(iops))
 		}
 
 		var mbps int
@@ -1314,13 +1317,13 @@ func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultra
 			mbps = diskMbps.(int)
 		}
 
-		if mbps > 0 && !ultraSSDEnabled && storageAccountType != compute.StorageAccountTypesPremiumV2LRS {
+		if mbps > 0 && !ultraSSDEnabled && storageAccountType != virtualmachinescalesets.StorageAccountTypesPremiumVTwoLRS {
 			return nil, fmt.Errorf("`ultra_ssd_disk_mbps_read_write` can only be set when `storage_account_type` is set to `PremiumV2_LRS` or `UltraSSD_LRS`")
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if mbps > 0 {
-			disk.DiskMBpsReadWrite = utils.Int64(int64(mbps))
+			disk.DiskMBpsReadWrite = pointer.To(int64(mbps))
 		}
 
 		disks = append(disks, disk)
@@ -1329,65 +1332,65 @@ func ExpandOrchestratedVirtualMachineScaleSetDataDisk(input []interface{}, ultra
 	return &disks, nil
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetOSDisk(input []interface{}, osType compute.OperatingSystemTypes) *compute.VirtualMachineScaleSetOSDisk {
+func ExpandOrchestratedVirtualMachineScaleSetOSDisk(input []interface{}, osType virtualmachinescalesets.OperatingSystemTypes) *virtualmachinescalesets.VirtualMachineScaleSetOSDisk {
 	raw := input[0].(map[string]interface{})
-	disk := compute.VirtualMachineScaleSetOSDisk{
-		Caching: compute.CachingTypes(raw["caching"].(string)),
-		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+	disk := virtualmachinescalesets.VirtualMachineScaleSetOSDisk{
+		Caching: pointer.To(virtualmachinescalesets.CachingTypes(raw["caching"].(string))),
+		ManagedDisk: &virtualmachinescalesets.VirtualMachineScaleSetManagedDiskParameters{
+			StorageAccountType: pointer.To(virtualmachinescalesets.StorageAccountTypes(raw["storage_account_type"].(string))),
 		},
-		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+		WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
 
 		// these have to be hard-coded so there's no point exposing them
-		CreateOption: compute.DiskCreateOptionTypesFromImage,
-		OsType:       osType,
+		CreateOption: virtualmachinescalesets.DiskCreateOptionTypesFromImage,
+		OsType:       pointer.To(osType),
 	}
 
 	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
-		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-			ID: utils.String(diskEncryptionSetId),
+		disk.ManagedDisk.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(diskEncryptionSetId),
 		}
 	}
 
 	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
-		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+		disk.DiskSizeGB = pointer.To(int64(osDiskSize))
 	}
 
 	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 {
 		diffDiskRaw := diffDiskSettingsRaw[0].(map[string]interface{})
-		disk.DiffDiskSettings = &compute.DiffDiskSettings{
-			Option:    compute.DiffDiskOptions(diffDiskRaw["option"].(string)),
-			Placement: compute.DiffDiskPlacement(diffDiskRaw["placement"].(string)),
+		disk.DiffDiskSettings = &virtualmachinescalesets.DiffDiskSettings{
+			Option:    pointer.To(virtualmachinescalesets.DiffDiskOptions(diffDiskRaw["option"].(string))),
+			Placement: pointer.To(virtualmachinescalesets.DiffDiskPlacement(diffDiskRaw["placement"].(string))),
 		}
 	}
 
 	return &disk
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetOSDiskUpdate(input []interface{}) *compute.VirtualMachineScaleSetUpdateOSDisk {
+func ExpandOrchestratedVirtualMachineScaleSetOSDiskUpdate(input []interface{}) *virtualmachinescalesets.VirtualMachineScaleSetUpdateOSDisk {
 	raw := input[0].(map[string]interface{})
-	disk := compute.VirtualMachineScaleSetUpdateOSDisk{
-		Caching: compute.CachingTypes(raw["caching"].(string)),
-		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+	disk := virtualmachinescalesets.VirtualMachineScaleSetUpdateOSDisk{
+		Caching: pointer.To(virtualmachinescalesets.CachingTypes(raw["caching"].(string))),
+		ManagedDisk: &virtualmachinescalesets.VirtualMachineScaleSetManagedDiskParameters{
+			StorageAccountType: pointer.To(virtualmachinescalesets.StorageAccountTypes(raw["storage_account_type"].(string))),
 		},
-		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+		WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
 	}
 
 	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
-		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-			ID: utils.String(diskEncryptionSetId),
+		disk.ManagedDisk.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(diskEncryptionSetId),
 		}
 	}
 
 	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
-		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+		disk.DiskSizeGB = pointer.To(int64(osDiskSize))
 	}
 
 	return &disk
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *compute.ScheduledEventsProfile {
+func ExpandOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *virtualmachinescalesets.ScheduledEventsProfile {
 	if len(input) == 0 {
 		return nil
 	}
@@ -1396,33 +1399,33 @@ func ExpandOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input []inte
 	enabled := raw["enabled"].(bool)
 	timeout := raw["timeout"].(string)
 
-	return &compute.ScheduledEventsProfile{
-		TerminateNotificationProfile: &compute.TerminateNotificationProfile{
+	return &virtualmachinescalesets.ScheduledEventsProfile{
+		TerminateNotificationProfile: &virtualmachinescalesets.TerminateNotificationProfile{
 			Enable:           &enabled,
 			NotBeforeTimeout: &timeout,
 		},
 	}
 }
 
-func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *compute.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
-	extensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
+	extensionProfile = &virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile{}
 	if len(input) == 0 {
 		return nil, false, nil
 	}
 
-	extensions := make([]compute.VirtualMachineScaleSetExtension, 0)
+	extensions := make([]virtualmachinescalesets.VirtualMachineScaleSetExtension, 0)
 	for _, v := range input {
 		extensionRaw := v.(map[string]interface{})
-		extension := compute.VirtualMachineScaleSetExtension{
-			Name: utils.String(extensionRaw["name"].(string)),
+		extension := virtualmachinescalesets.VirtualMachineScaleSetExtension{
+			Name: pointer.To(extensionRaw["name"].(string)),
 		}
 		extensionType := extensionRaw["type"].(string)
 
-		extensionProps := compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:                utils.String(extensionRaw["publisher"].(string)),
+		extensionProps := virtualmachinescalesets.VirtualMachineScaleSetExtensionProperties{
+			Publisher:                pointer.To(extensionRaw["publisher"].(string)),
 			Type:                     &extensionType,
-			TypeHandlerVersion:       utils.String(extensionRaw["type_handler_version"].(string)),
-			AutoUpgradeMinorVersion:  utils.Bool(extensionRaw["auto_upgrade_minor_version_enabled"].(bool)),
+			TypeHandlerVersion:       pointer.To(extensionRaw["type_handler_version"].(string)),
+			AutoUpgradeMinorVersion:  pointer.To(extensionRaw["auto_upgrade_minor_version_enabled"].(bool)),
 			ProvisionAfterExtensions: utils.ExpandStringSlice(extensionRaw["extensions_to_provision_after_vm_creation"].([]interface{})),
 		}
 
@@ -1431,37 +1434,39 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 		}
 
 		if val, ok := extensionRaw["failure_suppression_enabled"]; ok {
-			extensionProps.SuppressFailures = utils.Bool(val.(bool))
+			extensionProps.SuppressFailures = pointer.To(val.(bool))
 		}
 
 		if forceUpdateTag := extensionRaw["force_extension_execution_on_change"]; forceUpdateTag != nil {
-			extensionProps.ForceUpdateTag = utils.String(forceUpdateTag.(string))
+			extensionProps.ForceUpdateTag = pointer.To(forceUpdateTag.(string))
 		}
 
 		if val, ok := extensionRaw["settings"]; ok && val.(string) != "" {
-			settings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			var result interface{}
+			err := json.Unmarshal([]byte(val.(string)), &result)
 			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse JSON from `settings`: %+v", err)
+				return nil, false, fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
-			extensionProps.Settings = settings
+			extensionProps.Settings = pointer.To(result)
 		}
 
 		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVault(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
-		extensionProps.ProtectedSettingsFromKeyVault = protectedSettingsFromKeyVault
+		extensionProps.ProtectedSettingsFromKeyVault = (protectedSettingsFromKeyVault)
 
 		if val, ok := extensionRaw["protected_settings"]; ok && val.(string) != "" {
 			if protectedSettingsFromKeyVault != nil {
 				return nil, false, fmt.Errorf("`protected_settings_from_key_vault` cannot be used with `protected_settings`")
 			}
 
-			protectedSettings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			var result interface{}
+			err := json.Unmarshal([]byte(val.(string)), &result)
 			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse JSON for `protected_settings`: %+v", err)
+				return nil, false, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
-			extensionProps.ProtectedSettings = protectedSettings
+			extensionProps.ProtectedSettings = pointer.To(result)
 		}
 
-		extension.VirtualMachineScaleSetExtensionProperties = &extensionProps
+		extension.Properties = &extensionProps
 		extensions = append(extensions, extension)
 	}
 	extensionProfile.Extensions = &extensions
@@ -1469,20 +1474,20 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 	return extensionProfile, hasHealthExtension, nil
 }
 
-func ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(input []interface{}) *compute.PriorityMixPolicy {
+func ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(input []interface{}) *virtualmachinescalesets.PriorityMixPolicy {
 	if len(input) == 0 {
 		return nil
 	}
 
 	raw := input[0].(map[string]interface{})
 
-	return &compute.PriorityMixPolicy{
-		BaseRegularPriorityCount:           utils.Int32(int32(raw["base_regular_count"].(int))),
-		RegularPriorityPercentageAboveBase: utils.Int32(int32(raw["regular_percentage_above_base"].(int))),
+	return &virtualmachinescalesets.PriorityMixPolicy{
+		BaseRegularPriorityCount:           pointer.To(int64(raw["base_regular_count"].(int))),
+		RegularPriorityPercentageAboveBase: pointer.To(int64(raw["regular_percentage_above_base"].(int))),
 	}
 }
 
-func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleSetExtensionProfile, d *pluginsdk.ResourceData) ([]map[string]interface{}, error) {
+func flattenOrchestratedVirtualMachineScaleSetExtensions(input *virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile, d *pluginsdk.ResourceData) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0)
 	if input == nil || input.Extensions == nil {
 		return result, nil
@@ -1510,18 +1515,16 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 
 		autoUpgradeMinorVersion := false
 		suppressFailures := false
-		// Automatic Upgrade is not yet supported in VMSS Flex
-		// enableAutomaticUpgrade := false
 		forceUpdateTag := ""
 		provisionAfterExtension := make([]interface{}, 0)
 		protectedSettings := ""
-		var protectedSettingsFromKeyVault *compute.KeyVaultSecretReference
+		var protectedSettingsFromKeyVault *virtualmachinescalesets.KeyVaultSecretReference
 		extPublisher := ""
 		extSettings := ""
 		extType := ""
 		extTypeVersion := ""
 
-		if props := v.VirtualMachineScaleSetExtensionProperties; props != nil {
+		if props := v.Properties; props != nil {
 			if props.Publisher != nil {
 				extPublisher = *props.Publisher
 			}
@@ -1538,10 +1541,6 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 				autoUpgradeMinorVersion = *props.AutoUpgradeMinorVersion
 			}
 
-			// if props.EnableAutomaticUpgrade != nil {
-			// 	enableAutomaticUpgrade = *props.EnableAutomaticUpgrade
-			// }
-
 			if props.ForceUpdateTag != nil {
 				forceUpdateTag = *props.ForceUpdateTag
 			}
@@ -1555,11 +1554,12 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 			}
 
 			if props.Settings != nil {
-				extSettingsRaw, err := pluginsdk.FlattenJsonToString(props.Settings.(map[string]interface{}))
+				settings, err := json.Marshal(props.Settings)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unmarshaling `settings`: %+v", err)
 				}
-				extSettings = extSettingsRaw
+
+				extSettings = string(settings)
 			}
 
 			protectedSettingsFromKeyVault = props.ProtectedSettingsFromKeyVault
@@ -1574,9 +1574,8 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 		}
 
 		result = append(result, map[string]interface{}{
-			"name":                               name,
-			"auto_upgrade_minor_version_enabled": autoUpgradeMinorVersion,
-			// "automatic_upgrade_enabled":  enableAutomaticUpgrade,
+			"name":                                      name,
+			"auto_upgrade_minor_version_enabled":        autoUpgradeMinorVersion,
 			"force_extension_execution_on_change":       forceUpdateTag,
 			"failure_suppression_enabled":               suppressFailures,
 			"extensions_to_provision_after_vm_creation": provisionAfterExtension,
@@ -1591,35 +1590,38 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 	return result, nil
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetIPConfiguration(input compute.VirtualMachineScaleSetIPConfiguration) map[string]interface{} {
-	var name, subnetId string
-	if input.Name != nil {
-		name = *input.Name
-	}
-	if input.Subnet != nil && input.Subnet.ID != nil {
-		subnetId = *input.Subnet.ID
-	}
-
+func FlattenOrchestratedVirtualMachineScaleSetIPConfiguration(input virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration) map[string]interface{} {
+	var subnetId, version string
 	var primary bool
-	if input.Primary != nil {
-		primary = *input.Primary
-	}
+	var publicIPAddresses, applicationGatewayBackendAddressPoolIds, applicationSecurityGroupIds, loadBalancerBackendAddressPoolIds []interface{}
 
-	var publicIPAddresses []interface{}
-	if input.PublicIPAddressConfiguration != nil {
-		publicIPAddresses = append(publicIPAddresses, FlattenOrchestratedVirtualMachineScaleSetPublicIPAddress(*input.PublicIPAddressConfiguration))
-	}
+	if props := input.Properties; props != nil {
+		if props.Subnet != nil && props.Subnet.Id != nil {
+			subnetId = *props.Subnet.Id
+		}
 
-	applicationGatewayBackendAddressPoolIds := flattenSubResourcesToIDs(input.ApplicationGatewayBackendAddressPools)
-	applicationSecurityGroupIds := flattenSubResourcesToIDs(input.ApplicationSecurityGroups)
-	loadBalancerBackendAddressPoolIds := flattenSubResourcesToIDs(input.LoadBalancerBackendAddressPools)
+		if props.Primary != nil {
+			primary = *props.Primary
+		}
+
+		if props.PublicIPAddressConfiguration != nil {
+			publicIPAddresses = append(publicIPAddresses, FlattenOrchestratedVirtualMachineScaleSetPublicIPAddress(*props.PublicIPAddressConfiguration))
+		}
+
+		version = string(pointer.From(props.PrivateIPAddressVersion))
+
+		applicationGatewayBackendAddressPoolIds = flattenSubResourcesToIDs(props.ApplicationGatewayBackendAddressPools)
+		applicationSecurityGroupIds = flattenSubResourcesToIDs(props.ApplicationSecurityGroups)
+		loadBalancerBackendAddressPoolIds = flattenSubResourcesToIDs(props.LoadBalancerBackendAddressPools)
+
+	}
 
 	return map[string]interface{}{
-		"name":              name,
+		"name":              input.Name,
 		"primary":           primary,
 		"public_ip_address": publicIPAddresses,
 		"subnet_id":         subnetId,
-		"version":           string(input.PrivateIPAddressVersion),
+		"version":           version,
 		"application_gateway_backend_address_pool_ids": applicationGatewayBackendAddressPoolIds,
 		"application_security_group_ids":               applicationSecurityGroupIds,
 		"load_balancer_backend_address_pool_ids":       loadBalancerBackendAddressPoolIds,
@@ -1627,55 +1629,55 @@ func FlattenOrchestratedVirtualMachineScaleSetIPConfiguration(input compute.Virt
 	}
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input compute.VirtualMachineScaleSetPublicIPAddressConfiguration) map[string]interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration) map[string]interface{} {
 	ipTags := make([]interface{}, 0)
-	if input.IPTags != nil {
-		for _, rawTag := range *input.IPTags {
-			var tag, tagType string
-
-			if rawTag.IPTagType != nil {
-				tagType = *rawTag.IPTagType
-			}
-
-			if rawTag.Tag != nil {
-				tag = *rawTag.Tag
-			}
-
-			ipTags = append(ipTags, map[string]interface{}{
-				"tag":  tag,
-				"type": tagType,
-			})
-		}
-	}
-
-	var domainNameLabel, name, publicIPPrefixId string
-	if input.DNSSettings != nil && input.DNSSettings.DomainNameLabel != nil {
-		domainNameLabel = *input.DNSSettings.DomainNameLabel
-	}
-	if input.Name != nil {
-		name = *input.Name
-	}
-	if input.PublicIPPrefix != nil && input.PublicIPPrefix.ID != nil {
-		publicIPPrefixId = *input.PublicIPPrefix.ID
-	}
-
+	var domainNameLabel, publicIPPrefixId, version, sku string
 	var idleTimeoutInMinutes int
-	if input.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinutes = int(*input.IdleTimeoutInMinutes)
-	}
 
-	var version string
-	if input.PublicIPAddressVersion != "" {
-		version = string(input.PublicIPAddressVersion)
-	}
+	if props := input.Properties; props != nil {
+		if props.IPTags != nil {
+			for _, rawTag := range *props.IPTags {
+				var tag, tagType string
 
-	var sku string
-	if input.Sku != nil && input.Sku.Name != "" && input.Sku.Tier != "" {
-		sku = flattenOrchestratedVirtualMachineScaleSetPublicIPSku(input.Sku)
+				if rawTag.IPTagType != nil {
+					tagType = *rawTag.IPTagType
+				}
+
+				if rawTag.Tag != nil {
+					tag = *rawTag.Tag
+				}
+
+				ipTags = append(ipTags, map[string]interface{}{
+					"tag":  tag,
+					"type": tagType,
+				})
+			}
+		}
+
+		if props.DnsSettings != nil {
+			domainNameLabel = props.DnsSettings.DomainNameLabel
+		}
+
+		if props.PublicIPPrefix != nil && props.PublicIPPrefix.Id != nil {
+			publicIPPrefixId = *props.PublicIPPrefix.Id
+		}
+
+		if props.IdleTimeoutInMinutes != nil {
+			idleTimeoutInMinutes = int(*props.IdleTimeoutInMinutes)
+		}
+
+		if props.PublicIPAddressVersion != nil {
+			version = string(pointer.From(props.PublicIPAddressVersion))
+		}
+
+		if input.Sku != nil && input.Sku.Name != nil && input.Sku.Tier != nil {
+			sku = flattenOrchestratedVirtualMachineScaleSetPublicIPSku(input.Sku)
+		}
+
 	}
 
 	return map[string]interface{}{
-		"name":                    name,
+		"name":                    input.Name,
 		"domain_name_label":       domainNameLabel,
 		"idle_timeout_in_minutes": idleTimeoutInMinutes,
 		"ip_tag":                  ipTags,
@@ -1685,7 +1687,7 @@ func FlattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input compute.Virt
 	}
 }
 
-func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *compute.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
+func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *virtualmachinescalesets.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -1723,11 +1725,11 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *comput
 	}
 
 	if v := input.Secrets; v != nil {
-		output["secret"] = flattenWindowsSecrets(v)
+		output["secret"] = flattenWindowsSecretsVMSS(v)
 	}
 
 	if v := winConfig.WinRM; v != nil {
-		output["winrm_listener"] = flattenWinRMListener(winConfig.WinRM)
+		output["winrm_listener"] = flattenWinRMListenerVMSS(winConfig.WinRM)
 	}
 
 	if v := winConfig.TimeZone; v != nil {
@@ -1739,8 +1741,8 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *comput
 	output["hotpatching_enabled"] = false
 
 	if patchSettings != nil {
-		output["patch_mode"] = string(patchSettings.PatchMode)
-		output["patch_assessment_mode"] = string(patchSettings.AssessmentMode)
+		output["patch_mode"] = pointer.From(patchSettings.PatchMode)
+		output["patch_assessment_mode"] = pointer.From(patchSettings.AssessmentMode)
 
 		if v := patchSettings.EnableHotpatching; v != nil {
 			output["hotpatching_enabled"] = *v
@@ -1750,7 +1752,7 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *comput
 	return []interface{}{output}
 }
 
-func flattenOrchestratedVirtualMachineScaleSetLinuxConfiguration(input *compute.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
+func flattenOrchestratedVirtualMachineScaleSetLinuxConfiguration(input *virtualmachinescalesets.VirtualMachineScaleSetOSProfile, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -1774,8 +1776,8 @@ func flattenOrchestratedVirtualMachineScaleSetLinuxConfiguration(input *compute.
 		output["admin_password"] = *v
 	}
 
-	if v := linConfig.SSH; v != nil {
-		if sshKeys, _ := FlattenSSHKeys(v); sshKeys != nil {
+	if v := linConfig.Ssh; v != nil {
+		if sshKeys, _ := flattenSSHKeysVMSS(v); sshKeys != nil {
 			output["admin_ssh_key"] = pluginsdk.NewSet(SSHKeySchemaHash, *sshKeys)
 		}
 	}
@@ -1798,53 +1800,53 @@ func flattenOrchestratedVirtualMachineScaleSetLinuxConfiguration(input *compute.
 	}
 
 	if v := input.Secrets; v != nil {
-		output["secret"] = flattenLinuxSecrets(v)
+		output["secret"] = flattenLinuxSecretsVMSS(v)
 	}
 
 	return []interface{}{output}
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(input *[]compute.VirtualMachineScaleSetNetworkConfiguration) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(input *[]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
 
 	results := make([]interface{}, 0)
+	var networkSecurityGroupId string
+	var enableAcceleratedNetworking, enableIPForwarding, primary bool
+	var dnsServers []interface{}
+	var ipConfigurations []interface{}
 	for _, v := range *input {
-		var name, networkSecurityGroupId string
-		if v.Name != nil {
-			name = *v.Name
-		}
-		if v.NetworkSecurityGroup != nil && v.NetworkSecurityGroup.ID != nil {
-			networkSecurityGroupId = *v.NetworkSecurityGroup.ID
-		}
-
-		var enableAcceleratedNetworking, enableIPForwarding, primary bool
-		if v.EnableAcceleratedNetworking != nil {
-			enableAcceleratedNetworking = *v.EnableAcceleratedNetworking
-		}
-		if v.EnableIPForwarding != nil {
-			enableIPForwarding = *v.EnableIPForwarding
-		}
-		if v.Primary != nil {
-			primary = *v.Primary
-		}
-
-		var dnsServers []interface{}
-		if settings := v.DNSSettings; settings != nil {
-			dnsServers = utils.FlattenStringSlice(v.DNSSettings.DNSServers)
-		}
-
-		var ipConfigurations []interface{}
-		if v.IPConfigurations != nil {
-			for _, configRaw := range *v.IPConfigurations {
-				config := FlattenOrchestratedVirtualMachineScaleSetIPConfiguration(configRaw)
-				ipConfigurations = append(ipConfigurations, config)
+		if props := v.Properties; props != nil {
+			if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
+				networkSecurityGroupId = *props.NetworkSecurityGroup.Id
 			}
+
+			if props.EnableAcceleratedNetworking != nil {
+				enableAcceleratedNetworking = *props.EnableAcceleratedNetworking
+			}
+			if props.EnableIPForwarding != nil {
+				enableIPForwarding = *props.EnableIPForwarding
+			}
+			if props.Primary != nil {
+				primary = *props.Primary
+			}
+
+			if settings := props.DnsSettings; settings != nil {
+				dnsServers = utils.FlattenStringSlice(props.DnsSettings.DnsServers)
+			}
+
+			if len(props.IPConfigurations) != 0 {
+				for _, configRaw := range props.IPConfigurations {
+					config := FlattenOrchestratedVirtualMachineScaleSetIPConfiguration(configRaw)
+					ipConfigurations = append(ipConfigurations, config)
+				}
+			}
+
 		}
 
 		results = append(results, map[string]interface{}{
-			"name":                          name,
+			"name":                          v.Name,
 			"dns_servers":                   dnsServers,
 			"enable_accelerated_networking": enableAcceleratedNetworking,
 			"enable_ip_forwarding":          enableIPForwarding,
@@ -1857,7 +1859,7 @@ func FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(input *[]compute.
 	return results
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleSetDataDisk) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]virtualmachinescalesets.VirtualMachineScaleSetDataDisk) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -1870,17 +1872,12 @@ func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]compute.VirtualM
 			diskSizeGb = int(*v.DiskSizeGB)
 		}
 
-		lun := 0
-		if v.Lun != nil {
-			lun = int(*v.Lun)
-		}
-
 		storageAccountType := ""
 		diskEncryptionSetId := ""
 		if v.ManagedDisk != nil {
-			storageAccountType = string(v.ManagedDisk.StorageAccountType)
-			if v.ManagedDisk.DiskEncryptionSet != nil && v.ManagedDisk.DiskEncryptionSet.ID != nil {
-				diskEncryptionSetId = *v.ManagedDisk.DiskEncryptionSet.ID
+			storageAccountType = string(pointer.From(v.ManagedDisk.StorageAccountType))
+			if v.ManagedDisk.DiskEncryptionSet != nil && v.ManagedDisk.DiskEncryptionSet.Id != nil {
+				diskEncryptionSetId = *v.ManagedDisk.DiskEncryptionSet.Id
 			}
 		}
 
@@ -1900,9 +1897,9 @@ func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]compute.VirtualM
 		}
 
 		output = append(output, map[string]interface{}{
-			"caching":                        string(v.Caching),
+			"caching":                        pointer.From(v.Caching),
 			"create_option":                  string(v.CreateOption),
-			"lun":                            lun,
+			"lun":                            v.Lun,
 			"disk_encryption_set_id":         diskEncryptionSetId,
 			"disk_size_gb":                   diskSizeGb,
 			"storage_account_type":           storageAccountType,
@@ -1915,7 +1912,7 @@ func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]compute.VirtualM
 	return output
 }
 
-func flattenWindowsConfigurationAdditionalUnattendContent(input *compute.WindowsConfiguration, d *pluginsdk.ResourceData) []interface{} {
+func flattenWindowsConfigurationAdditionalUnattendContent(input *virtualmachinescalesets.WindowsConfiguration, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -1941,14 +1938,14 @@ func flattenWindowsConfigurationAdditionalUnattendContent(input *compute.Windows
 		}
 		output = append(output, map[string]interface{}{
 			"content": content,
-			"setting": string(v.SettingName),
+			"setting": pointer.From(v.SettingName),
 		})
 	}
 
 	return output
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachineScaleSetOSDisk) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *virtualmachinescalesets.VirtualMachineScaleSetOSDisk) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -1956,8 +1953,8 @@ func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachi
 	diffDiskSettings := make([]interface{}, 0)
 	if input.DiffDiskSettings != nil {
 		diffDiskSettings = append(diffDiskSettings, map[string]interface{}{
-			"option":    string(input.DiffDiskSettings.Option),
-			"placement": string(input.DiffDiskSettings.Placement),
+			"option":    pointer.From(input.DiffDiskSettings.Option),
+			"placement": pointer.From(input.DiffDiskSettings.Placement),
 		})
 	}
 
@@ -1969,9 +1966,9 @@ func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachi
 	storageAccountType := ""
 	diskEncryptionSetId := ""
 	if input.ManagedDisk != nil {
-		storageAccountType = string(input.ManagedDisk.StorageAccountType)
-		if input.ManagedDisk.DiskEncryptionSet != nil && input.ManagedDisk.DiskEncryptionSet.ID != nil {
-			diskEncryptionSetId = *input.ManagedDisk.DiskEncryptionSet.ID
+		storageAccountType = string(pointer.From(input.ManagedDisk.StorageAccountType))
+		if input.ManagedDisk.DiskEncryptionSet != nil && input.ManagedDisk.DiskEncryptionSet.Id != nil {
+			diskEncryptionSetId = *input.ManagedDisk.DiskEncryptionSet.Id
 		}
 	}
 
@@ -1982,7 +1979,7 @@ func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachi
 
 	return []interface{}{
 		map[string]interface{}{
-			"caching":                   string(input.Caching),
+			"caching":                   pointer.From(input.Caching),
 			"disk_size_gb":              diskSizeGb,
 			"diff_disk_settings":        diffDiskSettings,
 			"storage_account_type":      storageAccountType,
@@ -1992,7 +1989,7 @@ func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *compute.VirtualMachi
 	}
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input *compute.ScheduledEventsProfile) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input *virtualmachinescalesets.ScheduledEventsProfile) []interface{} {
 	// if enabled is set to false, there will be no ScheduledEventsProfile in response, to avoid plan non empty when
 	// a user explicitly set enabled to false, we need to assign a default block to this field
 
@@ -2014,14 +2011,14 @@ func FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(input *comp
 	}
 }
 
-func FlattenOrchestratedVirtualMachineScaleSetPriorityMixPolicy(input *compute.PriorityMixPolicy) []interface{} {
+func FlattenOrchestratedVirtualMachineScaleSetPriorityMixPolicy(input *virtualmachinescalesets.PriorityMixPolicy) []interface{} {
 
-	baseRegularPriorityCount := int32(0)
+	baseRegularPriorityCount := int64(0)
 	if input != nil && input.BaseRegularPriorityCount != nil {
 		baseRegularPriorityCount = *input.BaseRegularPriorityCount
 	}
 
-	regularPriorityPercentageAboveBase := int32(0)
+	regularPriorityPercentageAboveBase := int64(0)
 	if input != nil && input.RegularPriorityPercentageAboveBase != nil {
 		regularPriorityPercentageAboveBase = *input.RegularPriorityPercentageAboveBase
 	}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source.go
@@ -133,7 +133,7 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Attributes() map[string]*p
 			},
 		},
 
-		"identity": commonschema.SystemAssignedIdentityComputed(),
+		"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
 	}
 }
 
@@ -151,7 +151,9 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Read() sdk.ResourceFunc {
 
 			id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, orchestratedVMSS.ResourceGroup, orchestratedVMSS.Name)
 
-			existing, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
+			options := virtualmachinescalesets.DefaultGetOperationOptions()
+			options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+			existing, err := client.Get(ctx, id, options)
 			if err != nil {
 				if response.WasNotFound(existing.HttpResponse) {
 					return fmt.Errorf("%s not found", id)

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 type OrchestratedVirtualMachineScaleSetDataSource struct{}
@@ -24,11 +24,11 @@ type OrchestratedVirtualMachineScaleSetDataSource struct{}
 var _ sdk.DataSource = OrchestratedVirtualMachineScaleSetDataSource{}
 
 type OrchestratedVirtualMachineScaleSetDataSourceModel struct {
-	Name             string                                   `tfschema:"name"`
-	ResourceGroup    string                                   `tfschema:"resource_group_name"`
-	Location         string                                   `tfschema:"location"`
-	NetworkInterface []VirtualMachineScaleSetNetworkInterface `tfschema:"network_interface"`
-	Identity         []identity.ModelUserAssigned             `tfschema:"identity"`
+	Name             string                                     `tfschema:"name"`
+	ResourceGroup    string                                     `tfschema:"resource_group_name"`
+	Location         string                                     `tfschema:"location"`
+	NetworkInterface []VirtualMachineScaleSetNetworkInterface   `tfschema:"network_interface"`
+	Identity         []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
 }
 
 type VirtualMachineScaleSetNetworkInterface struct {
@@ -133,7 +133,7 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Attributes() map[string]*p
 			},
 		},
 
-		"identity": commonschema.UserAssignedIdentityComputed(),
+		"identity": commonschema.SystemAssignedIdentityComputed(),
 	}
 }
 
@@ -141,7 +141,7 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.Compute.VMScaleSetClient
+			client := metadata.Client.Compute.VirtualMachineScaleSetsClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			var orchestratedVMSS OrchestratedVirtualMachineScaleSetDataSourceModel
@@ -149,29 +149,33 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			id := commonids.NewVirtualMachineScaleSetID(subscriptionId, orchestratedVMSS.ResourceGroup, orchestratedVMSS.Name)
+			id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, orchestratedVMSS.ResourceGroup, orchestratedVMSS.Name)
 
-			existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+			existing, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 			if err != nil {
-				if utils.ResponseWasNotFound(existing.Response) {
+				if response.WasNotFound(existing.HttpResponse) {
 					return fmt.Errorf("%s not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			orchestratedVMSS.Location = location.NormalizeNilable(existing.Location)
+			if model := existing.Model; model != nil {
+				orchestratedVMSS.Location = location.Normalize(model.Location)
 
-			if profile := existing.VirtualMachineProfile; profile != nil {
-				if nwProfile := profile.NetworkProfile; nwProfile != nil {
-					orchestratedVMSS.NetworkInterface = flattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+				identityFlattened, err := identity.FlattenSystemAndUserAssignedMapToModel(model.Identity)
+				if err != nil {
+					return err
+				}
+				orchestratedVMSS.Identity = pointer.From(identityFlattened)
+				if props := model.Properties; props != nil {
+					if profile := props.VirtualMachineProfile; profile != nil {
+						if nwProfile := profile.NetworkProfile; nwProfile != nil {
+							orchestratedVMSS.NetworkInterface = flattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+						}
+					}
+
 				}
 			}
-
-			userIdentity, err := flattenOrchestratedVirtualMachineScaleSetIdentityToModel(existing.Identity)
-			if err != nil {
-				return err
-			}
-			orchestratedVMSS.Identity = userIdentity
 
 			metadata.SetID(id)
 
@@ -180,92 +184,93 @@ func (r OrchestratedVirtualMachineScaleSetDataSource) Read() sdk.ResourceFunc {
 	}
 }
 
-func flattenVirtualMachineScaleSetNetworkInterface(input *[]compute.VirtualMachineScaleSetNetworkConfiguration) []VirtualMachineScaleSetNetworkInterface {
+func flattenVirtualMachineScaleSetNetworkInterface(input *[]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration) []VirtualMachineScaleSetNetworkInterface {
 	if input == nil {
 		return []VirtualMachineScaleSetNetworkInterface{}
 	}
 
 	networkInterfaces := make([]VirtualMachineScaleSetNetworkInterface, 0)
 	for _, v := range *input {
-		var name, networkSecurityGroupId string
-		if v.Name != nil {
-			name = *v.Name
-		}
-		if v.NetworkSecurityGroup != nil && v.NetworkSecurityGroup.ID != nil {
-			networkSecurityGroupId = *v.NetworkSecurityGroup.ID
-		}
+		var networkSecurityGroupId string
 		var acceleratedNetworkingEnabled, ipForwardingEnabled, primary bool
-		if v.EnableAcceleratedNetworking != nil {
-			acceleratedNetworkingEnabled = *v.EnableAcceleratedNetworking
-		}
-		if v.EnableIPForwarding != nil {
-			ipForwardingEnabled = *v.EnableIPForwarding
-		}
-		if v.Primary != nil {
-			primary = *v.Primary
-		}
-
 		var dnsServers []string
-		if settings := v.DNSSettings; settings != nil {
-			dnsServers = *v.DNSSettings.DNSServers
-		}
 
-		networkInterfaces = append(networkInterfaces, VirtualMachineScaleSetNetworkInterface{
-			Name:                         name,
-			NetworkSecurityGroupId:       networkSecurityGroupId,
-			AcceleratedNetworkingEnabled: acceleratedNetworkingEnabled,
-			IPForwardingEnabled:          ipForwardingEnabled,
-			Primary:                      primary,
-			DNSServers:                   dnsServers,
-			IPConfiguration:              flattenOrchestratedVirtualMachineScaleSetNetworkInterfaceIPConfiguration(v.IPConfigurations),
-		})
+		if props := v.Properties; props != nil {
+			if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
+				networkSecurityGroupId = *props.NetworkSecurityGroup.Id
+			}
+			if props.EnableAcceleratedNetworking != nil {
+				acceleratedNetworkingEnabled = *props.EnableAcceleratedNetworking
+			}
+			if props.EnableIPForwarding != nil {
+				ipForwardingEnabled = *props.EnableIPForwarding
+			}
+			if props.Primary != nil {
+				primary = *props.Primary
+			}
+
+			if settings := props.DnsSettings; settings != nil {
+				dnsServers = *props.DnsSettings.DnsServers
+			}
+
+			networkInterfaces = append(networkInterfaces, VirtualMachineScaleSetNetworkInterface{
+				Name:                         v.Name,
+				NetworkSecurityGroupId:       networkSecurityGroupId,
+				AcceleratedNetworkingEnabled: acceleratedNetworkingEnabled,
+				IPForwardingEnabled:          ipForwardingEnabled,
+				Primary:                      primary,
+				DNSServers:                   dnsServers,
+				IPConfiguration:              flattenOrchestratedVirtualMachineScaleSetNetworkInterfaceIPConfiguration(&props.IPConfigurations),
+			})
+		}
 	}
 
 	return networkInterfaces
 }
 
-func flattenOrchestratedVirtualMachineScaleSetNetworkInterfaceIPConfiguration(input *[]compute.VirtualMachineScaleSetIPConfiguration) []VirtualMachineScaleSetNetworkInterfaceIPConfiguration {
+func flattenOrchestratedVirtualMachineScaleSetNetworkInterfaceIPConfiguration(input *[]virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration) []VirtualMachineScaleSetNetworkInterfaceIPConfiguration {
 	if input == nil {
 		return []VirtualMachineScaleSetNetworkInterfaceIPConfiguration{}
 	}
 
 	ipConfigurations := make([]VirtualMachineScaleSetNetworkInterfaceIPConfiguration, 0)
 	for _, v := range *input {
-		var name, subnetId string
-		if v.Name != nil {
-			name = *v.Name
-		}
-		if v.Subnet != nil && v.Subnet.ID != nil {
-			subnetId = *v.Subnet.ID
-		}
-
+		var subnetId string
 		var primary bool
-		if v.Primary != nil {
-			primary = *v.Primary
-		}
+		if props := v.Properties; props != nil {
+			if props.Subnet != nil && props.Subnet.Id != nil {
+				subnetId = *props.Subnet.Id
+			}
 
-		ipConfigurations = append(ipConfigurations, VirtualMachineScaleSetNetworkInterfaceIPConfiguration{
-			Name:                                    name,
-			SubnetId:                                subnetId,
-			Primary:                                 primary,
-			PublicIPAddress:                         flattenOrchestratedVirtualMachineScaleSetPublicIPAddress(v.PublicIPAddressConfiguration),
-			ApplicationGatewayBackendAddressPoolIds: flattenSubResourcesToStringIDs(v.ApplicationGatewayBackendAddressPools),
-			ApplicationSecurityGroupIds:             flattenSubResourcesToStringIDs(v.ApplicationSecurityGroups),
-			LoadBalancerBackendAddressPoolIds:       flattenSubResourcesToStringIDs(v.LoadBalancerBackendAddressPools),
-		})
+			if props.Primary != nil {
+				primary = *props.Primary
+			}
+
+			ipConfigurations = append(ipConfigurations, VirtualMachineScaleSetNetworkInterfaceIPConfiguration{
+				Name:                                    v.Name,
+				SubnetId:                                subnetId,
+				Primary:                                 primary,
+				PublicIPAddress:                         flattenOrchestratedVirtualMachineScaleSetPublicIPAddress(props.PublicIPAddressConfiguration),
+				ApplicationGatewayBackendAddressPoolIds: flattenSubResourcesToStringIDs(props.ApplicationGatewayBackendAddressPools),
+				ApplicationSecurityGroupIds:             flattenSubResourcesToStringIDs(props.ApplicationSecurityGroups),
+				LoadBalancerBackendAddressPoolIds:       flattenSubResourcesToStringIDs(props.LoadBalancerBackendAddressPools),
+			})
+		}
 	}
 
 	return ipConfigurations
 }
 
-func flattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input *compute.VirtualMachineScaleSetPublicIPAddressConfiguration) []VirtualMachineScaleSetNetworkInterfaceIPConfigurationPublicIPAddress {
+func flattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input *virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration) []VirtualMachineScaleSetNetworkInterfaceIPConfigurationPublicIPAddress {
 	if input == nil {
 		return []VirtualMachineScaleSetNetworkInterfaceIPConfigurationPublicIPAddress{}
 	}
 
 	ipTags := make([]VirtualMachineScaleSetNetworkInterfaceIPConfigurationPublicIPAddressIPTag, 0)
-	if input.IPTags != nil {
-		for _, rawTag := range *input.IPTags {
+	var domainNameLabel, publicIPPrefixId, version string
+	var idleTimeoutInMinutes int
+	if props := input.Properties; props != nil && props.IPTags != nil {
+		for _, rawTag := range *props.IPTags {
 			var tag, tagType string
 
 			if rawTag.IPTagType != nil {
@@ -281,64 +286,30 @@ func flattenOrchestratedVirtualMachineScaleSetPublicIPAddress(input *compute.Vir
 				Type: tagType,
 			})
 		}
-	}
 
-	var domainNameLabel, name, publicIPPrefixId, version string
-	if input.DNSSettings != nil && input.DNSSettings.DomainNameLabel != nil {
-		domainNameLabel = *input.DNSSettings.DomainNameLabel
-	}
+		if props.DnsSettings != nil {
+			domainNameLabel = props.DnsSettings.DomainNameLabel
+		}
 
-	if input.Name != nil {
-		name = *input.Name
-	}
+		if props.PublicIPPrefix != nil && props.PublicIPPrefix.Id != nil {
+			publicIPPrefixId = *props.PublicIPPrefix.Id
+		}
 
-	if input.PublicIPPrefix != nil && input.PublicIPPrefix.ID != nil {
-		publicIPPrefixId = *input.PublicIPPrefix.ID
-	}
+		if props.PublicIPAddressVersion != nil {
+			version = string(pointer.From(props.PublicIPAddressVersion))
+		}
 
-	if input.PublicIPAddressVersion != "" {
-		version = string(input.PublicIPAddressVersion)
-	}
-
-	var idleTimeoutInMinutes int
-	if input.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinutes = int(*input.IdleTimeoutInMinutes)
+		if props.IdleTimeoutInMinutes != nil {
+			idleTimeoutInMinutes = int(*props.IdleTimeoutInMinutes)
+		}
 	}
 
 	return []VirtualMachineScaleSetNetworkInterfaceIPConfigurationPublicIPAddress{{
-		Name:                 name,
+		Name:                 input.Name,
 		DomainNameLabel:      domainNameLabel,
 		IdleTimeoutInMinutes: idleTimeoutInMinutes,
 		IPTag:                ipTags,
 		PublicIpPrefixId:     publicIPPrefixId,
 		Version:              version,
 	}}
-}
-
-func flattenOrchestratedVirtualMachineScaleSetIdentityToModel(input *compute.VirtualMachineScaleSetIdentity) ([]identity.ModelUserAssigned, error) {
-	if input == nil {
-		return nil, nil
-	}
-
-	identityIds := make(map[string]identity.UserAssignedIdentityDetails, 0)
-	for k, v := range input.UserAssignedIdentities {
-		if v != nil {
-			identityIds[k] = identity.UserAssignedIdentityDetails{
-				ClientId:    v.ClientID,
-				PrincipalId: v.PrincipalID,
-			}
-		}
-	}
-
-	tmp := identity.UserAssignedMap{
-		Type:        identity.Type(input.Type),
-		IdentityIds: identityIds,
-	}
-
-	output, err := identity.FlattenUserAssignedMapToModel(&tmp)
-	if err != nil {
-		return nil, fmt.Errorf("expanding `identity`: %+v", err)
-	}
-
-	return *output, nil
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -640,7 +640,6 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		props.Properties.VirtualMachineProfile = &virtualMachineProfile
 	}
 
-	// TODO replace with createorupdatethenpoll, link this to a go-azure-sdk issue on retryable errors
 	log.Printf("[DEBUG] Creating Orchestrated %s.", id)
 	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Orchestrated %s: %+v", id, err)
@@ -1141,7 +1140,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			d.Set("instances", instances)
 		}
 
-		identityFlattened, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		identityFlattened, err := flattenOrchestratedVirtualMachineScaleSetIdentity(model.Identity)
 		if err != nil {
 			return fmt.Errorf("flattening `identity`: %+v", err)
 		}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -1271,7 +1271,9 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 					encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
 				}
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
-				d.Set("user_data_base64", profile.UserData)
+
+				// userData is not returned by the API
+				d.Set("user_data_base64", d.Get("user_data_base64").(string))
 			}
 
 			if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -155,6 +155,7 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				ValidateFunc: validate.ISO8601DurationBetween("PT15M", "PT2H"),
 			},
 
+			// whilst the Swagger defines multiple at this time only UAI is supported
 			"identity": commonschema.UserAssignedIdentityOptional(),
 
 			"license_type": {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -10,27 +10,29 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
@@ -125,8 +127,8 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.VirtualMachineEvictionPolicyTypesDeallocate),
-					string(compute.VirtualMachineEvictionPolicyTypesDelete),
+					string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDeallocate),
+					string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDelete),
 				}, false),
 			},
 
@@ -192,10 +194,10 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(compute.VirtualMachinePriorityTypesRegular),
+				Default:  string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.VirtualMachinePriorityTypesRegular),
-					string(compute.VirtualMachinePriorityTypesSpot),
+					string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
+					string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot),
 				}, false),
 			},
 
@@ -250,7 +252,7 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 
 			// Computed
 			"unique_id": {
@@ -271,40 +273,39 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 }
 
 func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	isLegacy := true
-	id := commonids.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
 		// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
-		existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+		existing, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for existing %s: %+v", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_orchestrated_virtual_machine_scale_set", id.ID())
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
-	props := compute.VirtualMachineScaleSet{
-		Location: utils.String(location),
+	props := virtualmachinescalesets.VirtualMachineScaleSet{
+		Location: location.Normalize(d.Get("location").(string)),
 		Tags:     tags.Expand(t),
-		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-			PlatformFaultDomainCount: utils.Int32(int32(d.Get("platform_fault_domain_count").(int))),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetProperties{
+			PlatformFaultDomainCount: pointer.To(int64(d.Get("platform_fault_domain_count").(int))),
 			// OrchestrationMode needs to be hardcoded to Uniform, for the
 			// standard VMSS resource, since virtualMachineProfile is now supported
 			// in both VMSS and Orchestrated VMSS...
-			OrchestrationMode: compute.OrchestrationModeFlexible,
+			OrchestrationMode: pointer.To(virtualmachinescalesets.OrchestrationModeFlexible),
 		},
 	}
 
@@ -313,7 +314,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	// single_placement_group is null(e.g. not passed in the props) the RP will
 	// automatically determine what values single_placement_group should be
 	if !pluginsdk.IsExplicitlyNullInConfig(d, "single_placement_group") {
-		props.VirtualMachineScaleSetProperties.SinglePlacementGroup = utils.Bool(d.Get("single_placement_group").(bool))
+		props.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
@@ -321,24 +322,24 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		props.Zones = &zones
 	}
 
-	virtualMachineProfile := compute.VirtualMachineScaleSetVMProfile{
-		StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{},
+	virtualMachineProfile := virtualmachinescalesets.VirtualMachineScaleSetVMProfile{
+		StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetStorageProfile{},
 	}
 
-	networkProfile := &compute.VirtualMachineScaleSetNetworkProfile{
+	networkProfile := &virtualmachinescalesets.VirtualMachineScaleSetNetworkProfile{
 		// 2020-11-01 is the only valid value for this value and is only valid for VMSS in Orchestration Mode flex
-		NetworkAPIVersion: compute.NetworkAPIVersionTwoZeroTwoZeroHyphenMinusOneOneHyphenMinusZeroOne,
+		NetworkApiVersion: pointer.To(virtualmachinescalesets.NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne),
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
-		props.VirtualMachineScaleSetProperties.ProximityPlacementGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		props.Properties.ProximityPlacementGroup = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	// Not currently supported in OVMSS
 	// healthProbeId := d.Get("health_probe_id").(string)
-	// upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	// upgradeMode := virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 
 	instances := d.Get("instances").(int)
 	if v, ok := d.GetOk("sku_name"); ok {
@@ -355,9 +356,9 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
 		}
 
-		virtualMachineProfile.CapacityReservation = &compute.CapacityReservationProfile{
-			CapacityReservationGroup: &compute.SubResource{
-				ID: utils.String(v.(string)),
+		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(v.(string)),
 			},
 		}
 	}
@@ -380,26 +381,26 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("extensions_time_budget"); ok {
 		if virtualMachineProfile.ExtensionProfile == nil {
-			virtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+			virtualMachineProfile.ExtensionProfile = &virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile{}
 		}
-		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(v.(string))
+		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(v.(string))
 	}
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
 	if len(sourceImageReferenceRaw) != 0 || sourceImageId != "" {
-		sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+		sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 		virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
 	}
 
 	if userData, ok := d.GetOk("user_data_base64"); ok {
-		virtualMachineProfile.UserData = utils.String(userData.(string))
+		virtualMachineProfile.UserData = pointer.To(userData.(string))
 	}
 
-	osType := compute.OperatingSystemTypesWindows
+	osType := virtualmachinescalesets.OperatingSystemTypesWindows
 	var winConfigRaw []interface{}
 	var linConfigRaw []interface{}
-	var vmssOsProfile *compute.VirtualMachineScaleSetOSProfile
+	var vmssOsProfile *virtualmachinescalesets.VirtualMachineScaleSetOSProfile
 	extensionOperationsEnabled := d.Get("extension_operations_enabled").(bool)
 	osProfileRaw := d.Get("os_profile").([]interface{})
 
@@ -427,15 +428,15 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				if len(errs) > 0 {
 					return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the 'name', or specify an explicit 'computer_name_prefix'", errs[0])
 				}
-				vmssOsProfile.ComputerNamePrefix = utils.String(id.VirtualMachineScaleSetName)
+				vmssOsProfile.ComputerNamePrefix = pointer.To(id.VirtualMachineScaleSetName)
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
 				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
 			}
 
-			if patchAssessmentMode == string(compute.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", compute.WindowsPatchAssessmentModeAutomaticByPlatform)
+			if patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
+				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate patch mode and hotpatching configuration
@@ -445,8 +446,8 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 			if isHotpatchEnabledImage {
 				// it is a hotpatching enabled image, validate hotpatching enabled settings
-				if patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
-					return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q", compute.WindowsVMGuestPatchModeAutomaticByPlatform)
+				if patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
+					return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)
 				}
 
 				if !provisionVMAgent {
@@ -462,7 +463,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				}
 			} else {
 				// not a hotpatching enabled image verify Automatic VM Guest Patching settings
-				if patchMode == string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
+				if patchMode == string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
 					if !provisionVMAgent {
 						return fmt.Errorf("when 'patch_mode' is set to %q then 'provision_vm_agent' must be set to 'true'", patchMode)
 					}
@@ -479,7 +480,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		}
 
 		if len(linConfigRaw) > 0 {
-			osType = compute.OperatingSystemTypesLinux
+			osType = virtualmachinescalesets.OperatingSystemTypesLinux
 			linConfig := linConfigRaw[0].(map[string]interface{})
 			provisionVMAgent := linConfig["provision_vm_agent"].(bool)
 			patchAssessmentMode := linConfig["patch_assessment_mode"].(string)
@@ -493,21 +494,21 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 					return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the 'name', or specify an explicit 'computer_name_prefix'", errs[0])
 				}
 
-				vmssOsProfile.ComputerNamePrefix = utils.String(id.VirtualMachineScaleSetName)
+				vmssOsProfile.ComputerNamePrefix = pointer.To(id.VirtualMachineScaleSetName)
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
 				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
 			}
 
-			if patchAssessmentMode == string(compute.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", compute.LinuxPatchAssessmentModeAutomaticByPlatform)
+			if patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
+				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate Automatic VM Guest Patching Settings
 			patchMode := linConfig["patch_mode"].(string)
 
-			if patchMode == string(compute.LinuxVMGuestPatchModeAutomaticByPlatform) {
+			if patchMode == string(virtualmachinescalesets.LinuxVMGuestPatchModeAutomaticByPlatform) {
 				if !provisionVMAgent {
 					return fmt.Errorf("when the 'patch_mode' field is set to %q the 'provision_vm_agent' field must always be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
 				}
@@ -524,23 +525,23 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	if !features.FourPointOhBeta() {
 		if !pluginsdk.IsExplicitlyNullInConfig(d, "extension_operations_enabled") {
 			if virtualMachineProfile.OsProfile == nil {
-				virtualMachineProfile.OsProfile = &compute.VirtualMachineScaleSetOSProfile{}
+				virtualMachineProfile.OsProfile = &virtualmachinescalesets.VirtualMachineScaleSetOSProfile{}
 			}
-			virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(extensionOperationsEnabled)
+			virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(extensionOperationsEnabled)
 		}
 	} else {
 		if virtualMachineProfile.OsProfile == nil {
-			virtualMachineProfile.OsProfile = &compute.VirtualMachineScaleSetOSProfile{}
+			virtualMachineProfile.OsProfile = &virtualmachinescalesets.VirtualMachineScaleSetOSProfile{}
 		}
-		virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(extensionOperationsEnabled)
+		virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(extensionOperationsEnabled)
 	}
 
 	if v, ok := d.GetOk("boot_diagnostics"); ok {
-		virtualMachineProfile.DiagnosticsProfile = expandBootDiagnostics(v.([]interface{}))
+		virtualMachineProfile.DiagnosticsProfile = expandBootDiagnosticsVMSS(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("priority"); ok {
-		virtualMachineProfile.Priority = compute.VirtualMachinePriorityTypes(v.(string))
+		virtualMachineProfile.Priority = pointer.To(virtualmachinescalesets.VirtualMachinePriorityTypes(v.(string)))
 	}
 
 	if v, ok := d.GetOk("os_disk"); ok {
@@ -549,7 +550,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := ExpandOrchestratedVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
-	props.VirtualMachineScaleSetProperties.AdditionalCapabilities = additionalCapabilities
+	props.Properties.AdditionalCapabilities = additionalCapabilities
 
 	if v, ok := d.GetOk("data_disk"); ok {
 		ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
@@ -571,32 +572,32 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	}
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
-		if virtualMachineProfile.Priority != compute.VirtualMachinePriorityTypesSpot {
+		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		virtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(v),
+		virtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+			MaxPrice: pointer.To(v),
 		}
 	}
 
 	if v, ok := d.GetOk("encryption_at_host_enabled"); ok {
-		virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
-			EncryptionAtHost: utils.Bool(v.(bool)),
+		virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{
+			EncryptionAtHost: pointer.To(v.(bool)),
 		}
 	}
 
 	if v, ok := d.GetOk("eviction_policy"); ok {
-		if virtualMachineProfile.Priority != compute.VirtualMachinePriorityTypesSpot {
+		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("an `eviction_policy` can only be specified when `priority` is set to `Spot`")
 		}
-		virtualMachineProfile.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(v.(string))
-	} else if virtualMachineProfile.Priority == compute.VirtualMachinePriorityTypesSpot {
+		virtualMachineProfile.EvictionPolicy = pointer.To(virtualmachinescalesets.VirtualMachineEvictionPolicyTypes(v.(string)))
+	} else if *virtualMachineProfile.Priority == virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 		return fmt.Errorf("an `eviction_policy` must be specified when `priority` is set to `Spot`")
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
-		virtualMachineProfile.LicenseType = utils.String(v.(string))
+		virtualMachineProfile.LicenseType = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("termination_notification"); ok {
@@ -606,19 +607,19 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	// Only inclued the virtual machine profile if this is not a legacy configuration
 	if !isLegacy {
 		if v, ok := d.GetOk("plan"); ok {
-			props.Plan = expandPlan(v.([]interface{}))
+			props.Plan = expandPlanVMSS(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("identity"); ok {
-			identity, err := expandVirtualMachineScaleSetIdentity(v.([]interface{}))
+			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(v.([]interface{}))
 			if err != nil {
 				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
-			props.Identity = identity
+			props.Identity = identityExpanded
 		}
 
 		if v, ok := d.GetOk("automatic_instance_repair"); ok {
-			props.VirtualMachineScaleSetProperties.AutomaticRepairsPolicy = ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(v.([]interface{}))
+			props.Properties.AutomaticRepairsPolicy = ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("zone_balance"); ok && v.(bool) {
@@ -626,59 +627,23 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				return fmt.Errorf("`zone_balance` can only be set to `true` when zones are specified")
 			}
 
-			props.VirtualMachineScaleSetProperties.ZoneBalance = utils.Bool(v.(bool))
+			props.Properties.ZoneBalance = pointer.To(v.(bool))
 		}
 
 		if v, ok := d.GetOk("priority_mix"); ok {
-			if virtualMachineProfile.Priority != compute.VirtualMachinePriorityTypesSpot {
+			if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 				return fmt.Errorf("a `priority_mix` can only be specified when `priority` is set to `Spot`")
 			}
-			props.VirtualMachineScaleSetProperties.PriorityMixPolicy = ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(v.([]interface{}))
+			props.Properties.PriorityMixPolicy = ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(v.([]interface{}))
 		}
 
-		props.VirtualMachineScaleSetProperties.VirtualMachineProfile = &virtualMachineProfile
+		props.Properties.VirtualMachineProfile = &virtualMachineProfile
 	}
 
+	// TODO replace with createorupdatethenpoll, link this to a go-azure-sdk issue on retryable errors
 	log.Printf("[DEBUG] Creating Orchestrated %s.", id)
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, props)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Orchestrated %s: %+v", id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for %s to be created.", id)
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		// If it is a Retryable Error re-issue the PUT for 10 loops until either the error goes away or the limit has been reached
-		if strings.Contains(err.Error(), "RetryableError") {
-			log.Printf("[DEBUG] Retryable error hit for %s to be created..", id)
-			errCount := 1
-
-			for {
-				log.Printf("[DEBUG] Retrying PUT %d for Orchestrated %s.", errCount, id)
-				future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, props)
-				if err != nil {
-					return fmt.Errorf("creating Orchestrated %s after %d retries: %+v", id, errCount, err)
-				}
-
-				err = future.WaitForCompletionRef(ctx, client.Client)
-				if err != nil && strings.Contains(err.Error(), "RetryableError") {
-					if errCount == 10 {
-						return fmt.Errorf("waiting for creation of Orchestrated %s after %d retries: %+v", id, err, errCount)
-					}
-					errCount++
-				} else {
-					if err != nil {
-						// Hit an error while retying that is not retryable anymore...
-						return fmt.Errorf("hit unretryable error waiting for creation of Orchestrated %s after %d retries: %+v", id, err, errCount)
-					} else {
-						// err is nil and finally succeeded continue with the rest of the create function...
-						break
-					}
-				}
-			}
-		} else {
-			// Not a retryable error...
-			return fmt.Errorf("waiting for creation of Orchestrated %s: %+v", id, err)
-		}
 	}
 
 	log.Printf("[DEBUG] Orchestrated %s was created", id)
@@ -690,11 +655,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 }
 
 func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -706,47 +671,50 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 	// retrieve
 	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving Orchestrated %s: %+v", id, err)
 	}
-	if existing.Sku != nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving Orchestrated %s: `model` was nil", id)
+	}
+	if existing.Model.Sku != nil {
 		isLegacy = false
 	}
-	if existing.VirtualMachineScaleSetProperties == nil {
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving Orchestrated %s: `properties` was nil", id)
 	}
 
 	if !isLegacy {
-		if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+		if existing.Model.Properties.VirtualMachineProfile == nil {
 			return fmt.Errorf("retrieving Orchestrated %s: `properties.virtualMachineProfile` was nil", id)
 		}
-		if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile == nil {
+		if existing.Model.Properties.VirtualMachineProfile.StorageProfile == nil {
 			return fmt.Errorf("retrieving Orchestrated %s: `properties.virtualMachineProfile,storageProfile` was nil", id)
 		}
 	}
 
-	updateProps := compute.VirtualMachineScaleSetUpdateProperties{}
-	update := compute.VirtualMachineScaleSetUpdate{}
-	osType := compute.OperatingSystemTypesWindows
+	updateProps := virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{}
+	update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{}
+	osType := virtualmachinescalesets.OperatingSystemTypesWindows
 
 	if !isLegacy {
-		updateProps = compute.VirtualMachineScaleSetUpdateProperties{
-			VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
+		updateProps = virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{
+			VirtualMachineProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateVMProfile{
 				// if an image reference has been configured previously (it has to be), we would better to include that in this
 				// update request to avoid some circumstances that the API will complain ImageReference is null
 				// issue tracking: https://github.com/Azure/azure-rest-api-specs/issues/10322
-				StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
-					ImageReference: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference,
+				StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{
+					ImageReference: existing.Model.Properties.VirtualMachineProfile.StorageProfile.ImageReference,
 				},
 			},
 			// Currently not suppored in orchestrated VMSS
 			// if an upgrade policy's been configured previously (which it will have) it must be threaded through
 			// this doesn't matter for Manual - but breaks when updating anything on a Automatic and Rolling Mode Scale Set
-			// UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+			// UpgradePolicy: existing.Properties.UpgradePolicy,
 		}
 
-		priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+		priority := virtualmachinescalesets.VirtualMachinePriorityTypes(d.Get("priority").(string))
 
 		if d.HasChange("single_placement_group") {
 			// Since null is now a valid value for single_placement_group
@@ -757,25 +725,25 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				if singlePlacementGroup {
 					return fmt.Errorf("'single_placement_group' can not be set to 'true' once it has been set to 'false'")
 				}
-				updateProps.SinglePlacementGroup = utils.Bool(singlePlacementGroup)
+				updateProps.SinglePlacementGroup = pointer.To(singlePlacementGroup)
 			}
 		}
 
 		if d.HasChange("max_bid_price") {
-			if priority != compute.VirtualMachinePriorityTypesSpot {
+			if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 				return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 			}
 
-			updateProps.VirtualMachineProfile.BillingProfile = &compute.BillingProfile{
-				MaxPrice: utils.Float(d.Get("max_bid_price").(float64)),
+			updateProps.VirtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+				MaxPrice: pointer.To(d.Get("max_bid_price").(float64)),
 			}
 		}
 
 		osProfileRaw := d.Get("os_profile").([]interface{})
-		vmssOsProfile := compute.VirtualMachineScaleSetUpdateOSProfile{}
-		windowsConfig := compute.WindowsConfiguration{}
-		windowsConfig.PatchSettings = &compute.PatchSettings{}
-		linuxConfig := compute.LinuxConfiguration{}
+		vmssOsProfile := virtualmachinescalesets.VirtualMachineScaleSetUpdateOSProfile{}
+		windowsConfig := virtualmachinescalesets.WindowsConfiguration{}
+		windowsConfig.PatchSettings = &virtualmachinescalesets.PatchSettings{}
+		linuxConfig := virtualmachinescalesets.LinuxConfiguration{}
 
 		if len(osProfileRaw) > 0 {
 			osProfile := osProfileRaw[0].(map[string]interface{})
@@ -787,7 +755,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 				// customData can only be sent if it's a base64 encoded string,
 				// so it's not possible to remove this without tainting the resource
-				vmssOsProfile.CustomData = utils.String(osProfile["custom_data"].(string))
+				vmssOsProfile.CustomData = pointer.To(osProfile["custom_data"].(string))
 			}
 
 			if len(winConfigRaw) > 0 {
@@ -804,9 +772,9 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 				// PatchSettings is required by PATCH API when running Hotpatch-compatible images.
 				if isHotpatchEnabledImage {
-					windowsConfig.PatchSettings.AssessmentMode = compute.WindowsPatchAssessmentMode(patchAssessmentMode)
-					windowsConfig.PatchSettings.PatchMode = compute.WindowsVMGuestPatchMode(patchMode)
-					windowsConfig.PatchSettings.EnableHotpatching = utils.Bool(hotpatchingEnabled)
+					windowsConfig.PatchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.WindowsPatchAssessmentMode(patchAssessmentMode))
+					windowsConfig.PatchSettings.PatchMode = pointer.To(virtualmachinescalesets.WindowsVMGuestPatchMode(patchMode))
+					windowsConfig.PatchSettings.EnableHotpatching = pointer.To(hotpatchingEnabled)
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.enable_automatic_updates") ||
@@ -818,28 +786,28 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.enable_automatic_updates") {
-					windowsConfig.EnableAutomaticUpdates = utils.Bool(winConfig["enable_automatic_updates"].(bool))
+					windowsConfig.EnableAutomaticUpdates = pointer.To(winConfig["enable_automatic_updates"].(bool))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.provision_vm_agent") {
 					if isHotpatchEnabledImage && !provisionVMAgent {
 						return fmt.Errorf("when referencing a hotpatching enabled image the 'provision_vm_agent' field must always be set to 'true', got %q", strconv.FormatBool(provisionVMAgent))
 					}
-					windowsConfig.ProvisionVMAgent = utils.Bool(provisionVMAgent)
+					windowsConfig.ProvisionVMAgent = pointer.To(provisionVMAgent)
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_assessment_mode") {
-					if !provisionVMAgent && (patchAssessmentMode == string(compute.WindowsPatchAssessmentModeAutomaticByPlatform)) {
-						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", compute.WindowsPatchAssessmentModeAutomaticByPlatform)
+					if !provisionVMAgent && (patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)) {
+						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 					}
-					windowsConfig.PatchSettings.AssessmentMode = compute.WindowsPatchAssessmentMode(patchAssessmentMode)
+					windowsConfig.PatchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.WindowsPatchAssessmentMode(patchAssessmentMode))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_mode") {
-					if isHotpatchEnabledImage && (patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform)) {
-						return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q, got %q", compute.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
+					if isHotpatchEnabledImage && (patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)) {
+						return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q, got %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
 					}
-					windowsConfig.PatchSettings.PatchMode = compute.WindowsVMGuestPatchMode(patchMode)
+					windowsConfig.PatchSettings.PatchMode = pointer.To(virtualmachinescalesets.WindowsVMGuestPatchMode(patchMode))
 				}
 
 				// Disabling hotpatching is not supported in images that support hotpatching
@@ -849,27 +817,27 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 					if isHotpatchEnabledImage && !hotpatchingEnabled {
 						return fmt.Errorf("when referencing a hotpatching enabled image the 'hotpatching_enabled' field must always be set to 'true', got %q", strconv.FormatBool(hotpatchingEnabled))
 					}
-					windowsConfig.PatchSettings.EnableHotpatching = utils.Bool(hotpatchingEnabled)
+					windowsConfig.PatchSettings.EnableHotpatching = pointer.To(hotpatchingEnabled)
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.secret") {
-					vmssOsProfile.Secrets = expandWindowsSecrets(winConfig["secret"].([]interface{}))
+					vmssOsProfile.Secrets = expandWindowsSecretsVMSS(winConfig["secret"].([]interface{}))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.timezone") {
-					windowsConfig.TimeZone = utils.String(winConfig["timezone"].(string))
+					windowsConfig.TimeZone = pointer.To(winConfig["timezone"].(string))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.winrm_listener") {
 					winRmListenersRaw := winConfig["winrm_listener"].(*pluginsdk.Set).List()
-					vmssOsProfile.WindowsConfiguration.WinRM = expandWinRMListener(winRmListenersRaw)
+					vmssOsProfile.WindowsConfiguration.WinRM = expandWinRMListenerVMSS(winRmListenersRaw)
 				}
 
 				vmssOsProfile.WindowsConfiguration = &windowsConfig
 			}
 
 			if len(linConfigRaw) > 0 {
-				osType = compute.OperatingSystemTypesLinux
+				osType = virtualmachinescalesets.OperatingSystemTypesLinux
 				linConfig := linConfigRaw[0].(map[string]interface{})
 				provisionVMAgent := linConfig["provision_vm_agent"].(bool)
 				patchAssessmentMode := linConfig["patch_assessment_mode"].(string)
@@ -882,34 +850,34 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				}
 
 				if d.HasChange("os_profile.0.linux_configuration.0.provision_vm_agent") {
-					linuxConfig.ProvisionVMAgent = utils.Bool(provisionVMAgent)
+					linuxConfig.ProvisionVMAgent = pointer.To(provisionVMAgent)
 				}
 
 				if d.HasChange("os_profile.0.linux_configuration.0.disable_password_authentication") {
-					linuxConfig.DisablePasswordAuthentication = utils.Bool(linConfig["disable_password_authentication"].(bool))
+					linuxConfig.DisablePasswordAuthentication = pointer.To(linConfig["disable_password_authentication"].(bool))
 				}
 
 				if d.HasChange("os_profile.0.linux_configuration.0.admin_ssh_key") {
-					sshPublicKeys := ExpandSSHKeys(linConfig["admin_ssh_key"].(*pluginsdk.Set).List())
-					if linuxConfig.SSH == nil {
-						linuxConfig.SSH = &compute.SSHConfiguration{}
+					sshPublicKeys := expandSSHKeysVMSS(linConfig["admin_ssh_key"].(*pluginsdk.Set).List())
+					if linuxConfig.Ssh == nil {
+						linuxConfig.Ssh = &virtualmachinescalesets.SshConfiguration{}
 					}
-					linuxConfig.SSH.PublicKeys = &sshPublicKeys
+					linuxConfig.Ssh.PublicKeys = &sshPublicKeys
 				}
 
 				if d.HasChange("os_profile.0.linux_configuration.0.patch_assessment_mode") {
-					if !provisionVMAgent && (patchAssessmentMode == string(compute.LinuxPatchAssessmentModeAutomaticByPlatform)) {
-						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", compute.LinuxPatchAssessmentModeAutomaticByPlatform)
+					if !provisionVMAgent && (patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)) {
+						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 					}
 
 					if linuxConfig.PatchSettings == nil {
-						linuxConfig.PatchSettings = &compute.LinuxPatchSettings{}
+						linuxConfig.PatchSettings = &virtualmachinescalesets.LinuxPatchSettings{}
 					}
-					linuxConfig.PatchSettings.AssessmentMode = compute.LinuxPatchAssessmentMode(patchAssessmentMode)
+					linuxConfig.PatchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.LinuxPatchAssessmentMode(patchAssessmentMode))
 				}
 
 				if d.HasChange("os_profile.0.linux_configuration.0.patch_mode") {
-					if patchMode == string(compute.LinuxPatchAssessmentModeAutomaticByPlatform) {
+					if patchMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) {
 						if !provisionVMAgent {
 							return fmt.Errorf("when the 'patch_mode' field is set to %q the 'provision_vm_agent' field must always be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
 						}
@@ -918,9 +886,9 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 					}
 
 					if linuxConfig.PatchSettings == nil {
-						linuxConfig.PatchSettings = &compute.LinuxPatchSettings{}
+						linuxConfig.PatchSettings = &virtualmachinescalesets.LinuxPatchSettings{}
 					}
-					linuxConfig.PatchSettings.PatchMode = compute.LinuxVMGuestPatchMode(patchMode)
+					linuxConfig.PatchSettings.PatchMode = pointer.To(virtualmachinescalesets.LinuxVMGuestPatchMode(patchMode))
 				}
 
 				vmssOsProfile.LinuxConfiguration = &linuxConfig
@@ -933,7 +901,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			updateInstances = true
 
 			if updateProps.VirtualMachineProfile.StorageProfile == nil {
-				updateProps.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetUpdateStorageProfile{}
+				updateProps.VirtualMachineProfile.StorageProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{}
 			}
 
 			if d.HasChange("data_disk") {
@@ -955,19 +923,19 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				sourceImageId := d.Get("source_image_id").(string)
 
 				if len(sourceImageReferenceRaw) != 0 || sourceImageId != "" {
-					sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+					sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 					updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
 				}
 
 				// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurerm/issues/8273
-				updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks
-				updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &compute.VirtualMachineScaleSetUpdateOSDisk{
-					Caching:                 existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
-					WriteAcceleratorEnabled: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
-					DiskSizeGB:              existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
-					Image:                   existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
-					VhdContainers:           existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
-					ManagedDisk:             existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
+				updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.Model.Properties.VirtualMachineProfile.StorageProfile.DataDisks
+				updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &virtualmachinescalesets.VirtualMachineScaleSetUpdateOSDisk{
+					Caching:                 existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
+					WriteAcceleratorEnabled: existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
+					DiskSizeGB:              existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
+					Image:                   existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
+					VhdContainers:           existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
+					ManagedDisk:             existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
 				}
 			}
 		}
@@ -979,10 +947,10 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				return fmt.Errorf("expanding `network_interface`: %+v", err)
 			}
 
-			updateProps.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetUpdateNetworkProfile{
+			updateProps.VirtualMachineProfile.NetworkProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkProfile{
 				NetworkInterfaceConfigurations: networkInterfaces,
 				// 2020-11-01 is the only valid value for this value and is only valid for VMSS in Orchestration Mode flex
-				NetworkAPIVersion: compute.NetworkAPIVersionTwoZeroTwoZeroHyphenMinusOneOneHyphenMinusZeroOne,
+				NetworkApiVersion: pointer.To(virtualmachinescalesets.NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne),
 			}
 		}
 
@@ -990,7 +958,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			updateInstances = true
 
 			bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
-			updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+			updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 		}
 
 		if d.HasChange("termination_notification") {
@@ -999,8 +967,8 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		}
 
 		if d.HasChange("encryption_at_host_enabled") {
-			updateProps.VirtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
-				EncryptionAtHost: utils.Bool(d.Get("encryption_at_host_enabled").(bool)),
+			updateProps.VirtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{
+				EncryptionAtHost: pointer.To(d.Get("encryption_at_host_enabled").(bool)),
 			}
 		}
 
@@ -1022,23 +990,23 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		}
 
 		if d.HasChange("identity") {
-			identity, err := expandVirtualMachineScaleSetIdentity(d.Get("identity").([]interface{}))
+			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 			if err != nil {
 				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
 
-			update.Identity = identity
+			update.Identity = identityExpanded
 		}
 
 		if d.HasChange("plan") {
 			planRaw := d.Get("plan").([]interface{})
-			update.Plan = expandPlan(planRaw)
+			update.Plan = expandPlanVMSS(planRaw)
 		}
 
 		if d.HasChange("sku_name") || d.HasChange("instances") {
 			// in-case ignore_changes is being used, since both fields are required
 			// look up the current values and override them as needed
-			sku := existing.Sku
+			sku := existing.Model.Sku
 			instances := int(*sku.Capacity)
 			skuName := d.Get("sku_name").(string)
 
@@ -1076,11 +1044,11 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			}
 
 			if linuxAutomaticVMGuestPatchingEnabled && !hasHealthExtension {
-				return fmt.Errorf("when the 'patch_mode' field is set to %q the 'extension' field must contain at least one 'application health extension', got 0", compute.LinuxPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when the 'patch_mode' field is set to %q the 'extension' field must contain at least one 'application health extension', got 0", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
-			updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+			updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(d.Get("extensions_time_budget").(string))
 		}
 	}
 
@@ -1088,8 +1056,8 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 	if d.HasChange("proximity_placement_group_id") {
 		if v, ok := d.GetOk("proximity_placement_group_id"); ok {
 			updateInstances = true
-			updateProps.ProximityPlacementGroup = &compute.SubResource{
-				ID: utils.String(v.(string)),
+			updateProps.ProximityPlacementGroup = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(v.(string)),
 			}
 		}
 	}
@@ -1100,10 +1068,10 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 	if d.HasChange("user_data_base64") {
 		updateInstances = true
-		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data_base64").(string))
+		updateProps.VirtualMachineProfile.UserData = pointer.To(d.Get("user_data_base64").(string))
 	}
 
-	update.VirtualMachineScaleSetUpdateProperties = &updateProps
+	update.Properties = &updateProps
 
 	if updateInstances {
 		log.Printf("[DEBUG] Orchestrated %s - updateInstances is true", id)
@@ -1116,7 +1084,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		CanRollInstancesWhenRequired: false,
 		UpdateInstances:              false,
 		Client:                       meta.(*clients.Client).Compute,
-		Existing:                     existing,
+		Existing:                     pointer.From(existing.Model),
 		ID:                           id,
 		OSType:                       osType,
 	}
@@ -1129,19 +1097,19 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 }
 
 func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Orchestrated %s was not found - removing from state!", id)
 			d.SetId("")
 			return nil
@@ -1152,188 +1120,188 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 
 	d.Set("name", id.VirtualMachineScaleSetName)
 	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
-	var skuName *string
-	var instances int
-	if resp.Sku != nil {
-		skuName, err = flattenOrchestratedVirtualMachineScaleSetSku(resp.Sku)
-		if err != nil || skuName == nil {
-			return fmt.Errorf("setting `sku_name`: %+v", err)
-		}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
-		if resp.Sku.Capacity != nil {
-			instances = int(*resp.Sku.Capacity)
-		}
-
-		d.Set("sku_name", skuName)
-		d.Set("instances", instances)
-	}
-
-	identity, err := flattenOrchestratedVirtualMachineScaleSetIdentity(resp.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-	if err := d.Set("identity", identity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
-	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
-		return fmt.Errorf("setting `plan`: %+v", err)
-	}
-
-	if resp.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("retrieving Orchestrated %s: `properties` was nil", id)
-	}
-	props := *resp.VirtualMachineScaleSetProperties
-
-	if err := d.Set("additional_capabilities", FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
-		return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
-	}
-
-	if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
-		return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
-	}
-
-	d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
-	proximityPlacementGroupId := ""
-	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
-		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID
-	}
-	d.Set("proximity_placement_group_id", proximityPlacementGroupId)
-
-	// only write state for single_placement_group if it is returned by the RP...
-	if props.SinglePlacementGroup != nil {
-		d.Set("single_placement_group", props.SinglePlacementGroup)
-	}
-	d.Set("unique_id", props.UniqueID)
-	d.Set("zone_balance", props.ZoneBalance)
-
-	extensionOperationsEnabled := true
-	if profile := props.VirtualMachineProfile; profile != nil {
-		if err := d.Set("boot_diagnostics", flattenBootDiagnostics(profile.DiagnosticsProfile)); err != nil {
-			return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
-		}
-
-		capacityReservationGroupId := ""
-		if profile.CapacityReservation != nil && profile.CapacityReservation.CapacityReservationGroup != nil && profile.CapacityReservation.CapacityReservationGroup.ID != nil {
-			capacityReservationGroupId = *profile.CapacityReservation.CapacityReservationGroup.ID
-		}
-		d.Set("capacity_reservation_group_id", capacityReservationGroupId)
-
-		// defaulted since BillingProfile isn't returned if it's unset
-		maxBidPrice := float64(-1.0)
-		if profile.BillingProfile != nil && profile.BillingProfile.MaxPrice != nil {
-			maxBidPrice = *profile.BillingProfile.MaxPrice
-		}
-		d.Set("max_bid_price", maxBidPrice)
-
-		d.Set("eviction_policy", string(profile.EvictionPolicy))
-		d.Set("license_type", profile.LicenseType)
-
-		// the service just return empty when this is not assigned when provisioned
-		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
-		priority := compute.VirtualMachinePriorityTypesRegular
-		if profile.Priority != "" {
-			priority = profile.Priority
-		}
-		d.Set("priority", priority)
-
-		if storageProfile := profile.StorageProfile; storageProfile != nil {
-			if err := d.Set("os_disk", FlattenOrchestratedVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
-				return fmt.Errorf("setting `os_disk`: %+v", err)
+		var skuName *string
+		var instances int
+		if model.Sku != nil {
+			skuName, err = flattenOrchestratedVirtualMachineScaleSetSku(model.Sku)
+			if err != nil || skuName == nil {
+				return fmt.Errorf("setting `sku_name`: %+v", err)
 			}
 
-			if err := d.Set("data_disk", FlattenOrchestratedVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
-				return fmt.Errorf("setting `data_disk`: %+v", err)
+			if resp.Model.Sku.Capacity != nil {
+				instances = int(*resp.Model.Sku.Capacity)
 			}
 
-			var storageImageId string
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
-				storageImageId = *storageProfile.ImageReference.ID
-			}
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.CommunityGalleryImageID != nil {
-				storageImageId = *storageProfile.ImageReference.CommunityGalleryImageID
-			}
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.SharedGalleryImageID != nil {
-				storageImageId = *storageProfile.ImageReference.SharedGalleryImageID
-			}
-			d.Set("source_image_id", storageImageId)
-
-			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference, storageImageId != "")); err != nil {
-				return fmt.Errorf("setting `source_image_reference`: %+v", err)
-			}
+			d.Set("sku_name", skuName)
+			d.Set("instances", instances)
 		}
 
-		if osProfile := profile.OsProfile; osProfile != nil {
-			if err := d.Set("os_profile", FlattenOrchestratedVirtualMachineScaleSetOSProfile(osProfile, d)); err != nil {
-				return fmt.Errorf("setting `os_profile`: %+v", err)
-			}
-
-			if osProfile.AllowExtensionOperations != nil {
-				extensionOperationsEnabled = *osProfile.AllowExtensionOperations
-			}
-		}
-
-		if nwProfile := profile.NetworkProfile; nwProfile != nil {
-			flattenedNics := FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
-			if err := d.Set("network_interface", flattenedNics); err != nil {
-				return fmt.Errorf("setting `network_interface`: %+v", err)
-			}
-		}
-
-		if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
-			if err := d.Set("termination_notification", FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
-				return fmt.Errorf("setting `termination_notification`: %+v", err)
-			}
-		}
-
-		extensionProfile, err := flattenOrchestratedVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
+		identityFlattened, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {
-			return fmt.Errorf("failed flattening `extension`: %+v", err)
+			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
-		d.Set("extension", extensionProfile)
+		if err := d.Set("identity", identityFlattened); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
 
-		extensionsTimeBudget := "PT1H30M"
-		if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
-			extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
+		if err := d.Set("plan", flattenPlanVMSS(model.Plan)); err != nil {
+			return fmt.Errorf("setting `plan`: %+v", err)
 		}
-		d.Set("extensions_time_budget", extensionsTimeBudget)
 
-		encryptionAtHostEnabled := false
-		if profile.SecurityProfile != nil && profile.SecurityProfile.EncryptionAtHost != nil {
-			encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
+		if props := model.Properties; props != nil {
+			if err := d.Set("additional_capabilities", FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+				return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
+			}
+
+			if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
+				return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
+			}
+
+			d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
+			proximityPlacementGroupId := ""
+			if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.Id != nil {
+				proximityPlacementGroupId = *props.ProximityPlacementGroup.Id
+			}
+			d.Set("proximity_placement_group_id", proximityPlacementGroupId)
+
+			// only write state for single_placement_group if it is returned by the RP...
+			if props.SinglePlacementGroup != nil {
+				d.Set("single_placement_group", props.SinglePlacementGroup)
+			}
+			d.Set("unique_id", props.UniqueId)
+			d.Set("zone_balance", props.ZoneBalance)
+
+			extensionOperationsEnabled := true
+			if profile := props.VirtualMachineProfile; profile != nil {
+				if err := d.Set("boot_diagnostics", flattenBootDiagnosticsVMSS(profile.DiagnosticsProfile)); err != nil {
+					return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+				}
+
+				capacityReservationGroupId := ""
+				if profile.CapacityReservation != nil && profile.CapacityReservation.CapacityReservationGroup != nil && profile.CapacityReservation.CapacityReservationGroup.Id != nil {
+					capacityReservationGroupId = *profile.CapacityReservation.CapacityReservationGroup.Id
+				}
+				d.Set("capacity_reservation_group_id", capacityReservationGroupId)
+
+				// defaulted since BillingProfile isn't returned if it's unset
+				maxBidPrice := float64(-1.0)
+				if profile.BillingProfile != nil && profile.BillingProfile.MaxPrice != nil {
+					maxBidPrice = *profile.BillingProfile.MaxPrice
+				}
+				d.Set("max_bid_price", maxBidPrice)
+
+				d.Set("eviction_policy", pointer.From(profile.EvictionPolicy))
+				d.Set("license_type", profile.LicenseType)
+
+				// the service just return empty when this is not assigned when provisioned
+				// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+				priority := virtualmachinescalesets.VirtualMachinePriorityTypesRegular
+				if profile.Priority != nil {
+					priority = pointer.From(profile.Priority)
+				}
+				d.Set("priority", priority)
+
+				if storageProfile := profile.StorageProfile; storageProfile != nil {
+					if err := d.Set("os_disk", FlattenOrchestratedVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
+						return fmt.Errorf("setting `os_disk`: %+v", err)
+					}
+
+					if err := d.Set("data_disk", FlattenOrchestratedVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
+						return fmt.Errorf("setting `data_disk`: %+v", err)
+					}
+
+					var storageImageId string
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.Id != nil {
+						storageImageId = *storageProfile.ImageReference.Id
+					}
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.CommunityGalleryImageId != nil {
+						storageImageId = *storageProfile.ImageReference.CommunityGalleryImageId
+					}
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.SharedGalleryImageId != nil {
+						storageImageId = *storageProfile.ImageReference.SharedGalleryImageId
+					}
+					d.Set("source_image_id", storageImageId)
+
+					if err := d.Set("source_image_reference", flattenSourceImageReferenceVMSS(storageProfile.ImageReference, storageImageId != "")); err != nil {
+						return fmt.Errorf("setting `source_image_reference`: %+v", err)
+					}
+				}
+
+				if osProfile := profile.OsProfile; osProfile != nil {
+					if err := d.Set("os_profile", FlattenOrchestratedVirtualMachineScaleSetOSProfile(osProfile, d)); err != nil {
+						return fmt.Errorf("setting `os_profile`: %+v", err)
+					}
+
+					if osProfile.AllowExtensionOperations != nil {
+						extensionOperationsEnabled = *osProfile.AllowExtensionOperations
+					}
+				}
+
+				if nwProfile := profile.NetworkProfile; nwProfile != nil {
+					flattenedNics := FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+					if err := d.Set("network_interface", flattenedNics); err != nil {
+						return fmt.Errorf("setting `network_interface`: %+v", err)
+					}
+				}
+
+				if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
+					if err := d.Set("termination_notification", FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
+						return fmt.Errorf("setting `termination_notification`: %+v", err)
+					}
+				}
+
+				extensionProfile, err := flattenOrchestratedVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
+				if err != nil {
+					return fmt.Errorf("failed flattening `extension`: %+v", err)
+				}
+				d.Set("extension", extensionProfile)
+
+				extensionsTimeBudget := "PT1H30M"
+				if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
+					extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
+				}
+				d.Set("extensions_time_budget", extensionsTimeBudget)
+
+				encryptionAtHostEnabled := false
+				if profile.SecurityProfile != nil && profile.SecurityProfile.EncryptionAtHost != nil {
+					encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
+				}
+				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+				d.Set("user_data_base64", profile.UserData)
+			}
+
+			if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {
+				if err := d.Set("priority_mix", FlattenOrchestratedVirtualMachineScaleSetPriorityMixPolicy(priorityMixPolicy)); err != nil {
+					return fmt.Errorf("setting `priority_mix`: %+v", err)
+				}
+			}
+
+			d.Set("extension_operations_enabled", extensionOperationsEnabled)
 		}
-		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
-		d.Set("user_data_base64", profile.UserData)
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {
-		if err := d.Set("priority_mix", FlattenOrchestratedVirtualMachineScaleSetPriorityMixPolicy(priorityMixPolicy)); err != nil {
-			return fmt.Errorf("setting `priority_mix`: %+v", err)
-		}
-	}
-
-	d.Set("extension_operations_enabled", extensionOperationsEnabled)
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return nil
 		}
 
@@ -1346,22 +1314,15 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	// Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet internal is in use by
 	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
 	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
-	if resp.Sku != nil {
-		resp.Sku.Capacity = utils.Int64(int64(0))
+	if resp.Model.Sku != nil {
+		resp.Model.Sku.Capacity = utils.Int64(int64(0))
 
 		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
-		update := compute.VirtualMachineScaleSetUpdate{
-			Sku: resp.Sku,
+		update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
+			Sku: resp.Model.Sku,
 		}
-		future, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update)
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating number of instances in Orchestrated %s to scale to 0: %+v", id, err)
-		}
-
-		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
-		err = future.WaitForCompletionRef(ctx, client.Client)
-		if err != nil {
-			return fmt.Errorf("waiting for number of instances in Orchestrated %s to scale to 0: %+v", id, err)
 		}
 		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 	} else {
@@ -1371,39 +1332,31 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	log.Printf("[DEBUG] Deleting Orchestrated %s", id)
 	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
-	// TODO: support force deletion once it's out of Preview, if applicable
-	var forceDeletion *bool = nil
-	future, err := client.Delete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, forceDeletion)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting Orchestrated %s: %+v", id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for deletion of Orchestrated %s", id)
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of Orchestrated %s: %+v", id, err)
 	}
 	log.Printf("[DEBUG] Deleted Orchestrated %s", id)
 
 	return nil
 }
 
-func expandOrchestratedVirtualMachineScaleSetSku(input string, capacity int) (*compute.Sku, error) {
+func expandOrchestratedVirtualMachineScaleSetSku(input string, capacity int) (*virtualmachinescalesets.Sku, error) {
 	skuParts := strings.Split(input, "_")
 
 	if len(skuParts) < 2 || strings.Contains(input, "__") || strings.Contains(input, " ") {
 		return nil, fmt.Errorf("'sku_name'(%q) is not formatted properly", input)
 	}
 
-	sku := &compute.Sku{
-		Name:     utils.String(input),
+	sku := &virtualmachinescalesets.Sku{
+		Name:     pointer.To(input),
 		Capacity: utils.Int64(int64(capacity)),
-		Tier:     utils.String("Standard"),
+		Tier:     pointer.To("Standard"),
 	}
 
 	return sku, nil
 }
 
-func flattenOrchestratedVirtualMachineScaleSetSku(input *compute.Sku) (*string, error) {
+func flattenOrchestratedVirtualMachineScaleSetSku(input *virtualmachinescalesets.Sku) (*string, error) {
 	var skuName string
 	if input != nil && input.Name != nil {
 		if strings.HasPrefix(strings.ToLower(*input.Name), "standard") {
@@ -1418,24 +1371,26 @@ func flattenOrchestratedVirtualMachineScaleSetSku(input *compute.Sku) (*string, 
 	return nil, fmt.Errorf("sku struct 'name' is nil")
 }
 
-func expandOrchestratedVirtualMachineScaleSetPublicIPSku(input string) *compute.PublicIPAddressSku {
+func expandOrchestratedVirtualMachineScaleSetPublicIPSku(input string) *virtualmachinescalesets.PublicIPAddressSku {
 	skuParts := strings.Split(input, "_")
 
 	if len(skuParts) < 2 || strings.Contains(input, "__") || strings.Contains(input, " ") {
-		return &compute.PublicIPAddressSku{}
+		return &virtualmachinescalesets.PublicIPAddressSku{}
 	}
 
-	return &compute.PublicIPAddressSku{
-		Name: compute.PublicIPAddressSkuName(skuParts[0]),
-		Tier: compute.PublicIPAddressSkuTier(skuParts[1]),
+	return &virtualmachinescalesets.PublicIPAddressSku{
+		Name: pointer.To(virtualmachinescalesets.PublicIPAddressSkuName(skuParts[0])),
+		Tier: pointer.To(virtualmachinescalesets.PublicIPAddressSkuTier(skuParts[1])),
 	}
 }
 
-func flattenOrchestratedVirtualMachineScaleSetPublicIPSku(input *compute.PublicIPAddressSku) string {
+func flattenOrchestratedVirtualMachineScaleSetPublicIPSku(input *virtualmachinescalesets.PublicIPAddressSku) string {
 	var skuName string
 	if input != nil {
-		if string(input.Name) != "" && string(input.Tier) != "" {
-			skuName = fmt.Sprintf("%s_%s", string(input.Name), string(input.Tier))
+		name := string(pointer.From(input.Name))
+		tier := string(pointer.From(input.Tier))
+		if name != "" && tier != "" {
+			skuName = fmt.Sprintf("%s_%s", name, tier)
 		}
 	}
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_network_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -250,7 +251,9 @@ func (OrchestratedVirtualMachineScaleSetResource) hasLoadBalancer(ctx context.Co
 		return err
 	}
 
-	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return err
 	}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_network_test.go
@@ -8,12 +8,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func TestAccOrchestratedVirtualMachineScaleSet_multipleNetworkProfiles(t *testing.T) {
@@ -246,33 +245,34 @@ func TestAccOrchestratedVirtualMachineScaleSet_networkPublicIPVersion(t *testing
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) hasLoadBalancer(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	read, err := client.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return err
 	}
 
-	if props := read.VirtualMachineScaleSetProperties; props != nil {
-		if vmProfile := props.VirtualMachineProfile; vmProfile != nil {
-			if nwProfile := vmProfile.NetworkProfile; nwProfile != nil {
-				if nics := nwProfile.NetworkInterfaceConfigurations; nics != nil {
-					for _, nic := range *nics {
-						if nic.IPConfigurations == nil {
-							continue
-						}
-
-						for _, config := range *nic.IPConfigurations {
-							if config.LoadBalancerBackendAddressPools == nil {
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if vmProfile := props.VirtualMachineProfile; vmProfile != nil {
+				if nwProfile := vmProfile.NetworkProfile; nwProfile != nil {
+					if nics := nwProfile.NetworkInterfaceConfigurations; nics != nil {
+						for _, nic := range *nics {
+							if nic.Properties == nil || nic.Properties.IPConfigurations == nil {
 								continue
 							}
 
-							if len(*config.LoadBalancerBackendAddressPools) > 0 {
-								return nil
+							for _, config := range nic.Properties.IPConfigurations {
+								if config.Properties == nil || config.Properties.LoadBalancerBackendAddressPools == nil {
+									continue
+								}
+
+								if len(*config.Properties.LoadBalancerBackendAddressPools) > 0 {
+									return nil
+								}
 							}
 						}
 					}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -289,14 +289,14 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.linux_configuration.0.admin_password", "user_data_base64"),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.linux_configuration.0.admin_password", "user_data_base64"),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 	})
 }
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -289,14 +289,14 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password", "user_data_base64"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password", "user_data_base64"),
 	})
 }
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -538,7 +538,9 @@ func (OrchestratedVirtualMachineScaleSetResource) hasApplicationGateway(ctx cont
 		return err
 	}
 
-	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return err
 	}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 type OrchestratedVirtualMachineScaleSetResource struct{}
@@ -502,74 +501,69 @@ func TestAccOrchestratedVirtualMachineScaleSet_updatePriorityMixPolicy(t *testin
 // }
 
 func (t OrchestratedVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := clients.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := clients.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Virtual Machine Scale Set %q", id)
+		return nil, fmt.Errorf("retrieving Orchestrated %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	// this is a preview feature we don't want to use right now
-	var forceDelete *bool = nil
-	future, err := client.Compute.VMScaleSetClient.Delete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, forceDelete)
-	if err != nil {
+	if err := client.Compute.VirtualMachineScaleSetsClient.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return nil, fmt.Errorf("Bad: deleting %s: %+v", *id, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Compute.VMScaleSetClient.Client); err != nil {
-		return nil, fmt.Errorf("Bad: waiting for deletion of %s: %+v", *id, err)
-	}
-
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) hasApplicationGateway(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	read, err := client.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return err
 	}
 
-	if props := read.VirtualMachineScaleSetProperties; props != nil {
-		if vmProfile := props.VirtualMachineProfile; vmProfile != nil {
-			if nwProfile := vmProfile.NetworkProfile; nwProfile != nil {
-				if nics := nwProfile.NetworkInterfaceConfigurations; nics != nil {
-					for _, nic := range *nics {
-						if nic.IPConfigurations == nil {
-							continue
-						}
-
-						for _, config := range *nic.IPConfigurations {
-							if config.ApplicationGatewayBackendAddressPools == nil {
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if vmProfile := props.VirtualMachineProfile; vmProfile != nil {
+				if nwProfile := vmProfile.NetworkProfile; nwProfile != nil {
+					if nics := nwProfile.NetworkInterfaceConfigurations; nics != nil {
+						for _, nic := range *nics {
+							if nic.Properties == nil || nic.Properties.IPConfigurations == nil {
 								continue
 							}
 
-							if len(*config.ApplicationGatewayBackendAddressPools) > 0 {
-								return nil
+							for _, config := range nic.Properties.IPConfigurations {
+								if config.Properties == nil || config.Properties.ApplicationGatewayBackendAddressPools == nil {
+									continue
+								}
+
+								if len(*config.Properties.ApplicationGatewayBackendAddressPools) > 0 {
+									return nil
+								}
 							}
 						}
 					}
 				}
 			}
 		}
+
 	}
 
 	return fmt.Errorf("application gateway configuration was missing")

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
@@ -521,7 +522,10 @@ func (OrchestratedVirtualMachineScaleSetResource) Destroy(ctx context.Context, c
 		return nil, err
 	}
 
-	if err := client.Compute.VirtualMachineScaleSetsClient.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if err := client.Compute.VirtualMachineScaleSetsClient.DeleteThenPoll(ctx2, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return nil, fmt.Errorf("Bad: deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -84,7 +84,7 @@ func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) er
 		image = &(*result.Model)[len(*result.Model)-1]
 	}
 
-	d.SetId(*image.Id)
+	d.SetId(id.ID())
 
 	d.Set("location", location.Normalize(image.Location))
 	d.Set("publisher", id.PublisherName)

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -84,7 +84,11 @@ func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) er
 		image = &(*result.Model)[len(*result.Model)-1]
 	}
 
-	d.SetId(*image.Id)
+	imageId, err := virtualmachineimages.ParseSkuVersionIDInsensitively(*image.Id)
+	if err != nil {
+		return err
+	}
+	d.SetId(imageId.ID())
 
 	d.Set("location", location.Normalize(image.Location))
 	d.Set("publisher", id.PublisherName)

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -84,7 +84,7 @@ func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) er
 		image = &(*result.Model)[len(*result.Model)-1]
 	}
 
-	d.SetId(id.ID())
+	d.SetId(*image.Id)
 
 	d.Set("location", location.Normalize(image.Location))
 	d.Set("publisher", id.PublisherName)

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -8,12 +8,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func dataSourcePlatformImage() *pluginsdk.Resource {
@@ -53,48 +52,44 @@ func dataSourcePlatformImage() *pluginsdk.Resource {
 
 func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMImageClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	publisher := d.Get("publisher").(string)
-	offer := d.Get("offer").(string)
-	sku := d.Get("sku").(string)
+	id := virtualmachineimages.NewSkuID(subscriptionId, location.Normalize(d.Get("location").(string)), d.Get("publisher").(string), d.Get("offer").(string), d.Get("sku").(string))
 
-	result, err := client.List(ctx, location, publisher, offer, sku, "", utils.Int32(int32(1000)), "name")
-	if err != nil || result.Value == nil {
-		return fmt.Errorf("reading Platform Images: %+v", err)
+	result, err := client.List(ctx, id, virtualmachineimages.DefaultListOperationOptions())
+	if err != nil || result.Model == nil {
+		return fmt.Errorf("retrieving: %+v", err)
 	}
 
-	var image *compute.VirtualMachineImageResource
+	var image *virtualmachineimages.VirtualMachineImageResource
 	if v, ok := d.GetOk("version"); ok {
 		version := v.(string)
-		for _, item := range *result.Value {
-			if item.Name != nil && *item.Name == version {
+		for _, item := range *result.Model {
+			if item.Name == version {
 				image = &item
 				break
 			}
 		}
 		if image == nil {
-			return fmt.Errorf("could not find image (location %q / publisher %q / offer %q / sku %q / version % q): %+v", location, publisher, offer, sku, version, err)
+			return fmt.Errorf("could not find image for %s: %+v", id, err)
 		}
 	} else {
 		// get the latest image (the last value is the latest, apparently)
 		// list can be empty if user hasn't licensed any matching images
-		if len(*result.Value) == 0 {
-			return fmt.Errorf("no images available to this user (location %q / publisher %q / offer %q / sku %q)", location, publisher, offer, sku)
+		if len(*result.Model) == 0 {
+			return fmt.Errorf("no images available to this user for %s", id)
 		}
-		image = &(*result.Value)[len(*result.Value)-1]
+		image = &(*result.Model)[len(*result.Model)-1]
 	}
 
-	d.SetId(*image.ID)
-	if location := image.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
+	d.SetId(*image.Id)
 
-	d.Set("publisher", publisher)
-	d.Set("offer", offer)
-	d.Set("sku", sku)
+	d.Set("location", location.Normalize(image.Location))
+	d.Set("publisher", id.PublisherName)
+	d.Set("offer", id.OfferName)
+	d.Set("sku", id.SkuName)
 	d.Set("version", image.Name)
 
 	return nil

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -37,17 +38,17 @@ func protectedSettingsFromKeyVaultSchema(conflictsWithProtectedSettings bool) *p
 	}
 }
 
-func expandProtectedSettingsFromKeyVault(input []interface{}) *compute.KeyVaultSecretReference {
+func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachinescalesets.KeyVaultSecretReference {
 	if len(input) == 0 {
 		return nil
 	}
 
 	v := input[0].(map[string]interface{})
 
-	return &compute.KeyVaultSecretReference{
-		SecretURL: utils.String(v["secret_url"].(string)),
-		SourceVault: &compute.SubResource{
-			ID: utils.String(v["source_vault_id"].(string)),
+	return &virtualmachinescalesets.KeyVaultSecretReference{
+		SecretUrl: v["secret_url"].(string),
+		SourceVault: virtualmachinescalesets.SubResource{
+			Id: utils.String(v["source_vault_id"].(string)),
 		},
 	}
 }

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -89,7 +89,7 @@ func flattenProtectedSettingsFromKeyVaultOld(input *compute.KeyVaultSecretRefere
 
 func flattenProtectedSettingsFromKeyVault(input *virtualmachinescalesets.KeyVaultSecretReference) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	sourceVaultId := ""

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
@@ -38,6 +39,21 @@ func protectedSettingsFromKeyVaultSchema(conflictsWithProtectedSettings bool) *p
 	}
 }
 
+func expandProtectedSettingsFromKeyVaultOld(input []interface{}) *compute.KeyVaultSecretReference {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	return &compute.KeyVaultSecretReference{
+		SecretURL: pointer.To(v["secret_url"].(string)),
+		SourceVault: &compute.SubResource{
+			ID: utils.String(v["source_vault_id"].(string)),
+		},
+	}
+}
+
 func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachinescalesets.KeyVaultSecretReference {
 	if len(input) == 0 {
 		return nil
@@ -53,24 +69,37 @@ func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachinesca
 	}
 }
 
-func flattenProtectedSettingsFromKeyVault(input *compute.KeyVaultSecretReference) []interface{} {
+func flattenProtectedSettingsFromKeyVaultOld(input *compute.KeyVaultSecretReference) []interface{} {
 	if input == nil {
 		return nil
 	}
 
-	secretUrl := ""
-	if input.SecretURL != nil {
-		secretUrl = *input.SecretURL
-	}
-
 	sourceVaultId := ""
-	if input.SourceVault != nil && input.SourceVault.ID != nil {
+	if input.SourceVault.ID != nil {
 		sourceVaultId = *input.SourceVault.ID
 	}
 
 	return []interface{}{
 		map[string]interface{}{
-			"secret_url":      secretUrl,
+			"secret_url":      input.SecretURL,
+			"source_vault_id": sourceVaultId,
+		},
+	}
+}
+
+func flattenProtectedSettingsFromKeyVault(input *virtualmachinescalesets.KeyVaultSecretReference) []interface{} {
+	if input == nil {
+		return nil
+	}
+
+	sourceVaultId := ""
+	if input.SourceVault.Id != nil {
+		sourceVaultId = *input.SourceVault.Id
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"secret_url":      input.SecretUrl,
 			"source_vault_id": sourceVaultId,
 		},
 	}

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func additionalUnattendContentSchema() *pluginsdk.Schema {
@@ -37,8 +37,9 @@ func additionalUnattendContentSchema() *pluginsdk.Schema {
 					Required: true,
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.SettingNamesAutoLogon),
-						string(compute.SettingNamesFirstLogonCommands),
+						// TODO review questions
+						string(virtualmachines.SettingNamesAutoLogon),
+						string(virtualmachines.SettingNamesFirstLogonCommands),
 					}, false),
 				},
 			},
@@ -46,26 +47,45 @@ func additionalUnattendContentSchema() *pluginsdk.Schema {
 	}
 }
 
-func expandAdditionalUnattendContent(input []interface{}) *[]compute.AdditionalUnattendContent {
-	output := make([]compute.AdditionalUnattendContent, 0)
+func expandAdditionalUnattendContent(input []interface{}) *[]virtualmachines.AdditionalUnattendContent {
+	output := make([]virtualmachines.AdditionalUnattendContent, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
-		output = append(output, compute.AdditionalUnattendContent{
-			SettingName: compute.SettingNames(raw["setting"].(string)),
+		output = append(output, virtualmachines.AdditionalUnattendContent{
+			SettingName: pointer.To(virtualmachines.SettingNames(raw["setting"].(string))),
 			Content:     pointer.To(raw["content"].(string)),
 
 			// no other possible values
-			PassName:      compute.PassNamesOobeSystem,
-			ComponentName: compute.ComponentNamesMicrosoftWindowsShellSetup,
+			PassName:      pointer.To(virtualmachines.PassNamesOobeSystem),
+			ComponentName: pointer.To(virtualmachines.ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup),
 		})
 	}
 
 	return &output
 }
 
-func flattenAdditionalUnattendContent(input *[]compute.AdditionalUnattendContent, d *pluginsdk.ResourceData) []interface{} {
+func expandAdditionalUnattendContentVMSS(input []interface{}) *[]virtualmachinescalesets.AdditionalUnattendContent {
+	output := make([]virtualmachinescalesets.AdditionalUnattendContent, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		output = append(output, virtualmachinescalesets.AdditionalUnattendContent{
+			SettingName: pointer.To(virtualmachinescalesets.SettingNames(raw["setting"].(string))),
+			Content:     pointer.To(raw["content"].(string)),
+
+			// no other possible values
+			PassName:      pointer.To(virtualmachinescalesets.PassNamesOobeSystem),
+			ComponentName: pointer.To(virtualmachinescalesets.ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup),
+		})
+	}
+
+	return &output
+}
+
+func flattenAdditionalUnattendContent(input *[]virtualmachines.AdditionalUnattendContent, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -92,7 +112,41 @@ func flattenAdditionalUnattendContent(input *[]compute.AdditionalUnattendContent
 
 		output = append(output, map[string]interface{}{
 			"content": content,
-			"setting": string(v.SettingName),
+			"setting": pointer.From(v.SettingName),
+		})
+	}
+
+	return output
+}
+
+func flattenAdditionalUnattendContentVMSS(input *[]virtualmachinescalesets.AdditionalUnattendContent, d *pluginsdk.ResourceData) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	existing := make([]interface{}, 0)
+	if v, ok := d.GetOk("additional_unattend_content"); ok {
+		existing = v.([]interface{})
+	}
+
+	output := make([]interface{}, 0)
+	for i, v := range *input {
+		// content isn't returned from the API as it's sensitive so we need to look it up
+		content := ""
+		if len(existing) > i {
+			existingVal := existing[i]
+			existingRaw, ok := existingVal.(map[string]interface{})
+			if ok {
+				contentRaw, ok := existingRaw["content"]
+				if ok {
+					content = contentRaw.(string)
+				}
+			}
+		}
+
+		output = append(output, map[string]interface{}{
+			"content": content,
+			"setting": pointer.From(v.SettingName),
 		})
 	}
 
@@ -150,7 +204,56 @@ func expandBootDiagnostics(input []interface{}) *virtualmachines.DiagnosticsProf
 	}
 }
 
+func expandBootDiagnosticsVMSS(input []interface{}) *virtualmachinescalesets.DiagnosticsProfile {
+	if len(input) == 0 {
+		return &virtualmachinescalesets.DiagnosticsProfile{
+			BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+				Enabled:    pointer.To(false),
+				StorageUri: pointer.To(""),
+			},
+		}
+	}
+
+	// this serves the managed boot diagnostics, in this case we only have this empty block without `storage_account_uri` set
+	if input[0] == nil {
+		return &virtualmachinescalesets.DiagnosticsProfile{
+			BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+				Enabled:    pointer.To(true),
+				StorageUri: pointer.To(""),
+			},
+		}
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	storageAccountUri := raw["storage_account_uri"].(string)
+
+	return &virtualmachinescalesets.DiagnosticsProfile{
+		BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+			Enabled:    pointer.To(true),
+			StorageUri: pointer.To(storageAccountUri),
+		},
+	}
+}
+
 func flattenBootDiagnostics(input *virtualmachines.DiagnosticsProfile) []interface{} {
+	if input == nil || input.BootDiagnostics == nil || input.BootDiagnostics.Enabled == nil || !*input.BootDiagnostics.Enabled {
+		return []interface{}{}
+	}
+
+	storageAccountUri := ""
+	if input.BootDiagnostics.StorageUri != nil {
+		storageAccountUri = *input.BootDiagnostics.StorageUri
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"storage_account_uri": storageAccountUri,
+		},
+	}
+}
+
+func flattenBootDiagnosticsVMSS(input *virtualmachinescalesets.DiagnosticsProfile) []interface{} {
 	if input == nil || input.BootDiagnostics == nil || input.BootDiagnostics.Enabled == nil || !*input.BootDiagnostics.Enabled {
 		return []interface{}{}
 	}
@@ -226,7 +329,72 @@ func expandLinuxSecrets(input []interface{}) *[]virtualmachines.VaultSecretGroup
 	return &output
 }
 
+func expandLinuxSecretsVMSS(input []interface{}) *[]virtualmachinescalesets.VaultSecretGroup {
+	output := make([]virtualmachinescalesets.VaultSecretGroup, 0)
+
+	for _, raw := range input {
+		v := raw.(map[string]interface{})
+
+		keyVaultId := v["key_vault_id"].(string)
+		certificatesRaw := v["certificate"].(*pluginsdk.Set).List()
+		certificates := make([]virtualmachinescalesets.VaultCertificate, 0)
+		for _, certificateRaw := range certificatesRaw {
+			certificateV := certificateRaw.(map[string]interface{})
+
+			url := certificateV["url"].(string)
+			certificates = append(certificates, virtualmachinescalesets.VaultCertificate{
+				CertificateUrl: pointer.To(url),
+			})
+		}
+
+		output = append(output, virtualmachinescalesets.VaultSecretGroup{
+			SourceVault: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(keyVaultId),
+			},
+			VaultCertificates: &certificates,
+		})
+	}
+
+	return &output
+}
+
 func flattenLinuxSecrets(input *[]virtualmachines.VaultSecretGroup) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		keyVaultId := ""
+		if v.SourceVault != nil && v.SourceVault.Id != nil {
+			keyVaultId = *v.SourceVault.Id
+		}
+
+		certificates := make([]interface{}, 0)
+
+		if v.VaultCertificates != nil {
+			for _, c := range *v.VaultCertificates {
+				if c.CertificateUrl == nil {
+					continue
+				}
+
+				certificates = append(certificates, map[string]interface{}{
+					"url": *c.CertificateUrl,
+				})
+			}
+		}
+
+		output = append(output, map[string]interface{}{
+			"key_vault_id": keyVaultId,
+			"certificate":  certificates,
+		})
+	}
+
+	return output
+}
+
+func flattenLinuxSecretsVMSS(input *[]virtualmachinescalesets.VaultSecretGroup) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -306,7 +474,50 @@ func expandPlan(input []interface{}) *virtualmachines.Plan {
 	}
 }
 
+func expandPlanVMSS(input []interface{}) *virtualmachinescalesets.Plan {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	return &virtualmachinescalesets.Plan{
+		Name:      pointer.To(raw["name"].(string)),
+		Product:   pointer.To(raw["product"].(string)),
+		Publisher: pointer.To(raw["publisher"].(string)),
+	}
+}
+
 func flattenPlan(input *virtualmachines.Plan) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	product := ""
+	if input.Product != nil {
+		product = *input.Product
+	}
+
+	publisher := ""
+	if input.Publisher != nil {
+		publisher = *input.Publisher
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":      name,
+			"product":   product,
+			"publisher": publisher,
+		},
+	}
+}
+
+func flattenPlanVMSS(input *virtualmachinescalesets.Plan) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -470,7 +681,70 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) *v
 	}
 }
 
+func expandSourceImageReferenceVMSS(referenceInput []interface{}, imageId string) *virtualmachinescalesets.ImageReference {
+	if imageId != "" {
+		// With Version            : "/communityGalleries/publicGalleryName/images/myGalleryImageName/versions/(major.minor.patch | latest)"
+		// Versionless(e.g. latest): "/communityGalleries/publicGalleryName/images/myGalleryImageName"
+		if _, errors := validation.Any(validate.CommunityGalleryImageID, validate.CommunityGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
+			return &virtualmachinescalesets.ImageReference{
+				CommunityGalleryImageId: pointer.To(imageId),
+			}
+		}
+
+		// With Version            : "/sharedGalleries/galleryUniqueName/images/myGalleryImageName/versions/(major.minor.patch | latest)"
+		// Versionless(e.g. latest): "/sharedGalleries/galleryUniqueName/images/myGalleryImageName"
+		if _, errors := validation.Any(validate.SharedGalleryImageID, validate.SharedGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
+			return &virtualmachinescalesets.ImageReference{
+				SharedGalleryImageId: pointer.To(imageId),
+			}
+		}
+
+		return &virtualmachinescalesets.ImageReference{
+			Id: pointer.To(imageId),
+		}
+	}
+
+	raw := referenceInput[0].(map[string]interface{})
+	return &virtualmachinescalesets.ImageReference{
+		Publisher: pointer.To(raw["publisher"].(string)),
+		Offer:     pointer.To(raw["offer"].(string)),
+		Sku:       pointer.To(raw["sku"].(string)),
+		Version:   pointer.To(raw["version"].(string)),
+	}
+}
+
 func flattenSourceImageReference(input *virtualmachines.ImageReference, hasImageId bool) []interface{} {
+	// since the image id is pulled out as a separate field, if that's set we should return an empty block here
+	if input == nil || hasImageId {
+		return []interface{}{}
+	}
+
+	var publisher, offer, sku, version string
+
+	if input.Publisher != nil {
+		publisher = *input.Publisher
+	}
+	if input.Offer != nil {
+		offer = *input.Offer
+	}
+	if input.Sku != nil {
+		sku = *input.Sku
+	}
+	if input.Version != nil {
+		version = *input.Version
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"publisher": publisher,
+			"offer":     offer,
+			"sku":       sku,
+			"version":   version,
+		},
+	}
+}
+
+func flattenSourceImageReferenceVMSS(input *virtualmachinescalesets.ImageReference, hasImageId bool) []interface{} {
 	// since the image id is pulled out as a separate field, if that's set we should return an empty block here
 	if input == nil || hasImageId {
 		return []interface{}{}
@@ -517,8 +791,8 @@ func winRmListenerSchema() *pluginsdk.Schema {
 					Required: true,
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.ProtocolTypesHTTP),
-						string(compute.ProtocolTypesHTTPS),
+						string(virtualmachines.ProtocolTypesHTTP),
+						string(virtualmachines.ProtocolTypesHTTPS),
 					}, false),
 				},
 
@@ -533,30 +807,53 @@ func winRmListenerSchema() *pluginsdk.Schema {
 	}
 }
 
-func expandWinRMListener(input []interface{}) *compute.WinRMConfiguration {
-	listeners := make([]compute.WinRMListener, 0)
+func expandWinRMListener(input []interface{}) *virtualmachines.WinRMConfiguration {
+	listeners := make([]virtualmachines.WinRMListener, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
-		listener := compute.WinRMListener{
-			Protocol: compute.ProtocolTypes(raw["protocol"].(string)),
+		listener := virtualmachines.WinRMListener{
+			Protocol: pointer.To(virtualmachines.ProtocolTypes(raw["protocol"].(string))),
 		}
 
 		certificateUrl := raw["certificate_url"].(string)
 		if certificateUrl != "" {
-			listener.CertificateURL = pointer.To(certificateUrl)
+			listener.CertificateUrl = pointer.To(certificateUrl)
 		}
 
 		listeners = append(listeners, listener)
 	}
 
-	return &compute.WinRMConfiguration{
+	return &virtualmachines.WinRMConfiguration{
 		Listeners: &listeners,
 	}
 }
 
-func flattenWinRMListener(input *compute.WinRMConfiguration) []interface{} {
+func expandWinRMListenerVMSS(input []interface{}) *virtualmachinescalesets.WinRMConfiguration {
+	listeners := make([]virtualmachinescalesets.WinRMListener, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		listener := virtualmachinescalesets.WinRMListener{
+			Protocol: pointer.To(virtualmachinescalesets.ProtocolTypes(raw["protocol"].(string))),
+		}
+
+		certificateUrl := raw["certificate_url"].(string)
+		if certificateUrl != "" {
+			listener.CertificateUrl = pointer.To(certificateUrl)
+		}
+
+		listeners = append(listeners, listener)
+	}
+
+	return &virtualmachinescalesets.WinRMConfiguration{
+		Listeners: &listeners,
+	}
+}
+
+func flattenWinRMListener(input *virtualmachines.WinRMConfiguration) []interface{} {
 	if input == nil || input.Listeners == nil {
 		return []interface{}{}
 	}
@@ -565,13 +862,35 @@ func flattenWinRMListener(input *compute.WinRMConfiguration) []interface{} {
 
 	for _, v := range *input.Listeners {
 		certificateUrl := ""
-		if v.CertificateURL != nil {
-			certificateUrl = *v.CertificateURL
+		if v.CertificateUrl != nil {
+			certificateUrl = *v.CertificateUrl
 		}
 
 		output = append(output, map[string]interface{}{
 			"certificate_url": certificateUrl,
-			"protocol":        string(v.Protocol),
+			"protocol":        pointer.From(v.Protocol),
+		})
+	}
+
+	return output
+}
+
+func flattenWinRMListenerVMSS(input *virtualmachinescalesets.WinRMConfiguration) []interface{} {
+	if input == nil || input.Listeners == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input.Listeners {
+		certificateUrl := ""
+		if v.CertificateUrl != nil {
+			certificateUrl = *v.CertificateUrl
+		}
+
+		output = append(output, map[string]interface{}{
+			"certificate_url": certificateUrl,
+			"protocol":        pointer.From(v.Protocol),
 		})
 	}
 
@@ -610,29 +929,29 @@ func windowsSecretSchema() *pluginsdk.Schema {
 	}
 }
 
-func expandWindowsSecrets(input []interface{}) *[]compute.VaultSecretGroup {
-	output := make([]compute.VaultSecretGroup, 0)
+func expandWindowsSecrets(input []interface{}) *[]virtualmachines.VaultSecretGroup {
+	output := make([]virtualmachines.VaultSecretGroup, 0)
 
 	for _, raw := range input {
 		v := raw.(map[string]interface{})
 
 		keyVaultId := v["key_vault_id"].(string)
 		certificatesRaw := v["certificate"].(*pluginsdk.Set).List()
-		certificates := make([]compute.VaultCertificate, 0)
+		certificates := make([]virtualmachines.VaultCertificate, 0)
 		for _, certificateRaw := range certificatesRaw {
 			certificateV := certificateRaw.(map[string]interface{})
 
 			store := certificateV["store"].(string)
 			url := certificateV["url"].(string)
-			certificates = append(certificates, compute.VaultCertificate{
+			certificates = append(certificates, virtualmachines.VaultCertificate{
 				CertificateStore: pointer.To(store),
-				CertificateURL:   pointer.To(url),
+				CertificateUrl:   pointer.To(url),
 			})
 		}
 
-		output = append(output, compute.VaultSecretGroup{
-			SourceVault: &compute.SubResource{
-				ID: pointer.To(keyVaultId),
+		output = append(output, virtualmachines.VaultSecretGroup{
+			SourceVault: &virtualmachines.SubResource{
+				Id: pointer.To(keyVaultId),
 			},
 			VaultCertificates: &certificates,
 		})
@@ -641,7 +960,38 @@ func expandWindowsSecrets(input []interface{}) *[]compute.VaultSecretGroup {
 	return &output
 }
 
-func flattenWindowsSecrets(input *[]compute.VaultSecretGroup) []interface{} {
+func expandWindowsSecretsVMSS(input []interface{}) *[]virtualmachinescalesets.VaultSecretGroup {
+	output := make([]virtualmachinescalesets.VaultSecretGroup, 0)
+
+	for _, raw := range input {
+		v := raw.(map[string]interface{})
+
+		keyVaultId := v["key_vault_id"].(string)
+		certificatesRaw := v["certificate"].(*pluginsdk.Set).List()
+		certificates := make([]virtualmachinescalesets.VaultCertificate, 0)
+		for _, certificateRaw := range certificatesRaw {
+			certificateV := certificateRaw.(map[string]interface{})
+
+			store := certificateV["store"].(string)
+			url := certificateV["url"].(string)
+			certificates = append(certificates, virtualmachinescalesets.VaultCertificate{
+				CertificateStore: pointer.To(store),
+				CertificateUrl:   pointer.To(url),
+			})
+		}
+
+		output = append(output, virtualmachinescalesets.VaultSecretGroup{
+			SourceVault: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(keyVaultId),
+			},
+			VaultCertificates: &certificates,
+		})
+	}
+
+	return &output
+}
+
+func flattenWindowsSecrets(input *[]virtualmachines.VaultSecretGroup) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -650,8 +1000,8 @@ func flattenWindowsSecrets(input *[]compute.VaultSecretGroup) []interface{} {
 
 	for _, v := range *input {
 		keyVaultId := ""
-		if v.SourceVault != nil && v.SourceVault.ID != nil {
-			keyVaultId = *v.SourceVault.ID
+		if v.SourceVault != nil && v.SourceVault.Id != nil {
+			keyVaultId = *v.SourceVault.Id
 		}
 
 		certificates := make([]interface{}, 0)
@@ -664,8 +1014,51 @@ func flattenWindowsSecrets(input *[]compute.VaultSecretGroup) []interface{} {
 				}
 
 				url := ""
-				if c.CertificateURL != nil {
-					url = *c.CertificateURL
+				if c.CertificateUrl != nil {
+					url = *c.CertificateUrl
+				}
+
+				certificates = append(certificates, map[string]interface{}{
+					"store": store,
+					"url":   url,
+				})
+			}
+		}
+
+		output = append(output, map[string]interface{}{
+			"key_vault_id": keyVaultId,
+			"certificate":  certificates,
+		})
+	}
+
+	return output
+}
+
+func flattenWindowsSecretsVMSS(input *[]virtualmachinescalesets.VaultSecretGroup) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		keyVaultId := ""
+		if v.SourceVault != nil && v.SourceVault.Id != nil {
+			keyVaultId = *v.SourceVault.Id
+		}
+
+		certificates := make([]interface{}, 0)
+
+		if v.VaultCertificates != nil {
+			for _, c := range *v.VaultCertificates {
+				store := ""
+				if c.CertificateStore != nil {
+					store = *c.CertificateStore
+				}
+
+				url := ""
+				if c.CertificateUrl != nil {
+					url = *c.CertificateUrl
 				}
 
 				certificates = append(certificates, map[string]interface{}{

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -37,7 +37,6 @@ func additionalUnattendContentSchema() *pluginsdk.Schema {
 					Required: true,
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						// TODO review questions
 						string(virtualmachines.SettingNamesAutoLogon),
 						string(virtualmachines.SettingNamesFirstLogonCommands),
 					}, false),

--- a/internal/services/compute/ssh_keys.go
+++ b/internal/services/compute/ssh_keys.go
@@ -6,14 +6,16 @@ package compute
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"log"
 	"regexp"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
@@ -32,7 +34,7 @@ func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
 					Required:         true,
 					ForceNew:         isVirtualMachine,
 					ValidateFunc:     validate.SSHKey,
-					DiffSuppressFunc: SSHKeyDiffSuppress,
+					DiffSuppressFunc: suppress.SSHKey,
 				},
 
 				"username": {
@@ -46,7 +48,7 @@ func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	}
 }
 
-func ExpandSSHKeys(input []interface{}) []virtualmachines.SshPublicKey {
+func expandSSHKeys(input []interface{}) []virtualmachines.SshPublicKey {
 	output := make([]virtualmachines.SshPublicKey, 0)
 
 	for _, v := range input {
@@ -54,15 +56,56 @@ func ExpandSSHKeys(input []interface{}) []virtualmachines.SshPublicKey {
 
 		username := raw["username"].(string)
 		output = append(output, virtualmachines.SshPublicKey{
-			KeyData: utils.String(raw["public_key"].(string)),
-			Path:    utils.String(formatUsernameForAuthorizedKeysPath(username)),
+			KeyData: pointer.To(raw["public_key"].(string)),
+			Path:    pointer.To(formatUsernameForAuthorizedKeysPath(username)),
 		})
 	}
 
 	return output
 }
 
-func FlattenSSHKeys(input *virtualmachines.SshConfiguration) (*[]interface{}, error) {
+func expandSSHKeysVMSS(input []interface{}) []virtualmachinescalesets.SshPublicKey {
+	output := make([]virtualmachinescalesets.SshPublicKey, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		username := raw["username"].(string)
+		output = append(output, virtualmachinescalesets.SshPublicKey{
+			KeyData: pointer.To(raw["public_key"].(string)),
+			Path:    pointer.To(formatUsernameForAuthorizedKeysPath(username)),
+		})
+	}
+
+	return output
+}
+
+func flattenSSHKeys(input *virtualmachines.SshConfiguration) (*[]interface{}, error) {
+	if input == nil || input.PublicKeys == nil {
+		return &[]interface{}{}, nil
+	}
+
+	output := make([]interface{}, 0)
+	for _, v := range *input.PublicKeys {
+		if v.KeyData == nil || v.Path == nil {
+			continue
+		}
+
+		username := parseUsernameFromAuthorizedKeysPath(*v.Path)
+		if username == nil {
+			return nil, fmt.Errorf("parsing username from %q", *v.Path)
+		}
+
+		output = append(output, map[string]interface{}{
+			"public_key": *v.KeyData,
+			"username":   *username,
+		})
+	}
+
+	return &output, nil
+}
+
+func flattenSSHKeysVMSS(input *virtualmachinescalesets.SshConfiguration) (*[]interface{}, error) {
 	if input == nil || input.PublicKeys == nil {
 		return &[]interface{}{}, nil
 	}
@@ -117,31 +160,11 @@ func parseUsernameFromAuthorizedKeysPath(input string) *string {
 	return nil
 }
 
-func SSHKeyDiffSuppress(_, old, new string, _ *pluginsdk.ResourceData) bool {
-	oldNormalized, err := NormalizeSSHKey(old)
-	if err != nil {
-		log.Printf("[DEBUG] error normalising ssh key %q: %+v", old, err)
-		return false
-	}
-
-	newNormalized, err := NormalizeSSHKey(new)
-	if err != nil {
-		log.Printf("[DEBUG] error normalising ssh key %q: %+v", new, err)
-		return false
-	}
-
-	if *oldNormalized == *newNormalized {
-		return true
-	}
-
-	return false
-}
-
 func SSHKeySchemaHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		normalisedKey, err := NormalizeSSHKey(m["public_key"].(string))
+		normalisedKey, err := suppress.NormalizeSSHKey(m["public_key"].(string))
 		if err != nil {
 			log.Printf("[DEBUG] error normalising ssh key %q: %+v", m["public_key"].(string), err)
 		}

--- a/internal/services/compute/ssh_keys.go
+++ b/internal/services/compute/ssh_keys.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"log"
 	"regexp"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
@@ -46,14 +46,14 @@ func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	}
 }
 
-func ExpandSSHKeys(input []interface{}) []compute.SSHPublicKey {
-	output := make([]compute.SSHPublicKey, 0)
+func ExpandSSHKeys(input []interface{}) []virtualmachines.SshPublicKey {
+	output := make([]virtualmachines.SshPublicKey, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
 		username := raw["username"].(string)
-		output = append(output, compute.SSHPublicKey{
+		output = append(output, virtualmachines.SshPublicKey{
 			KeyData: utils.String(raw["public_key"].(string)),
 			Path:    utils.String(formatUsernameForAuthorizedKeysPath(username)),
 		})
@@ -62,7 +62,7 @@ func ExpandSSHKeys(input []interface{}) []compute.SSHPublicKey {
 	return output
 }
 
-func FlattenSSHKeys(input *compute.SSHConfiguration) (*[]interface{}, error) {
+func FlattenSSHKeys(input *virtualmachines.SshConfiguration) (*[]interface{}, error) {
 	if input == nil || input.PublicKeys == nil {
 		return &[]interface{}{}, nil
 	}

--- a/internal/services/compute/ssh_public_key_data_source.go
+++ b/internal/services/compute/ssh_public_key_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -71,7 +72,7 @@ func dataSourceSshPublicKeyRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if model := resp.Model; model != nil {
 		var publicKey *string
 		if props := model.Properties; props.PublicKey != nil {
-			publicKey, err = NormalizeSSHKey(*props.PublicKey)
+			publicKey, err = suppress.NormalizeSSHKey(*props.PublicKey)
 			if err != nil {
 				return fmt.Errorf("normalising public key: %+v", err)
 			}

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -553,13 +553,14 @@ func expandVirtualMachineGalleryApplication(input []interface{}) *[]virtualmachi
 	}
 
 	for _, v := range input {
+		config := v.(map[string]interface{})
 		app := &virtualmachines.VMGalleryApplication{
-			PackageReferenceId:              v.(map[string]interface{})["version_id"].(string),
-			ConfigurationReference:          pointer.To(v.(map[string]interface{})["configuration_blob_uri"].(string)),
-			Order:                           pointer.To(int64(v.(map[string]interface{})["order"].(int))),
-			Tags:                            pointer.To(v.(map[string]interface{})["tag"].(string)),
-			EnableAutomaticUpgrade:          pointer.To(v.(map[string]interface{})["automatic_upgrade_enabled"].(bool)),
-			TreatFailureAsDeploymentFailure: pointer.To(v.(map[string]interface{})["treat_failure_as_deployment_failure_enabled"].(bool)),
+			PackageReferenceId:              config["version_id"].(string),
+			ConfigurationReference:          pointer.To(config["configuration_blob_uri"].(string)),
+			Order:                           pointer.To(int64(config["order"].(int))),
+			Tags:                            pointer.To(config["tag"].(string)),
+			EnableAutomaticUpgrade:          pointer.To(config["automatic_upgrade_enabled"].(bool)),
+			TreatFailureAsDeploymentFailure: pointer.To(config["treat_failure_as_deployment_failure_enabled"].(bool)),
 		}
 
 		out = append(out, *app)

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -173,7 +173,7 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 			TypeHandlerVersion:            &typeHandlerVersion,
 			AutoUpgradeMinorVersion:       &autoUpgradeMinor,
 			EnableAutomaticUpgrade:        &enableAutomaticUpgrade,
-			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{})),
 			SuppressFailures:              &suppressFailure,
 		},
 		Tags: tags.Expand(t),
@@ -252,7 +252,7 @@ func resourceVirtualMachineExtensionsRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("type_handler_version", props.TypeHandlerVersion)
 		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
 		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
-		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
+		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVaultOld(props.ProtectedSettingsFromKeyVault))
 		d.Set("provision_after_extensions", pointer.From(props.ProvisionAfterExtensions))
 
 		suppressFailure := false

--- a/internal/services/compute/virtual_machine_import.go
+++ b/internal/services/compute/virtual_machine_import.go
@@ -6,33 +6,31 @@ package compute
 import (
 	"context"
 	"fmt"
-
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
-func importVirtualMachine(osType compute.OperatingSystemTypes, resourceType string) pluginsdk.ImporterFunc {
+func importVirtualMachine(osType virtualmachines.OperatingSystemTypes, resourceType string) pluginsdk.ImporterFunc {
 	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
-		id, err := commonids.ParseVirtualMachineID(d.Id())
+		id, err := virtualmachines.ParseVirtualMachineID(d.Id())
 		if err != nil {
 			return []*pluginsdk.ResourceData{}, err
 		}
 
-		client := meta.(*clients.Client).Compute.VMClient
-		vm, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
+		client := meta.(*clients.Client).Compute.VirtualMachinesClient
+		vm, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 		if err != nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		if vm.VirtualMachineProperties == nil {
+		if model := vm.Model; model == nil || model.Properties == nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `properties` was nil", id)
 		}
 
 		isCorrectOS := false
-		if profile := vm.VirtualMachineProperties.StorageProfile; profile != nil {
-			if profile.OsDisk != nil && profile.OsDisk.OsType == osType {
+		if profile := vm.Model.Properties.StorageProfile; profile != nil {
+			if profile.OsDisk != nil && profile.OsDisk.OsType != nil && *profile.OsDisk.OsType == osType {
 				isCorrectOS = true
 			}
 
@@ -46,15 +44,15 @@ func importVirtualMachine(osType compute.OperatingSystemTypes, resourceType stri
 		}
 
 		// we don't support VM's without an OS Profile / attach
-		if vm.VirtualMachineProperties.OsProfile == nil {
+		if vm.Model.Properties.OsProfile == nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("The %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
 		}
 
 		hasSshKeys := false
-		if osType == compute.OperatingSystemTypesLinux {
-			if linux := vm.VirtualMachineProperties.OsProfile.LinuxConfiguration; linux != nil {
-				if linux.SSH != nil && linux.SSH.PublicKeys != nil {
-					hasSshKeys = len(*linux.SSH.PublicKeys) > 0
+		if osType == virtualmachines.OperatingSystemTypesLinux {
+			if linux := vm.Model.Properties.OsProfile.LinuxConfiguration; linux != nil {
+				if linux.Ssh != nil && linux.Ssh.PublicKeys != nil {
+					hasSshKeys = len(*linux.Ssh.PublicKeys) > 0
 				}
 			}
 		}

--- a/internal/services/compute/virtual_machine_import.go
+++ b/internal/services/compute/virtual_machine_import.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/compute/virtual_machine_instance.go
+++ b/internal/services/compute/virtual_machine_instance.go
@@ -4,16 +4,17 @@
 package compute
 
 import (
-	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 )
 
 // virtualMachineShouldBeStarted determines if the Virtual Machine should be started after
 // the Virtual Machine has been shut down for maintenance. This means that Virtual Machines
 // which are already stopped can be updated but will not be started
 // nolint: deadcode unused
-func virtualMachineShouldBeStarted(instanceView virtualmachines.VirtualMachineInstanceView) bool {
-	if instanceView.Statuses != nil {
+func virtualMachineShouldBeStarted(instanceView *virtualmachines.VirtualMachineInstanceView) bool {
+	if instanceView != nil && instanceView.Statuses != nil {
 		for _, status := range *instanceView.Statuses {
 			if status.Code == nil {
 				continue

--- a/internal/services/compute/virtual_machine_instance.go
+++ b/internal/services/compute/virtual_machine_instance.go
@@ -4,16 +4,15 @@
 package compute
 
 import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"strings"
-
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 // virtualMachineShouldBeStarted determines if the Virtual Machine should be started after
 // the Virtual Machine has been shut down for maintenance. This means that Virtual Machines
 // which are already stopped can be updated but will not be started
 // nolint: deadcode unused
-func virtualMachineShouldBeStarted(instanceView compute.VirtualMachineInstanceView) bool {
+func virtualMachineShouldBeStarted(instanceView virtualmachines.VirtualMachineInstanceView) bool {
 	if instanceView.Statuses != nil {
 		for _, status := range *instanceView.Statuses {
 			if status.Code == nil {

--- a/internal/services/compute/virtual_machine_instance_test.go
+++ b/internal/services/compute/virtual_machine_instance_test.go
@@ -6,17 +6,17 @@ package compute
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 )
 
 func TestVirtualMachineShouldBeStarted(t *testing.T) {
-	buildInstanceViewStatus := func(statuses ...string) *[]compute.InstanceViewStatus {
-		results := make([]compute.InstanceViewStatus, 0)
+	buildInstanceViewStatus := func(statuses ...string) *[]virtualmachines.InstanceViewStatus {
+		results := make([]virtualmachines.InstanceViewStatus, 0)
 
 		for _, v := range statuses {
-			results = append(results, compute.InstanceViewStatus{
-				Code: utils.String(v),
+			results = append(results, virtualmachines.InstanceViewStatus{
+				Code: pointer.To(v),
 			})
 		}
 
@@ -25,7 +25,7 @@ func TestVirtualMachineShouldBeStarted(t *testing.T) {
 
 	testCases := []struct {
 		Name     string
-		Input    *[]compute.InstanceViewStatus
+		Input    *[]virtualmachines.InstanceViewStatus
 		Expected bool
 	}{
 		{
@@ -73,10 +73,10 @@ func TestVirtualMachineShouldBeStarted(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Logf("Running %q..", testCase.Name)
 
-		instanceView := compute.VirtualMachineInstanceView{
+		instanceView := virtualmachines.VirtualMachineInstanceView{
 			Statuses: testCase.Input,
 		}
-		result := virtualMachineShouldBeStarted(instanceView)
+		result := virtualMachineShouldBeStarted(&instanceView)
 		if result != testCase.Expected {
 			t.Fatalf("Expected %t but got %t", testCase.Expected, result)
 		}

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -6,6 +6,8 @@ package compute
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -42,13 +44,13 @@ func VirtualMachineScaleSetAdditionalCapabilitiesSchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetAdditionalCapabilities(input []interface{}) *compute.AdditionalCapabilities {
-	capabilities := compute.AdditionalCapabilities{}
+func ExpandVirtualMachineScaleSetAdditionalCapabilities(input []interface{}) *virtualmachinescalesets.AdditionalCapabilities {
+	capabilities := virtualmachinescalesets.AdditionalCapabilities{}
 
 	if len(input) > 0 {
 		raw := input[0].(map[string]interface{})
 
-		capabilities.UltraSSDEnabled = utils.Bool(raw["ultra_ssd_enabled"].(bool))
+		capabilities.UltraSSDEnabled = pointer.To(raw["ultra_ssd_enabled"].(bool))
 	}
 
 	return &capabilities
@@ -280,12 +282,12 @@ func VirtualMachineScaleSetGalleryApplicationsSchema() *pluginsdk.Schema {
 	}
 }
 
-func expandVirtualMachineScaleSetGalleryApplication(input []interface{}) *[]compute.VMGalleryApplication {
+func expandVirtualMachineScaleSetGalleryApplication(input []interface{}) *[]virtualmachinescalesets.VMGalleryApplication {
 	if len(input) == 0 {
 		return nil
 	}
 
-	out := make([]compute.VMGalleryApplication, 0)
+	out := make([]virtualmachinescalesets.VMGalleryApplication, 0)
 
 	for _, v := range input {
 		packageReferenceId := v.(map[string]interface{})["version_id"].(string)
@@ -293,11 +295,11 @@ func expandVirtualMachineScaleSetGalleryApplication(input []interface{}) *[]comp
 		order := v.(map[string]interface{})["order"].(int)
 		tag := v.(map[string]interface{})["tag"].(string)
 
-		app := &compute.VMGalleryApplication{
-			PackageReferenceID:     utils.String(packageReferenceId),
-			ConfigurationReference: utils.String(configurationReference),
-			Order:                  utils.Int32(int32(order)),
-			Tags:                   utils.String(tag),
+		app := &virtualmachinescalesets.VMGalleryApplication{
+			PackageReferenceId:     packageReferenceId,
+			ConfigurationReference: pointer.To(configurationReference),
+			Order:                  pointer.To(int64(order)),
+			Tags:                   pointer.To(tag),
 		}
 
 		out = append(out, *app)
@@ -346,12 +348,12 @@ func flattenVirtualMachineScaleSetGalleryApplication(input *[]compute.VMGalleryA
 	return out
 }
 
-func expandVirtualMachineScaleSetGalleryApplications(input []interface{}) *[]compute.VMGalleryApplication {
+func expandVirtualMachineScaleSetGalleryApplications(input []interface{}) *[]virtualmachinescalesets.VMGalleryApplication {
 	if len(input) == 0 {
 		return nil
 	}
 
-	out := make([]compute.VMGalleryApplication, 0)
+	out := make([]virtualmachinescalesets.VMGalleryApplication, 0)
 
 	for _, v := range input {
 		packageReferenceId := v.(map[string]interface{})["package_reference_id"].(string)
@@ -359,11 +361,11 @@ func expandVirtualMachineScaleSetGalleryApplications(input []interface{}) *[]com
 		order := v.(map[string]interface{})["order"].(int)
 		tag := v.(map[string]interface{})["tag"].(string)
 
-		app := &compute.VMGalleryApplication{
-			PackageReferenceID:     utils.String(packageReferenceId),
-			ConfigurationReference: utils.String(configurationReference),
-			Order:                  utils.Int32(int32(order)),
-			Tags:                   utils.String(tag),
+		app := &virtualmachinescalesets.VMGalleryApplication{
+			PackageReferenceId:     packageReferenceId,
+			ConfigurationReference: pointer.To(configurationReference),
+			Order:                  pointer.To(int64(order)),
+			Tags:                   pointer.To(tag),
 		}
 
 		out = append(out, *app)
@@ -470,7 +472,7 @@ func VirtualMachineScaleSetScaleInPolicySchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetScaleInPolicy(input []interface{}) *compute.ScaleInPolicy {
+func ExpandVirtualMachineScaleSetScaleInPolicy(input []interface{}) *virtualmachinescalesets.ScaleInPolicy {
 	if len(input) == 0 {
 		return nil
 	}
@@ -478,9 +480,9 @@ func ExpandVirtualMachineScaleSetScaleInPolicy(input []interface{}) *compute.Sca
 	rule := input[0].(map[string]interface{})["rule"].(string)
 	forceDeletion := input[0].(map[string]interface{})["force_deletion_enabled"].(bool)
 
-	return &compute.ScaleInPolicy{
-		Rules:         &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(rule)},
-		ForceDeletion: utils.Bool(forceDeletion),
+	return &virtualmachinescalesets.ScaleInPolicy{
+		Rules:         &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(rule)},
+		ForceDeletion: pointer.To(forceDeletion),
 	}
 }
 
@@ -534,7 +536,7 @@ func VirtualMachineScaleSetSpotRestorePolicySchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetSpotRestorePolicy(input []interface{}) *compute.SpotRestorePolicy {
+func ExpandVirtualMachineScaleSetSpotRestorePolicy(input []interface{}) *virtualmachinescalesets.SpotRestorePolicy {
 	if len(input) == 0 {
 		return nil
 	}
@@ -542,9 +544,9 @@ func ExpandVirtualMachineScaleSetSpotRestorePolicy(input []interface{}) *compute
 	enabled := input[0].(map[string]interface{})["enabled"].(bool)
 	timeout := input[0].(map[string]interface{})["timeout"].(string)
 
-	return &compute.SpotRestorePolicy{
-		Enabled:        utils.Bool(enabled),
-		RestoreTimeout: utils.String(timeout),
+	return &virtualmachinescalesets.SpotRestorePolicy{
+		Enabled:        pointer.To(enabled),
+		RestoreTimeout: pointer.To(timeout),
 	}
 }
 
@@ -872,15 +874,15 @@ func virtualMachineScaleSetPublicIPAddressSchemaForDataSource() *pluginsdk.Schem
 	}
 }
 
-func ExpandVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compute.VirtualMachineScaleSetNetworkConfiguration, error) {
-	output := make([]compute.VirtualMachineScaleSetNetworkConfiguration, 0)
+func ExpandVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration, error) {
+	output := make([]virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
 		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
 
-		ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0)
+		ipConfigurations := make([]virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration, 0)
 		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
 		for _, configV := range ipConfigurationsRaw {
 			configRaw := configV.(map[string]interface{})
@@ -892,22 +894,22 @@ func ExpandVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compu
 			ipConfigurations = append(ipConfigurations, *ipConfiguration)
 		}
 
-		config := compute.VirtualMachineScaleSetNetworkConfiguration{
-			Name: utils.String(raw["name"].(string)),
-			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
-					DNSServers: dnsServers,
+		config := virtualmachinescalesets.VirtualMachineScaleSetNetworkConfiguration{
+			Name: raw["name"].(string),
+			Properties: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationProperties{
+				DnsSettings: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationDnsSettings{
+					DnsServers: dnsServers,
 				},
-				EnableAcceleratedNetworking: utils.Bool(raw["enable_accelerated_networking"].(bool)),
-				EnableIPForwarding:          utils.Bool(raw["enable_ip_forwarding"].(bool)),
-				IPConfigurations:            &ipConfigurations,
-				Primary:                     utils.Bool(raw["primary"].(bool)),
+				EnableAcceleratedNetworking: pointer.To(raw["enable_accelerated_networking"].(bool)),
+				EnableIPForwarding:          pointer.To(raw["enable_ip_forwarding"].(bool)),
+				IPConfigurations:            ipConfigurations,
+				Primary:                     pointer.To(raw["primary"].(bool)),
 			},
 		}
 
 		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
-			config.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
-				ID: utils.String(nsgId),
+			config.Properties.NetworkSecurityGroup = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(nsgId),
 			}
 		}
 
@@ -917,7 +919,7 @@ func ExpandVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compu
 	return &output, nil
 }
 
-func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*compute.VirtualMachineScaleSetIPConfiguration, error) {
+func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration, error) {
 	applicationGatewayBackendAddressPoolIdsRaw := raw["application_gateway_backend_address_pool_ids"].(*pluginsdk.Set).List()
 	applicationGatewayBackendAddressPoolIds := expandIDsToSubResources(applicationGatewayBackendAddressPoolIdsRaw)
 
@@ -931,16 +933,16 @@ func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*c
 	loadBalancerInboundNatPoolIds := expandIDsToSubResources(loadBalancerInboundNatPoolIdsRaw)
 
 	primary := raw["primary"].(bool)
-	version := compute.IPVersion(raw["version"].(string))
-	if primary && version == compute.IPVersionIPv6 {
+	version := virtualmachinescalesets.IPVersion(raw["version"].(string))
+	if primary && version == virtualmachinescalesets.IPVersionIPvSix {
 		return nil, fmt.Errorf("an IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary")
 	}
 
-	ipConfiguration := compute.VirtualMachineScaleSetIPConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-			Primary:                               utils.Bool(primary),
-			PrivateIPAddressVersion:               version,
+	ipConfiguration := virtualmachinescalesets.VirtualMachineScaleSetIPConfiguration{
+		Name: raw["name"].(string),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetIPConfigurationProperties{
+			Primary:                               pointer.To(primary),
+			PrivateIPAddressVersion:               pointer.To(version),
 			ApplicationGatewayBackendAddressPools: applicationGatewayBackendAddressPoolIds,
 			ApplicationSecurityGroups:             applicationSecurityGroupIds,
 			LoadBalancerBackendAddressPools:       loadBalancerBackendAddressPoolIds,
@@ -949,8 +951,8 @@ func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*c
 	}
 
 	if subnetId := raw["subnet_id"].(string); subnetId != "" {
-		ipConfiguration.VirtualMachineScaleSetIPConfigurationProperties.Subnet = &compute.APIEntityReference{
-			ID: utils.String(subnetId),
+		ipConfiguration.Properties.Subnet = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(subnetId),
 		}
 	}
 
@@ -958,61 +960,60 @@ func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*c
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
-		ipConfiguration.VirtualMachineScaleSetIPConfigurationProperties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
 	}
 
 	return &ipConfiguration, nil
 }
 
-func expandVirtualMachineScaleSetPublicIPAddress(raw map[string]interface{}) *compute.VirtualMachineScaleSetPublicIPAddressConfiguration {
-	version := compute.IPVersion(raw["version"].(string))
+func expandVirtualMachineScaleSetPublicIPAddress(raw map[string]interface{}) *virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration {
 	ipTagsRaw := raw["ip_tag"].([]interface{})
-	ipTags := make([]compute.VirtualMachineScaleSetIPTag, 0)
+	ipTags := make([]virtualmachinescalesets.VirtualMachineScaleSetIPTag, 0)
 	for _, ipTagV := range ipTagsRaw {
 		ipTagRaw := ipTagV.(map[string]interface{})
-		ipTags = append(ipTags, compute.VirtualMachineScaleSetIPTag{
-			Tag:       utils.String(ipTagRaw["tag"].(string)),
-			IPTagType: utils.String(ipTagRaw["type"].(string)),
+		ipTags = append(ipTags, virtualmachinescalesets.VirtualMachineScaleSetIPTag{
+			Tag:       pointer.To(ipTagRaw["tag"].(string)),
+			IPTagType: pointer.To(ipTagRaw["type"].(string)),
 		})
 	}
 
-	publicIPAddressConfig := compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetPublicIPAddressConfigurationProperties: &compute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
+	publicIPAddressConfig := virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfiguration{
+		Name: raw["name"].(string),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
 			IPTags:                 &ipTags,
-			PublicIPAddressVersion: version,
+			PublicIPAddressVersion: pointer.To(virtualmachinescalesets.IPVersion(raw["version"].(string))),
 		},
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &compute.VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings{
-			DomainNameLabel: utils.String(domainNameLabel),
+		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.DNSSettings = dns
+		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.IdleTimeoutInMinutes = utils.Int32(int32(raw["idle_timeout_in_minutes"].(int)))
+		publicIPAddressConfig.Properties.IdleTimeoutInMinutes = pointer.To(int64(raw["idle_timeout_in_minutes"].(int)))
 	}
 
 	if publicIPPrefixID := raw["public_ip_prefix_id"].(string); publicIPPrefixID != "" {
-		publicIPAddressConfig.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.PublicIPPrefix = &compute.SubResource{
-			ID: utils.String(publicIPPrefixID),
+		publicIPAddressConfig.Properties.PublicIPPrefix = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(publicIPPrefixID),
 		}
 	}
 
 	return &publicIPAddressConfig
 }
 
-func ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
-	output := make([]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, 0)
+func ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[]virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
+	output := make([]virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
 		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
 
-		ipConfigurations := make([]compute.VirtualMachineScaleSetUpdateIPConfiguration, 0)
+		ipConfigurations := make([]virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration, 0)
 		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
 		for _, configV := range ipConfigurationsRaw {
 			configRaw := configV.(map[string]interface{})
@@ -1024,22 +1025,22 @@ func ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[
 			ipConfigurations = append(ipConfigurations, *ipConfiguration)
 		}
 
-		config := compute.VirtualMachineScaleSetUpdateNetworkConfiguration{
-			Name: utils.String(raw["name"].(string)),
-			VirtualMachineScaleSetUpdateNetworkConfigurationProperties: &compute.VirtualMachineScaleSetUpdateNetworkConfigurationProperties{
-				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
-					DNSServers: dnsServers,
+		config := virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfiguration{
+			Name: pointer.To(raw["name"].(string)),
+			Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkConfigurationProperties{
+				DnsSettings: &virtualmachinescalesets.VirtualMachineScaleSetNetworkConfigurationDnsSettings{
+					DnsServers: dnsServers,
 				},
-				EnableAcceleratedNetworking: utils.Bool(raw["enable_accelerated_networking"].(bool)),
-				EnableIPForwarding:          utils.Bool(raw["enable_ip_forwarding"].(bool)),
+				EnableAcceleratedNetworking: pointer.To(raw["enable_accelerated_networking"].(bool)),
+				EnableIPForwarding:          pointer.To(raw["enable_ip_forwarding"].(bool)),
 				IPConfigurations:            &ipConfigurations,
-				Primary:                     utils.Bool(raw["primary"].(bool)),
+				Primary:                     pointer.To(raw["primary"].(bool)),
 			},
 		}
 
 		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
-			config.VirtualMachineScaleSetUpdateNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
-				ID: utils.String(nsgId),
+			config.Properties.NetworkSecurityGroup = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(nsgId),
 			}
 		}
 
@@ -1049,7 +1050,7 @@ func ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[
 	return &output, nil
 }
 
-func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{}) (*compute.VirtualMachineScaleSetUpdateIPConfiguration, error) {
+func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{}) (*virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration, error) {
 	applicationGatewayBackendAddressPoolIdsRaw := raw["application_gateway_backend_address_pool_ids"].(*pluginsdk.Set).List()
 	applicationGatewayBackendAddressPoolIds := expandIDsToSubResources(applicationGatewayBackendAddressPoolIdsRaw)
 
@@ -1063,17 +1064,17 @@ func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{
 	loadBalancerInboundNatPoolIds := expandIDsToSubResources(loadBalancerInboundNatPoolIdsRaw)
 
 	primary := raw["primary"].(bool)
-	version := compute.IPVersion(raw["version"].(string))
+	version := virtualmachinescalesets.IPVersion(raw["version"].(string))
 
-	if primary && version == compute.IPVersionIPv6 {
+	if primary && version == virtualmachinescalesets.IPVersionIPvSix {
 		return nil, fmt.Errorf("an IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary")
 	}
 
-	ipConfiguration := compute.VirtualMachineScaleSetUpdateIPConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetUpdateIPConfigurationProperties: &compute.VirtualMachineScaleSetUpdateIPConfigurationProperties{
-			Primary:                               utils.Bool(primary),
-			PrivateIPAddressVersion:               version,
+	ipConfiguration := virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfiguration{
+		Name: pointer.To(raw["name"].(string)),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdateIPConfigurationProperties{
+			Primary:                               pointer.To(primary),
+			PrivateIPAddressVersion:               pointer.To(version),
 			ApplicationGatewayBackendAddressPools: applicationGatewayBackendAddressPoolIds,
 			ApplicationSecurityGroups:             applicationSecurityGroupIds,
 			LoadBalancerBackendAddressPools:       loadBalancerBackendAddressPoolIds,
@@ -1082,8 +1083,8 @@ func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{
 	}
 
 	if subnetId := raw["subnet_id"].(string); subnetId != "" {
-		ipConfiguration.VirtualMachineScaleSetUpdateIPConfigurationProperties.Subnet = &compute.APIEntityReference{
-			ID: utils.String(subnetId),
+		ipConfiguration.Properties.Subnet = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(subnetId),
 		}
 	}
 
@@ -1091,32 +1092,32 @@ func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
-		ipConfiguration.VirtualMachineScaleSetUpdateIPConfigurationProperties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
 	}
 
 	return &ipConfiguration, nil
 }
 
-func expandVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{}) *compute.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration {
-	publicIPAddressConfig := compute.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration{
-		Name: utils.String(raw["name"].(string)),
-		VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties: &compute.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties{},
+func expandVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{}) *virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration {
+	publicIPAddressConfig := virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfiguration{
+		Name:       pointer.To(raw["name"].(string)),
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties{},
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &compute.VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings{
-			DomainNameLabel: utils.String(domainNameLabel),
+		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.DNSSettings = dns
+		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
-		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.IdleTimeoutInMinutes = utils.Int32(int32(raw["idle_timeout_in_minutes"].(int)))
+		publicIPAddressConfig.Properties.IdleTimeoutInMinutes = pointer.To(int64(raw["idle_timeout_in_minutes"].(int)))
 	}
 
 	if publicIPPrefixID := raw["public_ip_prefix_id"].(string); publicIPPrefixID != "" {
-		publicIPAddressConfig.VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties.PublicIPPrefix = &compute.SubResource{
-			ID: utils.String(publicIPPrefixID),
+		publicIPAddressConfig.Properties.PublicIPPrefix = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(publicIPPrefixID),
 		}
 	}
 
@@ -1360,31 +1361,31 @@ func VirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled bool) (*[]compute.VirtualMachineScaleSetDataDisk, error) {
-	disks := make([]compute.VirtualMachineScaleSetDataDisk, 0)
+func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled bool) (*[]virtualmachinescalesets.VirtualMachineScaleSetDataDisk, error) {
+	disks := make([]virtualmachinescalesets.VirtualMachineScaleSetDataDisk, 0)
 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 
-		storageAccountType := compute.StorageAccountTypes(raw["storage_account_type"].(string))
-		disk := compute.VirtualMachineScaleSetDataDisk{
-			Caching:    compute.CachingTypes(raw["caching"].(string)),
-			DiskSizeGB: utils.Int32(int32(raw["disk_size_gb"].(int))),
-			Lun:        utils.Int32(int32(raw["lun"].(int))),
-			ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-				StorageAccountType: storageAccountType,
+		storageAccountType := virtualmachinescalesets.StorageAccountTypes(raw["storage_account_type"].(string))
+		disk := virtualmachinescalesets.VirtualMachineScaleSetDataDisk{
+			Caching:    pointer.To(virtualmachinescalesets.CachingTypes(raw["caching"].(string))),
+			DiskSizeGB: pointer.To(int64(raw["disk_size_gb"].(int))),
+			Lun:        int64(raw["lun"].(int)),
+			ManagedDisk: &virtualmachinescalesets.VirtualMachineScaleSetManagedDiskParameters{
+				StorageAccountType: pointer.To(storageAccountType),
 			},
-			WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
-			CreateOption:            compute.DiskCreateOptionTypes(raw["create_option"].(string)),
+			WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
+			CreateOption:            virtualmachinescalesets.DiskCreateOptionTypes(raw["create_option"].(string)),
 		}
 
 		if name := raw["name"]; name != nil && name.(string) != "" {
-			disk.Name = utils.String(name.(string))
+			disk.Name = pointer.To(name.(string))
 		}
 
 		if id := raw["disk_encryption_set_id"].(string); id != "" {
-			disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-				ID: utils.String(id),
+			disk.ManagedDisk.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+				Id: pointer.To(id),
 			}
 		}
 
@@ -1393,7 +1394,7 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 			iops = diskIops.(int)
 		}
 
-		if iops > 0 && !ultraSSDEnabled && storageAccountType != compute.StorageAccountTypesPremiumV2LRS {
+		if iops > 0 && !ultraSSDEnabled && storageAccountType != virtualmachinescalesets.StorageAccountTypesPremiumVTwoLRS {
 			return nil, fmt.Errorf("`ultra_ssd_disk_iops_read_write` can only be set when `storage_account_type` is set to `PremiumV2_LRS` or `UltraSSD_LRS`")
 		}
 
@@ -1402,18 +1403,18 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 			mbps = diskMbps.(int)
 		}
 
-		if mbps > 0 && !ultraSSDEnabled && storageAccountType != compute.StorageAccountTypesPremiumV2LRS {
+		if mbps > 0 && !ultraSSDEnabled && storageAccountType != virtualmachinescalesets.StorageAccountTypesPremiumVTwoLRS {
 			return nil, fmt.Errorf("`ultra_ssd_disk_mbps_read_write` can only be set when `storage_account_type` is set to `PremiumV2_LRS` or `UltraSSD_LRS`")
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if iops > 0 {
-			disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
+			disk.DiskIOPSReadWrite = pointer.To(int64(iops))
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if mbps > 0 {
-			disk.DiskMBpsReadWrite = utils.Int64(int64(mbps))
+			disk.DiskMBpsReadWrite = pointer.To(int64(mbps))
 		}
 
 		disks = append(disks, disk)
@@ -1595,56 +1596,56 @@ func VirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetOSDisk(input []interface{}, osType compute.OperatingSystemTypes) (*compute.VirtualMachineScaleSetOSDisk, error) {
+func ExpandVirtualMachineScaleSetOSDisk(input []interface{}, osType virtualmachinescalesets.OperatingSystemTypes) (*virtualmachinescalesets.VirtualMachineScaleSetOSDisk, error) {
 	raw := input[0].(map[string]interface{})
 	caching := raw["caching"].(string)
-	disk := compute.VirtualMachineScaleSetOSDisk{
-		Caching: compute.CachingTypes(caching),
-		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
-			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+	disk := virtualmachinescalesets.VirtualMachineScaleSetOSDisk{
+		Caching: pointer.To(virtualmachinescalesets.CachingTypes(caching)),
+		ManagedDisk: &virtualmachinescalesets.VirtualMachineScaleSetManagedDiskParameters{
+			StorageAccountType: pointer.To(virtualmachinescalesets.StorageAccountTypes(raw["storage_account_type"].(string))),
 		},
-		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+		WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
 
 		// these have to be hard-coded so there's no point exposing them
-		CreateOption: compute.DiskCreateOptionTypesFromImage,
-		OsType:       osType,
+		CreateOption: virtualmachinescalesets.DiskCreateOptionTypesFromImage,
+		OsType:       pointer.To(osType),
 	}
 
 	securityEncryptionType := raw["security_encryption_type"].(string)
 	if securityEncryptionType != "" {
-		disk.ManagedDisk.SecurityProfile = &compute.VMDiskSecurityProfile{
-			SecurityEncryptionType: compute.SecurityEncryptionTypes(securityEncryptionType),
+		disk.ManagedDisk.SecurityProfile = &virtualmachinescalesets.VMDiskSecurityProfile{
+			SecurityEncryptionType: pointer.To(virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType)),
 		}
 	}
 	if secureVMDiskEncryptionId := raw["secure_vm_disk_encryption_set_id"].(string); secureVMDiskEncryptionId != "" {
-		if compute.SecurityEncryptionTypesDiskWithVMGuestState != compute.SecurityEncryptionTypes(securityEncryptionType) {
+		if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState != virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) {
 			return nil, fmt.Errorf("`secure_vm_disk_encryption_set_id` can only be specified when `security_encryption_type` is set to `DiskWithVMGuestState`")
 		}
-		disk.ManagedDisk.SecurityProfile.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-			ID: utils.String(secureVMDiskEncryptionId),
+		disk.ManagedDisk.SecurityProfile.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(secureVMDiskEncryptionId),
 		}
 	}
 
 	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
-		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-			ID: utils.String(diskEncryptionSetId),
+		disk.ManagedDisk.DiskEncryptionSet = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(diskEncryptionSetId),
 		}
 	}
 
 	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
-		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+		disk.DiskSizeGB = pointer.To(int64(osDiskSize))
 	}
 
 	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 {
-		if caching != string(compute.CachingTypesReadOnly) {
+		if caching != string(virtualmachinescalesets.CachingTypesReadOnly) {
 			// Restriction per https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment
 			return nil, fmt.Errorf("`diff_disk_settings` can only be set when `caching` is set to `ReadOnly`")
 		}
 
 		diffDiskRaw := diffDiskSettingsRaw[0].(map[string]interface{})
-		disk.DiffDiskSettings = &compute.DiffDiskSettings{
-			Option:    compute.DiffDiskOptions(diffDiskRaw["option"].(string)),
-			Placement: compute.DiffDiskPlacement(diffDiskRaw["placement"].(string)),
+		disk.DiffDiskSettings = &virtualmachinescalesets.DiffDiskSettings{
+			Option:    pointer.To(virtualmachinescalesets.DiffDiskOptions(diffDiskRaw["option"].(string))),
+			Placement: pointer.To(virtualmachinescalesets.DiffDiskPlacement(diffDiskRaw["placement"].(string))),
 		}
 	}
 
@@ -1658,17 +1659,17 @@ func ExpandVirtualMachineScaleSetOSDiskUpdate(input []interface{}) *compute.Virt
 		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
 			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
 		},
-		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+		WriteAcceleratorEnabled: pointer.To(raw["write_accelerator_enabled"].(bool)),
 	}
 
 	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
 		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
-			ID: utils.String(diskEncryptionSetId),
+			ID: pointer.To(diskEncryptionSetId),
 		}
 	}
 
 	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
-		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+		disk.DiskSizeGB = pointer.To(int32(osDiskSize))
 	}
 
 	return &disk
@@ -1751,15 +1752,15 @@ func VirtualMachineScaleSetAutomatedOSUpgradePolicySchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(input []interface{}) *compute.AutomaticOSUpgradePolicy {
+func ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(input []interface{}) *virtualmachinescalesets.AutomaticOSUpgradePolicy {
 	if len(input) == 0 {
 		return nil
 	}
 
 	raw := input[0].(map[string]interface{})
-	return &compute.AutomaticOSUpgradePolicy{
-		DisableAutomaticRollback: utils.Bool(raw["disable_automatic_rollback"].(bool)),
-		EnableAutomaticOSUpgrade: utils.Bool(raw["enable_automatic_os_upgrade"].(bool)),
+	return &virtualmachinescalesets.AutomaticOSUpgradePolicy{
+		DisableAutomaticRollback: pointer.To(raw["disable_automatic_rollback"].(bool)),
+		EnableAutomaticOSUpgrade: pointer.To(raw["enable_automatic_os_upgrade"].(bool)),
 	}
 }
 
@@ -1824,25 +1825,25 @@ func VirtualMachineScaleSetRollingUpgradePolicySchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetRollingUpgradePolicy(input []interface{}, isZonal bool) (*compute.RollingUpgradePolicy, error) {
+func ExpandVirtualMachineScaleSetRollingUpgradePolicy(input []interface{}, isZonal bool) (*virtualmachinescalesets.RollingUpgradePolicy, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
 
 	raw := input[0].(map[string]interface{})
 
-	rollingUpgradePolicy := &compute.RollingUpgradePolicy{
-		MaxBatchInstancePercent:             utils.Int32(int32(raw["max_batch_instance_percent"].(int))),
-		MaxUnhealthyInstancePercent:         utils.Int32(int32(raw["max_unhealthy_instance_percent"].(int))),
-		MaxUnhealthyUpgradedInstancePercent: utils.Int32(int32(raw["max_unhealthy_upgraded_instance_percent"].(int))),
-		PauseTimeBetweenBatches:             utils.String(raw["pause_time_between_batches"].(string)),
-		PrioritizeUnhealthyInstances:        utils.Bool(raw["prioritize_unhealthy_instances_enabled"].(bool)),
+	rollingUpgradePolicy := &virtualmachinescalesets.RollingUpgradePolicy{
+		MaxBatchInstancePercent:             pointer.To(int64(raw["max_batch_instance_percent"].(int))),
+		MaxUnhealthyInstancePercent:         pointer.To(int64(raw["max_unhealthy_instance_percent"].(int))),
+		MaxUnhealthyUpgradedInstancePercent: pointer.To(int64(raw["max_unhealthy_upgraded_instance_percent"].(int))),
+		PauseTimeBetweenBatches:             pointer.To(raw["pause_time_between_batches"].(string)),
+		PrioritizeUnhealthyInstances:        pointer.To(raw["prioritize_unhealthy_instances_enabled"].(bool)),
 	}
 
 	enableCrossZoneUpgrade := raw["cross_zone_upgrades_enabled"].(bool)
 	if isZonal {
 		// EnableCrossZoneUpgrade can only be set when for zonal scale set
-		rollingUpgradePolicy.EnableCrossZoneUpgrade = utils.Bool(enableCrossZoneUpgrade)
+		rollingUpgradePolicy.EnableCrossZoneUpgrade = pointer.To(enableCrossZoneUpgrade)
 	} else if enableCrossZoneUpgrade {
 		return nil, fmt.Errorf("`rolling_upgrade_policy.0.cross_zone_upgrades_enabled` can only be set to `true` when `zones` is specified")
 	}
@@ -1952,7 +1953,7 @@ func VirtualMachineScaleSetTerminationNotificationSchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *compute.ScheduledEventsProfile {
+func ExpandVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *virtualmachinescalesets.ScheduledEventsProfile {
 	if len(input) == 0 {
 		return nil
 	}
@@ -1961,8 +1962,8 @@ func ExpandVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *co
 	enabled := raw["enabled"].(bool)
 	timeout := raw["timeout"].(string)
 
-	return &compute.ScheduledEventsProfile{
-		TerminateNotificationProfile: &compute.TerminateNotificationProfile{
+	return &virtualmachinescalesets.ScheduledEventsProfile{
+		TerminateNotificationProfile: &virtualmachinescalesets.TerminateNotificationProfile{
 			Enable:           &enabled,
 			NotBeforeTimeout: &timeout,
 		},
@@ -2015,16 +2016,16 @@ func VirtualMachineScaleSetAutomaticRepairsPolicySchema() *pluginsdk.Schema {
 	}
 }
 
-func ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(input []interface{}) *compute.AutomaticRepairsPolicy {
+func ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(input []interface{}) *virtualmachinescalesets.AutomaticRepairsPolicy {
 	if len(input) == 0 {
 		return nil
 	}
 
 	raw := input[0].(map[string]interface{})
 
-	return &compute.AutomaticRepairsPolicy{
-		Enabled:     utils.Bool(raw["enabled"].(bool)),
-		GracePeriod: utils.String(raw["grace_period"].(string)),
+	return &virtualmachinescalesets.AutomaticRepairsPolicy{
+		Enabled:     pointer.To(raw["enabled"].(bool)),
+		GracePeriod: pointer.To(raw["grace_period"].(string)),
 	}
 }
 
@@ -2182,26 +2183,26 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 	return pluginsdk.HashString(buf.String())
 }
 
-func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *compute.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
-	extensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
+	extensionProfile = &virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile{}
 	if len(input) == 0 {
 		return extensionProfile, false, nil
 	}
 
-	extensions := make([]compute.VirtualMachineScaleSetExtension, 0)
+	extensions := make([]virtualmachinescalesets.VirtualMachineScaleSetExtension, 0)
 	for _, v := range input {
 		extensionRaw := v.(map[string]interface{})
-		extension := compute.VirtualMachineScaleSetExtension{
-			Name: utils.String(extensionRaw["name"].(string)),
+		extension := virtualmachinescalesets.VirtualMachineScaleSetExtension{
+			Name: pointer.To(extensionRaw["name"].(string)),
 		}
 		extensionType := extensionRaw["type"].(string)
 
-		extensionProps := compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:                utils.String(extensionRaw["publisher"].(string)),
+		extensionProps := virtualmachinescalesets.VirtualMachineScaleSetExtensionProperties{
+			Publisher:                pointer.To(extensionRaw["publisher"].(string)),
 			Type:                     &extensionType,
-			TypeHandlerVersion:       utils.String(extensionRaw["type_handler_version"].(string)),
-			AutoUpgradeMinorVersion:  utils.Bool(extensionRaw["auto_upgrade_minor_version"].(bool)),
-			EnableAutomaticUpgrade:   utils.Bool(extensionRaw["automatic_upgrade_enabled"].(bool)),
+			TypeHandlerVersion:       pointer.To(extensionRaw["type_handler_version"].(string)),
+			AutoUpgradeMinorVersion:  pointer.To(extensionRaw["auto_upgrade_minor_version"].(bool)),
+			EnableAutomaticUpgrade:   pointer.To(extensionRaw["automatic_upgrade_enabled"].(bool)),
 			ProvisionAfterExtensions: utils.ExpandStringSlice(extensionRaw["provision_after_extensions"].([]interface{})),
 		}
 
@@ -2210,15 +2211,16 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfi
 		}
 
 		if forceUpdateTag := extensionRaw["force_update_tag"]; forceUpdateTag != nil {
-			extensionProps.ForceUpdateTag = utils.String(forceUpdateTag.(string))
+			extensionProps.ForceUpdateTag = pointer.To(forceUpdateTag.(string))
 		}
 
 		if val, ok := extensionRaw["settings"]; ok && val.(string) != "" {
-			settings, err := pluginsdk.ExpandJsonFromString(val.(string))
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse JSON from `settings`: %+v", err)
-			}
-			extensionProps.Settings = settings
+			// TODO
+			//settings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			//if err != nil {
+			//	return nil, false, fmt.Errorf("failed to parse JSON from `settings`: %+v", err)
+			//}
+			extensionProps.Settings = pointer.To(val)
 		}
 
 		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVault(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
@@ -2229,14 +2231,15 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfi
 				return nil, false, fmt.Errorf("`protected_settings_from_key_vault` cannot be used with `protected_settings`")
 			}
 
-			protectedSettings, err := pluginsdk.ExpandJsonFromString(val.(string))
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse JSON from `protected_settings`: %+v", err)
-			}
-			extensionProps.ProtectedSettings = protectedSettings
+			// TODO
+			//protectedSettings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			//if err != nil {
+			//	return nil, false, fmt.Errorf("failed to parse JSON from `protected_settings`: %+v", err)
+			//}
+			extensionProps.ProtectedSettings = pointer.To(val)
 		}
 
-		extension.VirtualMachineScaleSetExtensionProperties = &extensionProps
+		extension.Properties = &extensionProps
 		extensions = append(extensions, extension)
 	}
 	extensionProfile.Extensions = &extensions
@@ -2344,4 +2347,127 @@ func flattenVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleS
 		})
 	}
 	return result, nil
+}
+
+func expandSSHKeys(input []interface{}) []virtualmachinescalesets.SshPublicKey {
+	output := make([]virtualmachinescalesets.SshPublicKey, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		username := raw["username"].(string)
+		output = append(output, virtualmachinescalesets.SshPublicKey{
+			KeyData: utils.String(raw["public_key"].(string)),
+			Path:    utils.String(formatUsernameForAuthorizedKeysPath(username)),
+		})
+	}
+
+	return output
+}
+
+func expandLinuxSecretsVMSS(input []interface{}) *[]virtualmachinescalesets.VaultSecretGroup {
+	output := make([]virtualmachinescalesets.VaultSecretGroup, 0)
+
+	for _, raw := range input {
+		v := raw.(map[string]interface{})
+
+		keyVaultId := v["key_vault_id"].(string)
+		certificatesRaw := v["certificate"].(*pluginsdk.Set).List()
+		certificates := make([]virtualmachinescalesets.VaultCertificate, 0)
+		for _, certificateRaw := range certificatesRaw {
+			certificateV := certificateRaw.(map[string]interface{})
+
+			url := certificateV["url"].(string)
+			certificates = append(certificates, virtualmachinescalesets.VaultCertificate{
+				CertificateUrl: pointer.To(url),
+			})
+		}
+
+		output = append(output, virtualmachinescalesets.VaultSecretGroup{
+			SourceVault: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(keyVaultId),
+			},
+			VaultCertificates: &certificates,
+		})
+	}
+
+	return &output
+}
+
+func expandBootDiagnosticsVMSS(input []interface{}) *virtualmachinescalesets.DiagnosticsProfile {
+	if len(input) == 0 {
+		return &virtualmachinescalesets.DiagnosticsProfile{
+			BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+				Enabled:    pointer.To(false),
+				StorageUri: pointer.To(""),
+			},
+		}
+	}
+
+	// this serves the managed boot diagnostics, in this case we only have this empty block without `storage_account_uri` set
+	if input[0] == nil {
+		return &virtualmachinescalesets.DiagnosticsProfile{
+			BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+				Enabled:    pointer.To(true),
+				StorageUri: pointer.To(""),
+			},
+		}
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	storageAccountUri := raw["storage_account_uri"].(string)
+
+	return &virtualmachinescalesets.DiagnosticsProfile{
+		BootDiagnostics: &virtualmachinescalesets.BootDiagnostics{
+			Enabled:    pointer.To(true),
+			StorageUri: pointer.To(storageAccountUri),
+		},
+	}
+}
+
+func expandSourceImageReferenceVMSS(referenceInput []interface{}, imageId string) *virtualmachinescalesets.ImageReference {
+	if imageId != "" {
+		// With Version            : "/communityGalleries/publicGalleryName/images/myGalleryImageName/versions/(major.minor.patch | latest)"
+		// Versionless(e.g. latest): "/communityGalleries/publicGalleryName/images/myGalleryImageName"
+		if _, errors := validation.Any(validate.CommunityGalleryImageID, validate.CommunityGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
+			return &virtualmachinescalesets.ImageReference{
+				CommunityGalleryImageId: pointer.To(imageId),
+			}
+		}
+
+		// With Version            : "/sharedGalleries/galleryUniqueName/images/myGalleryImageName/versions/(major.minor.patch | latest)"
+		// Versionless(e.g. latest): "/sharedGalleries/galleryUniqueName/images/myGalleryImageName"
+		if _, errors := validation.Any(validate.SharedGalleryImageID, validate.SharedGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
+			return &virtualmachinescalesets.ImageReference{
+				SharedGalleryImageId: pointer.To(imageId),
+			}
+		}
+
+		return &virtualmachinescalesets.ImageReference{
+			Id: pointer.To(imageId),
+		}
+	}
+
+	raw := referenceInput[0].(map[string]interface{})
+	return &virtualmachinescalesets.ImageReference{
+		Publisher: pointer.To(raw["publisher"].(string)),
+		Offer:     pointer.To(raw["offer"].(string)),
+		Sku:       pointer.To(raw["sku"].(string)),
+		Version:   pointer.To(raw["version"].(string)),
+	}
+}
+
+func expandPlanVMSS(input []interface{}) *virtualmachinescalesets.Plan {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	return &virtualmachinescalesets.Plan{
+		Name:      pointer.To(raw["name"].(string)),
+		Product:   pointer.To(raw["product"].(string)),
+		Publisher: pointer.To(raw["publisher"].(string)),
+	}
 }

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplicationversions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/applicationsecuritygroups"
@@ -2264,4 +2265,23 @@ func flattenVirtualMachineScaleSetExtensions(input *virtualmachinescalesets.Virt
 		})
 	}
 	return result, nil
+}
+
+func flattenOrchestratedVirtualMachineScaleSetIdentity(input *identity.SystemAndUserAssignedMap) (*[]interface{}, error) {
+	var transform *identity.UserAssignedMap
+
+	if input != nil {
+		transform = &identity.UserAssignedMap{
+			Type:        input.Type,
+			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
+		}
+		for k, v := range input.IdentityIds {
+			transform.IdentityIds[k] = identity.UserAssignedIdentityDetails{
+				ClientId:    v.ClientId,
+				PrincipalId: v.PrincipalId,
+			}
+		}
+	}
+
+	return identity.FlattenUserAssignedMap(transform)
 }

--- a/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -10,16 +10,19 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
@@ -119,95 +122,92 @@ func dataSourceVirtualMachineScaleSet() *pluginsdk.Resource {
 }
 
 func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
-	instancesClient := meta.(*clients.Client).Compute.VMScaleSetVMsClient
-	vmClient := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
+	instancesClient := meta.(*clients.Client).Compute.VirtualMachineScaleSetVMsClient
+	virtualMachinesClient := meta.(*clients.Client).Compute.VirtualMachinesClient
 	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
 	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := commonids.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	resp, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 
-		return fmt.Errorf("making Read request on %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("reading %s: ID is empty or nil", id)
-	}
 	d.SetId(id.ID())
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
 
-	if profile := resp.VirtualMachineProfile; profile != nil {
-		if nwProfile := profile.NetworkProfile; nwProfile != nil {
-			flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
-			if err := d.Set("network_interface", flattenedNics); err != nil {
-				return fmt.Errorf("setting `network_interface`: %+v", err)
+		identityFlattened, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		if err := d.Set("identity", identityFlattened); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
+
+		if props := model.Properties; props != nil {
+			if profile := props.VirtualMachineProfile; profile != nil {
+				if nwProfile := profile.NetworkProfile; nwProfile != nil {
+					flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+					if err := d.Set("network_interface", flattenedNics); err != nil {
+						return fmt.Errorf("setting `network_interface`: %+v", err)
+					}
+				}
 			}
 		}
 	}
 
-	identity, err := flattenVirtualMachineScaleSetIdentity(resp.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-	if err := d.Set("identity", identity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
 	instances := make([]interface{}, 0)
-	result, err := instancesClient.ListComplete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "", "", "")
+	virtualMachineScaleSetId := virtualmachinescalesetvms.NewVirtualMachineScaleSetID(subscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+	result, err := instancesClient.ListComplete(ctx, virtualMachineScaleSetId, virtualmachinescalesetvms.DefaultListOperationOptions())
 	if err != nil {
 		return fmt.Errorf("listing VM Instances for %q: %+v", id, err)
 	}
 
 	var connInfo *connectionInfo
-	for result.NotDone() {
-		instance := result.Value()
-		if instance.InstanceID != nil {
-			nics, err := networkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, *instance.InstanceID)
+	for _, item := range result.Items {
+		if item.InstanceId != nil {
+			nics, err := networkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, *item.InstanceId)
 			if err != nil {
 				if !utils.ResponseWasNotFound(nics.Response().Response) {
-					return fmt.Errorf("listing Network Interfaces for VM Instance %q for %q: %+v", *instance.InstanceID, id, err)
+					return fmt.Errorf("listing Network Interfaces for VM Instance %q for %q: %+v", *item.InstanceId, id, err)
 				}
 
 				// Network Interfaces of VM in Flexible VMSS are accessed from single VM
-				vm, err := vmClient.Get(ctx, id.ResourceGroupName, *instance.InstanceID, "")
+				virtualMachineId := virtualmachines.NewVirtualMachineID(subscriptionId, id.ResourceGroupName, *item.InstanceId)
+				vm, err := virtualMachinesClient.Get(ctx, virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 				if err != nil {
-					return fmt.Errorf("retrieving VM Instance %q for %q: %+v", *instance.InstanceID, id, err)
+					return fmt.Errorf("retrieving VM Instance %q for %q: %+v", *item.InstanceId, id, err)
 				}
-				connInfoRaw := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, vm.VirtualMachineProperties)
+				connInfoRaw := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, vm.Model.Properties)
 				connInfo = &connInfoRaw
 			} else {
 				networkInterfaces := make([]network.Interface, 0)
 				for nics.NotDone() {
 					networkInterfaces = append(networkInterfaces, nics.Value())
 					if err := nics.NextWithContext(ctx); err != nil {
-						return fmt.Errorf("listing next page of Network Interfaces for VM Instance %q of %q: %v", *instance.InstanceID, id, err)
+						return fmt.Errorf("listing next page of Network Interfaces for VM Instance %q of %q: %v", *item.InstanceId, id, err)
 					}
 				}
 
-				connInfo, err = getVirtualMachineScaleSetVMConnectionInfo(ctx, networkInterfaces, id.ResourceGroupName, id.VirtualMachineScaleSetName, *instance.InstanceID, publicIPAddressesClient)
+				connInfo, err = getVirtualMachineScaleSetVMConnectionInfo(ctx, networkInterfaces, id.ResourceGroupName, id.VirtualMachineScaleSetName, *item.InstanceId, publicIPAddressesClient)
 				if err != nil {
 					return err
 				}
 			}
 
-			flattenedInstances := flattenVirtualMachineScaleSetVM(instance, connInfo)
+			flattenedInstances := flattenVirtualMachineScaleSetVM(item, connInfo)
 			instances = append(instances, flattenedInstances)
-		}
-
-		if err := result.NextWithContext(ctx); err != nil {
-			return fmt.Errorf("listing next page VM Instances for %q: %+v", id, err)
 		}
 	}
 	if err := d.Set("instances", instances); err != nil {
@@ -273,18 +273,18 @@ func getVirtualMachineScaleSetVMConnectionInfo(ctx context.Context, networkInter
 	}, nil
 }
 
-func flattenVirtualMachineScaleSetVM(input compute.VirtualMachineScaleSetVM, connectionInfo *connectionInfo) map[string]interface{} {
+func flattenVirtualMachineScaleSetVM(input virtualmachinescalesetvms.VirtualMachineScaleSetVM, connectionInfo *connectionInfo) map[string]interface{} {
 	output := make(map[string]interface{})
 	output["name"] = *input.Name
-	output["instance_id"] = *input.InstanceID
+	output["instance_id"] = *input.InstanceId
 
-	if props := input.VirtualMachineScaleSetVMProperties; props != nil {
+	if props := input.Properties; props != nil {
 		if props.LatestModelApplied != nil {
 			output["latest_model_applied"] = *props.LatestModelApplied
 		}
 
-		if props.VMID != nil {
-			output["virtual_machine_id"] = *props.VMID
+		if props.VMId != nil {
+			output["virtual_machine_id"] = *props.VMId
 		}
 
 		if profile := props.OsProfile; profile != nil && profile.ComputerName != nil {

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -171,7 +171,7 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 			AutoUpgradeMinorVersion:       utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
 			EnableAutomaticUpgrade:        utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
 			SuppressFailures:              utils.Bool(d.Get("failure_suppression_enabled").(bool)),
-			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{})),
 			ProvisionAfterExtensions:      provisionAfterExtensions,
 			Settings:                      settings,
 		},
@@ -240,7 +240,7 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if d.HasChange("protected_settings_from_key_vault") {
-		props.ProtectedSettingsFromKeyVault = expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{}))
+		props.ProtectedSettingsFromKeyVault = expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{}))
 	}
 
 	if d.HasChange("provision_after_extensions") {
@@ -331,7 +331,7 @@ func resourceVirtualMachineScaleSetExtensionRead(d *pluginsdk.ResourceData, meta
 		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
 		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
 		d.Set("force_update_tag", props.ForceUpdateTag)
-		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
+		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVaultOld(props.ProtectedSettingsFromKeyVault))
 		d.Set("provision_after_extensions", utils.FlattenStringSlice(props.ProvisionAfterExtensions))
 		d.Set("publisher", props.Publisher)
 		d.Set("type", props.Type)

--- a/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/internal/services/compute/virtual_machine_scale_set_import.go
@@ -7,21 +7,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func importOrchestratedVirtualMachineScaleSet(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return []*pluginsdk.ResourceData{}, err
 	}
 
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	_, err = client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	_, err = client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -29,44 +28,48 @@ func importOrchestratedVirtualMachineScaleSet(ctx context.Context, d *pluginsdk.
 	return []*pluginsdk.ResourceData{d}, nil
 }
 
-func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceType string) pluginsdk.ImporterFunc {
+func importVirtualMachineScaleSet(osType virtualmachinescalesets.OperatingSystemTypes, resourceType string) pluginsdk.ImporterFunc {
 	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
-		id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+		id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 		if err != nil {
 			return []*pluginsdk.ResourceData{}, err
 		}
 
-		client := meta.(*clients.Client).Compute.VMScaleSetClient
+		client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 		// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-		vm, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+		vm, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 		if err != nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		if vm.VirtualMachineScaleSetProperties == nil {
+		if vm.Model == nil {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `model` was nil", id)
+		}
+
+		if vm.Model.Properties == nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `properties` was nil", id)
 		}
 
-		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+		if vm.Model.Properties.VirtualMachineProfile == nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `properties.virtualMachineProfile` was nil", id)
 		}
 
-		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile == nil {
+		if vm.Model.Properties.VirtualMachineProfile.OsProfile == nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `properties.virtualMachineProfile.osProfile` was nil", id)
 		}
 
 		isCorrectOS := false
 		hasSshKeys := false
-		if profile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile; profile != nil {
-			if profile.LinuxConfiguration != nil && osType == compute.OperatingSystemTypesLinux {
+		if profile := vm.Model.Properties.VirtualMachineProfile.OsProfile; profile != nil {
+			if profile.LinuxConfiguration != nil && osType == virtualmachinescalesets.OperatingSystemTypesLinux {
 				isCorrectOS = true
 
-				if profile.LinuxConfiguration.SSH != nil && profile.LinuxConfiguration.SSH.PublicKeys != nil {
-					hasSshKeys = len(*profile.LinuxConfiguration.SSH.PublicKeys) > 0
+				if profile.LinuxConfiguration.Ssh != nil && profile.LinuxConfiguration.Ssh.PublicKeys != nil {
+					hasSshKeys = len(*profile.LinuxConfiguration.Ssh.PublicKeys) > 0
 				}
 			}
 
-			if profile.WindowsConfiguration != nil && osType == compute.OperatingSystemTypesWindows {
+			if profile.WindowsConfiguration != nil && osType == virtualmachinescalesets.OperatingSystemTypesWindows {
 				isCorrectOS = true
 			}
 		}
@@ -80,10 +83,12 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 		}
 
 		var updatedExtensions []map[string]interface{}
-		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile != nil {
-			if extensionsProfile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {
+		if vm.Model.Properties.VirtualMachineProfile.ExtensionProfile != nil {
+			if extensionsProfile := vm.Model.Properties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {
 				for _, v := range *extensionsProfile.Extensions {
-					v.ProtectedSettings = ""
+					if v.Properties != nil {
+						v.Properties.ProtectedSettings = nil
+					}
 				}
 				updatedExtensions, err = flattenVirtualMachineScaleSetExtensions(extensionsProfile, d)
 				if err != nil {

--- a/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/internal/services/compute/virtual_machine_scale_set_import.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -19,8 +20,9 @@ func importOrchestratedVirtualMachineScaleSet(ctx context.Context, d *pluginsdk.
 	}
 
 	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	_, err = client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	options := virtualmachinescalesets.DefaultGetOperationOptions()
+	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+	_, err = client.Get(ctx, *id, options)
 	if err != nil {
 		return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -36,8 +38,9 @@ func importVirtualMachineScaleSet(osType virtualmachinescalesets.OperatingSystem
 		}
 
 		client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
-		// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-		vm, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+		options := virtualmachinescalesets.DefaultGetOperationOptions()
+		options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+		vm, err := client.Get(ctx, *id, options)
 		if err != nil {
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
 		}

--- a/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/internal/services/compute/virtual_machine_scale_set_update.go
@@ -9,10 +9,11 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/client"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 type virtualMachineScaleSetUpdateMetaData struct {
@@ -29,19 +30,19 @@ type virtualMachineScaleSetUpdateMetaData struct {
 	UpdateInstances bool
 
 	Client   *client.Client
-	Existing compute.VirtualMachineScaleSet
-	ID       *commonids.VirtualMachineScaleSetId
-	OSType   compute.OperatingSystemTypes
+	Existing virtualmachinescalesets.VirtualMachineScaleSet
+	ID       *virtualmachinescalesets.VirtualMachineScaleSetId
+	OSType   virtualmachinescalesets.OperatingSystemTypes
 }
 
-func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.Context, update compute.VirtualMachineScaleSetUpdate) error {
+func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.Context, update virtualmachinescalesets.VirtualMachineScaleSetUpdate) error {
 	if metadata.AutomaticOSUpgradeIsEnabled {
 		// Virtual Machine Scale Sets with Automatic OS Upgrade enabled must have all VM instances upgraded to same
 		// Platform Image. Upgrade all VM instances to latest Virtual Machine Scale Set model while property
 		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' is false and then update property
 		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' to true
 
-		update.VirtualMachineScaleSetUpdateProperties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = utils.Bool(false)
+		update.Properties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = pointer.To(false)
 	}
 
 	if err := metadata.updateVmss(ctx, update); err != nil {
@@ -51,18 +52,18 @@ func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.C
 	// if we update the SKU, we also need to subsequently roll the instances using the `UpdateInstances` API
 	if metadata.UpdateInstances {
 		userWantsToRollInstances := metadata.CanRollInstancesWhenRequired
-		upgradeMode := metadata.Existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode
+		upgradeMode := metadata.Existing.Properties.UpgradePolicy.Mode
 
 		if userWantsToRollInstances {
 			// If the updated image version is not "latest" and upgrade mode is automatic then azure will roll the instances automatically.
 			// Calling upgradeInstancesForAutomaticUpgradePolicy() in this case will cause an error.
-			if upgradeMode == compute.UpgradeModeAutomatic && isUsingLatestImage(update) {
+			if *upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic && isUsingLatestImage(update) {
 				if err := metadata.upgradeInstancesForAutomaticUpgradePolicy(ctx); err != nil {
 					return err
 				}
 			}
 
-			if upgradeMode == compute.UpgradeModeManual {
+			if *upgradeMode == virtualmachinescalesets.UpgradeModeManual {
 				if err := metadata.upgradeInstancesForManualUpgradePolicy(ctx); err != nil {
 					return err
 				}
@@ -77,7 +78,7 @@ func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.C
 		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' to true
 
 		// finally set this to true
-		update.VirtualMachineScaleSetUpdateProperties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = utils.Bool(true)
+		update.Properties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = pointer.To(true)
 
 		// then update the VM
 		if err := metadata.updateVmss(ctx, update); err != nil {
@@ -88,19 +89,13 @@ func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.C
 	return nil
 }
 
-func (metadata virtualMachineScaleSetUpdateMetaData) updateVmss(ctx context.Context, update compute.VirtualMachineScaleSetUpdate) error {
-	client := metadata.Client.VMScaleSetClient
+func (metadata virtualMachineScaleSetUpdateMetaData) updateVmss(ctx context.Context, update virtualmachinescalesets.VirtualMachineScaleSetUpdate) error {
+	client := metadata.Client.VirtualMachineScaleSetsClient
 	id := metadata.ID
 
 	log.Printf("[DEBUG] Updating %s %s", metadata.OSType, id)
-	future, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update)
-	if err != nil {
+	if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("updating %s %s: %+v", metadata.OSType, id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for update of %s %s", metadata.OSType, id)
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s %s: %+v", metadata.OSType, id, err)
 	}
 	log.Printf("[DEBUG] Updated %s %s", metadata.OSType, id)
 
@@ -108,19 +103,13 @@ func (metadata virtualMachineScaleSetUpdateMetaData) updateVmss(ctx context.Cont
 }
 
 func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForAutomaticUpgradePolicy(ctx context.Context) error {
-	client := metadata.Client.VMScaleSetClient
-	rollingUpgradesClient := metadata.Client.VMScaleSetRollingUpgradesClient
+	rollingUpgradesClient := metadata.Client.VirtualMachineScaleSetRollingUpgradesClient
 	id := metadata.ID
+	virtualMachineScaleSetId := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
 
 	log.Printf("[DEBUG] Updating instances for %s %s", metadata.OSType, id)
-	future, err := rollingUpgradesClient.StartOSUpgrade(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName)
-	if err != nil {
+	if err := rollingUpgradesClient.StartOSUpgradeThenPoll(ctx, virtualMachineScaleSetId); err != nil {
 		return fmt.Errorf("updating instances for %s %s: %+v", metadata.OSType, id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for update of instances for %s %s", metadata.OSType, id)
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of instances for %s %s: %+v", metadata.OSType, id, err)
 	}
 	log.Printf("[DEBUG] Updated instances for %s %s.", metadata.OSType, id)
 
@@ -128,30 +117,26 @@ func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForAutomati
 }
 
 func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForManualUpgradePolicy(ctx context.Context) error {
-	client := metadata.Client.VMScaleSetClient
+	client := metadata.Client.VirtualMachineScaleSetsClient
 	id := metadata.ID
 
 	log.Printf("[DEBUG] Rolling the VM Instances for %s %s", metadata.OSType, id)
-	instancesClient := metadata.Client.VMScaleSetVMsClient
-	instances, err := instancesClient.ListComplete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "", "", "")
+	instancesClient := metadata.Client.VirtualMachineScaleSetVMsClient
+	virtualMachineScaleSetId := virtualmachinescalesetvms.NewVirtualMachineScaleSetID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+	instances, err := instancesClient.ListComplete(ctx, virtualMachineScaleSetId, virtualmachinescalesetvms.DefaultListOperationOptions())
 	if err != nil {
 		return fmt.Errorf("listing VM Instances for %s %s: %+v", metadata.OSType, id, err)
 	}
 
 	log.Printf("[DEBUG] Determining instances to roll..")
 	instanceIdsToRoll := make([]string, 0)
-	for instances.NotDone() {
-		instance := instances.Value()
-		props := instance.VirtualMachineScaleSetVMProperties
-		if props != nil && instance.InstanceID != nil {
+	for _, item := range instances.Items {
+		props := item.Properties
+		if props != nil && item.InstanceId != nil {
 			latestModel := props.LatestModelApplied
 			if latestModel != nil || !*latestModel {
-				instanceIdsToRoll = append(instanceIdsToRoll, *instance.InstanceID)
+				instanceIdsToRoll = append(instanceIdsToRoll, *item.InstanceId)
 			}
-		}
-
-		if err := instances.NextWithContext(ctx); err != nil {
-			return fmt.Errorf("enumerating instances: %s", err)
 		}
 	}
 
@@ -160,31 +145,21 @@ func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForManualUp
 		instanceIds := []string{instanceId}
 
 		log.Printf("[DEBUG] Updating Instance %q to the Latest Configuration..", instanceId)
-		ids := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
-			InstanceIds: &instanceIds,
+		ids := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceRequiredIDs{
+			InstanceIds: instanceIds,
 		}
-		future, err := client.UpdateInstances(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, ids)
-		if err != nil {
+		if err := client.UpdateInstancesThenPoll(ctx, *id, ids); err != nil {
 			return fmt.Errorf("updating Instance %q (%s %s) to the Latest Configuration: %+v", instanceId, metadata.OSType, id, err)
-		}
-
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for update of Instance %q (%s %s) to the Latest Configuration: %+v", instanceId, metadata.OSType, id, err)
 		}
 		log.Printf("[DEBUG] Updated Instance %q to the Latest Configuration.", instanceId)
 
 		if metadata.CanReimageOnManualUpgrade {
 			log.Printf("[DEBUG] Reimaging Instance %q..", instanceId)
-			reimageInput := &compute.VirtualMachineScaleSetReimageParameters{
+			reImageInput := virtualmachinescalesets.VirtualMachineScaleSetReimageParameters{
 				InstanceIds: &instanceIds,
 			}
-			reimageFuture, err := client.Reimage(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, reimageInput)
-			if err != nil {
+			if err := client.ReimageThenPoll(ctx, *id, reImageInput); err != nil {
 				return fmt.Errorf("reimaging Instance %q (%s %s): %+v", instanceId, metadata.OSType, id, err)
-			}
-
-			if err = reimageFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting for reimage of Instance %q (%s %s): %+v", instanceId, metadata.OSType, id, err)
 			}
 			log.Printf("[DEBUG] Reimaged Instance %q..", instanceId)
 		}
@@ -194,13 +169,13 @@ func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForManualUp
 	return nil
 }
 
-func isUsingLatestImage(update compute.VirtualMachineScaleSetUpdate) bool {
-	if update.VirtualMachineProfile.StorageProfile == nil ||
-		update.VirtualMachineProfile.StorageProfile.ImageReference == nil ||
-		update.VirtualMachineProfile.StorageProfile.ImageReference.Version == nil {
+func isUsingLatestImage(update virtualmachinescalesets.VirtualMachineScaleSetUpdate) bool {
+	if update.Properties.VirtualMachineProfile.StorageProfile == nil ||
+		update.Properties.VirtualMachineProfile.StorageProfile.ImageReference == nil ||
+		update.Properties.VirtualMachineProfile.StorageProfile.ImageReference.Version == nil {
 		return false
 	}
-	if strings.EqualFold(*update.VirtualMachineProfile.StorageProfile.ImageReference.Version, "latest") {
+	if strings.EqualFold(*update.Properties.VirtualMachineProfile.StorageProfile.ImageReference.Version, "latest") {
 		return true
 	}
 	return false

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -14,26 +14,25 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/base64"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceWindowsVirtualMachine() *pluginsdk.Resource {
@@ -46,7 +45,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := commonids.ParseVirtualMachineID(id)
 			return err
-		}, importVirtualMachine(compute.OperatingSystemTypesWindows, "azurerm_windows_virtual_machine")),
+		}, importVirtualMachine(virtualmachines.OperatingSystemTypesWindows, "azurerm_windows_virtual_machine")),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(45 * time.Minute),
@@ -191,8 +190,8 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.DiskControllerTypesNVMe),
-					string(compute.DiskControllerTypesSCSI),
+					string(virtualmachines.DiskControllerTypesNVMe),
+					string(virtualmachines.DiskControllerTypesSCSI),
 				}, false),
 			},
 
@@ -217,8 +216,8 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.VirtualMachineEvictionPolicyTypesDeallocate),
-					string(compute.VirtualMachineEvictionPolicyTypesDelete),
+					string(virtualmachines.VirtualMachineEvictionPolicyTypesDeallocate),
+					string(virtualmachines.VirtualMachineEvictionPolicyTypesDelete),
 				}, false),
 			},
 
@@ -260,21 +259,21 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			"patch_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(compute.WindowsVMGuestPatchModeAutomaticByOS),
+				Default:  string(virtualmachines.WindowsVMGuestPatchModeAutomaticByOS),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.WindowsVMGuestPatchModeAutomaticByOS),
-					string(compute.WindowsVMGuestPatchModeAutomaticByPlatform),
-					string(compute.WindowsVMGuestPatchModeManual),
+					string(virtualmachines.WindowsVMGuestPatchModeAutomaticByOS),
+					string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform),
+					string(virtualmachines.WindowsVMGuestPatchModeManual),
 				}, false),
 			},
 
 			"patch_assessment_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(compute.WindowsPatchAssessmentModeImageDefault),
+				Default:  string(virtualmachines.WindowsPatchAssessmentModeImageDefault),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.WindowsPatchAssessmentModeAutomaticByPlatform),
-					string(compute.WindowsPatchAssessmentModeImageDefault),
+					string(virtualmachines.WindowsPatchAssessmentModeAutomaticByPlatform),
+					string(virtualmachines.WindowsPatchAssessmentModeImageDefault),
 				}, false),
 			},
 
@@ -290,10 +289,10 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(compute.VirtualMachinePriorityTypesRegular),
+				Default:  string(virtualmachines.VirtualMachinePriorityTypesRegular),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.VirtualMachinePriorityTypesRegular),
-					string(compute.VirtualMachinePriorityTypesSpot),
+					string(virtualmachines.VirtualMachinePriorityTypesRegular),
+					string(virtualmachines.VirtualMachinePriorityTypesSpot),
 				}, false),
 			},
 
@@ -320,9 +319,9 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways),
-					string(compute.WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
-					string(compute.WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever),
+					string(virtualmachines.WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways),
+					string(virtualmachines.WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
+					string(virtualmachines.WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever),
 				}, false),
 			},
 
@@ -355,7 +354,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 
 			"source_image_reference": sourceImageReferenceSchema(true),
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 
 			"os_image_notification": virtualMachineOsImageNotificationSchema(),
 
@@ -440,25 +439,25 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 }
 
 func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := commonids.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualmachines.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
+	resp, err := client.Get(ctx, id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if !utils.ResponseWasNotFound(resp.Response) {
+		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("checking for existing Windows %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(resp.Response) {
-		return tf.ImportAsExistsError("azurerm_windows_virtual_machine", *resp.ID)
+	if !response.WasNotFound(resp.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_windows_virtual_machine", id.ID())
 	}
 
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
@@ -485,9 +484,8 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		computerName = id.VirtualMachineName
 	}
 	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
-	location := azure.NormalizeLocation(d.Get("location").(string))
 
-	identity, err := expandVirtualMachineIdentity(d.Get("identity").([]interface{}))
+	identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
@@ -495,7 +493,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	planRaw := d.Get("plan").([]interface{})
 	plan := expandPlan(planRaw)
 
-	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	priority := pointer.To(virtualmachines.VirtualMachinePriorityTypes(d.Get("priority").(string)))
 	provisionVMAgent := d.Get("provision_vm_agent").(bool)
 	patchMode := d.Get("patch_mode").(string)
 	assessmentMode := d.Get("patch_assessment_mode").(string)
@@ -507,7 +505,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
 
 	osDiskRaw := d.Get("os_disk").([]interface{})
-	osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, compute.OperatingSystemTypesWindows)
+	osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, virtualmachines.OperatingSystemTypesWindows)
 	if err != nil {
 		return fmt.Errorf("expanding `os_disk`: %+v", err)
 	}
@@ -525,55 +523,55 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	winRmListenersRaw := d.Get("winrm_listener").(*pluginsdk.Set).List()
 	winRmListeners := expandWinRMListener(winRmListenersRaw)
 
-	params := compute.VirtualMachine{
-		Name:             utils.String(id.VirtualMachineName),
+	params := virtualmachines.VirtualMachine{
+		Name:             pointer.To(id.VirtualMachineName),
 		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
-		Location:         utils.String(location),
-		Identity:         identity,
+		Location:         location.Normalize(d.Get("location").(string)),
+		Identity:         identityExpanded,
 		Plan:             plan,
-		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ApplicationProfile: &compute.ApplicationProfile{
+		Properties: &virtualmachines.VirtualMachineProperties{
+			ApplicationProfile: &virtualmachines.ApplicationProfile{
 				GalleryApplications: expandVirtualMachineGalleryApplication(d.Get("gallery_application").([]interface{})),
 			},
-			HardwareProfile: &compute.HardwareProfile{
-				VMSize: compute.VirtualMachineSizeTypes(size),
+			HardwareProfile: &virtualmachines.HardwareProfile{
+				VMSize: pointer.To(virtualmachines.VirtualMachineSizeTypes(size)),
 			},
-			OsProfile: &compute.OSProfile{
-				AdminPassword:            utils.String(adminPassword),
-				AdminUsername:            utils.String(adminUsername),
-				ComputerName:             utils.String(computerName),
-				AllowExtensionOperations: utils.Bool(allowExtensionOperations),
-				WindowsConfiguration: &compute.WindowsConfiguration{
-					ProvisionVMAgent:             utils.Bool(provisionVMAgent),
-					EnableAutomaticUpdates:       utils.Bool(enableAutomaticUpdates),
-					EnableVMAgentPlatformUpdates: utils.Bool(vmAgentPlatformUpdatesEnabled),
+			OsProfile: &virtualmachines.OSProfile{
+				AdminPassword:            pointer.To(adminPassword),
+				AdminUsername:            pointer.To(adminUsername),
+				ComputerName:             pointer.To(computerName),
+				AllowExtensionOperations: pointer.To(allowExtensionOperations),
+				WindowsConfiguration: &virtualmachines.WindowsConfiguration{
+					ProvisionVMAgent:             pointer.To(provisionVMAgent),
+					EnableAutomaticUpdates:       pointer.To(enableAutomaticUpdates),
+					EnableVMAgentPlatformUpdates: pointer.To(vmAgentPlatformUpdatesEnabled),
 					WinRM:                        winRmListeners,
 				},
 				Secrets: secrets,
 			},
-			NetworkProfile: &compute.NetworkProfile{
+			NetworkProfile: &virtualmachines.NetworkProfile{
 				NetworkInterfaces: &networkInterfaceIds,
 			},
 			Priority: priority,
-			StorageProfile: &compute.StorageProfile{
+			StorageProfile: &virtualmachines.StorageProfile{
 				ImageReference: sourceImageReference,
 				OsDisk:         osDisk,
 
 				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
 				// but for Updates this'll need to be nil, else any associations will be overwritten
-				DataDisks: &[]compute.DataDisk{},
+				DataDisks: &[]virtualmachines.DataDisk{},
 			},
 
 			// Optional
 			AdditionalCapabilities: additionalCapabilities,
 			DiagnosticsProfile:     bootDiagnostics,
-			ExtensionsTimeBudget:   utils.String(d.Get("extensions_time_budget").(string)),
+			ExtensionsTimeBudget:   pointer.To(d.Get("extensions_time_budget").(string)),
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if diskControllerType, ok := d.GetOk("disk_controller_type"); ok {
-		params.StorageProfile.DiskControllerType = compute.DiskControllerTypes(diskControllerType.(string))
+		params.Properties.StorageProfile.DiskControllerType = pointer.To(virtualmachines.DiskControllerTypes(diskControllerType.(string)))
 	}
 
 	if !provisionVMAgent && allowExtensionOperations {
@@ -581,21 +579,21 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if len(additionalUnattendContentRaw) > 0 {
-		params.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
+		params.Properties.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
 	}
 
 	isHotpatchImage := isValidHotPatchSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 
 	// Validate VM Guest Patch Mode configuration
-	if patchMode == string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) && !provisionVMAgent {
+	if patchMode == string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform) && !provisionVMAgent {
 		return fmt.Errorf("%q cannot be set to %q when %q is set to %q", "patch_mode", "AutomaticByPlatform", "provision_vm_agent", "false")
 	}
 
-	if assessmentMode == string(compute.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
+	if assessmentMode == string(virtualmachines.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
 		return fmt.Errorf("`provision_vm_agent` must be set to `true` when `patch_assessment_mode` is set to `AutomaticByPlatform`")
 	}
 
-	if isHotpatchImage && patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
+	if isHotpatchImage && patchMode != string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform) {
 		return fmt.Errorf("%q must always be set to %q when %q points to a hotpatch enabled image", "patch_mode", "AutomaticByPlatform", "source_image_reference")
 	}
 
@@ -603,7 +601,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	// and if the image reference is using one of the following skus:
 	// 2022-datacenter-azure-edition-core or 2022-datacenter-azure-edition-core-smalldisk
 	if hotPatch {
-		if patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
+		if patchMode != string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform) {
 			return fmt.Errorf("%q cannot be set to %q when %q is set to %q", "hotpatching_enabled", "true", "patch_mode", patchMode)
 		}
 
@@ -620,166 +618,166 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	params.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{
-		PatchMode:         compute.WindowsVMGuestPatchMode(patchMode),
-		EnableHotpatching: utils.Bool(hotPatch),
-		AssessmentMode:    compute.WindowsPatchAssessmentMode(assessmentMode),
+	params.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{
+		PatchMode:         pointer.To(virtualmachines.WindowsVMGuestPatchMode(patchMode)),
+		EnableHotpatching: pointer.To(hotPatch),
+		AssessmentMode:    pointer.To(virtualmachines.WindowsPatchAssessmentMode(assessmentMode)),
 	}
 
 	if d.Get("bypass_platform_safety_checks_on_user_schedule_enabled").(bool) {
-		if patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
+		if patchMode != string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform) {
 			return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `bypass_platform_safety_checks_on_user_schedule_enabled` is set to `true`")
 		}
 
-		if params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-			params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &compute.WindowsVMGuestPatchAutomaticByPlatformSettings{}
+		if params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+			params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.WindowsVMGuestPatchAutomaticByPlatformSettings{}
 		}
 
-		params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(true)
+		params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(true)
 	}
 
 	if v, ok := d.GetOk("reboot_setting"); ok {
-		if patchMode != string(compute.WindowsVMGuestPatchModeAutomaticByPlatform) {
+		if patchMode != string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform) {
 			return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `reboot_setting` is specified")
 		}
 
-		if params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-			params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &compute.WindowsVMGuestPatchAutomaticByPlatformSettings{}
+		if params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+			params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.WindowsVMGuestPatchAutomaticByPlatformSettings{}
 		}
 
-		params.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = compute.WindowsVMGuestPatchAutomaticByPlatformRebootSetting(v.(string))
+		params.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = pointer.To(virtualmachines.WindowsVMGuestPatchAutomaticByPlatformRebootSetting(v.(string)))
 	}
 
 	if v, ok := d.GetOk("availability_set_id"); ok {
-		params.AvailabilitySet = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		params.Properties.AvailabilitySet = &virtualmachines.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-		params.CapacityReservation = &compute.CapacityReservationProfile{
-			CapacityReservationGroup: &compute.SubResource{
-				ID: utils.String(v.(string)),
+		params.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachines.SubResource{
+				Id: pointer.To(v.(string)),
 			},
 		}
 	}
 
 	if v, ok := d.GetOk("custom_data"); ok {
-		params.OsProfile.CustomData = utils.String(v.(string))
+		params.Properties.OsProfile.CustomData = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("dedicated_host_id"); ok {
-		params.Host = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		params.Properties.Host = &virtualmachines.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("dedicated_host_group_id"); ok {
-		params.HostGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		params.Properties.HostGroup = &virtualmachines.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
 		if encryptionAtHostEnabled.(bool) {
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachines.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachines.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
-		if params.SecurityProfile == nil {
-			params.SecurityProfile = &compute.SecurityProfile{}
+		if params.Properties.SecurityProfile == nil {
+			params.Properties.SecurityProfile = &virtualmachines.SecurityProfile{}
 		}
-		params.SecurityProfile.EncryptionAtHost = utils.Bool(encryptionAtHostEnabled.(bool))
+		params.Properties.SecurityProfile.EncryptionAtHost = pointer.To(encryptionAtHostEnabled.(bool))
 	}
 
 	secureBootEnabled := d.Get("secure_boot_enabled").(bool)
 	vtpmEnabled := d.Get("vtpm_enabled").(bool)
 	if securityEncryptionType != "" {
-		if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
+		if virtualmachines.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachines.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
 			return fmt.Errorf("`secure_boot_enabled` must be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 		}
 		if !vtpmEnabled {
 			return fmt.Errorf("`vtpm_enabled` must be set to `true` when `os_disk.0.security_encryption_type` is set")
 		}
 
-		if params.VirtualMachineProperties.SecurityProfile == nil {
-			params.VirtualMachineProperties.SecurityProfile = &compute.SecurityProfile{}
+		if params.Properties.SecurityProfile == nil {
+			params.Properties.SecurityProfile = &virtualmachines.SecurityProfile{}
 		}
-		params.VirtualMachineProperties.SecurityProfile.SecurityType = compute.SecurityTypesConfidentialVM
+		params.Properties.SecurityProfile.SecurityType = pointer.To(virtualmachines.SecurityTypesConfidentialVM)
 
-		if params.VirtualMachineProperties.SecurityProfile.UefiSettings == nil {
-			params.VirtualMachineProperties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		if params.Properties.SecurityProfile.UefiSettings == nil {
+			params.Properties.SecurityProfile.UefiSettings = &virtualmachines.UefiSettings{}
 		}
-		params.VirtualMachineProperties.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
-		params.VirtualMachineProperties.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+		params.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
+		params.Properties.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 	} else {
 		if secureBootEnabled {
-			if params.VirtualMachineProperties.SecurityProfile == nil {
-				params.VirtualMachineProperties.SecurityProfile = &compute.SecurityProfile{}
+			if params.Properties.SecurityProfile == nil {
+				params.Properties.SecurityProfile = &virtualmachines.SecurityProfile{}
 			}
-			if params.VirtualMachineProperties.SecurityProfile.UefiSettings == nil {
-				params.VirtualMachineProperties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+			if params.Properties.SecurityProfile.UefiSettings == nil {
+				params.Properties.SecurityProfile.UefiSettings = &virtualmachines.UefiSettings{}
 			}
-			params.VirtualMachineProperties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			params.VirtualMachineProperties.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
+			params.Properties.SecurityProfile.SecurityType = pointer.To(virtualmachines.SecurityTypesTrustedLaunch)
+			params.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
 		}
 
 		if vtpmEnabled {
-			if params.VirtualMachineProperties.SecurityProfile == nil {
-				params.VirtualMachineProperties.SecurityProfile = &compute.SecurityProfile{}
+			if params.Properties.SecurityProfile == nil {
+				params.Properties.SecurityProfile = &virtualmachines.SecurityProfile{}
 			}
-			if params.VirtualMachineProperties.SecurityProfile.UefiSettings == nil {
-				params.VirtualMachineProperties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+			if params.Properties.SecurityProfile.UefiSettings == nil {
+				params.Properties.SecurityProfile.UefiSettings = &virtualmachines.UefiSettings{}
 			}
-			params.VirtualMachineProperties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			params.VirtualMachineProperties.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+			params.Properties.SecurityProfile.SecurityType = pointer.To(virtualmachines.SecurityTypesTrustedLaunch)
+			params.Properties.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 		}
 	}
 
 	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
-		if params.Priority != compute.VirtualMachinePriorityTypesSpot {
+		if *params.Properties.Priority != virtualmachines.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("an `eviction_policy` can only be specified when `priority` is set to `Spot`")
 		}
 
-		params.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string))
-	} else if priority == compute.VirtualMachinePriorityTypesSpot {
+		params.Properties.EvictionPolicy = pointer.To(virtualmachines.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string)))
+	} else if *priority == virtualmachines.VirtualMachinePriorityTypesSpot {
 		return fmt.Errorf("an `eviction_policy` must be specified when `priority` is set to `Spot`")
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
-		params.LicenseType = utils.String(v.(string))
+		params.Properties.LicenseType = pointer.To(v.(string))
 	}
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
-		if priority != compute.VirtualMachinePriorityTypesSpot {
+		if *priority != virtualmachines.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		params.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(v),
+		params.Properties.BillingProfile = &virtualmachines.BillingProfile{
+			MaxPrice: pointer.To(v),
 		}
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
-		params.ProximityPlacementGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		params.Properties.ProximityPlacementGroup = &virtualmachines.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
-		params.VirtualMachineScaleSet = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		params.Properties.VirtualMachineScaleSet = &virtualmachines.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	platformFaultDomain := d.Get("platform_fault_domain").(int)
 	if platformFaultDomain != -1 {
-		params.PlatformFaultDomain = utils.Int32(int32(platformFaultDomain))
+		params.Properties.PlatformFaultDomain = pointer.To(int64(platformFaultDomain))
 	}
 
-	var osImageNotificationProfile *compute.OSImageNotificationProfile
-	var terminateNotificationProfile *compute.TerminateNotificationProfile
+	var osImageNotificationProfile *virtualmachines.OSImageNotificationProfile
+	var terminateNotificationProfile *virtualmachines.TerminateNotificationProfile
 
 	if v, ok := d.GetOk("os_image_notification"); ok {
 		osImageNotificationProfile = expandOsImageNotificationProfile(v.([]interface{}))
@@ -790,18 +788,18 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if terminateNotificationProfile != nil || osImageNotificationProfile != nil {
-		params.VirtualMachineProperties.ScheduledEventsProfile = &compute.ScheduledEventsProfile{
+		params.Properties.ScheduledEventsProfile = &virtualmachines.ScheduledEventsProfile{
 			OsImageNotificationProfile:   osImageNotificationProfile,
 			TerminateNotificationProfile: terminateNotificationProfile,
 		}
 	}
 
 	if v, ok := d.GetOk("timezone"); ok {
-		params.VirtualMachineProperties.OsProfile.WindowsConfiguration.TimeZone = utils.String(v.(string))
+		params.Properties.OsProfile.WindowsConfiguration.TimeZone = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("user_data"); ok {
-		params.UserData = utils.String(v.(string))
+		params.Properties.UserData = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("zone"); ok {
@@ -810,13 +808,8 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualMachineName, params)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, params, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Windows %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -824,21 +817,21 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 }
 
 func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	disksClient := meta.(*clients.Client).Compute.DisksClient
 	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
 	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineID(d.Id())
+	id, err := virtualmachines.ParseVirtualMachineID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
+	resp, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Windows %s was not found - removing from state!", id)
 			d.SetId("")
 			return nil
@@ -849,246 +842,243 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 
 	d.Set("name", id.VirtualMachineName)
 	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
+	d.Set("virtual_machine_id", id.ID())
 
-	identity, err := flattenVirtualMachineIdentity(resp.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-	if err := d.Set("identity", identity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
+		d.Set("edge_zone", flattenEdgeZone(model.ExtendedLocation))
 
-	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
-		return fmt.Errorf("setting `plan`: %+v", err)
-	}
-
-	if resp.VirtualMachineProperties == nil {
-		return fmt.Errorf("retrieving Windows %s: `properties` was nil", id)
-	}
-
-	props := *resp.VirtualMachineProperties
-	if err := d.Set("additional_capabilities", flattenVirtualMachineAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
-		return fmt.Errorf("setting `additional_capabilities`: %+v", err)
-	}
-
-	availabilitySetId := ""
-	if props.AvailabilitySet != nil && props.AvailabilitySet.ID != nil {
-		availabilitySetId = *props.AvailabilitySet.ID
-	}
-	d.Set("availability_set_id", availabilitySetId)
-
-	capacityReservationGroupId := ""
-	if props.CapacityReservation != nil && props.CapacityReservation.CapacityReservationGroup != nil && props.CapacityReservation.CapacityReservationGroup.ID != nil {
-		capacityReservationGroupId = *props.CapacityReservation.CapacityReservationGroup.ID
-	}
-	d.Set("capacity_reservation_group_id", capacityReservationGroupId)
-
-	if err := d.Set("boot_diagnostics", flattenBootDiagnostics(props.DiagnosticsProfile)); err != nil {
-		return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
-	}
-
-	d.Set("eviction_policy", string(props.EvictionPolicy))
-	if profile := props.HardwareProfile; profile != nil {
-		d.Set("size", string(profile.VMSize))
-	}
-	d.Set("license_type", props.LicenseType)
-
-	extensionsTimeBudget := "PT1H30M"
-	if props.ExtensionsTimeBudget != nil {
-		extensionsTimeBudget = *props.ExtensionsTimeBudget
-	}
-	d.Set("extensions_time_budget", extensionsTimeBudget)
-
-	if props.ApplicationProfile != nil && props.ApplicationProfile.GalleryApplications != nil {
-		d.Set("gallery_application", flattenVirtualMachineGalleryApplication(props.ApplicationProfile.GalleryApplications))
-	}
-
-	// defaulted since BillingProfile isn't returned if it's unset
-	maxBidPrice := float64(-1.0)
-	if props.BillingProfile != nil && props.BillingProfile.MaxPrice != nil {
-		maxBidPrice = *props.BillingProfile.MaxPrice
-	}
-	d.Set("max_bid_price", maxBidPrice)
-
-	if profile := props.NetworkProfile; profile != nil {
-		if err := d.Set("network_interface_ids", flattenVirtualMachineNetworkInterfaceIDs(props.NetworkProfile.NetworkInterfaces)); err != nil {
-			return fmt.Errorf("setting `network_interface_ids`: %+v", err)
-		}
-	}
-
-	dedicatedHostId := ""
-	if props.Host != nil && props.Host.ID != nil {
-		dedicatedHostId = *props.Host.ID
-	}
-	d.Set("dedicated_host_id", dedicatedHostId)
-
-	dedicatedHostGroupId := ""
-	if props.HostGroup != nil && props.HostGroup.ID != nil {
-		dedicatedHostGroupId = *props.HostGroup.ID
-	}
-	d.Set("dedicated_host_group_id", dedicatedHostGroupId)
-
-	virtualMachineScaleSetId := ""
-	if props.VirtualMachineScaleSet != nil && props.VirtualMachineScaleSet.ID != nil {
-		virtualMachineScaleSetId = *props.VirtualMachineScaleSet.ID
-	}
-	d.Set("virtual_machine_scale_set_id", virtualMachineScaleSetId)
-	platformFaultDomain := -1
-	if props.PlatformFaultDomain != nil {
-		platformFaultDomain = int(*props.PlatformFaultDomain)
-	}
-	d.Set("platform_fault_domain", platformFaultDomain)
-
-	if profile := props.OsProfile; profile != nil {
-		d.Set("admin_username", profile.AdminUsername)
-		d.Set("allow_extension_operations", profile.AllowExtensionOperations)
-		d.Set("computer_name", profile.ComputerName)
-
-		if config := profile.WindowsConfiguration; config != nil {
-			if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(config.AdditionalUnattendContent, d)); err != nil {
-				return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
-			}
-
-			d.Set("enable_automatic_updates", config.EnableAutomaticUpdates)
-			d.Set("provision_vm_agent", config.ProvisionVMAgent)
-			d.Set("vm_agent_platform_updates_enabled", config.EnableVMAgentPlatformUpdates)
-
-			assessmentMode := string(compute.WindowsPatchAssessmentModeImageDefault)
-			bypassPlatformSafetyChecksOnUserScheduleEnabled := false
-			rebootSetting := ""
-			if patchSettings := config.PatchSettings; patchSettings != nil {
-				d.Set("patch_mode", patchSettings.PatchMode)
-				d.Set("hotpatching_enabled", patchSettings.EnableHotpatching)
-
-				if patchSettings.AutomaticByPlatformSettings != nil {
-					bypassPlatformSafetyChecksOnUserScheduleEnabled = pointer.From(patchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule)
-					rebootSetting = string(patchSettings.AutomaticByPlatformSettings.RebootSetting)
-				}
-				if patchSettings.AssessmentMode != "" {
-					assessmentMode = string(patchSettings.AssessmentMode)
-				}
-			}
-
-			d.Set("patch_assessment_mode", assessmentMode)
-			d.Set("bypass_platform_safety_checks_on_user_schedule_enabled", bypassPlatformSafetyChecksOnUserScheduleEnabled)
-			d.Set("reboot_setting", rebootSetting)
-
-			d.Set("timezone", config.TimeZone)
-
-			if err := d.Set("winrm_listener", flattenWinRMListener(config.WinRM)); err != nil {
-				return fmt.Errorf("setting `winrm_listener`: %+v", err)
+		zone := ""
+		if model.Zones != nil {
+			if zones := *model.Zones; len(zones) > 0 {
+				zone = zones[0]
 			}
 		}
+		d.Set("zone", zone)
 
-		if err := d.Set("secret", flattenWindowsSecrets(profile.Secrets)); err != nil {
-			return fmt.Errorf("setting `secret`: %+v", err)
-		}
-	}
-	// Resources created with azurerm_virtual_machine have priority set to ""
-	// We need to treat "" as equal to "Regular" to allow migration azurerm_virtual_machine -> azurerm_linux_virtual_machine
-	priority := string(compute.VirtualMachinePriorityTypesRegular)
-	if props.Priority != "" {
-		priority = string(props.Priority)
-	}
-	d.Set("priority", priority)
-	proximityPlacementGroupId := ""
-	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
-		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID
-	}
-	d.Set("proximity_placement_group_id", proximityPlacementGroupId)
-
-	if profile := props.StorageProfile; profile != nil {
-		d.Set("disk_controller_type", string(props.StorageProfile.DiskControllerType))
-
-		// the storage_account_type isn't returned so we need to look it up
-		flattenedOSDisk, err := flattenVirtualMachineOSDisk(ctx, disksClient, profile.OsDisk)
+		identityFlattened, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {
-			return fmt.Errorf("flattening `os_disk`: %+v", err)
+			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
-		if err := d.Set("os_disk", flattenedOSDisk); err != nil {
-			return fmt.Errorf("settings `os_disk`: %+v", err)
-		}
-
-		var storageImageId string
-		if profile.ImageReference != nil && profile.ImageReference.ID != nil {
-			storageImageId = *profile.ImageReference.ID
-		}
-		if profile.ImageReference != nil && profile.ImageReference.CommunityGalleryImageID != nil {
-			storageImageId = *profile.ImageReference.CommunityGalleryImageID
-		}
-		if profile.ImageReference != nil && profile.ImageReference.SharedGalleryImageID != nil {
-			storageImageId = *profile.ImageReference.SharedGalleryImageID
-		}
-		d.Set("source_image_id", storageImageId)
-
-		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference, storageImageId != "")); err != nil {
-			return fmt.Errorf("setting `source_image_reference`: %+v", err)
-		}
-	}
-
-	if scheduleProfile := props.ScheduledEventsProfile; scheduleProfile != nil {
-		if err := d.Set("os_image_notification", flattenOsImageNotificationProfile(scheduleProfile.OsImageNotificationProfile)); err != nil {
-			return fmt.Errorf("setting `termination_notification`: %+v", err)
+		if err := d.Set("identity", identityFlattened); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
-		if err := d.Set("termination_notification", flattenTerminateNotificationProfile(scheduleProfile.TerminateNotificationProfile)); err != nil {
-			return fmt.Errorf("setting `termination_notification`: %+v", err)
+		if err := d.Set("plan", flattenPlan(model.Plan)); err != nil {
+			return fmt.Errorf("setting `plan`: %+v", err)
 		}
-	}
 
-	encryptionAtHostEnabled := false
-	vtpmEnabled := false
-	secureBootEnabled := false
-
-	if secprofile := props.SecurityProfile; secprofile != nil {
-		if secprofile.EncryptionAtHost != nil {
-			encryptionAtHostEnabled = *secprofile.EncryptionAtHost
-		}
-		if uefi := props.SecurityProfile.UefiSettings; uefi != nil {
-			if uefi.VTpmEnabled != nil {
-				vtpmEnabled = *uefi.VTpmEnabled
+		if props := model.Properties; props != nil {
+			if err := d.Set("additional_capabilities", flattenVirtualMachineAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+				return fmt.Errorf("setting `additional_capabilities`: %+v", err)
 			}
-			if uefi.SecureBootEnabled != nil {
-				secureBootEnabled = *uefi.SecureBootEnabled
+
+			availabilitySetId := ""
+			if props.AvailabilitySet != nil && props.AvailabilitySet.Id != nil {
+				availabilitySetId = *props.AvailabilitySet.Id
 			}
+			d.Set("availability_set_id", availabilitySetId)
+
+			capacityReservationGroupId := ""
+			if props.CapacityReservation != nil && props.CapacityReservation.CapacityReservationGroup != nil && props.CapacityReservation.CapacityReservationGroup.Id != nil {
+				capacityReservationGroupId = *props.CapacityReservation.CapacityReservationGroup.Id
+			}
+			d.Set("capacity_reservation_group_id", capacityReservationGroupId)
+
+			if err := d.Set("boot_diagnostics", flattenBootDiagnostics(props.DiagnosticsProfile)); err != nil {
+				return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+			}
+
+			d.Set("eviction_policy", pointer.From(props.EvictionPolicy))
+			if profile := props.HardwareProfile; profile != nil {
+				d.Set("size", pointer.From(profile.VMSize))
+			}
+			d.Set("license_type", props.LicenseType)
+
+			extensionsTimeBudget := "PT1H30M"
+			if props.ExtensionsTimeBudget != nil {
+				extensionsTimeBudget = *props.ExtensionsTimeBudget
+			}
+			d.Set("extensions_time_budget", extensionsTimeBudget)
+
+			if props.ApplicationProfile != nil && props.ApplicationProfile.GalleryApplications != nil {
+				d.Set("gallery_application", flattenVirtualMachineGalleryApplication(props.ApplicationProfile.GalleryApplications))
+			}
+
+			// defaulted since BillingProfile isn't returned if it's unset
+			maxBidPrice := float64(-1.0)
+			if props.BillingProfile != nil && props.BillingProfile.MaxPrice != nil {
+				maxBidPrice = *props.BillingProfile.MaxPrice
+			}
+			d.Set("max_bid_price", maxBidPrice)
+
+			if profile := props.NetworkProfile; profile != nil {
+				if err := d.Set("network_interface_ids", flattenVirtualMachineNetworkInterfaceIDs(props.NetworkProfile.NetworkInterfaces)); err != nil {
+					return fmt.Errorf("setting `network_interface_ids`: %+v", err)
+				}
+			}
+
+			dedicatedHostId := ""
+			if props.Host != nil && props.Host.Id != nil {
+				dedicatedHostId = *props.Host.Id
+			}
+			d.Set("dedicated_host_id", dedicatedHostId)
+
+			dedicatedHostGroupId := ""
+			if props.HostGroup != nil && props.HostGroup.Id != nil {
+				dedicatedHostGroupId = *props.HostGroup.Id
+			}
+			d.Set("dedicated_host_group_id", dedicatedHostGroupId)
+
+			virtualMachineScaleSetId := ""
+			if props.VirtualMachineScaleSet != nil && props.VirtualMachineScaleSet.Id != nil {
+				virtualMachineScaleSetId = *props.VirtualMachineScaleSet.Id
+			}
+			d.Set("virtual_machine_scale_set_id", virtualMachineScaleSetId)
+			platformFaultDomain := -1
+			if props.PlatformFaultDomain != nil {
+				platformFaultDomain = int(*props.PlatformFaultDomain)
+			}
+			d.Set("platform_fault_domain", platformFaultDomain)
+
+			if profile := props.OsProfile; profile != nil {
+				d.Set("admin_username", profile.AdminUsername)
+				d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+				d.Set("computer_name", profile.ComputerName)
+
+				if config := profile.WindowsConfiguration; config != nil {
+					if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(config.AdditionalUnattendContent, d)); err != nil {
+						return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
+					}
+
+					d.Set("enable_automatic_updates", config.EnableAutomaticUpdates)
+					d.Set("provision_vm_agent", config.ProvisionVMAgent)
+					d.Set("vm_agent_platform_updates_enabled", config.EnableVMAgentPlatformUpdates)
+
+					assessmentMode := string(virtualmachines.WindowsPatchAssessmentModeImageDefault)
+					bypassPlatformSafetyChecksOnUserScheduleEnabled := false
+					rebootSetting := ""
+					if patchSettings := config.PatchSettings; patchSettings != nil {
+						d.Set("patch_mode", patchSettings.PatchMode)
+						d.Set("hotpatching_enabled", patchSettings.EnableHotpatching)
+
+						if patchSettings.AutomaticByPlatformSettings != nil {
+							bypassPlatformSafetyChecksOnUserScheduleEnabled = pointer.From(patchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule)
+							rebootSetting = string(pointer.From(patchSettings.AutomaticByPlatformSettings.RebootSetting))
+						}
+						if patchSettings.AssessmentMode != nil {
+							assessmentMode = string(pointer.From(patchSettings.AssessmentMode))
+						}
+					}
+
+					d.Set("patch_assessment_mode", assessmentMode)
+					d.Set("bypass_platform_safety_checks_on_user_schedule_enabled", bypassPlatformSafetyChecksOnUserScheduleEnabled)
+					d.Set("reboot_setting", rebootSetting)
+
+					d.Set("timezone", config.TimeZone)
+
+					if err := d.Set("winrm_listener", flattenWinRMListener(config.WinRM)); err != nil {
+						return fmt.Errorf("setting `winrm_listener`: %+v", err)
+					}
+
+					if err := d.Set("secret", flattenWindowsSecrets(profile.Secrets)); err != nil {
+						return fmt.Errorf("setting `secret`: %+v", err)
+					}
+				}
+			}
+			// Resources created with azurerm_virtual_machine have priority set to ""
+			// We need to treat "" as equal to "Regular" to allow migration azurerm_virtual_machine -> azurerm_linux_virtual_machine
+			priority := string(virtualmachines.VirtualMachinePriorityTypesRegular)
+			if props.Priority != nil && *props.Priority != "" {
+				priority = string(pointer.From(props.Priority))
+			}
+			d.Set("priority", priority)
+
+			proximityPlacementGroupId := ""
+			if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.Id != nil {
+				proximityPlacementGroupId = *props.ProximityPlacementGroup.Id
+			}
+			d.Set("proximity_placement_group_id", proximityPlacementGroupId)
+
+			if profile := props.StorageProfile; profile != nil {
+				d.Set("disk_controller_type", pointer.From(props.StorageProfile.DiskControllerType))
+
+				// the storage_account_type isn't returned so we need to look it up
+				flattenedOSDisk, err := flattenVirtualMachineOSDisk(ctx, disksClient, profile.OsDisk)
+				if err != nil {
+					return fmt.Errorf("flattening `os_disk`: %+v", err)
+				}
+				if err := d.Set("os_disk", flattenedOSDisk); err != nil {
+					return fmt.Errorf("settings `os_disk`: %+v", err)
+				}
+
+				var storageImageId string
+				if profile.ImageReference != nil && profile.ImageReference.Id != nil {
+					storageImageId = *profile.ImageReference.Id
+				}
+				if profile.ImageReference != nil && profile.ImageReference.CommunityGalleryImageId != nil {
+					storageImageId = *profile.ImageReference.CommunityGalleryImageId
+				}
+				if profile.ImageReference != nil && profile.ImageReference.SharedGalleryImageId != nil {
+					storageImageId = *profile.ImageReference.SharedGalleryImageId
+				}
+				d.Set("source_image_id", storageImageId)
+
+				if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference, storageImageId != "")); err != nil {
+					return fmt.Errorf("setting `source_image_reference`: %+v", err)
+				}
+			}
+			if scheduleProfile := props.ScheduledEventsProfile; scheduleProfile != nil {
+				if err := d.Set("os_image_notification", flattenOsImageNotificationProfile(scheduleProfile.OsImageNotificationProfile)); err != nil {
+					return fmt.Errorf("setting `termination_notification`: %+v", err)
+				}
+
+				if err := d.Set("termination_notification", flattenTerminateNotificationProfile(scheduleProfile.TerminateNotificationProfile)); err != nil {
+					return fmt.Errorf("setting `termination_notification`: %+v", err)
+				}
+			}
+
+			encryptionAtHostEnabled := false
+			vtpmEnabled := false
+			secureBootEnabled := false
+			if securityProfile := props.SecurityProfile; securityProfile != nil {
+				if securityProfile.EncryptionAtHost != nil {
+					encryptionAtHostEnabled = *securityProfile.EncryptionAtHost
+				}
+				if uefi := props.SecurityProfile.UefiSettings; uefi != nil {
+					if uefi.VTpmEnabled != nil {
+						vtpmEnabled = *uefi.VTpmEnabled
+					}
+					if uefi.SecureBootEnabled != nil {
+						secureBootEnabled = *uefi.SecureBootEnabled
+					}
+				}
+			}
+			d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+			d.Set("vtpm_enabled", vtpmEnabled)
+			d.Set("secure_boot_enabled", secureBootEnabled)
+
+			d.Set("user_data", props.UserData)
+
+			connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, props)
+			d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)
+			d.Set("private_ip_addresses", connectionInfo.privateAddresses)
+			d.Set("public_ip_address", connectionInfo.primaryPublicAddress)
+			d.Set("public_ip_addresses", connectionInfo.publicAddresses)
+			isWindows := false
+			setConnectionInformation(d, connectionInfo, isWindows)
 		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
-	d.Set("vtpm_enabled", vtpmEnabled)
-	d.Set("secure_boot_enabled", secureBootEnabled)
-
-	d.Set("virtual_machine_id", props.VMID)
-
-	d.Set("user_data", props.UserData)
-
-	zone := ""
-	if resp.Zones != nil {
-		if zones := *resp.Zones; len(zones) > 0 {
-			zone = zones[0]
-		}
-	}
-	d.Set("zone", zone)
-
-	connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, resp.VirtualMachineProperties)
-	d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)
-	d.Set("private_ip_addresses", connectionInfo.privateAddresses)
-	d.Set("public_ip_address", connectionInfo.primaryPublicAddress)
-	d.Set("public_ip_addresses", connectionInfo.publicAddresses)
-	isWindows := false
-	setConnectionInformation(d, connectionInfo, isWindows)
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineID(d.Id())
+	id, err := virtualmachines.ParseVirtualMachineID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -1097,25 +1087,33 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
 	log.Printf("[DEBUG] Retrieving Windows %s", id)
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
+	existing, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
 
 	log.Printf("[DEBUG] Retrieving InstanceView for Windows %s", id)
-	instanceView, err := client.InstanceView(ctx, id.ResourceGroupName, id.VirtualMachineName)
+	instanceView, err := client.InstanceView(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving InstanceView for Windows %s: %+v", id, err)
 	}
 
-	shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView)
+	shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView.Model)
 	hasEphemeralOSDisk := false
-	if props := existing.VirtualMachineProperties; props != nil {
-		if storage := props.StorageProfile; storage != nil {
-			if disk := storage.OsDisk; disk != nil {
-				if settings := disk.DiffDiskSettings; settings != nil {
-					hasEphemeralOSDisk = settings.Option == compute.DiffDiskOptionsLocal
-				}
+
+	if existing.Model == nil {
+		return fmt.Errorf("`model` was nil for %s", id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("`properties` was nil for %s", id)
+	}
+
+	props := existing.Model.Properties
+	if storage := props.StorageProfile; storage != nil {
+		if disk := storage.OsDisk; disk != nil {
+			if settings := disk.DiffDiskSettings; settings != nil && settings.Option != nil {
+				hasEphemeralOSDisk = *settings.Option == virtualmachines.DiffDiskOptionsLocal
 			}
 		}
 	}
@@ -1124,28 +1122,28 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	shouldShutDown := false
 	shouldDeallocate := false
 
-	update := compute.VirtualMachineUpdate{
-		VirtualMachineProperties: &compute.VirtualMachineProperties{},
+	update := virtualmachines.VirtualMachineUpdate{
+		Properties: &virtualmachines.VirtualMachineProperties{},
 	}
 
 	if d.HasChange("boot_diagnostics") {
 		shouldUpdate = true
 
 		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
-		update.VirtualMachineProperties.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+		update.Properties.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
 	}
 
 	if d.HasChange("secret") {
 		shouldUpdate = true
 
-		profile := compute.OSProfile{}
+		profile := virtualmachines.OSProfile{}
 
 		if d.HasChange("secret") {
 			secretsRaw := d.Get("secret").([]interface{})
 			profile.Secrets = expandWindowsSecrets(secretsRaw)
 		}
 
-		update.VirtualMachineProperties.OsProfile = &profile
+		update.Properties.OsProfile = &profile
 	}
 
 	if d.HasChange("allow_extension_operations") {
@@ -1153,68 +1151,68 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		update.OsProfile.AllowExtensionOperations = utils.Bool(allowExtensionOperations)
+		update.Properties.OsProfile.AllowExtensionOperations = pointer.To(allowExtensionOperations)
 	}
 
 	if d.HasChange("vm_agent_platform_updates_enabled") {
 		shouldUpdate = true
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		update.OsProfile.WindowsConfiguration.EnableVMAgentPlatformUpdates = utils.Bool(d.Get("vm_agent_platform_updates_enabled").(bool))
+		update.Properties.OsProfile.WindowsConfiguration.EnableVMAgentPlatformUpdates = pointer.To(d.Get("vm_agent_platform_updates_enabled").(bool))
 	}
 
 	if d.HasChange("patch_mode") {
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		if update.OsProfile.WindowsConfiguration.PatchSettings == nil {
-			update.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{}
+		if update.Properties.OsProfile.WindowsConfiguration.PatchSettings == nil {
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{}
 		}
 
-		update.OsProfile.WindowsConfiguration.PatchSettings.PatchMode = compute.WindowsVMGuestPatchMode(d.Get("patch_mode").(string))
+		update.Properties.OsProfile.WindowsConfiguration.PatchSettings.PatchMode = pointer.To(virtualmachines.WindowsVMGuestPatchMode(d.Get("patch_mode").(string)))
 	}
 
 	if d.HasChange("patch_assessment_mode") {
 		assessmentMode := d.Get("patch_assessment_mode").(string)
-		if assessmentMode == string(compute.WindowsPatchAssessmentModeAutomaticByPlatform) && !d.Get("provision_vm_agent").(bool) {
+		if assessmentMode == string(virtualmachines.WindowsPatchAssessmentModeAutomaticByPlatform) && !d.Get("provision_vm_agent").(bool) {
 			return fmt.Errorf("`provision_vm_agent` must be set to `true` when `patch_assessment_mode` is set to `AutomaticByPlatform`")
 		}
 
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		if update.OsProfile.WindowsConfiguration.PatchSettings == nil {
-			update.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{}
+		if update.Properties.OsProfile.WindowsConfiguration.PatchSettings == nil {
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{}
 		}
 
-		update.OsProfile.WindowsConfiguration.PatchSettings.AssessmentMode = compute.WindowsPatchAssessmentMode(assessmentMode)
+		update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AssessmentMode = pointer.To(virtualmachines.WindowsPatchAssessmentMode(assessmentMode))
 	}
 
-	isPatchModeAutomaticByPlatform := d.Get("patch_mode") == string(compute.WindowsVMGuestPatchModeAutomaticByPlatform)
+	isPatchModeAutomaticByPlatform := d.Get("patch_mode") == string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform)
 	bypassPlatformSafetyChecksOnUserScheduleEnabled := d.Get("bypass_platform_safety_checks_on_user_schedule_enabled").(bool)
 	if bypassPlatformSafetyChecksOnUserScheduleEnabled && !isPatchModeAutomaticByPlatform {
 		return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `bypass_platform_safety_checks_on_user_schedule_enabled` is set to `true`")
@@ -1222,24 +1220,24 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	if d.HasChange("bypass_platform_safety_checks_on_user_schedule_enabled") {
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		if update.OsProfile.WindowsConfiguration.PatchSettings == nil {
-			update.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{}
+		if update.Properties.OsProfile.WindowsConfiguration.PatchSettings == nil {
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{}
 		}
 
 		if isPatchModeAutomaticByPlatform {
-			if update.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-				update.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &compute.WindowsVMGuestPatchAutomaticByPlatformSettings{}
+			if update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+				update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.WindowsVMGuestPatchAutomaticByPlatformSettings{}
 			}
 
-			update.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(bypassPlatformSafetyChecksOnUserScheduleEnabled)
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(bypassPlatformSafetyChecksOnUserScheduleEnabled)
 		}
 	}
 
@@ -1250,54 +1248,53 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	if d.HasChange("reboot_setting") {
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		if update.OsProfile.WindowsConfiguration.PatchSettings == nil {
-			update.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{}
+		if update.Properties.OsProfile.WindowsConfiguration.PatchSettings == nil {
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{}
 		}
 
 		if isPatchModeAutomaticByPlatform {
-			if update.VirtualMachineProperties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-				update.VirtualMachineProperties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &compute.WindowsVMGuestPatchAutomaticByPlatformSettings{}
+			if update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+				update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.WindowsVMGuestPatchAutomaticByPlatformSettings{}
 			}
 
-			update.VirtualMachineProperties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = compute.WindowsVMGuestPatchAutomaticByPlatformRebootSetting(rebootSetting)
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = pointer.To(virtualmachines.WindowsVMGuestPatchAutomaticByPlatformRebootSetting(rebootSetting))
 		}
 	}
 
 	if d.HasChange("hotpatching_enabled") {
 		shouldUpdate = true
 
-		if update.OsProfile == nil {
-			update.OsProfile = &compute.OSProfile{}
+		if update.Properties.OsProfile == nil {
+			update.Properties.OsProfile = &virtualmachines.OSProfile{}
 		}
 
-		if update.OsProfile.WindowsConfiguration == nil {
-			update.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{}
+		if update.Properties.OsProfile.WindowsConfiguration == nil {
+			update.Properties.OsProfile.WindowsConfiguration = &virtualmachines.WindowsConfiguration{}
 		}
 
-		if update.OsProfile.WindowsConfiguration.PatchSettings == nil {
-			update.OsProfile.WindowsConfiguration.PatchSettings = &compute.PatchSettings{}
+		if update.Properties.OsProfile.WindowsConfiguration.PatchSettings == nil {
+			update.Properties.OsProfile.WindowsConfiguration.PatchSettings = &virtualmachines.PatchSettings{}
 		}
 
-		update.OsProfile.WindowsConfiguration.PatchSettings.EnableHotpatching = utils.Bool(d.Get("hotpatching_enabled").(bool))
+		update.Properties.OsProfile.WindowsConfiguration.PatchSettings.EnableHotpatching = pointer.To(d.Get("hotpatching_enabled").(bool))
 	}
 
 	if d.HasChange("identity") {
 		shouldUpdate = true
 
-		identityRaw := d.Get("identity").([]interface{})
-		identity, err := expandVirtualMachineIdentity(identityRaw)
+		identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 		if err != nil {
 			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
-		update.Identity = identity
+		update.Identity = identityExpanded
 	}
 
 	if d.HasChange("capacity_reservation_group_id") {
@@ -1305,14 +1302,14 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-			update.CapacityReservation = &compute.CapacityReservationProfile{
-				CapacityReservationGroup: &compute.SubResource{
-					ID: utils.String(v.(string)),
+			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
+				CapacityReservationGroup: &virtualmachines.SubResource{
+					Id: pointer.To(v.(string)),
 				},
 			}
 		} else {
-			update.CapacityReservation = &compute.CapacityReservationProfile{
-				CapacityReservationGroup: &compute.SubResource{},
+			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
+				CapacityReservationGroup: &virtualmachines.SubResource{},
 			}
 		}
 	}
@@ -1324,11 +1321,11 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		if v, ok := d.GetOk("dedicated_host_id"); ok {
-			update.Host = &compute.SubResource{
-				ID: utils.String(v.(string)),
+			update.Properties.Host = &virtualmachines.SubResource{
+				Id: pointer.To(v.(string)),
 			}
 		} else {
-			update.Host = &compute.SubResource{}
+			update.Properties.Host = &virtualmachines.SubResource{}
 		}
 	}
 
@@ -1339,22 +1336,22 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		if v, ok := d.GetOk("dedicated_host_group_id"); ok {
-			update.HostGroup = &compute.SubResource{
-				ID: utils.String(v.(string)),
+			update.Properties.HostGroup = &virtualmachines.SubResource{
+				Id: pointer.To(v.(string)),
 			}
 		} else {
-			update.HostGroup = &compute.SubResource{}
+			update.Properties.HostGroup = &virtualmachines.SubResource{}
 		}
 	}
 
 	if d.HasChange("extensions_time_budget") {
 		shouldUpdate = true
-		update.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+		update.Properties.ExtensionsTimeBudget = pointer.To(d.Get("extensions_time_budget").(string))
 	}
 
 	if d.HasChange("gallery_application") {
 		shouldUpdate = true
-		update.ApplicationProfile = &compute.ApplicationProfile{
+		update.Properties.ApplicationProfile = &virtualmachines.ApplicationProfile{
 			GalleryApplications: expandVirtualMachineGalleryApplication(d.Get("gallery_application").([]interface{})),
 		}
 	}
@@ -1371,8 +1368,8 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		maxBidPrice := d.Get("max_bid_price").(float64)
-		update.VirtualMachineProperties.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(maxBidPrice),
+		update.Properties.BillingProfile = &virtualmachines.BillingProfile{
+			MaxPrice: pointer.To(maxBidPrice),
 		}
 	}
 
@@ -1389,7 +1386,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
 		networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
 
-		update.VirtualMachineProperties.NetworkProfile = &compute.NetworkProfile{
+		update.Properties.NetworkProfile = &virtualmachines.NetworkProfile{
 			NetworkInterfaces: &networkInterfaceIds,
 		}
 	}
@@ -1398,11 +1395,11 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldUpdate = true
 		shouldDeallocate = true
 
-		if update.VirtualMachineProperties.StorageProfile == nil {
-			update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{}
+		if update.Properties.StorageProfile == nil {
+			update.Properties.StorageProfile = &virtualmachines.StorageProfile{}
 		}
 
-		update.VirtualMachineProperties.StorageProfile.DiskControllerType = compute.DiskControllerTypes(d.Get("disk_controller_type").(string))
+		update.Properties.StorageProfile.DiskControllerType = pointer.To(virtualmachines.DiskControllerTypes(d.Get("disk_controller_type").(string)))
 	}
 
 	if d.HasChange("os_disk") {
@@ -1413,27 +1410,27 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		osDiskRaw := d.Get("os_disk").([]interface{})
-		osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, compute.OperatingSystemTypesWindows)
+		osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, virtualmachines.OperatingSystemTypesWindows)
 		if err != nil {
 			return fmt.Errorf("expanding `os_disk`: %+v", err)
 		}
 
-		if update.VirtualMachineProperties.StorageProfile == nil {
-			update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{}
+		if update.Properties.StorageProfile == nil {
+			update.Properties.StorageProfile = &virtualmachines.StorageProfile{}
 		}
 
-		update.VirtualMachineProperties.StorageProfile.OsDisk = osDisk
+		update.Properties.StorageProfile.OsDisk = osDisk
 	}
 
 	if d.HasChange("virtual_machine_scale_set_id") {
 		shouldUpdate = true
 
 		if vmssIDRaw, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
-			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{
-				ID: utils.String(vmssIDRaw.(string)),
+			update.Properties.VirtualMachineScaleSet = &virtualmachines.SubResource{
+				Id: pointer.To(vmssIDRaw.(string)),
 			}
 		} else {
-			update.VirtualMachineProperties.VirtualMachineScaleSet = &compute.SubResource{}
+			update.Properties.VirtualMachineScaleSet = &virtualmachines.SubResource{}
 		}
 	}
 
@@ -1445,11 +1442,11 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		shouldDeallocate = true
 
 		if ppgIDRaw, ok := d.GetOk("proximity_placement_group_id"); ok {
-			update.VirtualMachineProperties.ProximityPlacementGroup = &compute.SubResource{
-				ID: utils.String(ppgIDRaw.(string)),
+			update.Properties.ProximityPlacementGroup = &virtualmachines.SubResource{
+				Id: pointer.To(ppgIDRaw.(string)),
 			}
 		} else {
-			update.VirtualMachineProperties.ProximityPlacementGroup = &compute.SubResource{}
+			update.Properties.ProximityPlacementGroup = &virtualmachines.SubResource{}
 		}
 	}
 
@@ -1464,13 +1461,13 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		// Azure will auto-reboot this for us, providing this machine will fit on this host
 		// otherwise we need to shut down the VM to move it to another host to be able to use this size
 		availableOnThisHost := false
-		sizes, err := client.ListAvailableSizes(ctx, id.ResourceGroupName, id.VirtualMachineName)
+		sizes, err := client.ListAvailableSizes(ctx, *id)
 		if err != nil {
 			return fmt.Errorf("retrieving available sizes for Windows %s: %+v", id, err)
 		}
 
-		if sizes.Value != nil {
-			for _, size := range *sizes.Value {
+		if sizes.Model != nil && sizes.Model.Value != nil {
+			for _, size := range *sizes.Model.Value {
 				if size.Name == nil {
 					continue
 				}
@@ -1491,8 +1488,8 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			shouldDeallocate = true
 		}
 
-		update.VirtualMachineProperties.HardwareProfile = &compute.HardwareProfile{
-			VMSize: compute.VirtualMachineSizeTypes(vmSize),
+		update.Properties.HardwareProfile = &virtualmachines.HardwareProfile{
+			VMSize: pointer.To(virtualmachines.VirtualMachineSizeTypes(vmSize)),
 		}
 	}
 
@@ -1503,8 +1500,8 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		update.Tags = tags.Expand(tagsRaw)
 	}
 
-	var osImageNotificationProfile *compute.OSImageNotificationProfile
-	var terminateNotificationProfile *compute.TerminateNotificationProfile
+	var osImageNotificationProfile *virtualmachines.OSImageNotificationProfile
+	var terminateNotificationProfile *virtualmachines.TerminateNotificationProfile
 
 	if d.HasChange("os_image_notification") {
 		shouldUpdate = true
@@ -1517,7 +1514,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if osImageNotificationProfile != nil || terminateNotificationProfile != nil {
-		update.ScheduledEventsProfile = &compute.ScheduledEventsProfile{
+		update.Properties.ScheduledEventsProfile = &virtualmachines.ScheduledEventsProfile{
 			OsImageNotificationProfile:   osImageNotificationProfile,
 			TerminateNotificationProfile: terminateNotificationProfile,
 		}
@@ -1533,24 +1530,24 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 
 		additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
-		update.VirtualMachineProperties.AdditionalCapabilities = expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
+		update.Properties.AdditionalCapabilities = expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
 	}
 
 	if d.HasChange("encryption_at_host_enabled") {
 		if d.Get("encryption_at_host_enabled").(bool) {
 			osDiskRaw := d.Get("os_disk").([]interface{})
 			securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachines.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachines.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
 		shouldUpdate = true
 		shouldDeallocate = true // API returns the following error if not deallocate: 'securityProfile.encryptionAtHost' can be updated only when VM is in deallocated state
-		if update.SecurityProfile == nil {
-			update.SecurityProfile = &compute.SecurityProfile{}
+		if update.Properties.SecurityProfile == nil {
+			update.Properties.SecurityProfile = &virtualmachines.SecurityProfile{}
 		}
-		update.SecurityProfile.EncryptionAtHost = utils.Bool(d.Get("encryption_at_host_enabled").(bool))
+		update.Properties.SecurityProfile.EncryptionAtHost = pointer.To(d.Get("encryption_at_host_enabled").(bool))
 	}
 
 	if d.HasChange("license_type") {
@@ -1563,16 +1560,16 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			// To allow updating in this case set value explicitly to 'None'.
 			license = "None"
 		}
-		update.VirtualMachineProperties.LicenseType = &license
+		update.Properties.LicenseType = &license
 	}
 
 	if d.HasChange("user_data") {
 		shouldUpdate = true
-		update.UserData = utils.String(d.Get("user_data").(string))
+		update.Properties.UserData = pointer.To(d.Get("user_data").(string))
 	}
 
-	if instanceView.Statuses != nil {
-		for _, status := range *instanceView.Statuses {
+	if instanceView.Model != nil && instanceView.Model.Statuses != nil {
+		for _, status := range *instanceView.Model.Statuses {
 			if status.Code == nil {
 				continue
 			}
@@ -1603,14 +1600,8 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if shouldShutDown {
 		log.Printf("[DEBUG] Shutting Down Windows %s", id)
-		forceShutdown := false
-		future, err := client.PowerOff(ctx, id.ResourceGroupName, id.VirtualMachineName, utils.Bool(forceShutdown))
-		if err != nil {
+		if err := client.PowerOffThenPoll(ctx, *id, virtualmachines.DefaultPowerOffOperationOptions()); err != nil {
 			return fmt.Errorf("sending Power Off to Windows %s: %+v", id, err)
-		}
-
-		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for Power Off of Windows %s: %+v", id, err)
 		}
 
 		log.Printf("[DEBUG] Shut Down Windows %s", id)
@@ -1620,15 +1611,9 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		if !hasEphemeralOSDisk {
 			log.Printf("[DEBUG] Deallocating Windows %s", id)
 			// Upgrading to the 2021-07-01 exposed a new hibernate parameter in the Deallocate method
-			future, err := client.Deallocate(ctx, id.ResourceGroupName, id.VirtualMachineName, utils.Bool(false))
-			if err != nil {
+			if err := client.DeallocateThenPoll(ctx, *id, virtualmachines.DefaultDeallocateOperationOptions()); err != nil {
 				return fmt.Errorf("deallocating Windows %s: %+v", id, err)
 			}
-
-			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting for Deallocation of Windows %s: %+v", id, err)
-			}
-
 			log.Printf("[DEBUG] Deallocated Windows %s", id)
 		} else {
 			// Code="OperationNotAllowed" Message="Operation 'deallocate' is not supported for VMs or VM Scale Set instances using an ephemeral OS disk."
@@ -1650,7 +1635,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 		update := disks.DiskUpdate{
 			Properties: &disks.DiskUpdateProperties{
-				DiskSizeGB: utils.Int64(int64(newSize)),
+				DiskSizeGB: pointer.To(int64(newSize)),
 			},
 		}
 
@@ -1680,7 +1665,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 				Properties: &disks.DiskUpdateProperties{
 					Encryption: &disks.Encryption{
 						Type:                encryptionType,
-						DiskEncryptionSetId: utils.String(diskEncryptionSetId),
+						DiskEncryptionSetId: pointer.To(diskEncryptionSetId),
 					},
 				},
 			}
@@ -1698,13 +1683,8 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if shouldUpdate {
 		log.Printf("[DEBUG] Updating Windows %s", id)
-		future, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineName, update)
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Windows %s: %+v", id, err)
-		}
-
-		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for update of Windows %s: %+v", id, err)
 		}
 
 		log.Printf("[DEBUG] Updated Windows %s.", id)
@@ -1713,15 +1693,9 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	// if we've shut it down and it was turned off, let's boot it back up
 	if shouldTurnBackOn && (shouldShutDown || shouldDeallocate) {
 		log.Printf("[DEBUG] Starting Windows %s", id)
-		future, err := client.Start(ctx, id.ResourceGroupName, id.VirtualMachineName)
-		if err != nil {
+		if err := client.StartThenPoll(ctx, *id); err != nil {
 			return fmt.Errorf("starting Windows %s: %+v", id, err)
 		}
-
-		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for start of Windows %s: %+v", id, err)
-		}
-
 		log.Printf("[DEBUG] Started Windows %s", id)
 	}
 
@@ -1729,11 +1703,11 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 }
 
 func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineID(d.Id())
+	id, err := virtualmachines.ParseVirtualMachineID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -1742,9 +1716,9 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
 	log.Printf("[DEBUG] Retrieving Windows %s", id)
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, "")
+	existing, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
+		if response.WasNotFound(existing.HttpResponse) {
 			return nil
 		}
 
@@ -1753,8 +1727,8 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 
 	if !meta.(*clients.Client).Features.VirtualMachine.SkipShutdownAndForceDelete {
 		// If the VM was in a Failed state we can skip powering off, since that'll fail
-		if strings.EqualFold(*existing.ProvisioningState, "failed") {
-			log.Printf("[DEBUG] Powering Off Windows %s was skipped because the VM was in %q state", id, *existing.ProvisioningState)
+		if existing.Model != nil && existing.Model.Properties != nil && strings.EqualFold(*existing.Model.Properties.ProvisioningState, "failed") {
+			log.Printf("[DEBUG] Powering Off Windows %s was skipped because the VM was in %q state", id, *existing.Model.Properties.ProvisioningState)
 		} else {
 			// ISSUE: 4920
 			// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
@@ -1762,12 +1736,11 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 			// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
 			log.Printf("[DEBUG] Powering Off Windows %s.", id)
 			skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
-			powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroupName, id.VirtualMachineName, utils.Bool(skipShutdown))
-			if err != nil {
-				return fmt.Errorf("powering off Windows %s: %+v", id, err)
+			options := virtualmachines.PowerOffOperationOptions{
+				SkipShutdown: pointer.To(skipShutdown),
 			}
-			if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting for power off of Windows %s: %+v", id, err)
+			if err := client.PowerOffThenPoll(ctx, *id, options); err != nil {
+				return fmt.Errorf("powering off Windows %s: %+v", id, err)
 			}
 			log.Printf("[DEBUG] Powered Off Windows %s", id)
 		}
@@ -1778,16 +1751,9 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 	// Force Delete is in an opt-in Preview and can only be specified (true/false) if the feature is enabled
 	// as such we default this to `nil` which matches the previous behaviour (where this isn't sent) and
 	// conditionally set this if required
-	var forceDeletion *bool = nil
-	if meta.(*clients.Client).Features.VirtualMachine.SkipShutdownAndForceDelete {
-		forceDeletion = utils.Bool(true)
-	}
-	deleteFuture, err := client.Delete(ctx, id.ResourceGroupName, id.VirtualMachineName, forceDeletion)
-	if err != nil {
+
+	if err := client.DeleteThenPoll(ctx, *id, virtualmachines.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting Windows %s: %+v", id, err)
-	}
-	if err := deleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of Windows %s: %+v", id, err)
 	}
 	log.Printf("[DEBUG] Deleted Windows %s", id)
 
@@ -1796,9 +1762,11 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 		log.Printf("[DEBUG] Deleting OS Disk from Windows %s", id)
 		disksClient := meta.(*clients.Client).Compute.DisksClient
 		managedDiskId := ""
-		if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
-			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.ID != nil {
-				managedDiskId = *disk.ID
+		if model := existing.Model; model != nil {
+			if props := model.Properties; props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
+				if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.Id != nil {
+					managedDiskId = *disk.Id
+				}
 			}
 		}
 
@@ -1833,12 +1801,12 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 	// disks have actually been deleted.
 
 	log.Printf("[INFO] verifying Windows %s has been deleted", id)
-	virtualMachine, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, "")
-	if err != nil && !utils.ResponseWasNotFound(virtualMachine.Response) {
+	virtualMachine, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
+	if err != nil && !response.WasNotFound(virtualMachine.HttpResponse) {
 		return fmt.Errorf("verifying Windows %s has been deleted: %+v", id, err)
 	}
 
-	if !utils.ResponseWasNotFound(virtualMachine.Response) {
+	if !response.WasNotFound(virtualMachine.HttpResponse) {
 		log.Printf("[INFO] Windows %s still exists, waiting on vm to be deleted", id)
 
 		deleteWait := &pluginsdk.StateChangeConf{
@@ -1848,14 +1816,14 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 			Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
 			Refresh: func() (interface{}, string, error) {
 				log.Printf("[INFO] checking on state of Windows %s", id)
-				resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, "")
+				resp, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 				if err != nil {
-					if utils.ResponseWasNotFound(resp.Response) {
-						return resp, strconv.Itoa(resp.StatusCode), nil
+					if response.WasNotFound(resp.HttpResponse) {
+						return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
 					}
 					return nil, "nil", fmt.Errorf("polling for the status of Windows %s: %v", id, err)
 				}
-				return resp, strconv.Itoa(resp.StatusCode), nil
+				return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
 			},
 		}
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -959,7 +959,7 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 					bypassPlatformSafetyChecksOnUserScheduleEnabled := false
 					rebootSetting := ""
 					if patchSettings := config.PatchSettings; patchSettings != nil {
-						d.Set("patch_mode", patchSettings.PatchMode)
+						d.Set("patch_mode", pointer.From(patchSettings.PatchMode))
 						d.Set("hotpatching_enabled", patchSettings.EnableHotpatching)
 
 						if patchSettings.AutomaticByPlatformSettings != nil {

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1058,7 +1058,8 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("vtpm_enabled", vtpmEnabled)
 			d.Set("secure_boot_enabled", secureBootEnabled)
 
-			d.Set("user_data", props.UserData)
+			// userData is not returned by the API
+			d.Set("user_data", d.Get("user_data").(string))
 
 			connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, props)
 			d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -483,14 +483,14 @@ func TestAccWindowsVirtualMachine_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "user_data"),
+		data.ImportStep("admin_password"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "user_data"),
+		data.ImportStep("admin_password"),
 	})
 }
 

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -483,14 +483,14 @@ func TestAccWindowsVirtualMachine_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password"),
+		data.ImportStep("admin_password", "user_data"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password"),
+		data.ImportStep("admin_password", "user_data"),
 	})
 }
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -8,13 +8,18 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -22,14 +27,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/base64"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
@@ -42,7 +44,7 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := commonids.ParseVirtualMachineScaleSetID(id)
 			return err
-		}, importVirtualMachineScaleSet(compute.OperatingSystemTypesWindows, "azurerm_windows_virtual_machine_scale_set")),
+		}, importVirtualMachineScaleSet(virtualmachinescalesets.OperatingSystemTypesWindows, "azurerm_windows_virtual_machine_scale_set")),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
@@ -59,34 +61,33 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 }
 
 func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := commonids.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	exists, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	exists, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if !utils.ResponseWasNotFound(exists.Response) {
+		if !response.WasNotFound(exists.HttpResponse) {
 			return fmt.Errorf("checking for existing Windows %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(exists.Response) {
-		return tf.ImportAsExistsError("azurerm_windows_virtual_machine_scale_set", *exists.ID)
+	if !response.WasNotFound(exists.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_windows_virtual_machine_scale_set", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := ExpandVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
 
 	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
-	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
+	additionalUnattendContent := expandAdditionalUnattendContentVMSS(additionalUnattendContentRaw)
 
 	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
-	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+	bootDiagnostics := expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 
 	dataDisksRaw := d.Get("data_disk").([]interface{})
 	ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
@@ -95,7 +96,7 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		return fmt.Errorf("expanding `data_disk`: %+v", err)
 	}
 
-	identity, err := expandVirtualMachineScaleSetIdentity(d.Get("identity").([]interface{}))
+	identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
@@ -107,23 +108,23 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	osDiskRaw := d.Get("os_disk").([]interface{})
-	osDisk, err := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, compute.OperatingSystemTypesWindows)
+	osDisk, err := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, virtualmachinescalesets.OperatingSystemTypesWindows)
 	if err != nil {
 		return fmt.Errorf("expanding `os_disk`: %+v", err)
 	}
 	securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
 
 	planRaw := d.Get("plan").([]interface{})
-	plan := expandPlan(planRaw)
+	plan := expandPlanVMSS(planRaw)
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 
 	provisionVMAgent := d.Get("provision_vm_agent").(bool)
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	healthProbeId := d.Get("health_probe_id").(string)
-	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	upgradeMode := virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
 	automaticOSUpgradePolicy := ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticOSUpgradePolicyRaw)
 	rollingUpgradePolicyRaw := d.Get("rolling_upgrade_policy").([]interface{})
@@ -132,25 +133,25 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		return err
 	}
 
-	canHaveAutomaticOsUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	canHaveAutomaticOsUpgradePolicy := upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic || upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if !canHaveAutomaticOsUpgradePolicy && len(automaticOSUpgradePolicyRaw) > 0 {
 		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic` or `Rolling`")
 	}
 
-	shouldHaveRollingUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	shouldHaveRollingUpgradePolicy := upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic || upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if !shouldHaveRollingUpgradePolicy && len(rollingUpgradePolicyRaw) > 0 {
 		return fmt.Errorf("a `rolling_upgrade_policy` block cannot be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
-	shouldHaveRollingUpgradePolicy = upgradeMode == compute.UpgradeModeRolling
+	shouldHaveRollingUpgradePolicy = upgradeMode == virtualmachinescalesets.UpgradeModeRolling
 	if shouldHaveRollingUpgradePolicy && len(rollingUpgradePolicyRaw) == 0 {
 		return fmt.Errorf("a `rolling_upgrade_policy` block must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
 
 	winRmListenersRaw := d.Get("winrm_listener").(*pluginsdk.Set).List()
-	winRmListeners := expandWinRMListener(winRmListenersRaw)
+	winRmListeners := expandWinRMListenerVMSS(winRmListenersRaw)
 
 	secretsRaw := d.Get("secret").([]interface{})
-	secrets := expandWindowsSecrets(secretsRaw)
+	secrets := expandWindowsSecretsVMSS(secretsRaw)
 
 	var computerNamePrefix string
 	if v, ok := d.GetOk("computer_name_prefix"); ok && len(v.(string)) > 0 {
@@ -163,37 +164,37 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		computerNamePrefix = id.VirtualMachineScaleSetName
 	}
 
-	networkProfile := &compute.VirtualMachineScaleSetNetworkProfile{
+	networkProfile := &virtualmachinescalesets.VirtualMachineScaleSetNetworkProfile{
 		NetworkInterfaceConfigurations: networkInterfaces,
 	}
 	if healthProbeId != "" {
-		networkProfile.HealthProbe = &compute.APIEntityReference{
-			ID: utils.String(healthProbeId),
+		networkProfile.HealthProbe = &virtualmachinescalesets.ApiEntityReference{
+			Id: pointer.To(healthProbeId),
 		}
 	}
 
-	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
-	upgradePolicy := compute.UpgradePolicy{
-		Mode:                     upgradeMode,
+	priority := virtualmachinescalesets.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	upgradePolicy := virtualmachinescalesets.UpgradePolicy{
+		Mode:                     pointer.To(upgradeMode),
 		AutomaticOSUpgradePolicy: automaticOSUpgradePolicy,
 		RollingUpgradePolicy:     rollingUpgradePolicy,
 	}
 
-	virtualMachineProfile := compute.VirtualMachineScaleSetVMProfile{
-		Priority: priority,
-		OsProfile: &compute.VirtualMachineScaleSetOSProfile{
-			AdminPassword:      utils.String(d.Get("admin_password").(string)),
-			AdminUsername:      utils.String(d.Get("admin_username").(string)),
-			ComputerNamePrefix: utils.String(computerNamePrefix),
-			WindowsConfiguration: &compute.WindowsConfiguration{
-				ProvisionVMAgent: utils.Bool(provisionVMAgent),
+	virtualMachineProfile := virtualmachinescalesets.VirtualMachineScaleSetVMProfile{
+		Priority: pointer.To(priority),
+		OsProfile: &virtualmachinescalesets.VirtualMachineScaleSetOSProfile{
+			AdminPassword:      pointer.To(d.Get("admin_password").(string)),
+			AdminUsername:      pointer.To(d.Get("admin_username").(string)),
+			ComputerNamePrefix: pointer.To(computerNamePrefix),
+			WindowsConfiguration: &virtualmachinescalesets.WindowsConfiguration{
+				ProvisionVMAgent: pointer.To(provisionVMAgent),
 				WinRM:            winRmListeners,
 			},
 			Secrets: secrets,
 		},
 		DiagnosticsProfile: bootDiagnostics,
 		NetworkProfile:     networkProfile,
-		StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{
+		StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetStorageProfile{
 			ImageReference: sourceImageReference,
 			OsDisk:         osDisk,
 			DataDisks:      dataDisks,
@@ -202,14 +203,14 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 
 	if !features.FourPointOhBeta() {
 		if galleryApplications := expandVirtualMachineScaleSetGalleryApplications(d.Get("gallery_applications").([]interface{})); galleryApplications != nil {
-			virtualMachineProfile.ApplicationProfile = &compute.ApplicationProfile{
+			virtualMachineProfile.ApplicationProfile = &virtualmachinescalesets.ApplicationProfile{
 				GalleryApplications: galleryApplications,
 			}
 		}
 	}
 
 	if galleryApplications := expandVirtualMachineScaleSetGalleryApplication(d.Get("gallery_application").([]interface{})); galleryApplications != nil {
-		virtualMachineProfile.ApplicationProfile = &compute.ApplicationProfile{
+		virtualMachineProfile.ApplicationProfile = &virtualmachinescalesets.ApplicationProfile{
 			GalleryApplications: galleryApplications,
 		}
 	}
@@ -218,9 +219,9 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		if d.Get("single_placement_group").(bool) {
 			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
 		}
-		virtualMachineProfile.CapacityReservation = &compute.CapacityReservationProfile{
-			CapacityReservationGroup: &compute.SubResource{
-				ID: utils.String(v.(string)),
+		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(v.(string)),
 			},
 		}
 	}
@@ -240,60 +241,60 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 
 		if !features.FourPointOhBeta() {
 			if !pluginsdk.IsExplicitlyNullInConfig(d, "extension_operations_enabled") {
-				virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(v)
+				virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(v)
 			}
 		} else {
-			virtualMachineProfile.OsProfile.AllowExtensionOperations = utils.Bool(v)
+			virtualMachineProfile.OsProfile.AllowExtensionOperations = pointer.To(v)
 		}
 	}
 
 	if v, ok := d.GetOk("extensions_time_budget"); ok {
 		if virtualMachineProfile.ExtensionProfile == nil {
-			virtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+			virtualMachineProfile.ExtensionProfile = &virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile{}
 		}
-		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(v.(string))
+		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(v.(string))
 	}
 
 	// otherwise the service return the error:
 	// Rolling Upgrade mode is not supported for this Virtual Machine Scale Set because a health probe or health extension was not provided.
-	if upgradeMode == compute.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
+	if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
 		return fmt.Errorf("`health_probe_id` must be set or a health extension must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
 	}
 
 	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
-	virtualMachineProfile.OsProfile.WindowsConfiguration.EnableAutomaticUpdates = utils.Bool(enableAutomaticUpdates)
+	virtualMachineProfile.OsProfile.WindowsConfiguration.EnableAutomaticUpdates = pointer.To(enableAutomaticUpdates)
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
-		if priority != compute.VirtualMachinePriorityTypesSpot {
+		if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		virtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(v),
+		virtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+			MaxPrice: pointer.To(v),
 		}
 	}
 
 	if v, ok := d.GetOk("custom_data"); ok {
-		virtualMachineProfile.OsProfile.CustomData = utils.String(v.(string))
+		virtualMachineProfile.OsProfile.CustomData = pointer.To(v.(string))
 	}
 
 	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
 		if encryptionAtHostEnabled.(bool) {
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
 		if virtualMachineProfile.SecurityProfile == nil {
-			virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 		}
-		virtualMachineProfile.SecurityProfile.EncryptionAtHost = utils.Bool(encryptionAtHostEnabled.(bool))
+		virtualMachineProfile.SecurityProfile.EncryptionAtHost = pointer.To(encryptionAtHostEnabled.(bool))
 	}
 
 	secureBootEnabled := d.Get("secure_boot_enabled").(bool)
 	vtpmEnabled := d.Get("vtpm_enabled").(bool)
 	if securityEncryptionType != "" {
-		if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
+		if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) && !secureBootEnabled {
 			return fmt.Errorf("`secure_boot_enabled` must be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 		}
 		if !vtpmEnabled {
@@ -301,46 +302,46 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		}
 
 		if virtualMachineProfile.SecurityProfile == nil {
-			virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 		}
-		virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesConfidentialVM
+		virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesConfidentialVM)
 
 		if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-			virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+			virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 		}
-		virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
-		virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+		virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
+		virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 	} else {
 		if secureBootEnabled {
 			if virtualMachineProfile.SecurityProfile == nil {
-				virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+				virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 			}
 
 			if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-				virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+				virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 			}
-			virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = utils.Bool(secureBootEnabled)
+			virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+			virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
 		}
 
 		if vtpmEnabled {
 			if virtualMachineProfile.SecurityProfile == nil {
-				virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+				virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 			}
 			if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
-				virtualMachineProfile.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+				virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
 			}
-			virtualMachineProfile.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-			virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = utils.Bool(vtpmEnabled)
+			virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+			virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 		}
 	}
 
 	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
-		if virtualMachineProfile.Priority != compute.VirtualMachinePriorityTypesSpot {
+		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("an `eviction_policy` can only be specified when `priority` is set to `Spot`")
 		}
-		virtualMachineProfile.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string))
-	} else if priority == compute.VirtualMachinePriorityTypesSpot {
+		virtualMachineProfile.EvictionPolicy = pointer.To(virtualmachinescalesets.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string)))
+	} else if priority == virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 		return fmt.Errorf("an `eviction_policy` must be specified when `priority` is set to `Spot`")
 	}
 
@@ -349,21 +350,21 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
-		virtualMachineProfile.LicenseType = utils.String(v.(string))
+		virtualMachineProfile.LicenseType = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("timezone"); ok {
-		virtualMachineProfile.OsProfile.WindowsConfiguration.TimeZone = utils.String(v.(string))
+		virtualMachineProfile.OsProfile.WindowsConfiguration.TimeZone = pointer.To(v.(string))
 	}
 
-	scaleInPolicy := &compute.ScaleInPolicy{
-		Rules:         &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(string(compute.VirtualMachineScaleSetScaleInRulesDefault))},
-		ForceDeletion: utils.Bool(false),
+	scaleInPolicy := &virtualmachinescalesets.ScaleInPolicy{
+		Rules:         &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault))},
+		ForceDeletion: pointer.To(false),
 	}
 
 	if !features.FourPointOhBeta() {
 		if v, ok := d.GetOk("scale_in_policy"); ok {
-			scaleInPolicy.Rules = &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(v.(string))}
+			scaleInPolicy.Rules = &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(v.(string))}
 		}
 
 		if v, ok := d.GetOk("terminate_notification"); ok {
@@ -382,50 +383,50 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("user_data"); ok {
-		virtualMachineProfile.UserData = utils.String(v.(string))
+		virtualMachineProfile.UserData = pointer.To(v.(string))
 	}
 
 	automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
 	automaticRepairsPolicy := ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
 
-	props := compute.VirtualMachineScaleSet{
+	props := virtualmachinescalesets.VirtualMachineScaleSet{
 		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
-		Location:         utils.String(location),
-		Sku: &compute.Sku{
-			Name:     utils.String(d.Get("sku").(string)),
-			Capacity: utils.Int64(int64(d.Get("instances").(int))),
+		Location:         location.Normalize(d.Get("location").(string)),
+		Sku: &virtualmachinescalesets.Sku{
+			Name:     pointer.To(d.Get("sku").(string)),
+			Capacity: pointer.To(int64(d.Get("instances").(int))),
 
 			// doesn't appear this can be set to anything else, even Promo machines are Standard
-			Tier: utils.String("Standard"),
+			Tier: pointer.To("Standard"),
 		},
-		Identity: identity,
+		Identity: identityExpanded,
 		Plan:     plan,
 		Tags:     tags.Expand(t),
-		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+		Properties: &virtualmachinescalesets.VirtualMachineScaleSetProperties{
 			AdditionalCapabilities:                 additionalCapabilities,
 			AutomaticRepairsPolicy:                 automaticRepairsPolicy,
-			DoNotRunExtensionsOnOverprovisionedVMs: utils.Bool(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
-			Overprovision:                          utils.Bool(d.Get("overprovision").(bool)),
-			SinglePlacementGroup:                   utils.Bool(d.Get("single_placement_group").(bool)),
+			DoNotRunExtensionsOnOverprovisionedVMs: pointer.To(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
+			Overprovision:                          pointer.To(d.Get("overprovision").(bool)),
+			SinglePlacementGroup:                   pointer.To(d.Get("single_placement_group").(bool)),
 			VirtualMachineProfile:                  &virtualMachineProfile,
 			UpgradePolicy:                          &upgradePolicy,
 			// OrchestrationMode needs to be hardcoded to Uniform, for the
 			// standard VMSS resource, since virtualMachineProfile is now supported
 			// in both VMSS and Orchestrated VMSS...
-			OrchestrationMode: compute.OrchestrationModeUniform,
+			OrchestrationMode: pointer.To(virtualmachinescalesets.OrchestrationModeUniform),
 			ScaleInPolicy:     scaleInPolicy,
 		},
 	}
 
 	if v, ok := d.GetOk("host_group_id"); ok {
-		props.VirtualMachineScaleSetProperties.HostGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		props.Properties.HostGroup = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	spotRestoreRaw := d.Get("spot_restore").([]interface{})
 	if spotRestorePolicy := ExpandVirtualMachineScaleSetSpotRestorePolicy(spotRestoreRaw); spotRestorePolicy != nil {
-		props.SpotRestorePolicy = spotRestorePolicy
+		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
 	if len(zones) > 0 {
@@ -433,12 +434,12 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("platform_fault_domain_count"); ok {
-		props.VirtualMachineScaleSetProperties.PlatformFaultDomainCount = utils.Int32(int32(v.(int)))
+		props.Properties.PlatformFaultDomainCount = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
-		props.VirtualMachineScaleSetProperties.ProximityPlacementGroup = &compute.SubResource{
-			ID: utils.String(v.(string)),
+		props.Properties.ProximityPlacementGroup = &virtualmachinescalesets.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
@@ -447,18 +448,12 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 			return fmt.Errorf("`zone_balance` can only be set to `true` when zones are specified")
 		}
 
-		props.VirtualMachineScaleSetProperties.ZoneBalance = utils.Bool(v.(bool))
+		props.Properties.ZoneBalance = pointer.To(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Windows %s.", id)
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, props)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Windows %s: %+v", id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for Windows %s to be created.", id)
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
 	}
 	log.Printf("[DEBUG] Windows %s was created", id)
 
@@ -468,65 +463,66 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 }
 
 func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	updateInstances := false
 
-	// retrieve
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
-	if existing.VirtualMachineScaleSetProperties == nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving Windows %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving Windows %s: `properties` was nil", id)
 	}
-	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+	if existing.Model.Properties.VirtualMachineProfile == nil {
 		return fmt.Errorf("retrieving Windows %s: `properties.virtualMachineProfile` was nil", id)
 	}
-	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile == nil {
+	if existing.Model.Properties.VirtualMachineProfile.StorageProfile == nil {
 		return fmt.Errorf("retrieving Windows %s: `properties.virtualMachineProfile,storageProfile` was nil", id)
 	}
 
-	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
-		VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
+	updateProps := virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{
+		VirtualMachineProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateVMProfile{
 			// if an image reference has been configured previously (it has to be), we would better to include that in this
 			// update request to avoid some circumstances that the API will complain ImageReference is null
 			// issue tracking: https://github.com/Azure/azure-rest-api-specs/issues/10322
-			StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
-				ImageReference: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference,
+			StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{
+				ImageReference: existing.Model.Properties.VirtualMachineProfile.StorageProfile.ImageReference,
 			},
 		},
 		// if an upgrade policy's been configured previously (which it will have) it must be threaded through
 		// this doesn't matter for Manual - but breaks when updating anything on a Automatic and Rolling Mode Scale Set
-		UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+		UpgradePolicy: existing.Model.Properties.UpgradePolicy,
 	}
-	update := compute.VirtualMachineScaleSetUpdate{}
+	update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{}
 
-	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	upgradeMode := virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 	// first try and pull this from existing vm, which covers no changes being made to this block
 	automaticOSUpgradeIsEnabled := false
-	if policy := existing.VirtualMachineScaleSetProperties.UpgradePolicy; policy != nil {
+	if policy := existing.Model.Properties.UpgradePolicy; policy != nil {
 		if policy.AutomaticOSUpgradePolicy != nil && policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade != nil {
 			automaticOSUpgradeIsEnabled = *policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
 		}
 	}
 	if d.HasChange("automatic_os_upgrade_policy") || d.HasChange("rolling_upgrade_policy") {
-		upgradePolicy := compute.UpgradePolicy{}
-		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
-			upgradePolicy = compute.UpgradePolicy{
-				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+		upgradePolicy := virtualmachinescalesets.UpgradePolicy{}
+		if existing.Model.Properties.UpgradePolicy == nil {
+			upgradePolicy = virtualmachinescalesets.UpgradePolicy{
+				Mode: pointer.To(virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))),
 			}
 		} else {
-			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
-			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+			upgradePolicy = *existing.Model.Properties.UpgradePolicy
+			upgradePolicy.Mode = pointer.To(virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string)))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {
@@ -552,14 +548,14 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		updateProps.UpgradePolicy = &upgradePolicy
 	}
 
-	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	priority := virtualmachinescalesets.VirtualMachinePriorityTypes(d.Get("priority").(string))
 	if d.HasChange("max_bid_price") {
-		if priority != compute.VirtualMachinePriorityTypesSpot {
+		if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
 		}
 
-		updateProps.VirtualMachineProfile.BillingProfile = &compute.BillingProfile{
-			MaxPrice: utils.Float(d.Get("max_bid_price").(float64)),
+		updateProps.VirtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
+			MaxPrice: pointer.To(d.Get("max_bid_price").(float64)),
 		}
 	}
 
@@ -568,7 +564,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		if singlePlacementGroup {
 			return fmt.Errorf("%q can not be set to %q once it has been set to %q", "single_placement_group", "true", "false")
 		}
-		updateProps.SinglePlacementGroup = utils.Bool(singlePlacementGroup)
+		updateProps.SinglePlacementGroup = pointer.To(singlePlacementGroup)
 	}
 
 	if d.HasChange("enable_automatic_updates") ||
@@ -576,25 +572,25 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		d.HasChange("provision_vm_agent") ||
 		d.HasChange("secret") ||
 		d.HasChange("timezone") {
-		osProfile := compute.VirtualMachineScaleSetUpdateOSProfile{}
+		osProfile := virtualmachinescalesets.VirtualMachineScaleSetUpdateOSProfile{}
 
 		if d.HasChange("enable_automatic_updates") || d.HasChange("provision_vm_agent") || d.HasChange("timezone") {
-			windowsConfig := compute.WindowsConfiguration{}
+			windowsConfig := virtualmachinescalesets.WindowsConfiguration{}
 
 			if d.HasChange("enable_automatic_updates") {
-				if upgradeMode == compute.UpgradeModeAutomatic {
+				if upgradeMode == virtualmachinescalesets.UpgradeModeAutomatic {
 					return fmt.Errorf("`enable_automatic_updates` cannot be changed for when `upgrade_mode` is `Automatic`")
 				}
 
-				windowsConfig.EnableAutomaticUpdates = utils.Bool(d.Get("enable_automatic_updates").(bool))
+				windowsConfig.EnableAutomaticUpdates = pointer.To(d.Get("enable_automatic_updates").(bool))
 			}
 
 			if d.HasChange("provision_vm_agent") {
-				windowsConfig.ProvisionVMAgent = utils.Bool(d.Get("provision_vm_agent").(bool))
+				windowsConfig.ProvisionVMAgent = pointer.To(d.Get("provision_vm_agent").(bool))
 			}
 
 			if d.HasChange("timezone") {
-				windowsConfig.TimeZone = utils.String(d.Get("timezone").(string))
+				windowsConfig.TimeZone = pointer.To(d.Get("timezone").(string))
 			}
 
 			osProfile.WindowsConfiguration = &windowsConfig
@@ -606,13 +602,13 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 			// customData can only be sent if it's a base64 encoded string,
 			// so it's not possible to remove this without tainting the resource
 			if v, ok := d.GetOk("custom_data"); ok {
-				osProfile.CustomData = utils.String(v.(string))
+				osProfile.CustomData = pointer.To(v.(string))
 			}
 		}
 
 		if d.HasChange("secret") {
 			secretsRaw := d.Get("secret").([]interface{})
-			osProfile.Secrets = expandWindowsSecrets(secretsRaw)
+			osProfile.Secrets = expandWindowsSecretsVMSS(secretsRaw)
 		}
 
 		updateProps.VirtualMachineProfile.OsProfile = &osProfile
@@ -622,7 +618,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		updateInstances = true
 
 		if updateProps.VirtualMachineProfile.StorageProfile == nil {
-			updateProps.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetUpdateStorageProfile{}
+			updateProps.VirtualMachineProfile.StorageProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{}
 		}
 
 		if d.HasChange("data_disk") {
@@ -642,18 +638,18 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		if d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
 			sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 			sourceImageId := d.Get("source_image_id").(string)
-			sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+			sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 
 			// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurerm/issues/8273
-			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.Model.Properties.VirtualMachineProfile.StorageProfile.DataDisks
 			updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
-			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &compute.VirtualMachineScaleSetUpdateOSDisk{
-				Caching:                 existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
-				WriteAcceleratorEnabled: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
-				DiskSizeGB:              existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
-				Image:                   existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
-				VhdContainers:           existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
-				ManagedDisk:             existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &virtualmachinescalesets.VirtualMachineScaleSetUpdateOSDisk{
+				Caching:                 existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
+				WriteAcceleratorEnabled: existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
+				DiskSizeGB:              existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
+				Image:                   existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
+				VhdContainers:           existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
+				ManagedDisk:             existing.Model.Properties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
 			}
 		}
 	}
@@ -665,14 +661,14 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 			return fmt.Errorf("expanding `network_interface`: %+v", err)
 		}
 
-		updateProps.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetUpdateNetworkProfile{
+		updateProps.VirtualMachineProfile.NetworkProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkProfile{
 			NetworkInterfaceConfigurations: networkInterfaces,
 		}
 
 		healthProbeId := d.Get("health_probe_id").(string)
 		if healthProbeId != "" {
-			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &compute.APIEntityReference{
-				ID: utils.String(healthProbeId),
+			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &virtualmachinescalesets.ApiEntityReference{
+				Id: pointer.To(healthProbeId),
 			}
 		}
 	}
@@ -681,17 +677,17 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		updateInstances = true
 
 		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
-		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 	}
 
 	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
 		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
-		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = utils.Bool(v)
+		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = pointer.To(v)
 	}
 
 	if d.HasChange("overprovision") {
 		v := d.Get("overprovision").(bool)
-		updateProps.Overprovision = utils.Bool(v)
+		updateProps.Overprovision = pointer.To(v)
 	}
 
 	if d.HasChange("scale_in") {
@@ -702,11 +698,11 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 
 	if !features.FourPointOhBeta() {
 		if d.HasChange("scale_in_policy") {
-			updateScaleInPolicy := &compute.ScaleInPolicy{}
+			updateScaleInPolicy := &virtualmachinescalesets.ScaleInPolicy{}
 
 			if d.HasChange("scale_in_policy") {
 				scaleInPolicy := d.Get("scale_in_policy").(string)
-				updateScaleInPolicy.Rules = &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)}
+				updateScaleInPolicy.Rules = &[]virtualmachinescalesets.VirtualMachineScaleSetScaleInRules{virtualmachinescalesets.VirtualMachineScaleSetScaleInRules(scaleInPolicy)}
 			}
 
 			updateProps.ScaleInPolicy = updateScaleInPolicy
@@ -727,15 +723,15 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		if d.Get("encryption_at_host_enabled").(bool) {
 			osDiskRaw := d.Get("os_disk").([]interface{})
 			securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
-			if compute.SecurityEncryptionTypesDiskWithVMGuestState == compute.SecurityEncryptionTypes(securityEncryptionType) {
+			if virtualmachinescalesets.SecurityEncryptionTypesDiskWithVMGuestState == virtualmachinescalesets.SecurityEncryptionTypes(securityEncryptionType) {
 				return fmt.Errorf("`encryption_at_host_enabled` cannot be set to `true` when `os_disk.0.security_encryption_type` is set to `DiskWithVMGuestState`")
 			}
 		}
 
 		if updateProps.VirtualMachineProfile.SecurityProfile == nil {
-			updateProps.VirtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+			updateProps.VirtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 		}
-		updateProps.VirtualMachineProfile.SecurityProfile.EncryptionAtHost = utils.Bool(d.Get("encryption_at_host_enabled").(bool))
+		updateProps.VirtualMachineProfile.SecurityProfile.EncryptionAtHost = pointer.To(d.Get("encryption_at_host_enabled").(bool))
 	}
 
 	if d.HasChange("license_type") {
@@ -756,33 +752,32 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 	}
 
 	if d.HasChange("identity") {
-		identityRaw := d.Get("identity").([]interface{})
-		identity, err := expandVirtualMachineScaleSetIdentity(identityRaw)
+		identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 		if err != nil {
 			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
 
-		update.Identity = identity
+		update.Identity = identityExpanded
 	}
 
 	if d.HasChange("plan") {
 		planRaw := d.Get("plan").([]interface{})
-		update.Plan = expandPlan(planRaw)
+		update.Plan = expandPlanVMSS(planRaw)
 	}
 
 	if d.HasChange("sku") || d.HasChange("instances") {
 		// in-case ignore_changes is being used, since both fields are required
 		// look up the current values and override them as needed
-		sku := existing.Sku
+		sku := existing.Model.Sku
 
 		if d.HasChange("sku") {
 			updateInstances = true
 
-			sku.Name = utils.String(d.Get("sku").(string))
+			sku.Name = pointer.To(d.Get("sku").(string))
 		}
 
 		if d.HasChange("instances") {
-			sku.Capacity = utils.Int64(int64(d.Get("instances").(int)))
+			sku.Capacity = pointer.To(int64(d.Get("instances").(int)))
 		}
 
 		update.Sku = sku
@@ -796,19 +791,19 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 			return err
 		}
 		updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
-		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = pointer.To(d.Get("extensions_time_budget").(string))
 	}
 
 	if d.HasChange("user_data") {
 		updateInstances = true
-		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data").(string))
+		updateProps.VirtualMachineProfile.UserData = pointer.To(d.Get("user_data").(string))
 	}
 
 	if d.HasChange("tags") {
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	update.VirtualMachineScaleSetUpdateProperties = &updateProps
+	update.Properties = &updateProps
 
 	metaData := virtualMachineScaleSetUpdateMetaData{
 		AutomaticOSUpgradeIsEnabled:  automaticOSUpgradeIsEnabled,
@@ -816,9 +811,9 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		CanRollInstancesWhenRequired: meta.(*clients.Client).Features.VirtualMachineScaleSet.RollInstancesWhenRequired,
 		UpdateInstances:              updateInstances,
 		Client:                       meta.(*clients.Client).Compute,
-		Existing:                     existing,
+		Existing:                     *existing.Model,
 		ID:                           id,
-		OSType:                       compute.OperatingSystemTypesWindows,
+		OSType:                       virtualmachinescalesets.OperatingSystemTypesWindows,
 	}
 
 	if err := metaData.performUpdate(ctx, update); err != nil {
@@ -829,18 +824,18 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 }
 
 func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Windows %s was not found - removing from state!", id)
 			d.SetId("")
 			return nil
@@ -851,277 +846,276 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 
 	d.Set("name", id.VirtualMachineScaleSetName)
 	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
-	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
-	var skuName *string
-	var instances int
-	if resp.Sku != nil {
-		skuName = resp.Sku.Name
-		if resp.Sku.Capacity != nil {
-			instances = int(*resp.Sku.Capacity)
-		}
-	}
-	d.Set("instances", instances)
-	d.Set("sku", skuName)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
+		d.Set("edge_zone", flattenEdgeZone(model.ExtendedLocation))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
-	identity, err := flattenVirtualMachineScaleSetIdentity(resp.Identity)
-	if err != nil {
-		return err
-	}
-	if err := d.Set("identity", identity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
-	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
-		return fmt.Errorf("setting `plan`: %+v", err)
-	}
-
-	if resp.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("retrieving Windows %s: `properties` was nil", id)
-	}
-	props := *resp.VirtualMachineScaleSetProperties
-
-	if err := d.Set("additional_capabilities", FlattenVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
-		return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
-	}
-
-	if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
-		return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
-	}
-
-	d.Set("do_not_run_extensions_on_overprovisioned_machines", props.DoNotRunExtensionsOnOverprovisionedVMs)
-	if props.HostGroup != nil && props.HostGroup.ID != nil {
-		d.Set("host_group_id", props.HostGroup.ID)
-	}
-	d.Set("overprovision", props.Overprovision)
-	proximityPlacementGroupId := ""
-	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
-		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID
-	}
-	d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
-	d.Set("proximity_placement_group_id", proximityPlacementGroupId)
-	d.Set("single_placement_group", props.SinglePlacementGroup)
-	d.Set("unique_id", props.UniqueID)
-	d.Set("zone_balance", props.ZoneBalance)
-	d.Set("scale_in", FlattenVirtualMachineScaleSetScaleInPolicy(props.ScaleInPolicy))
-
-	if !features.FourPointOhBeta() {
-		rule := string(compute.VirtualMachineScaleSetScaleInRulesDefault)
-
-		if props.ScaleInPolicy != nil {
-			if rules := props.ScaleInPolicy.Rules; rules != nil && len(*rules) > 0 {
-				rule = string((*rules)[0])
+		var skuName *string
+		var instances int
+		if model.Sku != nil {
+			skuName = model.Sku.Name
+			if model.Sku.Capacity != nil {
+				instances = int(*model.Sku.Capacity)
 			}
 		}
+		d.Set("instances", instances)
+		d.Set("sku", skuName)
 
-		d.Set("scale_in_policy", rule)
-	}
-
-	if props.SpotRestorePolicy != nil {
-		d.Set("spot_restore", FlattenVirtualMachineScaleSetSpotRestorePolicy(props.SpotRestorePolicy))
-	}
-
-	var upgradeMode compute.UpgradeMode
-	if policy := props.UpgradePolicy; policy != nil {
-		upgradeMode = policy.Mode
-		d.Set("upgrade_mode", string(policy.Mode))
-
-		flattenedAutomatic := FlattenVirtualMachineScaleSetAutomaticOSUpgradePolicy(policy.AutomaticOSUpgradePolicy)
-		if err := d.Set("automatic_os_upgrade_policy", flattenedAutomatic); err != nil {
-			return fmt.Errorf("setting `automatic_os_upgrade_policy`: %+v", err)
+		identityFlattened, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("identity", identityFlattened); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
-		flattenedRolling := FlattenVirtualMachineScaleSetRollingUpgradePolicy(policy.RollingUpgradePolicy)
-		if err := d.Set("rolling_upgrade_policy", flattenedRolling); err != nil {
-			return fmt.Errorf("setting `rolling_upgrade_policy`: %+v", err)
-		}
-	}
-
-	if profile := props.VirtualMachineProfile; profile != nil {
-		if err := d.Set("boot_diagnostics", flattenBootDiagnostics(profile.DiagnosticsProfile)); err != nil {
-			return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+		if err := d.Set("plan", flattenPlanVMSS(model.Plan)); err != nil {
+			return fmt.Errorf("setting `plan`: %+v", err)
 		}
 
-		capacityReservationGroupId := ""
-		if profile.CapacityReservation != nil && profile.CapacityReservation.CapacityReservationGroup != nil && profile.CapacityReservation.CapacityReservationGroup.ID != nil {
-			capacityReservationGroupId = *profile.CapacityReservation.CapacityReservationGroup.ID
-		}
-		d.Set("capacity_reservation_group_id", capacityReservationGroupId)
+		if props := model.Properties; props != nil {
+			if err := d.Set("additional_capabilities", FlattenVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+				return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
+			}
 
-		// defaulted since BillingProfile isn't returned if it's unset
-		maxBidPrice := float64(-1.0)
-		if profile.BillingProfile != nil && profile.BillingProfile.MaxPrice != nil {
-			maxBidPrice = *profile.BillingProfile.MaxPrice
-		}
-		d.Set("max_bid_price", maxBidPrice)
+			if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
+				return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
+			}
 
-		d.Set("eviction_policy", string(profile.EvictionPolicy))
-		d.Set("license_type", profile.LicenseType)
-
-		if profile.ApplicationProfile != nil && profile.ApplicationProfile.GalleryApplications != nil {
-			d.Set("gallery_application", flattenVirtualMachineScaleSetGalleryApplication(profile.ApplicationProfile.GalleryApplications))
+			d.Set("do_not_run_extensions_on_overprovisioned_machines", props.DoNotRunExtensionsOnOverprovisionedVMs)
+			if props.HostGroup != nil && props.HostGroup.Id != nil {
+				d.Set("host_group_id", props.HostGroup.Id)
+			}
+			d.Set("overprovision", props.Overprovision)
+			proximityPlacementGroupId := ""
+			if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.Id != nil {
+				proximityPlacementGroupId = *props.ProximityPlacementGroup.Id
+			}
+			d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
+			d.Set("proximity_placement_group_id", proximityPlacementGroupId)
+			d.Set("single_placement_group", props.SinglePlacementGroup)
+			d.Set("unique_id", props.UniqueId)
+			d.Set("zone_balance", props.ZoneBalance)
+			d.Set("scale_in", FlattenVirtualMachineScaleSetScaleInPolicy(props.ScaleInPolicy))
 
 			if !features.FourPointOhBeta() {
-				d.Set("gallery_applications", flattenVirtualMachineScaleSetGalleryApplications(profile.ApplicationProfile.GalleryApplications))
-			}
-		}
-
-		// the service just return empty when this is not assigned when provisioned
-		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
-		priority := compute.VirtualMachinePriorityTypesRegular
-		if profile.Priority != "" {
-			priority = profile.Priority
-		}
-		d.Set("priority", priority)
-
-		if storageProfile := profile.StorageProfile; storageProfile != nil {
-			if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
-				return fmt.Errorf("setting `os_disk`: %+v", err)
-			}
-
-			if err := d.Set("data_disk", FlattenVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
-				return fmt.Errorf("setting `data_disk`: %+v", err)
-			}
-
-			var storageImageId string
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
-				storageImageId = *storageProfile.ImageReference.ID
-			}
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.CommunityGalleryImageID != nil {
-				storageImageId = *storageProfile.ImageReference.CommunityGalleryImageID
-			}
-			if storageProfile.ImageReference != nil && storageProfile.ImageReference.SharedGalleryImageID != nil {
-				storageImageId = *storageProfile.ImageReference.SharedGalleryImageID
-			}
-			d.Set("source_image_id", storageImageId)
-
-			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference, storageImageId != "")); err != nil {
-				return fmt.Errorf("setting `source_image_reference`: %+v", err)
-			}
-		}
-
-		extensionOperationsEnabled := true
-		if osProfile := profile.OsProfile; osProfile != nil {
-			// admin_password isn't returned, but it's a top level field so we can ignore it without consequence
-			d.Set("admin_username", osProfile.AdminUsername)
-			d.Set("computer_name_prefix", osProfile.ComputerNamePrefix)
-
-			if osProfile.AllowExtensionOperations != nil {
-				extensionOperationsEnabled = *osProfile.AllowExtensionOperations
-			}
-
-			if err := d.Set("secret", flattenWindowsSecrets(osProfile.Secrets)); err != nil {
-				return fmt.Errorf("setting `secret`: %+v", err)
-			}
-
-			if windows := osProfile.WindowsConfiguration; windows != nil {
-				if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(windows.AdditionalUnattendContent, d)); err != nil {
-					return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
+				rule := string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault)
+				if props.ScaleInPolicy != nil {
+					if rules := props.ScaleInPolicy.Rules; rules != nil && len(*rules) > 0 {
+						rule = string((*rules)[0])
+					}
 				}
 
-				enableAutomaticUpdates := false
-				if windows.EnableAutomaticUpdates != nil {
-					enableAutomaticUpdates = *windows.EnableAutomaticUpdates
+				d.Set("scale_in_policy", rule)
+			}
+
+			if props.SpotRestorePolicy != nil {
+				d.Set("spot_restore", FlattenVirtualMachineScaleSetSpotRestorePolicy(props.SpotRestorePolicy))
+			}
+
+			var upgradeMode virtualmachinescalesets.UpgradeMode
+			if policy := props.UpgradePolicy; policy != nil && policy.Mode != nil {
+				upgradeMode = *policy.Mode
+				d.Set("upgrade_mode", string(upgradeMode))
+
+				flattenedAutomatic := FlattenVirtualMachineScaleSetAutomaticOSUpgradePolicy(policy.AutomaticOSUpgradePolicy)
+				if err := d.Set("automatic_os_upgrade_policy", flattenedAutomatic); err != nil {
+					return fmt.Errorf("setting `automatic_os_upgrade_policy`: %+v", err)
 				}
 
-				// the API requires this is set to 'true' on submission (since it's now required for Windows VMSS's with
-				// an Automatic Upgrade Mode configured) however it actually returns false from the API..
-				// after a bunch of testing the least bad option appears to be not to set this if it's an Automatic Upgrade Mode
-				if upgradeMode != compute.UpgradeModeAutomatic {
-					d.Set("enable_automatic_updates", enableAutomaticUpdates)
-				}
-
-				d.Set("provision_vm_agent", windows.ProvisionVMAgent)
-				d.Set("timezone", windows.TimeZone)
-
-				if err := d.Set("winrm_listener", flattenWinRMListener(windows.WinRM)); err != nil {
-					return fmt.Errorf("setting `winrm_listener`: %+v", err)
+				flattenedRolling := FlattenVirtualMachineScaleSetRollingUpgradePolicy(policy.RollingUpgradePolicy)
+				if err := d.Set("rolling_upgrade_policy", flattenedRolling); err != nil {
+					return fmt.Errorf("setting `rolling_upgrade_policy`: %+v", err)
 				}
 			}
-		}
-		d.Set("extension_operations_enabled", extensionOperationsEnabled)
 
-		if nwProfile := profile.NetworkProfile; nwProfile != nil {
-			flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
-			if err := d.Set("network_interface", flattenedNics); err != nil {
-				return fmt.Errorf("setting `network_interface`: %+v", err)
-			}
-
-			healthProbeId := ""
-			if nwProfile.HealthProbe != nil && nwProfile.HealthProbe.ID != nil {
-				healthProbeId = *nwProfile.HealthProbe.ID
-			}
-			d.Set("health_probe_id", healthProbeId)
-		}
-
-		if !features.FourPointOhBeta() {
-			if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
-				if err := d.Set("terminate_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
-					return fmt.Errorf("setting `terminate_notification`: %+v", err)
+			if profile := props.VirtualMachineProfile; profile != nil {
+				if err := d.Set("boot_diagnostics", flattenBootDiagnosticsVMSS(profile.DiagnosticsProfile)); err != nil {
+					return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
 				}
-			}
-		}
 
-		if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
-			if err := d.Set("termination_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
-				return fmt.Errorf("setting `termination_notification`: %+v", err)
-			}
-		}
-
-		extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
-		if err != nil {
-			return fmt.Errorf("failed flattening `extension`: %+v", err)
-		}
-		d.Set("extension", extensionProfile)
-
-		extensionsTimeBudget := "PT1H30M"
-		if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
-			extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
-		}
-		d.Set("extensions_time_budget", extensionsTimeBudget)
-
-		encryptionAtHostEnabled := false
-		vtpmEnabled := false
-		secureBootEnabled := false
-
-		if secprofile := profile.SecurityProfile; secprofile != nil {
-			if secprofile.EncryptionAtHost != nil {
-				encryptionAtHostEnabled = *secprofile.EncryptionAtHost
-			}
-			if uefi := profile.SecurityProfile.UefiSettings; uefi != nil {
-				if uefi.VTpmEnabled != nil {
-					vtpmEnabled = *uefi.VTpmEnabled
+				capacityReservationGroupId := ""
+				if profile.CapacityReservation != nil && profile.CapacityReservation.CapacityReservationGroup != nil && profile.CapacityReservation.CapacityReservationGroup.Id != nil {
+					capacityReservationGroupId = *profile.CapacityReservation.CapacityReservationGroup.Id
 				}
-				if uefi.SecureBootEnabled != nil {
-					secureBootEnabled = *uefi.SecureBootEnabled
+				d.Set("capacity_reservation_group_id", capacityReservationGroupId)
+
+				// defaulted since BillingProfile isn't returned if it's unset
+				maxBidPrice := float64(-1.0)
+				if profile.BillingProfile != nil && profile.BillingProfile.MaxPrice != nil {
+					maxBidPrice = *profile.BillingProfile.MaxPrice
 				}
+				d.Set("max_bid_price", maxBidPrice)
+
+				d.Set("eviction_policy", pointer.From(profile.EvictionPolicy))
+				d.Set("license_type", profile.LicenseType)
+
+				if profile.ApplicationProfile != nil && profile.ApplicationProfile.GalleryApplications != nil {
+					d.Set("gallery_application", flattenVirtualMachineScaleSetGalleryApplication(profile.ApplicationProfile.GalleryApplications))
+
+					if !features.FourPointOhBeta() {
+						d.Set("gallery_applications", flattenVirtualMachineScaleSetGalleryApplications(profile.ApplicationProfile.GalleryApplications))
+					}
+				}
+
+				// the service just return empty when this is not assigned when provisioned
+				// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+				priority := virtualmachinescalesets.VirtualMachinePriorityTypesRegular
+				if profile.Priority != nil && *profile.Priority != "" {
+					priority = *profile.Priority
+				}
+				d.Set("priority", priority)
+
+				if storageProfile := profile.StorageProfile; storageProfile != nil {
+					if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
+						return fmt.Errorf("setting `os_disk`: %+v", err)
+					}
+
+					if err := d.Set("data_disk", FlattenVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
+						return fmt.Errorf("setting `data_disk`: %+v", err)
+					}
+
+					var storageImageId string
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.Id != nil {
+						storageImageId = *storageProfile.ImageReference.Id
+					}
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.CommunityGalleryImageId != nil {
+						storageImageId = *storageProfile.ImageReference.CommunityGalleryImageId
+					}
+					if storageProfile.ImageReference != nil && storageProfile.ImageReference.SharedGalleryImageId != nil {
+						storageImageId = *storageProfile.ImageReference.SharedGalleryImageId
+					}
+					d.Set("source_image_id", storageImageId)
+
+					if err := d.Set("source_image_reference", flattenSourceImageReferenceVMSS(storageProfile.ImageReference, storageImageId != "")); err != nil {
+						return fmt.Errorf("setting `source_image_reference`: %+v", err)
+					}
+				}
+
+				extensionOperationsEnabled := true
+				if osProfile := profile.OsProfile; osProfile != nil {
+					// admin_password isn't returned, but it's a top level field so we can ignore it without consequence
+					d.Set("admin_username", osProfile.AdminUsername)
+					d.Set("computer_name_prefix", osProfile.ComputerNamePrefix)
+
+					if osProfile.AllowExtensionOperations != nil {
+						extensionOperationsEnabled = *osProfile.AllowExtensionOperations
+					}
+
+					if err := d.Set("secret", flattenWindowsSecretsVMSS(osProfile.Secrets)); err != nil {
+						return fmt.Errorf("setting `secret`: %+v", err)
+					}
+
+					if windows := osProfile.WindowsConfiguration; windows != nil {
+						if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContentVMSS(windows.AdditionalUnattendContent, d)); err != nil {
+							return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
+						}
+
+						enableAutomaticUpdates := false
+						if windows.EnableAutomaticUpdates != nil {
+							enableAutomaticUpdates = *windows.EnableAutomaticUpdates
+						}
+
+						// the API requires this is set to 'true' on submission (since it's now required for Windows VMSS's with
+						// an Automatic Upgrade Mode configured) however it actually returns false from the API..
+						// after a bunch of testing the least bad option appears to be not to set this if it's an Automatic Upgrade Mode
+						if upgradeMode != virtualmachinescalesets.UpgradeModeAutomatic {
+							d.Set("enable_automatic_updates", enableAutomaticUpdates)
+						}
+
+						d.Set("provision_vm_agent", windows.ProvisionVMAgent)
+						d.Set("timezone", windows.TimeZone)
+
+						if err := d.Set("winrm_listener", flattenWinRMListenerVMSS(windows.WinRM)); err != nil {
+							return fmt.Errorf("setting `winrm_listener`: %+v", err)
+						}
+					}
+				}
+				d.Set("extension_operations_enabled", extensionOperationsEnabled)
+
+				if nwProfile := profile.NetworkProfile; nwProfile != nil {
+					flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+					if err := d.Set("network_interface", flattenedNics); err != nil {
+						return fmt.Errorf("setting `network_interface`: %+v", err)
+					}
+
+					healthProbeId := ""
+					if nwProfile.HealthProbe != nil && nwProfile.HealthProbe.Id != nil {
+						healthProbeId = *nwProfile.HealthProbe.Id
+					}
+					d.Set("health_probe_id", healthProbeId)
+				}
+
+				if !features.FourPointOhBeta() {
+					if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
+						if err := d.Set("terminate_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
+							return fmt.Errorf("setting `terminate_notification`: %+v", err)
+						}
+					}
+				}
+
+				if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
+					if err := d.Set("termination_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
+						return fmt.Errorf("setting `termination_notification`: %+v", err)
+					}
+				}
+
+				extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
+				if err != nil {
+					return fmt.Errorf("failed flattening `extension`: %+v", err)
+				}
+				d.Set("extension", extensionProfile)
+
+				extensionsTimeBudget := "PT1H30M"
+				if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
+					extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
+				}
+				d.Set("extensions_time_budget", extensionsTimeBudget)
+
+				encryptionAtHostEnabled := false
+				vtpmEnabled := false
+				secureBootEnabled := false
+
+				if securityProfile := profile.SecurityProfile; securityProfile != nil {
+					if securityProfile.EncryptionAtHost != nil {
+						encryptionAtHostEnabled = *securityProfile.EncryptionAtHost
+					}
+					if uefi := profile.SecurityProfile.UefiSettings; uefi != nil {
+						if uefi.VTpmEnabled != nil {
+							vtpmEnabled = *uefi.VTpmEnabled
+						}
+						if uefi.SecureBootEnabled != nil {
+							secureBootEnabled = *uefi.SecureBootEnabled
+						}
+					}
+				}
+
+				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+				d.Set("vtpm_enabled", vtpmEnabled)
+				d.Set("secure_boot_enabled", secureBootEnabled)
+				d.Set("user_data", profile.UserData)
 			}
 		}
-
-		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
-		d.Set("vtpm_enabled", vtpmEnabled)
-		d.Set("secure_boot_enabled", secureBootEnabled)
-		d.Set("user_data", profile.UserData)
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := commonids.ParseVirtualMachineScaleSetID(d.Id())
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return nil
 		}
 
@@ -1140,22 +1134,15 @@ func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta
 	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
 	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
 	scaleToZeroOnDelete := meta.(*clients.Client).Features.VirtualMachineScaleSet.ScaleToZeroOnDelete
-	if scaleToZeroOnDelete && resp.Sku != nil {
-		resp.Sku.Capacity = utils.Int64(int64(0))
+	if scaleToZeroOnDelete && resp.Model != nil && resp.Model.Sku != nil {
+		resp.Model.Sku.Capacity = pointer.To(int64(0))
 
 		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
-		update := compute.VirtualMachineScaleSetUpdate{
-			Sku: resp.Sku,
+		update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
+			Sku: resp.Model.Sku,
 		}
-		future, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update)
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating number of instances in Windows %s to scale to 0: %+v", id, err)
-		}
-
-		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
-		err = future.WaitForCompletionRef(ctx, client.Client)
-		if err != nil {
-			return fmt.Errorf("waiting for number of instances in Windows %s to scale to 0: %+v", id, err)
 		}
 		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 	} else {
@@ -1166,15 +1153,8 @@ func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta
 	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
 	// TODO: support force deletion once it's out of Preview, if applicable
-	var forceDeletion *bool = nil
-	future, err := client.Delete(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, forceDeletion)
-	if err != nil {
+	if err := client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting Windows %s: %+v", id, err)
-	}
-
-	log.Printf("[DEBUG] Waiting for deletion of Windows %s.", id)
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of Windows %s: %+v", id, err)
 	}
 	log.Printf("[DEBUG] Deleted Windows %s", id)
 
@@ -1194,7 +1174,6 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 
 		"location": commonschema.Location(),
 
-		// Required
 		"admin_username": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -1227,7 +1206,6 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 
-		// Optional
 		"additional_capabilities": VirtualMachineScaleSetAdditionalCapabilitiesSchema(),
 
 		"additional_unattend_content": additionalUnattendContentSchema(),
@@ -1289,8 +1267,8 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 			Optional: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachineEvictionPolicyTypesDeallocate),
-				string(compute.VirtualMachineEvictionPolicyTypesDelete),
+				string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDeallocate),
+				string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDelete),
 			}, false),
 		},
 
@@ -1379,10 +1357,10 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
-			Default:  string(compute.VirtualMachinePriorityTypesRegular),
+			Default:  string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachinePriorityTypesRegular),
-				string(compute.VirtualMachinePriorityTypesSpot),
+				string(virtualmachinescalesets.VirtualMachinePriorityTypesRegular),
+				string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot),
 			}, false),
 		},
 
@@ -1441,7 +1419,7 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 
 		"source_image_reference": sourceImageReferenceSchema(false),
 
-		"tags": tags.Schema(),
+		"tags": commonschema.Tags(),
 
 		"timezone": {
 			Type:         pluginsdk.TypeString,
@@ -1453,11 +1431,11 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
-			Default:  string(compute.UpgradeModeManual),
+			Default:  string(virtualmachinescalesets.UpgradeModeManual),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.UpgradeModeAutomatic),
-				string(compute.UpgradeModeManual),
-				string(compute.UpgradeModeRolling),
+				string(virtualmachinescalesets.UpgradeModeAutomatic),
+				string(virtualmachinescalesets.UpgradeModeManual),
+				string(virtualmachinescalesets.UpgradeModeRolling),
 			}, false),
 		},
 
@@ -1490,7 +1468,6 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 
 		"zones": commonschema.ZonesMultipleOptionalForceNew(),
 
-		// Computed
 		"unique_id": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
@@ -1506,9 +1483,9 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 			Optional: true,
 			Computed: !features.FourPointOhBeta(),
 			ValidateFunc: validation.StringInSlice([]string{
-				string(compute.VirtualMachineScaleSetScaleInRulesDefault),
-				string(compute.VirtualMachineScaleSetScaleInRulesNewestVM),
-				string(compute.VirtualMachineScaleSetScaleInRulesOldestVM),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesDefault),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesNewestVM),
+				string(virtualmachinescalesets.VirtualMachineScaleSetScaleInRulesOldestVM),
 			}, false),
 			Deprecated:    "`scale_in_policy` will be removed in favour of the `scale_in` code block in version 4.0 of the AzureRM Provider.",
 			ConflictsWith: []string{"scale_in"},

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -474,7 +474,9 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 
 	updateInstances := false
 
-	existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	options := virtualmachinescalesets.DefaultGetOperationOptions()
+	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+	existing, err := client.Get(ctx, *id, options)
 	if err != nil {
 		return fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
@@ -833,7 +835,9 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	resp, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+	options := virtualmachinescalesets.DefaultGetOperationOptions()
+	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+	resp, err := client.Get(ctx, *id, options)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Windows %s was not found - removing from state!", id)
@@ -1095,9 +1099,7 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 				d.Set("vtpm_enabled", vtpmEnabled)
 				d.Set("secure_boot_enabled", secureBootEnabled)
-
-				// userData is not returned by the API
-				d.Set("user_data", d.Get("user_data").(string))
+				d.Set("user_data", profile.UserData)
 			}
 		}
 		return tags.FlattenAndSet(d, model.Tags)

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -1095,7 +1095,9 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 				d.Set("vtpm_enabled", vtpmEnabled)
 				d.Set("secure_boot_enabled", secureBootEnabled)
-				d.Set("user_data", profile.UserData)
+
+				// userData is not returned by the API
+				d.Set("user_data", d.Get("user_data").(string))
 			}
 		}
 		return tags.FlattenAndSet(d, model.Tags)

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
@@ -195,6 +196,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
+			"user_data",
 		),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
@@ -204,6 +206,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
+			"user_data",
 		),
 		{
 			// removed
@@ -925,7 +928,9 @@ func TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.
 						return err
 					}
 
-					existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+					defer cancel()
+					existing, err := client.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -956,7 +956,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.
 						Properties: &updateProps,
 					}
 
-					if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
+					if err := client.UpdateThenPoll(ctx2, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 						return fmt.Errorf("updating %s: %+v", *id, err)
 					}
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -196,7 +196,6 @@ func TestAccWindowsVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
-			"user_data",
 		),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
@@ -206,7 +205,6 @@ func TestAccWindowsVirtualMachineScaleSet_otherUserData(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
-			"user_data",
 		),
 		{
 			// removed
@@ -930,7 +928,9 @@ func TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.
 
 					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
 					defer cancel()
-					existing, err := client.Get(ctx2, *id, virtualmachinescalesets.DefaultGetOperationOptions())
+					options := virtualmachinescalesets.DefaultGetOperationOptions()
+					options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
+					existing, err := client.Get(ctx2, *id, options)
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func TestAccWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent(t *testing.T) {
@@ -919,40 +918,40 @@ func TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.
 				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
 					// This function manually updates the value for the image sku which triggers rolling upgrades
 					// and simulates the scenario where rolling upgrades are running when we try to delete a VMSS
-					client := clients.Compute.VMScaleSetClient
+					client := clients.Compute.VirtualMachineScaleSetsClient
 
-					id, err := commonids.ParseVirtualMachineScaleSetID(state.Attributes["id"])
+					id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.Attributes["id"])
 					if err != nil {
 						return err
 					}
 
-					existing, err := client.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, compute.ExpandTypesForGetVMScaleSetsUserData)
+					existing, err := client.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", *id, err)
 					}
 
-					existingImageReference := existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference
+					existingImageReference := existing.Model.Properties.VirtualMachineProfile.StorageProfile.ImageReference
 
-					imageReference := compute.ImageReference{
+					imageReference := virtualmachinescalesets.ImageReference{
 						Publisher: existingImageReference.Publisher,
 						Offer:     existingImageReference.Offer,
 						Sku:       pointer.To("2019-Datacenter"),
 						Version:   existingImageReference.Version,
 					}
 
-					updateProps := compute.VirtualMachineScaleSetUpdateProperties{
-						VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
-							StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
+					updateProps := virtualmachinescalesets.VirtualMachineScaleSetUpdateProperties{
+						VirtualMachineProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateVMProfile{
+							StorageProfile: &virtualmachinescalesets.VirtualMachineScaleSetUpdateStorageProfile{
 								ImageReference: &imageReference,
 							},
 						},
-						UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+						UpgradePolicy: existing.Model.Properties.UpgradePolicy,
 					}
-					update := compute.VirtualMachineScaleSetUpdate{
-						VirtualMachineScaleSetUpdateProperties: &updateProps,
+					update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
+						Properties: &updateProps,
 					}
 
-					if _, err := client.Update(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, update); err != nil {
+					if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
 						return fmt.Errorf("updating %s: %+v", *id, err)
 					}
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
@@ -7,27 +7,27 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WindowsVirtualMachineScaleSetResource struct{}
 
 func (r WindowsVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	resp, err := clients.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (WindowsVirtualMachineScaleSetResource) vmName(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -6,7 +6,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"strings"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	computevalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )

--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"strings"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/localusers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute"
 	computevalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -94,7 +94,7 @@ func (r LocalUserResource) Arguments() map[string]*pluginsdk.Schema {
 						Type:             pluginsdk.TypeString,
 						Required:         true,
 						ValidateFunc:     computevalidate.SSHKey,
-						DiffSuppressFunc: compute.SSHKeyDiffSuppress,
+						DiffSuppressFunc: suppress.SSHKey,
 					},
 					"description": {
 						Type:     pluginsdk.TypeString,

--- a/internal/tf/suppress/ssh_keys_test.go
+++ b/internal/tf/suppress/ssh_keys_test.go
@@ -1,9 +1,8 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+package suppress
 
-package compute
-
-import "testing"
+import (
+	"testing"
+)
 
 func TestNormalizeSSHKey(t *testing.T) {
 	cases := []struct {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/README.md
@@ -1,0 +1,197 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages` Documentation
+
+The `virtualmachineimages` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachineimages.NewVirtualMachineImagesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.EdgeZoneGet`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewOfferSkuVersionID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue", "publisherValue", "offerValue", "skuValue", "versionValue")
+
+read, err := client.EdgeZoneGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.EdgeZoneList`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewOfferSkuID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue", "publisherValue", "offerValue", "skuValue")
+
+read, err := client.EdgeZoneList(ctx, id, virtualmachineimages.DefaultEdgeZoneListOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.EdgeZoneListOffers`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewEdgeZonePublisherID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue", "publisherValue")
+
+read, err := client.EdgeZoneListOffers(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.EdgeZoneListPublishers`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewEdgeZoneID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue")
+
+read, err := client.EdgeZoneListPublishers(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.EdgeZoneListSkus`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewVMImageOfferID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue", "publisherValue", "offerValue")
+
+read, err := client.EdgeZoneListSkus(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewSkuVersionID("12345678-1234-9876-4563-123456789012", "locationValue", "publisherValue", "offerValue", "skuValue", "versionValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.List`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewSkuID("12345678-1234-9876-4563-123456789012", "locationValue", "publisherValue", "offerValue", "skuValue")
+
+read, err := client.List(ctx, id, virtualmachineimages.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.ListByEdgeZone`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewEdgeZoneID("12345678-1234-9876-4563-123456789012", "locationValue", "edgeZoneValue")
+
+// alternatively `client.ListByEdgeZone(ctx, id)` can be used to do batched pagination
+items, err := client.ListByEdgeZoneComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.ListOffers`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewPublisherID("12345678-1234-9876-4563-123456789012", "locationValue", "publisherValue")
+
+read, err := client.ListOffers(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.ListPublishers`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+read, err := client.ListPublishers(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImagesClient.ListSkus`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimages.NewOfferID("12345678-1234-9876-4563-123456789012", "locationValue", "publisherValue", "offerValue")
+
+read, err := client.ListSkus(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/client.go
@@ -1,0 +1,26 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImagesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineImagesClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineImagesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachineimages", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineImagesClient: %+v", err)
+	}
+
+	return &VirtualMachineImagesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/constants.go
@@ -1,0 +1,262 @@
+package virtualmachineimages
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AlternativeType string
+
+const (
+	AlternativeTypeNone  AlternativeType = "None"
+	AlternativeTypeOffer AlternativeType = "Offer"
+	AlternativeTypePlan  AlternativeType = "Plan"
+)
+
+func PossibleValuesForAlternativeType() []string {
+	return []string{
+		string(AlternativeTypeNone),
+		string(AlternativeTypeOffer),
+		string(AlternativeTypePlan),
+	}
+}
+
+func (s *AlternativeType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAlternativeType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAlternativeType(input string) (*AlternativeType, error) {
+	vals := map[string]AlternativeType{
+		"none":  AlternativeTypeNone,
+		"offer": AlternativeTypeOffer,
+		"plan":  AlternativeTypePlan,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AlternativeType(input)
+	return &out, nil
+}
+
+type ArchitectureTypes string
+
+const (
+	ArchitectureTypesArmSixFour ArchitectureTypes = "Arm64"
+	ArchitectureTypesXSixFour   ArchitectureTypes = "x64"
+)
+
+func PossibleValuesForArchitectureTypes() []string {
+	return []string{
+		string(ArchitectureTypesArmSixFour),
+		string(ArchitectureTypesXSixFour),
+	}
+}
+
+func (s *ArchitectureTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseArchitectureTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseArchitectureTypes(input string) (*ArchitectureTypes, error) {
+	vals := map[string]ArchitectureTypes{
+		"arm64": ArchitectureTypesArmSixFour,
+		"x64":   ArchitectureTypesXSixFour,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ArchitectureTypes(input)
+	return &out, nil
+}
+
+type HyperVGenerationTypes string
+
+const (
+	HyperVGenerationTypesVOne HyperVGenerationTypes = "V1"
+	HyperVGenerationTypesVTwo HyperVGenerationTypes = "V2"
+)
+
+func PossibleValuesForHyperVGenerationTypes() []string {
+	return []string{
+		string(HyperVGenerationTypesVOne),
+		string(HyperVGenerationTypesVTwo),
+	}
+}
+
+func (s *HyperVGenerationTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHyperVGenerationTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHyperVGenerationTypes(input string) (*HyperVGenerationTypes, error) {
+	vals := map[string]HyperVGenerationTypes{
+		"v1": HyperVGenerationTypesVOne,
+		"v2": HyperVGenerationTypesVTwo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HyperVGenerationTypes(input)
+	return &out, nil
+}
+
+type ImageState string
+
+const (
+	ImageStateActive                  ImageState = "Active"
+	ImageStateDeprecated              ImageState = "Deprecated"
+	ImageStateScheduledForDeprecation ImageState = "ScheduledForDeprecation"
+)
+
+func PossibleValuesForImageState() []string {
+	return []string{
+		string(ImageStateActive),
+		string(ImageStateDeprecated),
+		string(ImageStateScheduledForDeprecation),
+	}
+}
+
+func (s *ImageState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseImageState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseImageState(input string) (*ImageState, error) {
+	vals := map[string]ImageState{
+		"active":                  ImageStateActive,
+		"deprecated":              ImageStateDeprecated,
+		"scheduledfordeprecation": ImageStateScheduledForDeprecation,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ImageState(input)
+	return &out, nil
+}
+
+type OperatingSystemTypes string
+
+const (
+	OperatingSystemTypesLinux   OperatingSystemTypes = "Linux"
+	OperatingSystemTypesWindows OperatingSystemTypes = "Windows"
+)
+
+func PossibleValuesForOperatingSystemTypes() []string {
+	return []string{
+		string(OperatingSystemTypesLinux),
+		string(OperatingSystemTypesWindows),
+	}
+}
+
+func (s *OperatingSystemTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOperatingSystemTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOperatingSystemTypes(input string) (*OperatingSystemTypes, error) {
+	vals := map[string]OperatingSystemTypes{
+		"linux":   OperatingSystemTypesLinux,
+		"windows": OperatingSystemTypesWindows,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperatingSystemTypes(input)
+	return &out, nil
+}
+
+type VMDiskTypes string
+
+const (
+	VMDiskTypesNone      VMDiskTypes = "None"
+	VMDiskTypesUnmanaged VMDiskTypes = "Unmanaged"
+)
+
+func PossibleValuesForVMDiskTypes() []string {
+	return []string{
+		string(VMDiskTypesNone),
+		string(VMDiskTypesUnmanaged),
+	}
+}
+
+func (s *VMDiskTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVMDiskTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVMDiskTypes(input string) (*VMDiskTypes, error) {
+	vals := map[string]VMDiskTypes{
+		"none":      VMDiskTypesNone,
+		"unmanaged": VMDiskTypesUnmanaged,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VMDiskTypes(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_edgezone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_edgezone.go
@@ -1,0 +1,125 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &EdgeZoneId{}
+
+// EdgeZoneId is a struct representing the Resource ID for a Edge Zone
+type EdgeZoneId struct {
+	SubscriptionId string
+	LocationName   string
+	EdgeZoneName   string
+}
+
+// NewEdgeZoneID returns a new EdgeZoneId struct
+func NewEdgeZoneID(subscriptionId string, locationName string, edgeZoneName string) EdgeZoneId {
+	return EdgeZoneId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		EdgeZoneName:   edgeZoneName,
+	}
+}
+
+// ParseEdgeZoneID parses 'input' into a EdgeZoneId
+func ParseEdgeZoneID(input string) (*EdgeZoneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EdgeZoneId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EdgeZoneId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseEdgeZoneIDInsensitively parses 'input' case-insensitively into a EdgeZoneId
+// note: this method should only be used for API response data and not user input
+func ParseEdgeZoneIDInsensitively(input string) (*EdgeZoneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EdgeZoneId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EdgeZoneId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *EdgeZoneId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.EdgeZoneName, ok = input.Parsed["edgeZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "edgeZoneName", input)
+	}
+
+	return nil
+}
+
+// ValidateEdgeZoneID checks that 'input' can be parsed as a Edge Zone ID
+func ValidateEdgeZoneID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseEdgeZoneID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Edge Zone ID
+func (id EdgeZoneId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/edgeZones/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.EdgeZoneName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Edge Zone ID
+func (id EdgeZoneId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticEdgeZones", "edgeZones", "edgeZones"),
+		resourceids.UserSpecifiedSegment("edgeZoneName", "edgeZoneValue"),
+	}
+}
+
+// String returns a human-readable description of this Edge Zone ID
+func (id EdgeZoneId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Edge Zone Name: %q", id.EdgeZoneName),
+	}
+	return fmt.Sprintf("Edge Zone (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_edgezonepublisher.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_edgezonepublisher.go
@@ -1,0 +1,134 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &EdgeZonePublisherId{}
+
+// EdgeZonePublisherId is a struct representing the Resource ID for a Edge Zone Publisher
+type EdgeZonePublisherId struct {
+	SubscriptionId string
+	LocationName   string
+	EdgeZoneName   string
+	PublisherName  string
+}
+
+// NewEdgeZonePublisherID returns a new EdgeZonePublisherId struct
+func NewEdgeZonePublisherID(subscriptionId string, locationName string, edgeZoneName string, publisherName string) EdgeZonePublisherId {
+	return EdgeZonePublisherId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		EdgeZoneName:   edgeZoneName,
+		PublisherName:  publisherName,
+	}
+}
+
+// ParseEdgeZonePublisherID parses 'input' into a EdgeZonePublisherId
+func ParseEdgeZonePublisherID(input string) (*EdgeZonePublisherId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EdgeZonePublisherId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EdgeZonePublisherId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseEdgeZonePublisherIDInsensitively parses 'input' case-insensitively into a EdgeZonePublisherId
+// note: this method should only be used for API response data and not user input
+func ParseEdgeZonePublisherIDInsensitively(input string) (*EdgeZonePublisherId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EdgeZonePublisherId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EdgeZonePublisherId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *EdgeZonePublisherId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.EdgeZoneName, ok = input.Parsed["edgeZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "edgeZoneName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	return nil
+}
+
+// ValidateEdgeZonePublisherID checks that 'input' can be parsed as a Edge Zone Publisher ID
+func ValidateEdgeZonePublisherID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseEdgeZonePublisherID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Edge Zone Publisher ID
+func (id EdgeZonePublisherId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/edgeZones/%s/publishers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.EdgeZoneName, id.PublisherName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Edge Zone Publisher ID
+func (id EdgeZonePublisherId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticEdgeZones", "edgeZones", "edgeZones"),
+		resourceids.UserSpecifiedSegment("edgeZoneName", "edgeZoneValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+	}
+}
+
+// String returns a human-readable description of this Edge Zone Publisher ID
+func (id EdgeZonePublisherId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Edge Zone Name: %q", id.EdgeZoneName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+	}
+	return fmt.Sprintf("Edge Zone Publisher (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_location.go
@@ -1,0 +1,116 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offer.go
@@ -1,0 +1,136 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &OfferId{}
+
+// OfferId is a struct representing the Resource ID for a Offer
+type OfferId struct {
+	SubscriptionId string
+	LocationName   string
+	PublisherName  string
+	OfferName      string
+}
+
+// NewOfferID returns a new OfferId struct
+func NewOfferID(subscriptionId string, locationName string, publisherName string, offerName string) OfferId {
+	return OfferId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+	}
+}
+
+// ParseOfferID parses 'input' into a OfferId
+func ParseOfferID(input string) (*OfferId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOfferIDInsensitively parses 'input' case-insensitively into a OfferId
+// note: this method should only be used for API response data and not user input
+func ParseOfferIDInsensitively(input string) (*OfferId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OfferId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	return nil
+}
+
+// ValidateOfferID checks that 'input' can be parsed as a Offer ID
+func ValidateOfferID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOfferID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Offer ID
+func (id OfferId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifactTypes/vmImage/offers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.PublisherName, id.OfferName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Offer ID
+func (id OfferId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+	}
+}
+
+// String returns a human-readable description of this Offer ID
+func (id OfferId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+	}
+	return fmt.Sprintf("Offer (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offersku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offersku.go
@@ -1,0 +1,154 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &OfferSkuId{}
+
+// OfferSkuId is a struct representing the Resource ID for a Offer Sku
+type OfferSkuId struct {
+	SubscriptionId string
+	LocationName   string
+	EdgeZoneName   string
+	PublisherName  string
+	OfferName      string
+	SkuName        string
+}
+
+// NewOfferSkuID returns a new OfferSkuId struct
+func NewOfferSkuID(subscriptionId string, locationName string, edgeZoneName string, publisherName string, offerName string, skuName string) OfferSkuId {
+	return OfferSkuId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		EdgeZoneName:   edgeZoneName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+		SkuName:        skuName,
+	}
+}
+
+// ParseOfferSkuID parses 'input' into a OfferSkuId
+func ParseOfferSkuID(input string) (*OfferSkuId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferSkuId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferSkuId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOfferSkuIDInsensitively parses 'input' case-insensitively into a OfferSkuId
+// note: this method should only be used for API response data and not user input
+func ParseOfferSkuIDInsensitively(input string) (*OfferSkuId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferSkuId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferSkuId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OfferSkuId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.EdgeZoneName, ok = input.Parsed["edgeZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "edgeZoneName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	if id.SkuName, ok = input.Parsed["skuName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "skuName", input)
+	}
+
+	return nil
+}
+
+// ValidateOfferSkuID checks that 'input' can be parsed as a Offer Sku ID
+func ValidateOfferSkuID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOfferSkuID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Offer Sku ID
+func (id OfferSkuId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/edgeZones/%s/publishers/%s/artifactTypes/vmImage/offers/%s/skus/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.EdgeZoneName, id.PublisherName, id.OfferName, id.SkuName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Offer Sku ID
+func (id OfferSkuId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticEdgeZones", "edgeZones", "edgeZones"),
+		resourceids.UserSpecifiedSegment("edgeZoneName", "edgeZoneValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+		resourceids.StaticSegment("staticSkus", "skus", "skus"),
+		resourceids.UserSpecifiedSegment("skuName", "skuValue"),
+	}
+}
+
+// String returns a human-readable description of this Offer Sku ID
+func (id OfferSkuId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Edge Zone Name: %q", id.EdgeZoneName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+		fmt.Sprintf("Sku Name: %q", id.SkuName),
+	}
+	return fmt.Sprintf("Offer Sku (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offerskuversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_offerskuversion.go
@@ -1,0 +1,163 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &OfferSkuVersionId{}
+
+// OfferSkuVersionId is a struct representing the Resource ID for a Offer Sku Version
+type OfferSkuVersionId struct {
+	SubscriptionId string
+	LocationName   string
+	EdgeZoneName   string
+	PublisherName  string
+	OfferName      string
+	SkuName        string
+	VersionName    string
+}
+
+// NewOfferSkuVersionID returns a new OfferSkuVersionId struct
+func NewOfferSkuVersionID(subscriptionId string, locationName string, edgeZoneName string, publisherName string, offerName string, skuName string, versionName string) OfferSkuVersionId {
+	return OfferSkuVersionId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		EdgeZoneName:   edgeZoneName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+		SkuName:        skuName,
+		VersionName:    versionName,
+	}
+}
+
+// ParseOfferSkuVersionID parses 'input' into a OfferSkuVersionId
+func ParseOfferSkuVersionID(input string) (*OfferSkuVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferSkuVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferSkuVersionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOfferSkuVersionIDInsensitively parses 'input' case-insensitively into a OfferSkuVersionId
+// note: this method should only be used for API response data and not user input
+func ParseOfferSkuVersionIDInsensitively(input string) (*OfferSkuVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OfferSkuVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OfferSkuVersionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OfferSkuVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.EdgeZoneName, ok = input.Parsed["edgeZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "edgeZoneName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	if id.SkuName, ok = input.Parsed["skuName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "skuName", input)
+	}
+
+	if id.VersionName, ok = input.Parsed["versionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "versionName", input)
+	}
+
+	return nil
+}
+
+// ValidateOfferSkuVersionID checks that 'input' can be parsed as a Offer Sku Version ID
+func ValidateOfferSkuVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOfferSkuVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Offer Sku Version ID
+func (id OfferSkuVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/edgeZones/%s/publishers/%s/artifactTypes/vmImage/offers/%s/skus/%s/versions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.EdgeZoneName, id.PublisherName, id.OfferName, id.SkuName, id.VersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Offer Sku Version ID
+func (id OfferSkuVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticEdgeZones", "edgeZones", "edgeZones"),
+		resourceids.UserSpecifiedSegment("edgeZoneName", "edgeZoneValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+		resourceids.StaticSegment("staticSkus", "skus", "skus"),
+		resourceids.UserSpecifiedSegment("skuName", "skuValue"),
+		resourceids.StaticSegment("staticVersions", "versions", "versions"),
+		resourceids.UserSpecifiedSegment("versionName", "versionValue"),
+	}
+}
+
+// String returns a human-readable description of this Offer Sku Version ID
+func (id OfferSkuVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Edge Zone Name: %q", id.EdgeZoneName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+		fmt.Sprintf("Sku Name: %q", id.SkuName),
+		fmt.Sprintf("Version Name: %q", id.VersionName),
+	}
+	return fmt.Sprintf("Offer Sku Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_publisher.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_publisher.go
@@ -1,0 +1,125 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &PublisherId{}
+
+// PublisherId is a struct representing the Resource ID for a Publisher
+type PublisherId struct {
+	SubscriptionId string
+	LocationName   string
+	PublisherName  string
+}
+
+// NewPublisherID returns a new PublisherId struct
+func NewPublisherID(subscriptionId string, locationName string, publisherName string) PublisherId {
+	return PublisherId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		PublisherName:  publisherName,
+	}
+}
+
+// ParsePublisherID parses 'input' into a PublisherId
+func ParsePublisherID(input string) (*PublisherId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PublisherId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PublisherId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParsePublisherIDInsensitively parses 'input' case-insensitively into a PublisherId
+// note: this method should only be used for API response data and not user input
+func ParsePublisherIDInsensitively(input string) (*PublisherId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PublisherId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PublisherId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *PublisherId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	return nil
+}
+
+// ValidatePublisherID checks that 'input' can be parsed as a Publisher ID
+func ValidatePublisherID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePublisherID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Publisher ID
+func (id PublisherId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.PublisherName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Publisher ID
+func (id PublisherId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+	}
+}
+
+// String returns a human-readable description of this Publisher ID
+func (id PublisherId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+	}
+	return fmt.Sprintf("Publisher (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_sku.go
@@ -1,0 +1,145 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &SkuId{}
+
+// SkuId is a struct representing the Resource ID for a Sku
+type SkuId struct {
+	SubscriptionId string
+	LocationName   string
+	PublisherName  string
+	OfferName      string
+	SkuName        string
+}
+
+// NewSkuID returns a new SkuId struct
+func NewSkuID(subscriptionId string, locationName string, publisherName string, offerName string, skuName string) SkuId {
+	return SkuId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+		SkuName:        skuName,
+	}
+}
+
+// ParseSkuID parses 'input' into a SkuId
+func ParseSkuID(input string) (*SkuId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SkuId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SkuId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseSkuIDInsensitively parses 'input' case-insensitively into a SkuId
+// note: this method should only be used for API response data and not user input
+func ParseSkuIDInsensitively(input string) (*SkuId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SkuId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SkuId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *SkuId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	if id.SkuName, ok = input.Parsed["skuName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "skuName", input)
+	}
+
+	return nil
+}
+
+// ValidateSkuID checks that 'input' can be parsed as a Sku ID
+func ValidateSkuID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSkuID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Sku ID
+func (id SkuId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifactTypes/vmImage/offers/%s/skus/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.PublisherName, id.OfferName, id.SkuName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Sku ID
+func (id SkuId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+		resourceids.StaticSegment("staticSkus", "skus", "skus"),
+		resourceids.UserSpecifiedSegment("skuName", "skuValue"),
+	}
+}
+
+// String returns a human-readable description of this Sku ID
+func (id SkuId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+		fmt.Sprintf("Sku Name: %q", id.SkuName),
+	}
+	return fmt.Sprintf("Sku (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_skuversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_skuversion.go
@@ -1,0 +1,154 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &SkuVersionId{}
+
+// SkuVersionId is a struct representing the Resource ID for a Sku Version
+type SkuVersionId struct {
+	SubscriptionId string
+	LocationName   string
+	PublisherName  string
+	OfferName      string
+	SkuName        string
+	VersionName    string
+}
+
+// NewSkuVersionID returns a new SkuVersionId struct
+func NewSkuVersionID(subscriptionId string, locationName string, publisherName string, offerName string, skuName string, versionName string) SkuVersionId {
+	return SkuVersionId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+		SkuName:        skuName,
+		VersionName:    versionName,
+	}
+}
+
+// ParseSkuVersionID parses 'input' into a SkuVersionId
+func ParseSkuVersionID(input string) (*SkuVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SkuVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SkuVersionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseSkuVersionIDInsensitively parses 'input' case-insensitively into a SkuVersionId
+// note: this method should only be used for API response data and not user input
+func ParseSkuVersionIDInsensitively(input string) (*SkuVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SkuVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SkuVersionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *SkuVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	if id.SkuName, ok = input.Parsed["skuName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "skuName", input)
+	}
+
+	if id.VersionName, ok = input.Parsed["versionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "versionName", input)
+	}
+
+	return nil
+}
+
+// ValidateSkuVersionID checks that 'input' can be parsed as a Sku Version ID
+func ValidateSkuVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSkuVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Sku Version ID
+func (id SkuVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifactTypes/vmImage/offers/%s/skus/%s/versions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.PublisherName, id.OfferName, id.SkuName, id.VersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Sku Version ID
+func (id SkuVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+		resourceids.StaticSegment("staticSkus", "skus", "skus"),
+		resourceids.UserSpecifiedSegment("skuName", "skuValue"),
+		resourceids.StaticSegment("staticVersions", "versions", "versions"),
+		resourceids.UserSpecifiedSegment("versionName", "versionValue"),
+	}
+}
+
+// String returns a human-readable description of this Sku Version ID
+func (id SkuVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+		fmt.Sprintf("Sku Name: %q", id.SkuName),
+		fmt.Sprintf("Version Name: %q", id.VersionName),
+	}
+	return fmt.Sprintf("Sku Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_vmimageoffer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/id_vmimageoffer.go
@@ -1,0 +1,145 @@
+package virtualmachineimages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VMImageOfferId{}
+
+// VMImageOfferId is a struct representing the Resource ID for a V M Image Offer
+type VMImageOfferId struct {
+	SubscriptionId string
+	LocationName   string
+	EdgeZoneName   string
+	PublisherName  string
+	OfferName      string
+}
+
+// NewVMImageOfferID returns a new VMImageOfferId struct
+func NewVMImageOfferID(subscriptionId string, locationName string, edgeZoneName string, publisherName string, offerName string) VMImageOfferId {
+	return VMImageOfferId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		EdgeZoneName:   edgeZoneName,
+		PublisherName:  publisherName,
+		OfferName:      offerName,
+	}
+}
+
+// ParseVMImageOfferID parses 'input' into a VMImageOfferId
+func ParseVMImageOfferID(input string) (*VMImageOfferId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VMImageOfferId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VMImageOfferId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVMImageOfferIDInsensitively parses 'input' case-insensitively into a VMImageOfferId
+// note: this method should only be used for API response data and not user input
+func ParseVMImageOfferIDInsensitively(input string) (*VMImageOfferId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VMImageOfferId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VMImageOfferId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VMImageOfferId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.EdgeZoneName, ok = input.Parsed["edgeZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "edgeZoneName", input)
+	}
+
+	if id.PublisherName, ok = input.Parsed["publisherName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "publisherName", input)
+	}
+
+	if id.OfferName, ok = input.Parsed["offerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "offerName", input)
+	}
+
+	return nil
+}
+
+// ValidateVMImageOfferID checks that 'input' can be parsed as a V M Image Offer ID
+func ValidateVMImageOfferID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVMImageOfferID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted V M Image Offer ID
+func (id VMImageOfferId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s/edgeZones/%s/publishers/%s/artifactTypes/vmImage/offers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.EdgeZoneName, id.PublisherName, id.OfferName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this V M Image Offer ID
+func (id VMImageOfferId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticEdgeZones", "edgeZones", "edgeZones"),
+		resourceids.UserSpecifiedSegment("edgeZoneName", "edgeZoneValue"),
+		resourceids.StaticSegment("staticPublishers", "publishers", "publishers"),
+		resourceids.UserSpecifiedSegment("publisherName", "publisherValue"),
+		resourceids.StaticSegment("staticArtifactTypes", "artifactTypes", "artifactTypes"),
+		resourceids.StaticSegment("staticVmImage", "vmImage", "vmImage"),
+		resourceids.StaticSegment("staticOffers", "offers", "offers"),
+		resourceids.UserSpecifiedSegment("offerName", "offerValue"),
+	}
+}
+
+// String returns a human-readable description of this V M Image Offer ID
+func (id VMImageOfferId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Edge Zone Name: %q", id.EdgeZoneName),
+		fmt.Sprintf("Publisher Name: %q", id.PublisherName),
+		fmt.Sprintf("Offer Name: %q", id.OfferName),
+	}
+	return fmt.Sprintf("V M Image Offer (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezoneget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezoneget.go
@@ -1,0 +1,54 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EdgeZoneGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineImage
+}
+
+// EdgeZoneGet ...
+func (c VirtualMachineImagesClient) EdgeZoneGet(ctx context.Context, id OfferSkuVersionId) (result EdgeZoneGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineImage
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelist.go
@@ -1,0 +1,91 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EdgeZoneListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+type EdgeZoneListOperationOptions struct {
+	Expand  *string
+	Orderby *string
+	Top     *int64
+}
+
+func DefaultEdgeZoneListOperationOptions() EdgeZoneListOperationOptions {
+	return EdgeZoneListOperationOptions{}
+}
+
+func (o EdgeZoneListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o EdgeZoneListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o EdgeZoneListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Orderby != nil {
+		out.Append("$orderby", fmt.Sprintf("%v", *o.Orderby))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// EdgeZoneList ...
+func (c VirtualMachineImagesClient) EdgeZoneList(ctx context.Context, id OfferSkuId, options EdgeZoneListOperationOptions) (result EdgeZoneListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/versions", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistoffers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistoffers.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EdgeZoneListOffersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// EdgeZoneListOffers ...
+func (c VirtualMachineImagesClient) EdgeZoneListOffers(ctx context.Context, id EdgeZonePublisherId) (result EdgeZoneListOffersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/artifactTypes/vmImage/offers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistpublishers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistpublishers.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EdgeZoneListPublishersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// EdgeZoneListPublishers ...
+func (c VirtualMachineImagesClient) EdgeZoneListPublishers(ctx context.Context, id EdgeZoneId) (result EdgeZoneListPublishersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/publishers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistskus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_edgezonelistskus.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EdgeZoneListSkusOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// EdgeZoneListSkus ...
+func (c VirtualMachineImagesClient) EdgeZoneListSkus(ctx context.Context, id VMImageOfferId) (result EdgeZoneListSkusOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/skus", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_get.go
@@ -1,0 +1,54 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineImage
+}
+
+// Get ...
+func (c VirtualMachineImagesClient) Get(ctx context.Context, id SkuVersionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineImage
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_list.go
@@ -1,0 +1,91 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+type ListOperationOptions struct {
+	Expand  *string
+	Orderby *string
+	Top     *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Orderby != nil {
+		out.Append("$orderby", fmt.Sprintf("%v", *o.Orderby))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// List ...
+func (c VirtualMachineImagesClient) List(ctx context.Context, id SkuId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/versions", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listbyedgezone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listbyedgezone.go
@@ -1,0 +1,91 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByEdgeZoneOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+type ListByEdgeZoneCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineImageResource
+}
+
+// ListByEdgeZone ...
+func (c VirtualMachineImagesClient) ListByEdgeZone(ctx context.Context, id EdgeZoneId) (result ListByEdgeZoneOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/vmimages", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineImageResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByEdgeZoneComplete retrieves all the results into a single object
+func (c VirtualMachineImagesClient) ListByEdgeZoneComplete(ctx context.Context, id EdgeZoneId) (ListByEdgeZoneCompleteResult, error) {
+	return c.ListByEdgeZoneCompleteMatchingPredicate(ctx, id, VirtualMachineImageResourceOperationPredicate{})
+}
+
+// ListByEdgeZoneCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineImagesClient) ListByEdgeZoneCompleteMatchingPredicate(ctx context.Context, id EdgeZoneId, predicate VirtualMachineImageResourceOperationPredicate) (result ListByEdgeZoneCompleteResult, err error) {
+	items := make([]VirtualMachineImageResource, 0)
+
+	resp, err := c.ListByEdgeZone(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByEdgeZoneCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listoffers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listoffers.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOffersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// ListOffers ...
+func (c VirtualMachineImagesClient) ListOffers(ctx context.Context, id PublisherId) (result ListOffersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/artifactTypes/vmImage/offers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listpublishers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listpublishers.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListPublishersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// ListPublishers ...
+func (c VirtualMachineImagesClient) ListPublishers(ctx context.Context, id LocationId) (result ListPublishersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/publishers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listskus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/method_listskus.go
@@ -1,0 +1,55 @@
+package virtualmachineimages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListSkusOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineImageResource
+}
+
+// ListSkus ...
+func (c VirtualMachineImagesClient) ListSkus(ctx context.Context, id OfferId) (result ListSkusOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/skus", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []VirtualMachineImageResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_alternativeoption.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_alternativeoption.go
@@ -1,0 +1,9 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AlternativeOption struct {
+	Type  *AlternativeType `json:"type,omitempty"`
+	Value *string          `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_automaticosupgradeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_automaticosupgradeproperties.go
@@ -1,0 +1,8 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomaticOSUpgradeProperties struct {
+	AutomaticOSUpgradeSupported bool `json:"automaticOSUpgradeSupported"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_datadiskimage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_datadiskimage.go
@@ -1,0 +1,8 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataDiskImage struct {
+	Lun *int64 `json:"lun,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_disallowedconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_disallowedconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DisallowedConfiguration struct {
+	VMDiskType *VMDiskTypes `json:"vmDiskType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_imagedeprecationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_imagedeprecationstatus.go
@@ -1,0 +1,28 @@
+package virtualmachineimages
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageDeprecationStatus struct {
+	AlternativeOption        *AlternativeOption `json:"alternativeOption,omitempty"`
+	ImageState               *ImageState        `json:"imageState,omitempty"`
+	ScheduledDeprecationTime *string            `json:"scheduledDeprecationTime,omitempty"`
+}
+
+func (o *ImageDeprecationStatus) GetScheduledDeprecationTimeAsTime() (*time.Time, error) {
+	if o.ScheduledDeprecationTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ScheduledDeprecationTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ImageDeprecationStatus) SetScheduledDeprecationTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ScheduledDeprecationTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_osdiskimage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_osdiskimage.go
@@ -1,0 +1,8 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSDiskImage struct {
+	OperatingSystem OperatingSystemTypes `json:"operatingSystem"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_purchaseplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_purchaseplan.go
@@ -1,0 +1,10 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PurchasePlan struct {
+	Name      string `json:"name"`
+	Product   string `json:"product"`
+	Publisher string `json:"publisher"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimage.go
@@ -1,0 +1,17 @@
+package virtualmachineimages
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImage struct {
+	ExtendedLocation *edgezones.Model               `json:"extendedLocation,omitempty"`
+	Id               *string                        `json:"id,omitempty"`
+	Location         string                         `json:"location"`
+	Name             string                         `json:"name"`
+	Properties       *VirtualMachineImageProperties `json:"properties,omitempty"`
+	Tags             *map[string]string             `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimagefeature.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimagefeature.go
@@ -1,0 +1,9 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImageFeature struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimageproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimageproperties.go
@@ -1,0 +1,16 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImageProperties struct {
+	Architecture                 *ArchitectureTypes            `json:"architecture,omitempty"`
+	AutomaticOSUpgradeProperties *AutomaticOSUpgradeProperties `json:"automaticOSUpgradeProperties,omitempty"`
+	DataDiskImages               *[]DataDiskImage              `json:"dataDiskImages,omitempty"`
+	Disallowed                   *DisallowedConfiguration      `json:"disallowed,omitempty"`
+	Features                     *[]VirtualMachineImageFeature `json:"features,omitempty"`
+	HyperVGeneration             *HyperVGenerationTypes        `json:"hyperVGeneration,omitempty"`
+	ImageDeprecationStatus       *ImageDeprecationStatus       `json:"imageDeprecationStatus,omitempty"`
+	OsDiskImage                  *OSDiskImage                  `json:"osDiskImage,omitempty"`
+	Plan                         *PurchasePlan                 `json:"plan,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimageresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/model_virtualmachineimageresource.go
@@ -1,0 +1,16 @@
+package virtualmachineimages
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImageResource struct {
+	ExtendedLocation *edgezones.Model   `json:"extendedLocation,omitempty"`
+	Id               *string            `json:"id,omitempty"`
+	Location         string             `json:"location"`
+	Name             string             `json:"name"`
+	Tags             *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/predicates.go
@@ -1,0 +1,27 @@
+package virtualmachineimages
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImageResourceOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+}
+
+func (p VirtualMachineImageResourceOperationPredicate) Matches(input VirtualMachineImageResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && *p.Name != input.Name {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages/version.go
@@ -1,0 +1,12 @@
+package virtualmachineimages
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachineimages/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/README.md
@@ -1,0 +1,72 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades` Documentation
+
+The `virtualmachinescalesetrollingupgrades` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetRollingUpgradesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineScaleSetRollingUpgradesClient.Cancel`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+if err := client.CancelThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetRollingUpgradesClient.GetLatest`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+read, err := client.GetLatest(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+if err := client.StartExtensionUpgradeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+if err := client.StartOSUpgradeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/client.go
@@ -1,0 +1,26 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetRollingUpgradesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineScaleSetRollingUpgradesClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineScaleSetRollingUpgradesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachinescalesetrollingupgrades", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineScaleSetRollingUpgradesClient: %+v", err)
+	}
+
+	return &VirtualMachineScaleSetRollingUpgradesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/constants.go
@@ -1,0 +1,98 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeActionType string
+
+const (
+	RollingUpgradeActionTypeCancel RollingUpgradeActionType = "Cancel"
+	RollingUpgradeActionTypeStart  RollingUpgradeActionType = "Start"
+)
+
+func PossibleValuesForRollingUpgradeActionType() []string {
+	return []string{
+		string(RollingUpgradeActionTypeCancel),
+		string(RollingUpgradeActionTypeStart),
+	}
+}
+
+func (s *RollingUpgradeActionType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRollingUpgradeActionType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRollingUpgradeActionType(input string) (*RollingUpgradeActionType, error) {
+	vals := map[string]RollingUpgradeActionType{
+		"cancel": RollingUpgradeActionTypeCancel,
+		"start":  RollingUpgradeActionTypeStart,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RollingUpgradeActionType(input)
+	return &out, nil
+}
+
+type RollingUpgradeStatusCode string
+
+const (
+	RollingUpgradeStatusCodeCancelled      RollingUpgradeStatusCode = "Cancelled"
+	RollingUpgradeStatusCodeCompleted      RollingUpgradeStatusCode = "Completed"
+	RollingUpgradeStatusCodeFaulted        RollingUpgradeStatusCode = "Faulted"
+	RollingUpgradeStatusCodeRollingForward RollingUpgradeStatusCode = "RollingForward"
+)
+
+func PossibleValuesForRollingUpgradeStatusCode() []string {
+	return []string{
+		string(RollingUpgradeStatusCodeCancelled),
+		string(RollingUpgradeStatusCodeCompleted),
+		string(RollingUpgradeStatusCodeFaulted),
+		string(RollingUpgradeStatusCodeRollingForward),
+	}
+}
+
+func (s *RollingUpgradeStatusCode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRollingUpgradeStatusCode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRollingUpgradeStatusCode(input string) (*RollingUpgradeStatusCode, error) {
+	vals := map[string]RollingUpgradeStatusCode{
+		"cancelled":      RollingUpgradeStatusCodeCancelled,
+		"completed":      RollingUpgradeStatusCodeCompleted,
+		"faulted":        RollingUpgradeStatusCodeFaulted,
+		"rollingforward": RollingUpgradeStatusCodeRollingForward,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RollingUpgradeStatusCode(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/id_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/id_virtualmachinescaleset.go
@@ -1,0 +1,125 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetId{}
+
+// VirtualMachineScaleSetId is a struct representing the Resource ID for a Virtual Machine Scale Set
+type VirtualMachineScaleSetId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+}
+
+// NewVirtualMachineScaleSetID returns a new VirtualMachineScaleSetId struct
+func NewVirtualMachineScaleSetID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string) VirtualMachineScaleSetId {
+	return VirtualMachineScaleSetId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+	}
+}
+
+// ParseVirtualMachineScaleSetID parses 'input' into a VirtualMachineScaleSetId
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetIDInsensitively(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetID checks that 'input' can be parsed as a Virtual Machine Scale Set ID
+func ValidateVirtualMachineScaleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_cancel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_cancel.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CancelOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Cancel ...
+func (c VirtualMachineScaleSetRollingUpgradesClient) Cancel(ctx context.Context, id VirtualMachineScaleSetId) (result CancelOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/rollingUpgrades/cancel", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CancelThenPoll performs Cancel then polls until it's completed
+func (c VirtualMachineScaleSetRollingUpgradesClient) CancelThenPoll(ctx context.Context, id VirtualMachineScaleSetId) error {
+	result, err := c.Cancel(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Cancel: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Cancel: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_getlatest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_getlatest.go
@@ -1,0 +1,55 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetLatestOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RollingUpgradeStatusInfo
+}
+
+// GetLatest ...
+func (c VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context.Context, id VirtualMachineScaleSetId) (result GetLatestOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/rollingUpgrades/latest", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RollingUpgradeStatusInfo
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_startextensionupgrade.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_startextensionupgrade.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StartExtensionUpgradeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// StartExtensionUpgrade ...
+func (c VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade(ctx context.Context, id VirtualMachineScaleSetId) (result StartExtensionUpgradeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/extensionRollingUpgrade", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// StartExtensionUpgradeThenPoll performs StartExtensionUpgrade then polls until it's completed
+func (c VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgradeThenPoll(ctx context.Context, id VirtualMachineScaleSetId) error {
+	result, err := c.StartExtensionUpgrade(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing StartExtensionUpgrade: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after StartExtensionUpgrade: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_startosupgrade.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/method_startosupgrade.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StartOSUpgradeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// StartOSUpgrade ...
+func (c VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgrade(ctx context.Context, id VirtualMachineScaleSetId) (result StartOSUpgradeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/osRollingUpgrade", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// StartOSUpgradeThenPoll performs StartOSUpgrade then polls until it's completed
+func (c VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgradeThenPoll(ctx context.Context, id VirtualMachineScaleSetId) error {
+	result, err := c.StartOSUpgrade(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing StartOSUpgrade: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after StartOSUpgrade: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_apierror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_apierror.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiError struct {
+	Code       *string         `json:"code,omitempty"`
+	Details    *[]ApiErrorBase `json:"details,omitempty"`
+	Innererror *InnerError     `json:"innererror,omitempty"`
+	Message    *string         `json:"message,omitempty"`
+	Target     *string         `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_apierrorbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_apierrorbase.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiErrorBase struct {
+	Code    *string `json:"code,omitempty"`
+	Message *string `json:"message,omitempty"`
+	Target  *string `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_innererror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_innererror.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InnerError struct {
+	Errordetail   *string `json:"errordetail,omitempty"`
+	Exceptiontype *string `json:"exceptiontype,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradepolicy.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradePolicy struct {
+	EnableCrossZoneUpgrade                *bool   `json:"enableCrossZoneUpgrade,omitempty"`
+	MaxBatchInstancePercent               *int64  `json:"maxBatchInstancePercent,omitempty"`
+	MaxSurge                              *bool   `json:"maxSurge,omitempty"`
+	MaxUnhealthyInstancePercent           *int64  `json:"maxUnhealthyInstancePercent,omitempty"`
+	MaxUnhealthyUpgradedInstancePercent   *int64  `json:"maxUnhealthyUpgradedInstancePercent,omitempty"`
+	PauseTimeBetweenBatches               *string `json:"pauseTimeBetweenBatches,omitempty"`
+	PrioritizeUnhealthyInstances          *bool   `json:"prioritizeUnhealthyInstances,omitempty"`
+	RollbackFailedInstancesOnPolicyBreach *bool   `json:"rollbackFailedInstancesOnPolicyBreach,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradeprogressinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradeprogressinfo.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeProgressInfo struct {
+	FailedInstanceCount     *int64 `json:"failedInstanceCount,omitempty"`
+	InProgressInstanceCount *int64 `json:"inProgressInstanceCount,omitempty"`
+	PendingInstanceCount    *int64 `json:"pendingInstanceCount,omitempty"`
+	SuccessfulInstanceCount *int64 `json:"successfulInstanceCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgraderunningstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgraderunningstatus.go
@@ -1,0 +1,41 @@
+package virtualmachinescalesetrollingupgrades
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeRunningStatus struct {
+	Code           *RollingUpgradeStatusCode `json:"code,omitempty"`
+	LastAction     *RollingUpgradeActionType `json:"lastAction,omitempty"`
+	LastActionTime *string                   `json:"lastActionTime,omitempty"`
+	StartTime      *string                   `json:"startTime,omitempty"`
+}
+
+func (o *RollingUpgradeRunningStatus) GetLastActionTimeAsTime() (*time.Time, error) {
+	if o.LastActionTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastActionTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RollingUpgradeRunningStatus) SetLastActionTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastActionTime = &formatted
+}
+
+func (o *RollingUpgradeRunningStatus) GetStartTimeAsTime() (*time.Time, error) {
+	if o.StartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RollingUpgradeRunningStatus) SetStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradestatusinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradestatusinfo.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeStatusInfo struct {
+	Id         *string                             `json:"id,omitempty"`
+	Location   string                              `json:"location"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *RollingUpgradeStatusInfoProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                  `json:"tags,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradestatusinfoproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/model_rollingupgradestatusinfoproperties.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetrollingupgrades
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeStatusInfoProperties struct {
+	Error         *ApiError                    `json:"error,omitempty"`
+	Policy        *RollingUpgradePolicy        `json:"policy,omitempty"`
+	Progress      *RollingUpgradeProgressInfo  `json:"progress,omitempty"`
+	RunningStatus *RollingUpgradeRunningStatus `json:"runningStatus,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades/version.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetrollingupgrades
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachinescalesetrollingupgrades/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/README.md
@@ -1,0 +1,437 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets` Documentation
+
+The `virtualmachinescalesets` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachinescalesets.NewVirtualMachineScaleSetsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ApproveRollingUpgrade`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.ApproveRollingUpgradeThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ConvertToSinglePlacementGroup`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VMScaleSetConvertToSinglePlacementGroupInput{
+	// ...
+}
+
+
+read, err := client.ConvertToSinglePlacementGroup(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSet{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Deallocate`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.DeallocateThenPoll(ctx, id, payload, virtualmachinescalesets.DefaultDeallocateOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+if err := client.DeleteThenPoll(ctx, id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.DeleteInstances`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceRequiredIDs{
+	// ...
+}
+
+
+if err := client.DeleteInstancesThenPoll(ctx, id, payload, virtualmachinescalesets.DefaultDeleteInstancesOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ForceRecoveryServiceFabricPlatformUpdateDomainWalk`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+read, err := client.ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx, id, virtualmachinescalesets.DefaultForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+read, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.GetInstanceView`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+read, err := client.GetInstanceView(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.GetOSUpgradeHistory`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+// alternatively `client.GetOSUpgradeHistory(ctx, id)` can be used to do batched pagination
+items, err := client.GetOSUpgradeHistoryComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ListAll`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
+items, err := client.ListAllComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ListSkus`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+// alternatively `client.ListSkus(ctx, id)` can be used to do batched pagination
+items, err := client.ListSkusComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.PerformMaintenance`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.PerformMaintenanceThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.PowerOff`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.PowerOffThenPoll(ctx, id, payload, virtualmachinescalesets.DefaultPowerOffOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Reapply`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+if err := client.ReapplyThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Redeploy`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.RedeployThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Reimage`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetReimageParameters{
+	// ...
+}
+
+
+if err := client.ReimageThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.ReimageAll`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.ReimageAllThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Restart`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.RestartThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.SetOrchestrationServiceState`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.OrchestrationServiceStateInput{
+	// ...
+}
+
+
+if err := client.SetOrchestrationServiceStateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Start`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceIDs{
+	// ...
+}
+
+
+if err := client.StartThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.Update`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetsClient.UpdateInstances`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesets.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+payload := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceRequiredIDs{
+	// ...
+}
+
+
+if err := client.UpdateInstancesThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/client.go
@@ -1,0 +1,26 @@
+package virtualmachinescalesets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineScaleSetsClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineScaleSetsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachinescalesets", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineScaleSetsClient: %+v", err)
+	}
+
+	return &VirtualMachineScaleSetsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/constants.go
@@ -1,0 +1,1807 @@
+package virtualmachinescalesets
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CachingTypes string
+
+const (
+	CachingTypesNone      CachingTypes = "None"
+	CachingTypesReadOnly  CachingTypes = "ReadOnly"
+	CachingTypesReadWrite CachingTypes = "ReadWrite"
+)
+
+func PossibleValuesForCachingTypes() []string {
+	return []string{
+		string(CachingTypesNone),
+		string(CachingTypesReadOnly),
+		string(CachingTypesReadWrite),
+	}
+}
+
+func (s *CachingTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCachingTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCachingTypes(input string) (*CachingTypes, error) {
+	vals := map[string]CachingTypes{
+		"none":      CachingTypesNone,
+		"readonly":  CachingTypesReadOnly,
+		"readwrite": CachingTypesReadWrite,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CachingTypes(input)
+	return &out, nil
+}
+
+type ComponentNames string
+
+const (
+	ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup ComponentNames = "Microsoft-Windows-Shell-Setup"
+)
+
+func PossibleValuesForComponentNames() []string {
+	return []string{
+		string(ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup),
+	}
+}
+
+func (s *ComponentNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComponentNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComponentNames(input string) (*ComponentNames, error) {
+	vals := map[string]ComponentNames{
+		"microsoft-windows-shell-setup": ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComponentNames(input)
+	return &out, nil
+}
+
+type DeleteOptions string
+
+const (
+	DeleteOptionsDelete DeleteOptions = "Delete"
+	DeleteOptionsDetach DeleteOptions = "Detach"
+)
+
+func PossibleValuesForDeleteOptions() []string {
+	return []string{
+		string(DeleteOptionsDelete),
+		string(DeleteOptionsDetach),
+	}
+}
+
+func (s *DeleteOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeleteOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeleteOptions(input string) (*DeleteOptions, error) {
+	vals := map[string]DeleteOptions{
+		"delete": DeleteOptionsDelete,
+		"detach": DeleteOptionsDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeleteOptions(input)
+	return &out, nil
+}
+
+type DiffDiskOptions string
+
+const (
+	DiffDiskOptionsLocal DiffDiskOptions = "Local"
+)
+
+func PossibleValuesForDiffDiskOptions() []string {
+	return []string{
+		string(DiffDiskOptionsLocal),
+	}
+}
+
+func (s *DiffDiskOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiffDiskOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiffDiskOptions(input string) (*DiffDiskOptions, error) {
+	vals := map[string]DiffDiskOptions{
+		"local": DiffDiskOptionsLocal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiffDiskOptions(input)
+	return &out, nil
+}
+
+type DiffDiskPlacement string
+
+const (
+	DiffDiskPlacementCacheDisk    DiffDiskPlacement = "CacheDisk"
+	DiffDiskPlacementNVMeDisk     DiffDiskPlacement = "NvmeDisk"
+	DiffDiskPlacementResourceDisk DiffDiskPlacement = "ResourceDisk"
+)
+
+func PossibleValuesForDiffDiskPlacement() []string {
+	return []string{
+		string(DiffDiskPlacementCacheDisk),
+		string(DiffDiskPlacementNVMeDisk),
+		string(DiffDiskPlacementResourceDisk),
+	}
+}
+
+func (s *DiffDiskPlacement) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiffDiskPlacement(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiffDiskPlacement(input string) (*DiffDiskPlacement, error) {
+	vals := map[string]DiffDiskPlacement{
+		"cachedisk":    DiffDiskPlacementCacheDisk,
+		"nvmedisk":     DiffDiskPlacementNVMeDisk,
+		"resourcedisk": DiffDiskPlacementResourceDisk,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiffDiskPlacement(input)
+	return &out, nil
+}
+
+type DiskCreateOptionTypes string
+
+const (
+	DiskCreateOptionTypesAttach    DiskCreateOptionTypes = "Attach"
+	DiskCreateOptionTypesCopy      DiskCreateOptionTypes = "Copy"
+	DiskCreateOptionTypesEmpty     DiskCreateOptionTypes = "Empty"
+	DiskCreateOptionTypesFromImage DiskCreateOptionTypes = "FromImage"
+	DiskCreateOptionTypesRestore   DiskCreateOptionTypes = "Restore"
+)
+
+func PossibleValuesForDiskCreateOptionTypes() []string {
+	return []string{
+		string(DiskCreateOptionTypesAttach),
+		string(DiskCreateOptionTypesCopy),
+		string(DiskCreateOptionTypesEmpty),
+		string(DiskCreateOptionTypesFromImage),
+		string(DiskCreateOptionTypesRestore),
+	}
+}
+
+func (s *DiskCreateOptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskCreateOptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskCreateOptionTypes(input string) (*DiskCreateOptionTypes, error) {
+	vals := map[string]DiskCreateOptionTypes{
+		"attach":    DiskCreateOptionTypesAttach,
+		"copy":      DiskCreateOptionTypesCopy,
+		"empty":     DiskCreateOptionTypesEmpty,
+		"fromimage": DiskCreateOptionTypesFromImage,
+		"restore":   DiskCreateOptionTypesRestore,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskCreateOptionTypes(input)
+	return &out, nil
+}
+
+type DiskDeleteOptionTypes string
+
+const (
+	DiskDeleteOptionTypesDelete DiskDeleteOptionTypes = "Delete"
+	DiskDeleteOptionTypesDetach DiskDeleteOptionTypes = "Detach"
+)
+
+func PossibleValuesForDiskDeleteOptionTypes() []string {
+	return []string{
+		string(DiskDeleteOptionTypesDelete),
+		string(DiskDeleteOptionTypesDetach),
+	}
+}
+
+func (s *DiskDeleteOptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskDeleteOptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskDeleteOptionTypes(input string) (*DiskDeleteOptionTypes, error) {
+	vals := map[string]DiskDeleteOptionTypes{
+		"delete": DiskDeleteOptionTypesDelete,
+		"detach": DiskDeleteOptionTypesDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskDeleteOptionTypes(input)
+	return &out, nil
+}
+
+type DomainNameLabelScopeTypes string
+
+const (
+	DomainNameLabelScopeTypesNoReuse            DomainNameLabelScopeTypes = "NoReuse"
+	DomainNameLabelScopeTypesResourceGroupReuse DomainNameLabelScopeTypes = "ResourceGroupReuse"
+	DomainNameLabelScopeTypesSubscriptionReuse  DomainNameLabelScopeTypes = "SubscriptionReuse"
+	DomainNameLabelScopeTypesTenantReuse        DomainNameLabelScopeTypes = "TenantReuse"
+)
+
+func PossibleValuesForDomainNameLabelScopeTypes() []string {
+	return []string{
+		string(DomainNameLabelScopeTypesNoReuse),
+		string(DomainNameLabelScopeTypesResourceGroupReuse),
+		string(DomainNameLabelScopeTypesSubscriptionReuse),
+		string(DomainNameLabelScopeTypesTenantReuse),
+	}
+}
+
+func (s *DomainNameLabelScopeTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDomainNameLabelScopeTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDomainNameLabelScopeTypes(input string) (*DomainNameLabelScopeTypes, error) {
+	vals := map[string]DomainNameLabelScopeTypes{
+		"noreuse":            DomainNameLabelScopeTypesNoReuse,
+		"resourcegroupreuse": DomainNameLabelScopeTypesResourceGroupReuse,
+		"subscriptionreuse":  DomainNameLabelScopeTypesSubscriptionReuse,
+		"tenantreuse":        DomainNameLabelScopeTypesTenantReuse,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DomainNameLabelScopeTypes(input)
+	return &out, nil
+}
+
+type ExpandTypesForGetVMScaleSets string
+
+const (
+	ExpandTypesForGetVMScaleSetsUserData ExpandTypesForGetVMScaleSets = "userData"
+)
+
+func PossibleValuesForExpandTypesForGetVMScaleSets() []string {
+	return []string{
+		string(ExpandTypesForGetVMScaleSetsUserData),
+	}
+}
+
+func (s *ExpandTypesForGetVMScaleSets) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseExpandTypesForGetVMScaleSets(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseExpandTypesForGetVMScaleSets(input string) (*ExpandTypesForGetVMScaleSets, error) {
+	vals := map[string]ExpandTypesForGetVMScaleSets{
+		"userdata": ExpandTypesForGetVMScaleSetsUserData,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ExpandTypesForGetVMScaleSets(input)
+	return &out, nil
+}
+
+type IPVersion string
+
+const (
+	IPVersionIPvFour IPVersion = "IPv4"
+	IPVersionIPvSix  IPVersion = "IPv6"
+)
+
+func PossibleValuesForIPVersion() []string {
+	return []string{
+		string(IPVersionIPvFour),
+		string(IPVersionIPvSix),
+	}
+}
+
+func (s *IPVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersion(input string) (*IPVersion, error) {
+	vals := map[string]IPVersion{
+		"ipv4": IPVersionIPvFour,
+		"ipv6": IPVersionIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersion(input)
+	return &out, nil
+}
+
+type LinuxPatchAssessmentMode string
+
+const (
+	LinuxPatchAssessmentModeAutomaticByPlatform LinuxPatchAssessmentMode = "AutomaticByPlatform"
+	LinuxPatchAssessmentModeImageDefault        LinuxPatchAssessmentMode = "ImageDefault"
+)
+
+func PossibleValuesForLinuxPatchAssessmentMode() []string {
+	return []string{
+		string(LinuxPatchAssessmentModeAutomaticByPlatform),
+		string(LinuxPatchAssessmentModeImageDefault),
+	}
+}
+
+func (s *LinuxPatchAssessmentMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxPatchAssessmentMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxPatchAssessmentMode(input string) (*LinuxPatchAssessmentMode, error) {
+	vals := map[string]LinuxPatchAssessmentMode{
+		"automaticbyplatform": LinuxPatchAssessmentModeAutomaticByPlatform,
+		"imagedefault":        LinuxPatchAssessmentModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxPatchAssessmentMode(input)
+	return &out, nil
+}
+
+type LinuxVMGuestPatchAutomaticByPlatformRebootSetting string
+
+const (
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways     LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Always"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "IfRequired"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever      LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Never"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown    LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Unknown"
+)
+
+func PossibleValuesForLinuxVMGuestPatchAutomaticByPlatformRebootSetting() []string {
+	return []string{
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown),
+	}
+}
+
+func (s *LinuxVMGuestPatchAutomaticByPlatformRebootSetting) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxVMGuestPatchAutomaticByPlatformRebootSetting(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxVMGuestPatchAutomaticByPlatformRebootSetting(input string) (*LinuxVMGuestPatchAutomaticByPlatformRebootSetting, error) {
+	vals := map[string]LinuxVMGuestPatchAutomaticByPlatformRebootSetting{
+		"always":     LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways,
+		"ifrequired": LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired,
+		"never":      LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever,
+		"unknown":    LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxVMGuestPatchAutomaticByPlatformRebootSetting(input)
+	return &out, nil
+}
+
+type LinuxVMGuestPatchMode string
+
+const (
+	LinuxVMGuestPatchModeAutomaticByPlatform LinuxVMGuestPatchMode = "AutomaticByPlatform"
+	LinuxVMGuestPatchModeImageDefault        LinuxVMGuestPatchMode = "ImageDefault"
+)
+
+func PossibleValuesForLinuxVMGuestPatchMode() []string {
+	return []string{
+		string(LinuxVMGuestPatchModeAutomaticByPlatform),
+		string(LinuxVMGuestPatchModeImageDefault),
+	}
+}
+
+func (s *LinuxVMGuestPatchMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxVMGuestPatchMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxVMGuestPatchMode(input string) (*LinuxVMGuestPatchMode, error) {
+	vals := map[string]LinuxVMGuestPatchMode{
+		"automaticbyplatform": LinuxVMGuestPatchModeAutomaticByPlatform,
+		"imagedefault":        LinuxVMGuestPatchModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxVMGuestPatchMode(input)
+	return &out, nil
+}
+
+type Mode string
+
+const (
+	ModeAudit   Mode = "Audit"
+	ModeEnforce Mode = "Enforce"
+)
+
+func PossibleValuesForMode() []string {
+	return []string{
+		string(ModeAudit),
+		string(ModeEnforce),
+	}
+}
+
+func (s *Mode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMode(input string) (*Mode, error) {
+	vals := map[string]Mode{
+		"audit":   ModeAudit,
+		"enforce": ModeEnforce,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Mode(input)
+	return &out, nil
+}
+
+type NetworkApiVersion string
+
+const (
+	NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne NetworkApiVersion = "2020-11-01"
+)
+
+func PossibleValuesForNetworkApiVersion() []string {
+	return []string{
+		string(NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne),
+	}
+}
+
+func (s *NetworkApiVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkApiVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkApiVersion(input string) (*NetworkApiVersion, error) {
+	vals := map[string]NetworkApiVersion{
+		"2020-11-01": NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkApiVersion(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliaryMode string
+
+const (
+	NetworkInterfaceAuxiliaryModeAcceleratedConnections NetworkInterfaceAuxiliaryMode = "AcceleratedConnections"
+	NetworkInterfaceAuxiliaryModeFloating               NetworkInterfaceAuxiliaryMode = "Floating"
+	NetworkInterfaceAuxiliaryModeNone                   NetworkInterfaceAuxiliaryMode = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliaryMode() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+		string(NetworkInterfaceAuxiliaryModeFloating),
+		string(NetworkInterfaceAuxiliaryModeNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliaryMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliaryMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliaryMode(input string) (*NetworkInterfaceAuxiliaryMode, error) {
+	vals := map[string]NetworkInterfaceAuxiliaryMode{
+		"acceleratedconnections": NetworkInterfaceAuxiliaryModeAcceleratedConnections,
+		"floating":               NetworkInterfaceAuxiliaryModeFloating,
+		"none":                   NetworkInterfaceAuxiliaryModeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliaryMode(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliarySku string
+
+const (
+	NetworkInterfaceAuxiliarySkuAEight NetworkInterfaceAuxiliarySku = "A8"
+	NetworkInterfaceAuxiliarySkuAFour  NetworkInterfaceAuxiliarySku = "A4"
+	NetworkInterfaceAuxiliarySkuAOne   NetworkInterfaceAuxiliarySku = "A1"
+	NetworkInterfaceAuxiliarySkuATwo   NetworkInterfaceAuxiliarySku = "A2"
+	NetworkInterfaceAuxiliarySkuNone   NetworkInterfaceAuxiliarySku = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliarySku() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliarySkuAEight),
+		string(NetworkInterfaceAuxiliarySkuAFour),
+		string(NetworkInterfaceAuxiliarySkuAOne),
+		string(NetworkInterfaceAuxiliarySkuATwo),
+		string(NetworkInterfaceAuxiliarySkuNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliarySku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliarySku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliarySku(input string) (*NetworkInterfaceAuxiliarySku, error) {
+	vals := map[string]NetworkInterfaceAuxiliarySku{
+		"a8":   NetworkInterfaceAuxiliarySkuAEight,
+		"a4":   NetworkInterfaceAuxiliarySkuAFour,
+		"a1":   NetworkInterfaceAuxiliarySkuAOne,
+		"a2":   NetworkInterfaceAuxiliarySkuATwo,
+		"none": NetworkInterfaceAuxiliarySkuNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliarySku(input)
+	return &out, nil
+}
+
+type OperatingSystemTypes string
+
+const (
+	OperatingSystemTypesLinux   OperatingSystemTypes = "Linux"
+	OperatingSystemTypesWindows OperatingSystemTypes = "Windows"
+)
+
+func PossibleValuesForOperatingSystemTypes() []string {
+	return []string{
+		string(OperatingSystemTypesLinux),
+		string(OperatingSystemTypesWindows),
+	}
+}
+
+func (s *OperatingSystemTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOperatingSystemTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOperatingSystemTypes(input string) (*OperatingSystemTypes, error) {
+	vals := map[string]OperatingSystemTypes{
+		"linux":   OperatingSystemTypesLinux,
+		"windows": OperatingSystemTypesWindows,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperatingSystemTypes(input)
+	return &out, nil
+}
+
+type OrchestrationMode string
+
+const (
+	OrchestrationModeFlexible OrchestrationMode = "Flexible"
+	OrchestrationModeUniform  OrchestrationMode = "Uniform"
+)
+
+func PossibleValuesForOrchestrationMode() []string {
+	return []string{
+		string(OrchestrationModeFlexible),
+		string(OrchestrationModeUniform),
+	}
+}
+
+func (s *OrchestrationMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOrchestrationMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOrchestrationMode(input string) (*OrchestrationMode, error) {
+	vals := map[string]OrchestrationMode{
+		"flexible": OrchestrationModeFlexible,
+		"uniform":  OrchestrationModeUniform,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OrchestrationMode(input)
+	return &out, nil
+}
+
+type OrchestrationServiceNames string
+
+const (
+	OrchestrationServiceNamesAutomaticRepairs OrchestrationServiceNames = "AutomaticRepairs"
+)
+
+func PossibleValuesForOrchestrationServiceNames() []string {
+	return []string{
+		string(OrchestrationServiceNamesAutomaticRepairs),
+	}
+}
+
+func (s *OrchestrationServiceNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOrchestrationServiceNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOrchestrationServiceNames(input string) (*OrchestrationServiceNames, error) {
+	vals := map[string]OrchestrationServiceNames{
+		"automaticrepairs": OrchestrationServiceNamesAutomaticRepairs,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OrchestrationServiceNames(input)
+	return &out, nil
+}
+
+type OrchestrationServiceState string
+
+const (
+	OrchestrationServiceStateNotRunning OrchestrationServiceState = "NotRunning"
+	OrchestrationServiceStateRunning    OrchestrationServiceState = "Running"
+	OrchestrationServiceStateSuspended  OrchestrationServiceState = "Suspended"
+)
+
+func PossibleValuesForOrchestrationServiceState() []string {
+	return []string{
+		string(OrchestrationServiceStateNotRunning),
+		string(OrchestrationServiceStateRunning),
+		string(OrchestrationServiceStateSuspended),
+	}
+}
+
+func (s *OrchestrationServiceState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOrchestrationServiceState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOrchestrationServiceState(input string) (*OrchestrationServiceState, error) {
+	vals := map[string]OrchestrationServiceState{
+		"notrunning": OrchestrationServiceStateNotRunning,
+		"running":    OrchestrationServiceStateRunning,
+		"suspended":  OrchestrationServiceStateSuspended,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OrchestrationServiceState(input)
+	return &out, nil
+}
+
+type OrchestrationServiceStateAction string
+
+const (
+	OrchestrationServiceStateActionResume  OrchestrationServiceStateAction = "Resume"
+	OrchestrationServiceStateActionSuspend OrchestrationServiceStateAction = "Suspend"
+)
+
+func PossibleValuesForOrchestrationServiceStateAction() []string {
+	return []string{
+		string(OrchestrationServiceStateActionResume),
+		string(OrchestrationServiceStateActionSuspend),
+	}
+}
+
+func (s *OrchestrationServiceStateAction) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOrchestrationServiceStateAction(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOrchestrationServiceStateAction(input string) (*OrchestrationServiceStateAction, error) {
+	vals := map[string]OrchestrationServiceStateAction{
+		"resume":  OrchestrationServiceStateActionResume,
+		"suspend": OrchestrationServiceStateActionSuspend,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OrchestrationServiceStateAction(input)
+	return &out, nil
+}
+
+type PassNames string
+
+const (
+	PassNamesOobeSystem PassNames = "OobeSystem"
+)
+
+func PossibleValuesForPassNames() []string {
+	return []string{
+		string(PassNamesOobeSystem),
+	}
+}
+
+func (s *PassNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePassNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePassNames(input string) (*PassNames, error) {
+	vals := map[string]PassNames{
+		"oobesystem": PassNamesOobeSystem,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PassNames(input)
+	return &out, nil
+}
+
+type ProtocolTypes string
+
+const (
+	ProtocolTypesHTTP  ProtocolTypes = "Http"
+	ProtocolTypesHTTPS ProtocolTypes = "Https"
+)
+
+func PossibleValuesForProtocolTypes() []string {
+	return []string{
+		string(ProtocolTypesHTTP),
+		string(ProtocolTypesHTTPS),
+	}
+}
+
+func (s *ProtocolTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProtocolTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProtocolTypes(input string) (*ProtocolTypes, error) {
+	vals := map[string]ProtocolTypes{
+		"http":  ProtocolTypesHTTP,
+		"https": ProtocolTypesHTTPS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtocolTypes(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuName string
+
+const (
+	PublicIPAddressSkuNameBasic    PublicIPAddressSkuName = "Basic"
+	PublicIPAddressSkuNameStandard PublicIPAddressSkuName = "Standard"
+)
+
+func PossibleValuesForPublicIPAddressSkuName() []string {
+	return []string{
+		string(PublicIPAddressSkuNameBasic),
+		string(PublicIPAddressSkuNameStandard),
+	}
+}
+
+func (s *PublicIPAddressSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuName(input string) (*PublicIPAddressSkuName, error) {
+	vals := map[string]PublicIPAddressSkuName{
+		"basic":    PublicIPAddressSkuNameBasic,
+		"standard": PublicIPAddressSkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuName(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuTier string
+
+const (
+	PublicIPAddressSkuTierGlobal   PublicIPAddressSkuTier = "Global"
+	PublicIPAddressSkuTierRegional PublicIPAddressSkuTier = "Regional"
+)
+
+func PossibleValuesForPublicIPAddressSkuTier() []string {
+	return []string{
+		string(PublicIPAddressSkuTierGlobal),
+		string(PublicIPAddressSkuTierRegional),
+	}
+}
+
+func (s *PublicIPAddressSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuTier(input string) (*PublicIPAddressSkuTier, error) {
+	vals := map[string]PublicIPAddressSkuTier{
+		"global":   PublicIPAddressSkuTierGlobal,
+		"regional": PublicIPAddressSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuTier(input)
+	return &out, nil
+}
+
+type RepairAction string
+
+const (
+	RepairActionReimage RepairAction = "Reimage"
+	RepairActionReplace RepairAction = "Replace"
+	RepairActionRestart RepairAction = "Restart"
+)
+
+func PossibleValuesForRepairAction() []string {
+	return []string{
+		string(RepairActionReimage),
+		string(RepairActionReplace),
+		string(RepairActionRestart),
+	}
+}
+
+func (s *RepairAction) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRepairAction(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRepairAction(input string) (*RepairAction, error) {
+	vals := map[string]RepairAction{
+		"reimage": RepairActionReimage,
+		"replace": RepairActionReplace,
+		"restart": RepairActionRestart,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RepairAction(input)
+	return &out, nil
+}
+
+type SecurityEncryptionTypes string
+
+const (
+	SecurityEncryptionTypesDiskWithVMGuestState SecurityEncryptionTypes = "DiskWithVMGuestState"
+	SecurityEncryptionTypesNonPersistedTPM      SecurityEncryptionTypes = "NonPersistedTPM"
+	SecurityEncryptionTypesVMGuestStateOnly     SecurityEncryptionTypes = "VMGuestStateOnly"
+)
+
+func PossibleValuesForSecurityEncryptionTypes() []string {
+	return []string{
+		string(SecurityEncryptionTypesDiskWithVMGuestState),
+		string(SecurityEncryptionTypesNonPersistedTPM),
+		string(SecurityEncryptionTypesVMGuestStateOnly),
+	}
+}
+
+func (s *SecurityEncryptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityEncryptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityEncryptionTypes(input string) (*SecurityEncryptionTypes, error) {
+	vals := map[string]SecurityEncryptionTypes{
+		"diskwithvmgueststate": SecurityEncryptionTypesDiskWithVMGuestState,
+		"nonpersistedtpm":      SecurityEncryptionTypesNonPersistedTPM,
+		"vmgueststateonly":     SecurityEncryptionTypesVMGuestStateOnly,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityEncryptionTypes(input)
+	return &out, nil
+}
+
+type SecurityTypes string
+
+const (
+	SecurityTypesConfidentialVM SecurityTypes = "ConfidentialVM"
+	SecurityTypesTrustedLaunch  SecurityTypes = "TrustedLaunch"
+)
+
+func PossibleValuesForSecurityTypes() []string {
+	return []string{
+		string(SecurityTypesConfidentialVM),
+		string(SecurityTypesTrustedLaunch),
+	}
+}
+
+func (s *SecurityTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityTypes(input string) (*SecurityTypes, error) {
+	vals := map[string]SecurityTypes{
+		"confidentialvm": SecurityTypesConfidentialVM,
+		"trustedlaunch":  SecurityTypesTrustedLaunch,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityTypes(input)
+	return &out, nil
+}
+
+type SettingNames string
+
+const (
+	SettingNamesAutoLogon          SettingNames = "AutoLogon"
+	SettingNamesFirstLogonCommands SettingNames = "FirstLogonCommands"
+)
+
+func PossibleValuesForSettingNames() []string {
+	return []string{
+		string(SettingNamesAutoLogon),
+		string(SettingNamesFirstLogonCommands),
+	}
+}
+
+func (s *SettingNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSettingNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSettingNames(input string) (*SettingNames, error) {
+	vals := map[string]SettingNames{
+		"autologon":          SettingNamesAutoLogon,
+		"firstlogoncommands": SettingNamesFirstLogonCommands,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SettingNames(input)
+	return &out, nil
+}
+
+type StatusLevelTypes string
+
+const (
+	StatusLevelTypesError   StatusLevelTypes = "Error"
+	StatusLevelTypesInfo    StatusLevelTypes = "Info"
+	StatusLevelTypesWarning StatusLevelTypes = "Warning"
+)
+
+func PossibleValuesForStatusLevelTypes() []string {
+	return []string{
+		string(StatusLevelTypesError),
+		string(StatusLevelTypesInfo),
+		string(StatusLevelTypesWarning),
+	}
+}
+
+func (s *StatusLevelTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStatusLevelTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStatusLevelTypes(input string) (*StatusLevelTypes, error) {
+	vals := map[string]StatusLevelTypes{
+		"error":   StatusLevelTypesError,
+		"info":    StatusLevelTypesInfo,
+		"warning": StatusLevelTypesWarning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StatusLevelTypes(input)
+	return &out, nil
+}
+
+type StorageAccountTypes string
+
+const (
+	StorageAccountTypesPremiumLRS     StorageAccountTypes = "Premium_LRS"
+	StorageAccountTypesPremiumVTwoLRS StorageAccountTypes = "PremiumV2_LRS"
+	StorageAccountTypesPremiumZRS     StorageAccountTypes = "Premium_ZRS"
+	StorageAccountTypesStandardLRS    StorageAccountTypes = "Standard_LRS"
+	StorageAccountTypesStandardSSDLRS StorageAccountTypes = "StandardSSD_LRS"
+	StorageAccountTypesStandardSSDZRS StorageAccountTypes = "StandardSSD_ZRS"
+	StorageAccountTypesUltraSSDLRS    StorageAccountTypes = "UltraSSD_LRS"
+)
+
+func PossibleValuesForStorageAccountTypes() []string {
+	return []string{
+		string(StorageAccountTypesPremiumLRS),
+		string(StorageAccountTypesPremiumVTwoLRS),
+		string(StorageAccountTypesPremiumZRS),
+		string(StorageAccountTypesStandardLRS),
+		string(StorageAccountTypesStandardSSDLRS),
+		string(StorageAccountTypesStandardSSDZRS),
+		string(StorageAccountTypesUltraSSDLRS),
+	}
+}
+
+func (s *StorageAccountTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStorageAccountTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStorageAccountTypes(input string) (*StorageAccountTypes, error) {
+	vals := map[string]StorageAccountTypes{
+		"premium_lrs":     StorageAccountTypesPremiumLRS,
+		"premiumv2_lrs":   StorageAccountTypesPremiumVTwoLRS,
+		"premium_zrs":     StorageAccountTypesPremiumZRS,
+		"standard_lrs":    StorageAccountTypesStandardLRS,
+		"standardssd_lrs": StorageAccountTypesStandardSSDLRS,
+		"standardssd_zrs": StorageAccountTypesStandardSSDZRS,
+		"ultrassd_lrs":    StorageAccountTypesUltraSSDLRS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StorageAccountTypes(input)
+	return &out, nil
+}
+
+type UpgradeMode string
+
+const (
+	UpgradeModeAutomatic UpgradeMode = "Automatic"
+	UpgradeModeManual    UpgradeMode = "Manual"
+	UpgradeModeRolling   UpgradeMode = "Rolling"
+)
+
+func PossibleValuesForUpgradeMode() []string {
+	return []string{
+		string(UpgradeModeAutomatic),
+		string(UpgradeModeManual),
+		string(UpgradeModeRolling),
+	}
+}
+
+func (s *UpgradeMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseUpgradeMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseUpgradeMode(input string) (*UpgradeMode, error) {
+	vals := map[string]UpgradeMode{
+		"automatic": UpgradeModeAutomatic,
+		"manual":    UpgradeModeManual,
+		"rolling":   UpgradeModeRolling,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UpgradeMode(input)
+	return &out, nil
+}
+
+type UpgradeOperationInvoker string
+
+const (
+	UpgradeOperationInvokerPlatform UpgradeOperationInvoker = "Platform"
+	UpgradeOperationInvokerUnknown  UpgradeOperationInvoker = "Unknown"
+	UpgradeOperationInvokerUser     UpgradeOperationInvoker = "User"
+)
+
+func PossibleValuesForUpgradeOperationInvoker() []string {
+	return []string{
+		string(UpgradeOperationInvokerPlatform),
+		string(UpgradeOperationInvokerUnknown),
+		string(UpgradeOperationInvokerUser),
+	}
+}
+
+func (s *UpgradeOperationInvoker) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseUpgradeOperationInvoker(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseUpgradeOperationInvoker(input string) (*UpgradeOperationInvoker, error) {
+	vals := map[string]UpgradeOperationInvoker{
+		"platform": UpgradeOperationInvokerPlatform,
+		"unknown":  UpgradeOperationInvokerUnknown,
+		"user":     UpgradeOperationInvokerUser,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UpgradeOperationInvoker(input)
+	return &out, nil
+}
+
+type UpgradeState string
+
+const (
+	UpgradeStateCancelled      UpgradeState = "Cancelled"
+	UpgradeStateCompleted      UpgradeState = "Completed"
+	UpgradeStateFaulted        UpgradeState = "Faulted"
+	UpgradeStateRollingForward UpgradeState = "RollingForward"
+)
+
+func PossibleValuesForUpgradeState() []string {
+	return []string{
+		string(UpgradeStateCancelled),
+		string(UpgradeStateCompleted),
+		string(UpgradeStateFaulted),
+		string(UpgradeStateRollingForward),
+	}
+}
+
+func (s *UpgradeState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseUpgradeState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseUpgradeState(input string) (*UpgradeState, error) {
+	vals := map[string]UpgradeState{
+		"cancelled":      UpgradeStateCancelled,
+		"completed":      UpgradeStateCompleted,
+		"faulted":        UpgradeStateFaulted,
+		"rollingforward": UpgradeStateRollingForward,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UpgradeState(input)
+	return &out, nil
+}
+
+type VirtualMachineEvictionPolicyTypes string
+
+const (
+	VirtualMachineEvictionPolicyTypesDeallocate VirtualMachineEvictionPolicyTypes = "Deallocate"
+	VirtualMachineEvictionPolicyTypesDelete     VirtualMachineEvictionPolicyTypes = "Delete"
+)
+
+func PossibleValuesForVirtualMachineEvictionPolicyTypes() []string {
+	return []string{
+		string(VirtualMachineEvictionPolicyTypesDeallocate),
+		string(VirtualMachineEvictionPolicyTypesDelete),
+	}
+}
+
+func (s *VirtualMachineEvictionPolicyTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualMachineEvictionPolicyTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualMachineEvictionPolicyTypes(input string) (*VirtualMachineEvictionPolicyTypes, error) {
+	vals := map[string]VirtualMachineEvictionPolicyTypes{
+		"deallocate": VirtualMachineEvictionPolicyTypesDeallocate,
+		"delete":     VirtualMachineEvictionPolicyTypesDelete,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualMachineEvictionPolicyTypes(input)
+	return &out, nil
+}
+
+type VirtualMachinePriorityTypes string
+
+const (
+	VirtualMachinePriorityTypesLow     VirtualMachinePriorityTypes = "Low"
+	VirtualMachinePriorityTypesRegular VirtualMachinePriorityTypes = "Regular"
+	VirtualMachinePriorityTypesSpot    VirtualMachinePriorityTypes = "Spot"
+)
+
+func PossibleValuesForVirtualMachinePriorityTypes() []string {
+	return []string{
+		string(VirtualMachinePriorityTypesLow),
+		string(VirtualMachinePriorityTypesRegular),
+		string(VirtualMachinePriorityTypesSpot),
+	}
+}
+
+func (s *VirtualMachinePriorityTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualMachinePriorityTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualMachinePriorityTypes(input string) (*VirtualMachinePriorityTypes, error) {
+	vals := map[string]VirtualMachinePriorityTypes{
+		"low":     VirtualMachinePriorityTypesLow,
+		"regular": VirtualMachinePriorityTypesRegular,
+		"spot":    VirtualMachinePriorityTypesSpot,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualMachinePriorityTypes(input)
+	return &out, nil
+}
+
+type VirtualMachineScaleSetScaleInRules string
+
+const (
+	VirtualMachineScaleSetScaleInRulesDefault  VirtualMachineScaleSetScaleInRules = "Default"
+	VirtualMachineScaleSetScaleInRulesNewestVM VirtualMachineScaleSetScaleInRules = "NewestVM"
+	VirtualMachineScaleSetScaleInRulesOldestVM VirtualMachineScaleSetScaleInRules = "OldestVM"
+)
+
+func PossibleValuesForVirtualMachineScaleSetScaleInRules() []string {
+	return []string{
+		string(VirtualMachineScaleSetScaleInRulesDefault),
+		string(VirtualMachineScaleSetScaleInRulesNewestVM),
+		string(VirtualMachineScaleSetScaleInRulesOldestVM),
+	}
+}
+
+func (s *VirtualMachineScaleSetScaleInRules) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualMachineScaleSetScaleInRules(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualMachineScaleSetScaleInRules(input string) (*VirtualMachineScaleSetScaleInRules, error) {
+	vals := map[string]VirtualMachineScaleSetScaleInRules{
+		"default":  VirtualMachineScaleSetScaleInRulesDefault,
+		"newestvm": VirtualMachineScaleSetScaleInRulesNewestVM,
+		"oldestvm": VirtualMachineScaleSetScaleInRulesOldestVM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualMachineScaleSetScaleInRules(input)
+	return &out, nil
+}
+
+type VirtualMachineScaleSetSkuScaleType string
+
+const (
+	VirtualMachineScaleSetSkuScaleTypeAutomatic VirtualMachineScaleSetSkuScaleType = "Automatic"
+	VirtualMachineScaleSetSkuScaleTypeNone      VirtualMachineScaleSetSkuScaleType = "None"
+)
+
+func PossibleValuesForVirtualMachineScaleSetSkuScaleType() []string {
+	return []string{
+		string(VirtualMachineScaleSetSkuScaleTypeAutomatic),
+		string(VirtualMachineScaleSetSkuScaleTypeNone),
+	}
+}
+
+func (s *VirtualMachineScaleSetSkuScaleType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualMachineScaleSetSkuScaleType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualMachineScaleSetSkuScaleType(input string) (*VirtualMachineScaleSetSkuScaleType, error) {
+	vals := map[string]VirtualMachineScaleSetSkuScaleType{
+		"automatic": VirtualMachineScaleSetSkuScaleTypeAutomatic,
+		"none":      VirtualMachineScaleSetSkuScaleTypeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualMachineScaleSetSkuScaleType(input)
+	return &out, nil
+}
+
+type WindowsPatchAssessmentMode string
+
+const (
+	WindowsPatchAssessmentModeAutomaticByPlatform WindowsPatchAssessmentMode = "AutomaticByPlatform"
+	WindowsPatchAssessmentModeImageDefault        WindowsPatchAssessmentMode = "ImageDefault"
+)
+
+func PossibleValuesForWindowsPatchAssessmentMode() []string {
+	return []string{
+		string(WindowsPatchAssessmentModeAutomaticByPlatform),
+		string(WindowsPatchAssessmentModeImageDefault),
+	}
+}
+
+func (s *WindowsPatchAssessmentMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsPatchAssessmentMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsPatchAssessmentMode(input string) (*WindowsPatchAssessmentMode, error) {
+	vals := map[string]WindowsPatchAssessmentMode{
+		"automaticbyplatform": WindowsPatchAssessmentModeAutomaticByPlatform,
+		"imagedefault":        WindowsPatchAssessmentModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsPatchAssessmentMode(input)
+	return &out, nil
+}
+
+type WindowsVMGuestPatchAutomaticByPlatformRebootSetting string
+
+const (
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways     WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Always"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "IfRequired"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever      WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Never"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown    WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Unknown"
+)
+
+func PossibleValuesForWindowsVMGuestPatchAutomaticByPlatformRebootSetting() []string {
+	return []string{
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown),
+	}
+}
+
+func (s *WindowsVMGuestPatchAutomaticByPlatformRebootSetting) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsVMGuestPatchAutomaticByPlatformRebootSetting(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsVMGuestPatchAutomaticByPlatformRebootSetting(input string) (*WindowsVMGuestPatchAutomaticByPlatformRebootSetting, error) {
+	vals := map[string]WindowsVMGuestPatchAutomaticByPlatformRebootSetting{
+		"always":     WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways,
+		"ifrequired": WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired,
+		"never":      WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever,
+		"unknown":    WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsVMGuestPatchAutomaticByPlatformRebootSetting(input)
+	return &out, nil
+}
+
+type WindowsVMGuestPatchMode string
+
+const (
+	WindowsVMGuestPatchModeAutomaticByOS       WindowsVMGuestPatchMode = "AutomaticByOS"
+	WindowsVMGuestPatchModeAutomaticByPlatform WindowsVMGuestPatchMode = "AutomaticByPlatform"
+	WindowsVMGuestPatchModeManual              WindowsVMGuestPatchMode = "Manual"
+)
+
+func PossibleValuesForWindowsVMGuestPatchMode() []string {
+	return []string{
+		string(WindowsVMGuestPatchModeAutomaticByOS),
+		string(WindowsVMGuestPatchModeAutomaticByPlatform),
+		string(WindowsVMGuestPatchModeManual),
+	}
+}
+
+func (s *WindowsVMGuestPatchMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsVMGuestPatchMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsVMGuestPatchMode(input string) (*WindowsVMGuestPatchMode, error) {
+	vals := map[string]WindowsVMGuestPatchMode{
+		"automaticbyos":       WindowsVMGuestPatchModeAutomaticByOS,
+		"automaticbyplatform": WindowsVMGuestPatchModeAutomaticByPlatform,
+		"manual":              WindowsVMGuestPatchModeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsVMGuestPatchMode(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/id_location.go
@@ -1,0 +1,116 @@
+package virtualmachinescalesets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Compute/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/id_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/id_virtualmachinescaleset.go
@@ -1,0 +1,125 @@
+package virtualmachinescalesets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetId{}
+
+// VirtualMachineScaleSetId is a struct representing the Resource ID for a Virtual Machine Scale Set
+type VirtualMachineScaleSetId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+}
+
+// NewVirtualMachineScaleSetID returns a new VirtualMachineScaleSetId struct
+func NewVirtualMachineScaleSetID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string) VirtualMachineScaleSetId {
+	return VirtualMachineScaleSetId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+	}
+}
+
+// ParseVirtualMachineScaleSetID parses 'input' into a VirtualMachineScaleSetId
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetIDInsensitively(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetID checks that 'input' can be parsed as a Virtual Machine Scale Set ID
+func ValidateVirtualMachineScaleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_approverollingupgrade.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_approverollingupgrade.go
@@ -1,0 +1,73 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApproveRollingUpgradeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ApproveRollingUpgrade ...
+func (c VirtualMachineScaleSetsClient) ApproveRollingUpgrade(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result ApproveRollingUpgradeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/approveRollingUpgrade", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ApproveRollingUpgradeThenPoll performs ApproveRollingUpgrade then polls until it's completed
+func (c VirtualMachineScaleSetsClient) ApproveRollingUpgradeThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.ApproveRollingUpgrade(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ApproveRollingUpgrade: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ApproveRollingUpgrade: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_converttosingleplacementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_converttosingleplacementgroup.go
@@ -1,0 +1,51 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConvertToSinglePlacementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ConvertToSinglePlacementGroup ...
+func (c VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroup(ctx context.Context, id VirtualMachineScaleSetId, input VMScaleSetConvertToSinglePlacementGroupInput) (result ConvertToSinglePlacementGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/convertToSinglePlacementGroup", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_createorupdate.go
@@ -1,0 +1,107 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSet
+}
+
+type CreateOrUpdateOperationOptions struct {
+	IfMatch     *string
+	IfNoneMatch *string
+}
+
+func DefaultCreateOrUpdateOperationOptions() CreateOrUpdateOperationOptions {
+	return CreateOrUpdateOperationOptions{}
+}
+
+func (o CreateOrUpdateOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	if o.IfMatch != nil {
+		out.Append("If-Match", fmt.Sprintf("%v", *o.IfMatch))
+	}
+	if o.IfNoneMatch != nil {
+		out.Append("If-None-Match", fmt.Sprintf("%v", *o.IfNoneMatch))
+	}
+	return &out
+}
+
+func (o CreateOrUpdateOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o CreateOrUpdateOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+
+	return &out
+}
+
+// CreateOrUpdate ...
+func (c VirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSet, options CreateOrUpdateOperationOptions) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPut,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualMachineScaleSetsClient) CreateOrUpdateThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSet, options CreateOrUpdateOperationOptions) error {
+	result, err := c.CreateOrUpdate(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_deallocate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_deallocate.go
@@ -1,0 +1,102 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeallocateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeallocateOperationOptions struct {
+	Hibernate *bool
+}
+
+func DefaultDeallocateOperationOptions() DeallocateOperationOptions {
+	return DeallocateOperationOptions{}
+}
+
+func (o DeallocateOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeallocateOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeallocateOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Hibernate != nil {
+		out.Append("hibernate", fmt.Sprintf("%v", *o.Hibernate))
+	}
+	return &out
+}
+
+// Deallocate ...
+func (c VirtualMachineScaleSetsClient) Deallocate(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs, options DeallocateOperationOptions) (result DeallocateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/deallocate", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeallocateThenPoll performs Deallocate then polls until it's completed
+func (c VirtualMachineScaleSetsClient) DeallocateThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs, options DeallocateOperationOptions) error {
+	result, err := c.Deallocate(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing Deallocate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Deallocate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_delete.go
@@ -1,0 +1,99 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteOperationOptions struct {
+	ForceDeletion *bool
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeleteOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeleteOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ForceDeletion != nil {
+		out.Append("forceDeletion", fmt.Sprintf("%v", *o.ForceDeletion))
+	}
+	return &out
+}
+
+// Delete ...
+func (c VirtualMachineScaleSetsClient) Delete(ctx context.Context, id VirtualMachineScaleSetId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualMachineScaleSetsClient) DeleteThenPoll(ctx context.Context, id VirtualMachineScaleSetId, options DeleteOperationOptions) error {
+	result, err := c.Delete(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_deleteinstances.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_deleteinstances.go
@@ -1,0 +1,102 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteInstancesOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteInstancesOperationOptions struct {
+	ForceDeletion *bool
+}
+
+func DefaultDeleteInstancesOperationOptions() DeleteInstancesOperationOptions {
+	return DeleteInstancesOperationOptions{}
+}
+
+func (o DeleteInstancesOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeleteInstancesOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeleteInstancesOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ForceDeletion != nil {
+		out.Append("forceDeletion", fmt.Sprintf("%v", *o.ForceDeletion))
+	}
+	return &out
+}
+
+// DeleteInstances ...
+func (c VirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceRequiredIDs, options DeleteInstancesOperationOptions) (result DeleteInstancesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/delete", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteInstancesThenPoll performs DeleteInstances then polls until it's completed
+func (c VirtualMachineScaleSetsClient) DeleteInstancesThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceRequiredIDs, options DeleteInstancesOperationOptions) error {
+	result, err := c.DeleteInstances(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing DeleteInstances: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after DeleteInstances: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_forcerecoveryservicefabricplatformupdatedomainwalk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_forcerecoveryservicefabricplatformupdatedomainwalk.go
@@ -1,0 +1,91 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RecoveryWalkResponse
+}
+
+type ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions struct {
+	PlacementGroupId     *string
+	PlatformUpdateDomain *int64
+	Zone                 *string
+}
+
+func DefaultForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions() ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions {
+	return ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions{}
+}
+
+func (o ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PlacementGroupId != nil {
+		out.Append("placementGroupId", fmt.Sprintf("%v", *o.PlacementGroupId))
+	}
+	if o.PlatformUpdateDomain != nil {
+		out.Append("platformUpdateDomain", fmt.Sprintf("%v", *o.PlatformUpdateDomain))
+	}
+	if o.Zone != nil {
+		out.Append("zone", fmt.Sprintf("%v", *o.Zone))
+	}
+	return &out
+}
+
+// ForceRecoveryServiceFabricPlatformUpdateDomainWalk ...
+func (c VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx context.Context, id VirtualMachineScaleSetId, options ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationOptions) (result ForceRecoveryServiceFabricPlatformUpdateDomainWalkOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/forceRecoveryServiceFabricPlatformUpdateDomainWalk", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RecoveryWalkResponse
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_get.go
@@ -1,0 +1,83 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSet
+}
+
+type GetOperationOptions struct {
+	Expand *ExpandTypesForGetVMScaleSets
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c VirtualMachineScaleSetsClient) Get(ctx context.Context, id VirtualMachineScaleSetId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineScaleSet
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_getinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_getinstanceview.go
@@ -1,0 +1,55 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetInstanceViewOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetInstanceView
+}
+
+// GetInstanceView ...
+func (c VirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context, id VirtualMachineScaleSetId) (result GetInstanceViewOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/instanceView", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineScaleSetInstanceView
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_getosupgradehistory.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_getosupgradehistory.go
@@ -1,0 +1,91 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOSUpgradeHistoryOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]UpgradeOperationHistoricalStatusInfo
+}
+
+type GetOSUpgradeHistoryCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []UpgradeOperationHistoricalStatusInfo
+}
+
+// GetOSUpgradeHistory ...
+func (c VirtualMachineScaleSetsClient) GetOSUpgradeHistory(ctx context.Context, id VirtualMachineScaleSetId) (result GetOSUpgradeHistoryOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/osUpgradeHistory", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]UpgradeOperationHistoricalStatusInfo `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// GetOSUpgradeHistoryComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetsClient) GetOSUpgradeHistoryComplete(ctx context.Context, id VirtualMachineScaleSetId) (GetOSUpgradeHistoryCompleteResult, error) {
+	return c.GetOSUpgradeHistoryCompleteMatchingPredicate(ctx, id, UpgradeOperationHistoricalStatusInfoOperationPredicate{})
+}
+
+// GetOSUpgradeHistoryCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetsClient) GetOSUpgradeHistoryCompleteMatchingPredicate(ctx context.Context, id VirtualMachineScaleSetId, predicate UpgradeOperationHistoricalStatusInfoOperationPredicate) (result GetOSUpgradeHistoryCompleteResult, err error) {
+	items := make([]UpgradeOperationHistoricalStatusInfo, 0)
+
+	resp, err := c.GetOSUpgradeHistory(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = GetOSUpgradeHistoryCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_list.go
@@ -1,0 +1,92 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSet
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSet
+}
+
+// List ...
+func (c VirtualMachineScaleSetsClient) List(ctx context.Context, id commonids.ResourceGroupId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Compute/virtualMachineScaleSets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetsClient) ListComplete(ctx context.Context, id commonids.ResourceGroupId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, VirtualMachineScaleSetOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate VirtualMachineScaleSetOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSet, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listall.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listall.go
@@ -1,0 +1,92 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListAllOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSet
+}
+
+type ListAllCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSet
+}
+
+// ListAll ...
+func (c VirtualMachineScaleSetsClient) ListAll(ctx context.Context, id commonids.SubscriptionId) (result ListAllOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Compute/virtualMachineScaleSets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListAllComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetsClient) ListAllComplete(ctx context.Context, id commonids.SubscriptionId) (ListAllCompleteResult, error) {
+	return c.ListAllCompleteMatchingPredicate(ctx, id, VirtualMachineScaleSetOperationPredicate{})
+}
+
+// ListAllCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetsClient) ListAllCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate VirtualMachineScaleSetOperationPredicate) (result ListAllCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSet, 0)
+
+	resp, err := c.ListAll(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListAllCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listbylocation.go
@@ -1,0 +1,91 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSet
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSet
+}
+
+// ListByLocation ...
+func (c VirtualMachineScaleSetsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/virtualMachineScaleSets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, VirtualMachineScaleSetOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate VirtualMachineScaleSetOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSet, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listskus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_listskus.go
@@ -1,0 +1,91 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListSkusOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSetSku
+}
+
+type ListSkusCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSetSku
+}
+
+// ListSkus ...
+func (c VirtualMachineScaleSetsClient) ListSkus(ctx context.Context, id VirtualMachineScaleSetId) (result ListSkusOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/skus", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSetSku `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListSkusComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetsClient) ListSkusComplete(ctx context.Context, id VirtualMachineScaleSetId) (ListSkusCompleteResult, error) {
+	return c.ListSkusCompleteMatchingPredicate(ctx, id, VirtualMachineScaleSetSkuOperationPredicate{})
+}
+
+// ListSkusCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetsClient) ListSkusCompleteMatchingPredicate(ctx context.Context, id VirtualMachineScaleSetId, predicate VirtualMachineScaleSetSkuOperationPredicate) (result ListSkusCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSetSku, 0)
+
+	resp, err := c.ListSkus(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListSkusCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_performmaintenance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_performmaintenance.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PerformMaintenanceOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// PerformMaintenance ...
+func (c VirtualMachineScaleSetsClient) PerformMaintenance(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result PerformMaintenanceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/performMaintenance", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// PerformMaintenanceThenPoll performs PerformMaintenance then polls until it's completed
+func (c VirtualMachineScaleSetsClient) PerformMaintenanceThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.PerformMaintenance(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing PerformMaintenance: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after PerformMaintenance: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_poweroff.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_poweroff.go
@@ -1,0 +1,102 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PowerOffOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type PowerOffOperationOptions struct {
+	SkipShutdown *bool
+}
+
+func DefaultPowerOffOperationOptions() PowerOffOperationOptions {
+	return PowerOffOperationOptions{}
+}
+
+func (o PowerOffOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o PowerOffOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o PowerOffOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.SkipShutdown != nil {
+		out.Append("skipShutdown", fmt.Sprintf("%v", *o.SkipShutdown))
+	}
+	return &out
+}
+
+// PowerOff ...
+func (c VirtualMachineScaleSetsClient) PowerOff(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs, options PowerOffOperationOptions) (result PowerOffOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/poweroff", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// PowerOffThenPoll performs PowerOff then polls until it's completed
+func (c VirtualMachineScaleSetsClient) PowerOffThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs, options PowerOffOperationOptions) error {
+	result, err := c.PowerOff(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing PowerOff: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after PowerOff: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reapply.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reapply.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReapplyOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Reapply ...
+func (c VirtualMachineScaleSetsClient) Reapply(ctx context.Context, id VirtualMachineScaleSetId) (result ReapplyOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/reapply", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReapplyThenPoll performs Reapply then polls until it's completed
+func (c VirtualMachineScaleSetsClient) ReapplyThenPoll(ctx context.Context, id VirtualMachineScaleSetId) error {
+	result, err := c.Reapply(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Reapply: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Reapply: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_redeploy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_redeploy.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RedeployOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Redeploy ...
+func (c VirtualMachineScaleSetsClient) Redeploy(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result RedeployOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/redeploy", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RedeployThenPoll performs Redeploy then polls until it's completed
+func (c VirtualMachineScaleSetsClient) RedeployThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.Redeploy(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Redeploy: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Redeploy: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reimage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reimage.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReimageOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Reimage ...
+func (c VirtualMachineScaleSetsClient) Reimage(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetReimageParameters) (result ReimageOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/reimage", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReimageThenPoll performs Reimage then polls until it's completed
+func (c VirtualMachineScaleSetsClient) ReimageThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetReimageParameters) error {
+	result, err := c.Reimage(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Reimage: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Reimage: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reimageall.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_reimageall.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReimageAllOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ReimageAll ...
+func (c VirtualMachineScaleSetsClient) ReimageAll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result ReimageAllOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/reimageall", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReimageAllThenPoll performs ReimageAll then polls until it's completed
+func (c VirtualMachineScaleSetsClient) ReimageAllThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.ReimageAll(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ReimageAll: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ReimageAll: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_restart.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_restart.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RestartOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Restart ...
+func (c VirtualMachineScaleSetsClient) Restart(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result RestartOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/restart", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RestartThenPoll performs Restart then polls until it's completed
+func (c VirtualMachineScaleSetsClient) RestartThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.Restart(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Restart: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Restart: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_setorchestrationservicestate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_setorchestrationservicestate.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SetOrchestrationServiceStateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// SetOrchestrationServiceState ...
+func (c VirtualMachineScaleSetsClient) SetOrchestrationServiceState(ctx context.Context, id VirtualMachineScaleSetId, input OrchestrationServiceStateInput) (result SetOrchestrationServiceStateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/setOrchestrationServiceState", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SetOrchestrationServiceStateThenPoll performs SetOrchestrationServiceState then polls until it's completed
+func (c VirtualMachineScaleSetsClient) SetOrchestrationServiceStateThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input OrchestrationServiceStateInput) error {
+	result, err := c.SetOrchestrationServiceState(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing SetOrchestrationServiceState: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after SetOrchestrationServiceState: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_start.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_start.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StartOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Start ...
+func (c VirtualMachineScaleSetsClient) Start(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) (result StartOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/start", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// StartThenPoll performs Start then polls until it's completed
+func (c VirtualMachineScaleSetsClient) StartThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceIDs) error {
+	result, err := c.Start(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Start: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Start: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_update.go
@@ -1,0 +1,106 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSet
+}
+
+type UpdateOperationOptions struct {
+	IfMatch     *string
+	IfNoneMatch *string
+}
+
+func DefaultUpdateOperationOptions() UpdateOperationOptions {
+	return UpdateOperationOptions{}
+}
+
+func (o UpdateOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	if o.IfMatch != nil {
+		out.Append("If-Match", fmt.Sprintf("%v", *o.IfMatch))
+	}
+	if o.IfNoneMatch != nil {
+		out.Append("If-None-Match", fmt.Sprintf("%v", *o.IfNoneMatch))
+	}
+	return &out
+}
+
+func (o UpdateOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o UpdateOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+
+	return &out
+}
+
+// Update ...
+func (c VirtualMachineScaleSetsClient) Update(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetUpdate, options UpdateOperationOptions) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPatch,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c VirtualMachineScaleSetsClient) UpdateThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetUpdate, options UpdateOperationOptions) error {
+	result, err := c.Update(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_updateinstances.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/method_updateinstances.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateInstancesOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// UpdateInstances ...
+func (c VirtualMachineScaleSetsClient) UpdateInstances(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceRequiredIDs) (result UpdateInstancesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/manualupgrade", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateInstancesThenPoll performs UpdateInstances then polls until it's completed
+func (c VirtualMachineScaleSetsClient) UpdateInstancesThenPoll(ctx context.Context, id VirtualMachineScaleSetId, input VirtualMachineScaleSetVMInstanceRequiredIDs) error {
+	result, err := c.UpdateInstances(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UpdateInstances: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after UpdateInstances: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_additionalcapabilities.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_additionalcapabilities.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AdditionalCapabilities struct {
+	HibernationEnabled *bool `json:"hibernationEnabled,omitempty"`
+	UltraSSDEnabled    *bool `json:"ultraSSDEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_additionalunattendcontent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_additionalunattendcontent.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AdditionalUnattendContent struct {
+	ComponentName *ComponentNames `json:"componentName,omitempty"`
+	Content       *string         `json:"content,omitempty"`
+	PassName      *PassNames      `json:"passName,omitempty"`
+	SettingName   *SettingNames   `json:"settingName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apientityreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apientityreference.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiEntityReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apierror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apierror.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiError struct {
+	Code       *string         `json:"code,omitempty"`
+	Details    *[]ApiErrorBase `json:"details,omitempty"`
+	Innererror *InnerError     `json:"innererror,omitempty"`
+	Message    *string         `json:"message,omitempty"`
+	Target     *string         `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apierrorbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_apierrorbase.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiErrorBase struct {
+	Code    *string `json:"code,omitempty"`
+	Message *string `json:"message,omitempty"`
+	Target  *string `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_applicationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_applicationprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationProfile struct {
+	GalleryApplications *[]VMGalleryApplication `json:"galleryApplications,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_automaticosupgradepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_automaticosupgradepolicy.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomaticOSUpgradePolicy struct {
+	DisableAutomaticRollback *bool `json:"disableAutomaticRollback,omitempty"`
+	EnableAutomaticOSUpgrade *bool `json:"enableAutomaticOSUpgrade,omitempty"`
+	OsRollingUpgradeDeferral *bool `json:"osRollingUpgradeDeferral,omitempty"`
+	UseRollingUpgradePolicy  *bool `json:"useRollingUpgradePolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_automaticrepairspolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_automaticrepairspolicy.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutomaticRepairsPolicy struct {
+	Enabled      *bool         `json:"enabled,omitempty"`
+	GracePeriod  *string       `json:"gracePeriod,omitempty"`
+	RepairAction *RepairAction `json:"repairAction,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_billingprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_billingprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BillingProfile struct {
+	MaxPrice *float64 `json:"maxPrice,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_bootdiagnostics.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_bootdiagnostics.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BootDiagnostics struct {
+	Enabled    *bool   `json:"enabled,omitempty"`
+	StorageUri *string `json:"storageUri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_capacityreservationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_capacityreservationprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CapacityReservationProfile struct {
+	CapacityReservationGroup *SubResource `json:"capacityReservationGroup,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_diagnosticsprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_diagnosticsprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiagnosticsProfile struct {
+	BootDiagnostics *BootDiagnostics `json:"bootDiagnostics,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_diffdisksettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_diffdisksettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiffDiskSettings struct {
+	Option    *DiffDiskOptions   `json:"option,omitempty"`
+	Placement *DiffDiskPlacement `json:"placement,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_encryptionidentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_encryptionidentity.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EncryptionIdentity struct {
+	UserAssignedIdentityResourceId *string `json:"userAssignedIdentityResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_eventgridandresourcegraph.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_eventgridandresourcegraph.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EventGridAndResourceGraph struct {
+	Enable *bool `json:"enable,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_imagereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_imagereference.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageReference struct {
+	CommunityGalleryImageId *string `json:"communityGalleryImageId,omitempty"`
+	ExactVersion            *string `json:"exactVersion,omitempty"`
+	Id                      *string `json:"id,omitempty"`
+	Offer                   *string `json:"offer,omitempty"`
+	Publisher               *string `json:"publisher,omitempty"`
+	SharedGalleryImageId    *string `json:"sharedGalleryImageId,omitempty"`
+	Sku                     *string `json:"sku,omitempty"`
+	Version                 *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_innererror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_innererror.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InnerError struct {
+	Errordetail   *string `json:"errordetail,omitempty"`
+	Exceptiontype *string `json:"exceptiontype,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_instanceviewstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_instanceviewstatus.go
@@ -1,0 +1,30 @@
+package virtualmachinescalesets
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstanceViewStatus struct {
+	Code          *string           `json:"code,omitempty"`
+	DisplayStatus *string           `json:"displayStatus,omitempty"`
+	Level         *StatusLevelTypes `json:"level,omitempty"`
+	Message       *string           `json:"message,omitempty"`
+	Time          *string           `json:"time,omitempty"`
+}
+
+func (o *InstanceViewStatus) GetTimeAsTime() (*time.Time, error) {
+	if o.Time == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.Time, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InstanceViewStatus) SetTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.Time = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_keyvaultsecretreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_keyvaultsecretreference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyVaultSecretReference struct {
+	SecretUrl   string      `json:"secretUrl"`
+	SourceVault SubResource `json:"sourceVault"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxconfiguration.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxConfiguration struct {
+	DisablePasswordAuthentication *bool               `json:"disablePasswordAuthentication,omitempty"`
+	EnableVMAgentPlatformUpdates  *bool               `json:"enableVMAgentPlatformUpdates,omitempty"`
+	PatchSettings                 *LinuxPatchSettings `json:"patchSettings,omitempty"`
+	ProvisionVMAgent              *bool               `json:"provisionVMAgent,omitempty"`
+	Ssh                           *SshConfiguration   `json:"ssh,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxpatchsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxpatchsettings.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxPatchSettings struct {
+	AssessmentMode              *LinuxPatchAssessmentMode                     `json:"assessmentMode,omitempty"`
+	AutomaticByPlatformSettings *LinuxVMGuestPatchAutomaticByPlatformSettings `json:"automaticByPlatformSettings,omitempty"`
+	PatchMode                   *LinuxVMGuestPatchMode                        `json:"patchMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxvmguestpatchautomaticbyplatformsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_linuxvmguestpatchautomaticbyplatformsettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxVMGuestPatchAutomaticByPlatformSettings struct {
+	BypassPlatformSafetyChecksOnUserSchedule *bool                                              `json:"bypassPlatformSafetyChecksOnUserSchedule,omitempty"`
+	RebootSetting                            *LinuxVMGuestPatchAutomaticByPlatformRebootSetting `json:"rebootSetting,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_orchestrationservicestateinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_orchestrationservicestateinput.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrchestrationServiceStateInput struct {
+	Action      OrchestrationServiceStateAction `json:"action"`
+	ServiceName OrchestrationServiceNames       `json:"serviceName"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_orchestrationservicesummary.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_orchestrationservicesummary.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrchestrationServiceSummary struct {
+	ServiceName  *OrchestrationServiceNames `json:"serviceName,omitempty"`
+	ServiceState *OrchestrationServiceState `json:"serviceState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_osimagenotificationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_osimagenotificationprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSImageNotificationProfile struct {
+	Enable           *bool   `json:"enable,omitempty"`
+	NotBeforeTimeout *string `json:"notBeforeTimeout,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_osprofileprovisioningdata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_osprofileprovisioningdata.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSProfileProvisioningData struct {
+	AdminPassword *string `json:"adminPassword,omitempty"`
+	CustomData    *string `json:"customData,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_patchsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_patchsettings.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PatchSettings struct {
+	AssessmentMode              *WindowsPatchAssessmentMode                     `json:"assessmentMode,omitempty"`
+	AutomaticByPlatformSettings *WindowsVMGuestPatchAutomaticByPlatformSettings `json:"automaticByPlatformSettings,omitempty"`
+	EnableHotpatching           *bool                                           `json:"enableHotpatching,omitempty"`
+	PatchMode                   *WindowsVMGuestPatchMode                        `json:"patchMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_plan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_plan.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Plan struct {
+	Name          *string `json:"name,omitempty"`
+	Product       *string `json:"product,omitempty"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     *string `json:"publisher,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_prioritymixpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_prioritymixpolicy.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PriorityMixPolicy struct {
+	BaseRegularPriorityCount           *int64 `json:"baseRegularPriorityCount,omitempty"`
+	RegularPriorityPercentageAboveBase *int64 `json:"regularPriorityPercentageAboveBase,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_proxyagentsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_proxyagentsettings.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProxyAgentSettings struct {
+	Enabled          *bool  `json:"enabled,omitempty"`
+	KeyIncarnationId *int64 `json:"keyIncarnationId,omitempty"`
+	Mode             *Mode  `json:"mode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_publicipaddresssku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_publicipaddresssku.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressSku struct {
+	Name *PublicIPAddressSkuName `json:"name,omitempty"`
+	Tier *PublicIPAddressSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_recoverywalkresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_recoverywalkresponse.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryWalkResponse struct {
+	NextPlatformUpdateDomain *int64 `json:"nextPlatformUpdateDomain,omitempty"`
+	WalkPerformed            *bool  `json:"walkPerformed,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resiliencypolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resiliencypolicy.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResiliencyPolicy struct {
+	ResilientVMCreationPolicy *ResilientVMCreationPolicy `json:"resilientVMCreationPolicy,omitempty"`
+	ResilientVMDeletionPolicy *ResilientVMDeletionPolicy `json:"resilientVMDeletionPolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resilientvmcreationpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resilientvmcreationpolicy.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResilientVMCreationPolicy struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resilientvmdeletionpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_resilientvmdeletionpolicy.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResilientVMDeletionPolicy struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollbackstatusinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollbackstatusinfo.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollbackStatusInfo struct {
+	FailedRolledbackInstanceCount       *int64    `json:"failedRolledbackInstanceCount,omitempty"`
+	RollbackError                       *ApiError `json:"rollbackError,omitempty"`
+	SuccessfullyRolledbackInstanceCount *int64    `json:"successfullyRolledbackInstanceCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollingupgradepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollingupgradepolicy.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradePolicy struct {
+	EnableCrossZoneUpgrade                *bool   `json:"enableCrossZoneUpgrade,omitempty"`
+	MaxBatchInstancePercent               *int64  `json:"maxBatchInstancePercent,omitempty"`
+	MaxSurge                              *bool   `json:"maxSurge,omitempty"`
+	MaxUnhealthyInstancePercent           *int64  `json:"maxUnhealthyInstancePercent,omitempty"`
+	MaxUnhealthyUpgradedInstancePercent   *int64  `json:"maxUnhealthyUpgradedInstancePercent,omitempty"`
+	PauseTimeBetweenBatches               *string `json:"pauseTimeBetweenBatches,omitempty"`
+	PrioritizeUnhealthyInstances          *bool   `json:"prioritizeUnhealthyInstances,omitempty"`
+	RollbackFailedInstancesOnPolicyBreach *bool   `json:"rollbackFailedInstancesOnPolicyBreach,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollingupgradeprogressinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_rollingupgradeprogressinfo.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RollingUpgradeProgressInfo struct {
+	FailedInstanceCount     *int64 `json:"failedInstanceCount,omitempty"`
+	InProgressInstanceCount *int64 `json:"inProgressInstanceCount,omitempty"`
+	PendingInstanceCount    *int64 `json:"pendingInstanceCount,omitempty"`
+	SuccessfulInstanceCount *int64 `json:"successfulInstanceCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scaleinpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scaleinpolicy.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScaleInPolicy struct {
+	ForceDeletion *bool                                 `json:"forceDeletion,omitempty"`
+	Rules         *[]VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventsadditionalpublishingtargets.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventsadditionalpublishingtargets.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledEventsAdditionalPublishingTargets struct {
+	EventGridAndResourceGraph *EventGridAndResourceGraph `json:"eventGridAndResourceGraph,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventspolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventspolicy.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledEventsPolicy struct {
+	ScheduledEventsAdditionalPublishingTargets *ScheduledEventsAdditionalPublishingTargets `json:"scheduledEventsAdditionalPublishingTargets,omitempty"`
+	UserInitiatedReboot                        *UserInitiatedReboot                        `json:"userInitiatedReboot,omitempty"`
+	UserInitiatedRedeploy                      *UserInitiatedRedeploy                      `json:"userInitiatedRedeploy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventsprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_scheduledeventsprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledEventsProfile struct {
+	OsImageNotificationProfile   *OSImageNotificationProfile   `json:"osImageNotificationProfile,omitempty"`
+	TerminateNotificationProfile *TerminateNotificationProfile `json:"terminateNotificationProfile,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_securityposturereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_securityposturereference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityPostureReference struct {
+	ExcludeExtensions *[]VirtualMachineExtension `json:"excludeExtensions,omitempty"`
+	Id                *string                    `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_securityprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_securityprofile.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityProfile struct {
+	EncryptionAtHost   *bool               `json:"encryptionAtHost,omitempty"`
+	EncryptionIdentity *EncryptionIdentity `json:"encryptionIdentity,omitempty"`
+	ProxyAgentSettings *ProxyAgentSettings `json:"proxyAgentSettings,omitempty"`
+	SecurityType       *SecurityTypes      `json:"securityType,omitempty"`
+	UefiSettings       *UefiSettings       `json:"uefiSettings,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_serviceartifactreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_serviceartifactreference.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceArtifactReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sku.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Capacity *int64  `json:"capacity,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Tier     *string `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_spotrestorepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_spotrestorepolicy.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SpotRestorePolicy struct {
+	Enabled        *bool   `json:"enabled,omitempty"`
+	RestoreTimeout *string `json:"restoreTimeout,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sshconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sshconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SshConfiguration struct {
+	PublicKeys *[]SshPublicKey `json:"publicKeys,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sshpublickey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_sshpublickey.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SshPublicKey struct {
+	KeyData *string `json:"keyData,omitempty"`
+	Path    *string `json:"path,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_subresource.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_terminatenotificationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_terminatenotificationprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TerminateNotificationProfile struct {
+	Enable           *bool   `json:"enable,omitempty"`
+	NotBeforeTimeout *string `json:"notBeforeTimeout,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_uefisettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_uefisettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UefiSettings struct {
+	SecureBootEnabled *bool `json:"secureBootEnabled,omitempty"`
+	VTpmEnabled       *bool `json:"vTpmEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistoricalstatusinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistoricalstatusinfo.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpgradeOperationHistoricalStatusInfo struct {
+	Location   *string                                         `json:"location,omitempty"`
+	Properties *UpgradeOperationHistoricalStatusInfoProperties `json:"properties,omitempty"`
+	Type       *string                                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistoricalstatusinfoproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistoricalstatusinfoproperties.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpgradeOperationHistoricalStatusInfoProperties struct {
+	Error                *ApiError                      `json:"error,omitempty"`
+	Progress             *RollingUpgradeProgressInfo    `json:"progress,omitempty"`
+	RollbackInfo         *RollbackStatusInfo            `json:"rollbackInfo,omitempty"`
+	RunningStatus        *UpgradeOperationHistoryStatus `json:"runningStatus,omitempty"`
+	StartedBy            *UpgradeOperationInvoker       `json:"startedBy,omitempty"`
+	TargetImageReference *ImageReference                `json:"targetImageReference,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistorystatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradeoperationhistorystatus.go
@@ -1,0 +1,40 @@
+package virtualmachinescalesets
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpgradeOperationHistoryStatus struct {
+	Code      *UpgradeState `json:"code,omitempty"`
+	EndTime   *string       `json:"endTime,omitempty"`
+	StartTime *string       `json:"startTime,omitempty"`
+}
+
+func (o *UpgradeOperationHistoryStatus) GetEndTimeAsTime() (*time.Time, error) {
+	if o.EndTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EndTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *UpgradeOperationHistoryStatus) SetEndTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EndTime = &formatted
+}
+
+func (o *UpgradeOperationHistoryStatus) GetStartTimeAsTime() (*time.Time, error) {
+	if o.StartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *UpgradeOperationHistoryStatus) SetStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_upgradepolicy.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpgradePolicy struct {
+	AutomaticOSUpgradePolicy *AutomaticOSUpgradePolicy `json:"automaticOSUpgradePolicy,omitempty"`
+	Mode                     *UpgradeMode              `json:"mode,omitempty"`
+	RollingUpgradePolicy     *RollingUpgradePolicy     `json:"rollingUpgradePolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_userinitiatedreboot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_userinitiatedreboot.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserInitiatedReboot struct {
+	AutomaticallyApprove *bool `json:"automaticallyApprove,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_userinitiatedredeploy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_userinitiatedredeploy.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserInitiatedRedeploy struct {
+	AutomaticallyApprove *bool `json:"automaticallyApprove,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vaultcertificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vaultcertificate.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCertificate struct {
+	CertificateStore *string `json:"certificateStore,omitempty"`
+	CertificateUrl   *string `json:"certificateUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vaultsecretgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vaultsecretgroup.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSecretGroup struct {
+	SourceVault       *SubResource        `json:"sourceVault,omitempty"`
+	VaultCertificates *[]VaultCertificate `json:"vaultCertificates,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualharddisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualharddisk.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualHardDisk struct {
+	Uri *string `json:"uri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextension.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtension struct {
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualMachineExtensionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextensioninstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextensioninstanceview.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionInstanceView struct {
+	Name               *string               `json:"name,omitempty"`
+	Statuses           *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Substatuses        *[]InstanceViewStatus `json:"substatuses,omitempty"`
+	Type               *string               `json:"type,omitempty"`
+	TypeHandlerVersion *string               `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextensionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachineextensionproperties.go
@@ -1,0 +1,20 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionProperties struct {
+	AutoUpgradeMinorVersion       *bool                                `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                                `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                              `json:"forceUpdateTag,omitempty"`
+	InstanceView                  *VirtualMachineExtensionInstanceView `json:"instanceView,omitempty"`
+	ProtectedSettings             *interface{}                         `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference             `json:"protectedSettingsFromKeyVault,omitempty"`
+	ProvisionAfterExtensions      *[]string                            `json:"provisionAfterExtensions,omitempty"`
+	ProvisioningState             *string                              `json:"provisioningState,omitempty"`
+	Publisher                     *string                              `json:"publisher,omitempty"`
+	Settings                      *interface{}                         `json:"settings,omitempty"`
+	SuppressFailures              *bool                                `json:"suppressFailures,omitempty"`
+	Type                          *string                              `json:"type,omitempty"`
+	TypeHandlerVersion            *string                              `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescaleset.go
@@ -1,0 +1,25 @@
+package virtualmachinescalesets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSet struct {
+	Etag             *string                            `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                   `json:"extendedLocation,omitempty"`
+	Id               *string                            `json:"id,omitempty"`
+	Identity         *identity.SystemAndUserAssignedMap `json:"identity,omitempty"`
+	Location         string                             `json:"location"`
+	Name             *string                            `json:"name,omitempty"`
+	Plan             *Plan                              `json:"plan,omitempty"`
+	Properties       *VirtualMachineScaleSetProperties  `json:"properties,omitempty"`
+	Sku              *Sku                               `json:"sku,omitempty"`
+	Tags             *map[string]string                 `json:"tags,omitempty"`
+	Type             *string                            `json:"type,omitempty"`
+	Zones            *zones.Schema                      `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetdatadisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetdatadisk.go
@@ -1,0 +1,17 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetDataDisk struct {
+	Caching                 *CachingTypes                                `json:"caching,omitempty"`
+	CreateOption            DiskCreateOptionTypes                        `json:"createOption"`
+	DeleteOption            *DiskDeleteOptionTypes                       `json:"deleteOption,omitempty"`
+	DiskIOPSReadWrite       *int64                                       `json:"diskIOPSReadWrite,omitempty"`
+	DiskMBpsReadWrite       *int64                                       `json:"diskMBpsReadWrite,omitempty"`
+	DiskSizeGB              *int64                                       `json:"diskSizeGB,omitempty"`
+	Lun                     int64                                        `json:"lun"`
+	ManagedDisk             *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	Name                    *string                                      `json:"name,omitempty"`
+	WriteAcceleratorEnabled *bool                                        `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextension.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtension struct {
+	Id         *string                                    `json:"id,omitempty"`
+	Name       *string                                    `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetExtensionProperties `json:"properties,omitempty"`
+	Type       *string                                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextensionprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextensionprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionProfile struct {
+	Extensions           *[]VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
+	ExtensionsTimeBudget *string                            `json:"extensionsTimeBudget,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextensionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetextensionproperties.go
@@ -1,0 +1,19 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionProperties struct {
+	AutoUpgradeMinorVersion       *bool                    `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                    `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                  `json:"forceUpdateTag,omitempty"`
+	ProtectedSettings             *interface{}             `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference `json:"protectedSettingsFromKeyVault,omitempty"`
+	ProvisionAfterExtensions      *[]string                `json:"provisionAfterExtensions,omitempty"`
+	ProvisioningState             *string                  `json:"provisioningState,omitempty"`
+	Publisher                     *string                  `json:"publisher,omitempty"`
+	Settings                      *interface{}             `json:"settings,omitempty"`
+	SuppressFailures              *bool                    `json:"suppressFailures,omitempty"`
+	Type                          *string                  `json:"type,omitempty"`
+	TypeHandlerVersion            *string                  `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesethardwareprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesethardwareprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetHardwareProfile struct {
+	VMSizeProperties *VMSizeProperties `json:"vmSizeProperties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetinstanceview.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetInstanceView struct {
+	Extensions            *[]VirtualMachineScaleSetVMExtensionsSummary       `json:"extensions,omitempty"`
+	OrchestrationServices *[]OrchestrationServiceSummary                     `json:"orchestrationServices,omitempty"`
+	Statuses              *[]InstanceViewStatus                              `json:"statuses,omitempty"`
+	VirtualMachine        *VirtualMachineScaleSetInstanceViewStatusesSummary `json:"virtualMachine,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetinstanceviewstatusessummary.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetinstanceviewstatusessummary.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetInstanceViewStatusesSummary struct {
+	StatusesSummary *[]VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetipconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPConfiguration struct {
+	Name       string                                           `json:"name"`
+	Properties *VirtualMachineScaleSetIPConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetipconfigurationproperties.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPConfigurationProperties struct {
+	ApplicationGatewayBackendAddressPools *[]SubResource                                      `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]SubResource                                      `json:"applicationSecurityGroups,omitempty"`
+	LoadBalancerBackendAddressPools       *[]SubResource                                      `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatPools           *[]SubResource                                      `json:"loadBalancerInboundNatPools,omitempty"`
+	Primary                               *bool                                               `json:"primary,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                          `json:"privateIPAddressVersion,omitempty"`
+	PublicIPAddressConfiguration          *VirtualMachineScaleSetPublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	Subnet                                *ApiEntityReference                                 `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetiptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetiptag.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetmanageddiskparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetmanageddiskparameters.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetManagedDiskParameters struct {
+	DiskEncryptionSet  *SubResource           `json:"diskEncryptionSet,omitempty"`
+	SecurityProfile    *VMDiskSecurityProfile `json:"securityProfile,omitempty"`
+	StorageAccountType *StorageAccountTypes   `json:"storageAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfiguration struct {
+	Name       string                                                `json:"name"`
+	Properties *VirtualMachineScaleSetNetworkConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfigurationdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfigurationdnssettings.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfigurationDnsSettings struct {
+	DnsServers *[]string `json:"dnsServers,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkconfigurationproperties.go
@@ -1,0 +1,18 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfigurationProperties struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode                         `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku                          `json:"auxiliarySku,omitempty"`
+	DeleteOption                *DeleteOptions                                         `json:"deleteOption,omitempty"`
+	DisableTcpStateTracking     *bool                                                  `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *VirtualMachineScaleSetNetworkConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	EnableAcceleratedNetworking *bool                                                  `json:"enableAcceleratedNetworking,omitempty"`
+	EnableFpga                  *bool                                                  `json:"enableFpga,omitempty"`
+	EnableIPForwarding          *bool                                                  `json:"enableIPForwarding,omitempty"`
+	IPConfigurations            []VirtualMachineScaleSetIPConfiguration                `json:"ipConfigurations"`
+	NetworkSecurityGroup        *SubResource                                           `json:"networkSecurityGroup,omitempty"`
+	Primary                     *bool                                                  `json:"primary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetnetworkprofile.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkProfile struct {
+	HealthProbe                    *ApiEntityReference                           `json:"healthProbe,omitempty"`
+	NetworkApiVersion              *NetworkApiVersion                            `json:"networkApiVersion,omitempty"`
+	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetosdisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetosdisk.go
@@ -1,0 +1,18 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetOSDisk struct {
+	Caching                 *CachingTypes                                `json:"caching,omitempty"`
+	CreateOption            DiskCreateOptionTypes                        `json:"createOption"`
+	DeleteOption            *DiskDeleteOptionTypes                       `json:"deleteOption,omitempty"`
+	DiffDiskSettings        *DiffDiskSettings                            `json:"diffDiskSettings,omitempty"`
+	DiskSizeGB              *int64                                       `json:"diskSizeGB,omitempty"`
+	Image                   *VirtualHardDisk                             `json:"image,omitempty"`
+	ManagedDisk             *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	Name                    *string                                      `json:"name,omitempty"`
+	OsType                  *OperatingSystemTypes                        `json:"osType,omitempty"`
+	VhdContainers           *[]string                                    `json:"vhdContainers,omitempty"`
+	WriteAcceleratorEnabled *bool                                        `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetosprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetosprofile.go
@@ -1,0 +1,16 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetOSProfile struct {
+	AdminPassword               *string               `json:"adminPassword,omitempty"`
+	AdminUsername               *string               `json:"adminUsername,omitempty"`
+	AllowExtensionOperations    *bool                 `json:"allowExtensionOperations,omitempty"`
+	ComputerNamePrefix          *string               `json:"computerNamePrefix,omitempty"`
+	CustomData                  *string               `json:"customData,omitempty"`
+	LinuxConfiguration          *LinuxConfiguration   `json:"linuxConfiguration,omitempty"`
+	RequireGuestProvisionSignal *bool                 `json:"requireGuestProvisionSignal,omitempty"`
+	Secrets                     *[]VaultSecretGroup   `json:"secrets,omitempty"`
+	WindowsConfiguration        *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetproperties.go
@@ -1,0 +1,46 @@
+package virtualmachinescalesets
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetProperties struct {
+	AdditionalCapabilities                 *AdditionalCapabilities          `json:"additionalCapabilities,omitempty"`
+	AutomaticRepairsPolicy                 *AutomaticRepairsPolicy          `json:"automaticRepairsPolicy,omitempty"`
+	ConstrainedMaximumCapacity             *bool                            `json:"constrainedMaximumCapacity,omitempty"`
+	DoNotRunExtensionsOnOverprovisionedVMs *bool                            `json:"doNotRunExtensionsOnOverprovisionedVMs,omitempty"`
+	HostGroup                              *SubResource                     `json:"hostGroup,omitempty"`
+	OrchestrationMode                      *OrchestrationMode               `json:"orchestrationMode,omitempty"`
+	Overprovision                          *bool                            `json:"overprovision,omitempty"`
+	PlatformFaultDomainCount               *int64                           `json:"platformFaultDomainCount,omitempty"`
+	PriorityMixPolicy                      *PriorityMixPolicy               `json:"priorityMixPolicy,omitempty"`
+	ProvisioningState                      *string                          `json:"provisioningState,omitempty"`
+	ProximityPlacementGroup                *SubResource                     `json:"proximityPlacementGroup,omitempty"`
+	ResiliencyPolicy                       *ResiliencyPolicy                `json:"resiliencyPolicy,omitempty"`
+	ScaleInPolicy                          *ScaleInPolicy                   `json:"scaleInPolicy,omitempty"`
+	ScheduledEventsPolicy                  *ScheduledEventsPolicy           `json:"scheduledEventsPolicy,omitempty"`
+	SinglePlacementGroup                   *bool                            `json:"singlePlacementGroup,omitempty"`
+	SpotRestorePolicy                      *SpotRestorePolicy               `json:"spotRestorePolicy,omitempty"`
+	TimeCreated                            *string                          `json:"timeCreated,omitempty"`
+	UniqueId                               *string                          `json:"uniqueId,omitempty"`
+	UpgradePolicy                          *UpgradePolicy                   `json:"upgradePolicy,omitempty"`
+	VirtualMachineProfile                  *VirtualMachineScaleSetVMProfile `json:"virtualMachineProfile,omitempty"`
+	ZoneBalance                            *bool                            `json:"zoneBalance,omitempty"`
+}
+
+func (o *VirtualMachineScaleSetProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *VirtualMachineScaleSetProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfiguration.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfiguration struct {
+	Name       string                                                        `json:"name"`
+	Properties *VirtualMachineScaleSetPublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+	Sku        *PublicIPAddressSku                                           `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfigurationdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfigurationdnssettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings struct {
+	DomainNameLabel      string                     `json:"domainNameLabel"`
+	DomainNameLabelScope *DomainNameLabelScopeTypes `json:"domainNameLabelScope,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetpublicipaddressconfigurationproperties.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
+	DeleteOption           *DeleteOptions                                                 `json:"deleteOption,omitempty"`
+	DnsSettings            *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	IPTags                 *[]VirtualMachineScaleSetIPTag                                 `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes   *int64                                                         `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPAddressVersion *IPVersion                                                     `json:"publicIPAddressVersion,omitempty"`
+	PublicIPPrefix         *SubResource                                                   `json:"publicIPPrefix,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetreimageparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetreimageparameters.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetReimageParameters struct {
+	ExactVersion                  *string                    `json:"exactVersion,omitempty"`
+	ForceUpdateOSDiskForEphemeral *bool                      `json:"forceUpdateOSDiskForEphemeral,omitempty"`
+	InstanceIds                   *[]string                  `json:"instanceIds,omitempty"`
+	OsProfile                     *OSProfileProvisioningData `json:"osProfile,omitempty"`
+	TempDisk                      *bool                      `json:"tempDisk,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetsku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetsku.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetSku struct {
+	Capacity     *VirtualMachineScaleSetSkuCapacity `json:"capacity,omitempty"`
+	ResourceType *string                            `json:"resourceType,omitempty"`
+	Sku          *Sku                               `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetskucapacity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetskucapacity.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetSkuCapacity struct {
+	DefaultCapacity *int64                              `json:"defaultCapacity,omitempty"`
+	Maximum         *int64                              `json:"maximum,omitempty"`
+	Minimum         *int64                              `json:"minimum,omitempty"`
+	ScaleType       *VirtualMachineScaleSetSkuScaleType `json:"scaleType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetstorageprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetstorageprofile.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetStorageProfile struct {
+	DataDisks          *[]VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DiskControllerType *string                           `json:"diskControllerType,omitempty"`
+	ImageReference     *ImageReference                   `json:"imageReference,omitempty"`
+	OsDisk             *VirtualMachineScaleSetOSDisk     `json:"osDisk,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdate.go
@@ -1,0 +1,16 @@
+package virtualmachinescalesets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdate struct {
+	Identity   *identity.SystemAndUserAssignedMap      `json:"identity,omitempty"`
+	Plan       *Plan                                   `json:"plan,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateProperties `json:"properties,omitempty"`
+	Sku        *Sku                                    `json:"sku,omitempty"`
+	Tags       *map[string]string                      `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateipconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateIPConfiguration struct {
+	Name       *string                                                `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateIPConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateipconfigurationproperties.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateIPConfigurationProperties struct {
+	ApplicationGatewayBackendAddressPools *[]SubResource                                            `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]SubResource                                            `json:"applicationSecurityGroups,omitempty"`
+	LoadBalancerBackendAddressPools       *[]SubResource                                            `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatPools           *[]SubResource                                            `json:"loadBalancerInboundNatPools,omitempty"`
+	Primary                               *bool                                                     `json:"primary,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                                `json:"privateIPAddressVersion,omitempty"`
+	PublicIPAddressConfiguration          *VirtualMachineScaleSetUpdatePublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	Subnet                                *ApiEntityReference                                       `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateNetworkConfiguration struct {
+	Name       *string                                                     `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateNetworkConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkconfigurationproperties.go
@@ -1,0 +1,18 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateNetworkConfigurationProperties struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode                         `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku                          `json:"auxiliarySku,omitempty"`
+	DeleteOption                *DeleteOptions                                         `json:"deleteOption,omitempty"`
+	DisableTcpStateTracking     *bool                                                  `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *VirtualMachineScaleSetNetworkConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	EnableAcceleratedNetworking *bool                                                  `json:"enableAcceleratedNetworking,omitempty"`
+	EnableFpga                  *bool                                                  `json:"enableFpga,omitempty"`
+	EnableIPForwarding          *bool                                                  `json:"enableIPForwarding,omitempty"`
+	IPConfigurations            *[]VirtualMachineScaleSetUpdateIPConfiguration         `json:"ipConfigurations,omitempty"`
+	NetworkSecurityGroup        *SubResource                                           `json:"networkSecurityGroup,omitempty"`
+	Primary                     *bool                                                  `json:"primary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatenetworkprofile.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateNetworkProfile struct {
+	HealthProbe                    *ApiEntityReference                                 `json:"healthProbe,omitempty"`
+	NetworkApiVersion              *NetworkApiVersion                                  `json:"networkApiVersion,omitempty"`
+	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateosdisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateosdisk.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateOSDisk struct {
+	Caching                 *CachingTypes                                `json:"caching,omitempty"`
+	DeleteOption            *DiskDeleteOptionTypes                       `json:"deleteOption,omitempty"`
+	DiffDiskSettings        *DiffDiskSettings                            `json:"diffDiskSettings,omitempty"`
+	DiskSizeGB              *int64                                       `json:"diskSizeGB,omitempty"`
+	Image                   *VirtualHardDisk                             `json:"image,omitempty"`
+	ManagedDisk             *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	VhdContainers           *[]string                                    `json:"vhdContainers,omitempty"`
+	WriteAcceleratorEnabled *bool                                        `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateosprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateosprofile.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateOSProfile struct {
+	CustomData           *string               `json:"customData,omitempty"`
+	LinuxConfiguration   *LinuxConfiguration   `json:"linuxConfiguration,omitempty"`
+	Secrets              *[]VaultSecretGroup   `json:"secrets,omitempty"`
+	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdateproperties.go
@@ -1,0 +1,19 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateProperties struct {
+	AdditionalCapabilities                 *AdditionalCapabilities                `json:"additionalCapabilities,omitempty"`
+	AutomaticRepairsPolicy                 *AutomaticRepairsPolicy                `json:"automaticRepairsPolicy,omitempty"`
+	DoNotRunExtensionsOnOverprovisionedVMs *bool                                  `json:"doNotRunExtensionsOnOverprovisionedVMs,omitempty"`
+	Overprovision                          *bool                                  `json:"overprovision,omitempty"`
+	PriorityMixPolicy                      *PriorityMixPolicy                     `json:"priorityMixPolicy,omitempty"`
+	ProximityPlacementGroup                *SubResource                           `json:"proximityPlacementGroup,omitempty"`
+	ResiliencyPolicy                       *ResiliencyPolicy                      `json:"resiliencyPolicy,omitempty"`
+	ScaleInPolicy                          *ScaleInPolicy                         `json:"scaleInPolicy,omitempty"`
+	SinglePlacementGroup                   *bool                                  `json:"singlePlacementGroup,omitempty"`
+	SpotRestorePolicy                      *SpotRestorePolicy                     `json:"spotRestorePolicy,omitempty"`
+	UpgradePolicy                          *UpgradePolicy                         `json:"upgradePolicy,omitempty"`
+	VirtualMachineProfile                  *VirtualMachineScaleSetUpdateVMProfile `json:"virtualMachineProfile,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatepublicipaddressconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatepublicipaddressconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdatePublicIPAddressConfiguration struct {
+	Name       *string                                                             `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatepublicipaddressconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatepublicipaddressconfigurationproperties.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties struct {
+	DeleteOption         *DeleteOptions                                                 `json:"deleteOption,omitempty"`
+	DnsSettings          *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	IdleTimeoutInMinutes *int64                                                         `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPPrefix       *SubResource                                                   `json:"publicIPPrefix,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatestorageprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatestorageprofile.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateStorageProfile struct {
+	DataDisks          *[]VirtualMachineScaleSetDataDisk   `json:"dataDisks,omitempty"`
+	DiskControllerType *string                             `json:"diskControllerType,omitempty"`
+	ImageReference     *ImageReference                     `json:"imageReference,omitempty"`
+	OsDisk             *VirtualMachineScaleSetUpdateOSDisk `json:"osDisk,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatevmprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetupdatevmprofile.go
@@ -1,0 +1,18 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetUpdateVMProfile struct {
+	BillingProfile         *BillingProfile                             `json:"billingProfile,omitempty"`
+	DiagnosticsProfile     *DiagnosticsProfile                         `json:"diagnosticsProfile,omitempty"`
+	ExtensionProfile       *VirtualMachineScaleSetExtensionProfile     `json:"extensionProfile,omitempty"`
+	HardwareProfile        *VirtualMachineScaleSetHardwareProfile      `json:"hardwareProfile,omitempty"`
+	LicenseType            *string                                     `json:"licenseType,omitempty"`
+	NetworkProfile         *VirtualMachineScaleSetUpdateNetworkProfile `json:"networkProfile,omitempty"`
+	OsProfile              *VirtualMachineScaleSetUpdateOSProfile      `json:"osProfile,omitempty"`
+	ScheduledEventsProfile *ScheduledEventsProfile                     `json:"scheduledEventsProfile,omitempty"`
+	SecurityProfile        *SecurityProfile                            `json:"securityProfile,omitempty"`
+	StorageProfile         *VirtualMachineScaleSetUpdateStorageProfile `json:"storageProfile,omitempty"`
+	UserData               *string                                     `json:"userData,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvmextensionssummary.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvmextensionssummary.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMExtensionsSummary struct {
+	Name            *string                          `json:"name,omitempty"`
+	StatusesSummary *[]VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvminstanceids.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvminstanceids.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMInstanceIDs struct {
+	InstanceIds *[]string `json:"instanceIds,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvminstancerequiredids.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvminstancerequiredids.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMInstanceRequiredIDs struct {
+	InstanceIds []string `json:"instanceIds"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvmprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinescalesetvmprofile.go
@@ -1,0 +1,43 @@
+package virtualmachinescalesets
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMProfile struct {
+	ApplicationProfile       *ApplicationProfile                     `json:"applicationProfile,omitempty"`
+	BillingProfile           *BillingProfile                         `json:"billingProfile,omitempty"`
+	CapacityReservation      *CapacityReservationProfile             `json:"capacityReservation,omitempty"`
+	DiagnosticsProfile       *DiagnosticsProfile                     `json:"diagnosticsProfile,omitempty"`
+	EvictionPolicy           *VirtualMachineEvictionPolicyTypes      `json:"evictionPolicy,omitempty"`
+	ExtensionProfile         *VirtualMachineScaleSetExtensionProfile `json:"extensionProfile,omitempty"`
+	HardwareProfile          *VirtualMachineScaleSetHardwareProfile  `json:"hardwareProfile,omitempty"`
+	LicenseType              *string                                 `json:"licenseType,omitempty"`
+	NetworkProfile           *VirtualMachineScaleSetNetworkProfile   `json:"networkProfile,omitempty"`
+	OsProfile                *VirtualMachineScaleSetOSProfile        `json:"osProfile,omitempty"`
+	Priority                 *VirtualMachinePriorityTypes            `json:"priority,omitempty"`
+	ScheduledEventsProfile   *ScheduledEventsProfile                 `json:"scheduledEventsProfile,omitempty"`
+	SecurityPostureReference *SecurityPostureReference               `json:"securityPostureReference,omitempty"`
+	SecurityProfile          *SecurityProfile                        `json:"securityProfile,omitempty"`
+	ServiceArtifactReference *ServiceArtifactReference               `json:"serviceArtifactReference,omitempty"`
+	StorageProfile           *VirtualMachineScaleSetStorageProfile   `json:"storageProfile,omitempty"`
+	TimeCreated              *string                                 `json:"timeCreated,omitempty"`
+	UserData                 *string                                 `json:"userData,omitempty"`
+}
+
+func (o *VirtualMachineScaleSetVMProfile) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *VirtualMachineScaleSetVMProfile) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinestatuscodecount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_virtualmachinestatuscodecount.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineStatusCodeCount struct {
+	Code  *string `json:"code,omitempty"`
+	Count *int64  `json:"count,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmdisksecurityprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmdisksecurityprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMDiskSecurityProfile struct {
+	DiskEncryptionSet      *SubResource             `json:"diskEncryptionSet,omitempty"`
+	SecurityEncryptionType *SecurityEncryptionTypes `json:"securityEncryptionType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmgalleryapplication.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmgalleryapplication.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMGalleryApplication struct {
+	ConfigurationReference          *string `json:"configurationReference,omitempty"`
+	EnableAutomaticUpgrade          *bool   `json:"enableAutomaticUpgrade,omitempty"`
+	Order                           *int64  `json:"order,omitempty"`
+	PackageReferenceId              string  `json:"packageReferenceId"`
+	Tags                            *string `json:"tags,omitempty"`
+	TreatFailureAsDeploymentFailure *bool   `json:"treatFailureAsDeploymentFailure,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmscalesetconverttosingleplacementgroupinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmscalesetconverttosingleplacementgroupinput.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMScaleSetConvertToSinglePlacementGroupInput struct {
+	ActivePlacementGroupId *string `json:"activePlacementGroupId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmsizeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_vmsizeproperties.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMSizeProperties struct {
+	VCPUsAvailable *int64 `json:"vCPUsAvailable,omitempty"`
+	VCPUsPerCore   *int64 `json:"vCPUsPerCore,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_windowsconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_windowsconfiguration.go
@@ -1,0 +1,14 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WindowsConfiguration struct {
+	AdditionalUnattendContent    *[]AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
+	EnableAutomaticUpdates       *bool                        `json:"enableAutomaticUpdates,omitempty"`
+	EnableVMAgentPlatformUpdates *bool                        `json:"enableVMAgentPlatformUpdates,omitempty"`
+	PatchSettings                *PatchSettings               `json:"patchSettings,omitempty"`
+	ProvisionVMAgent             *bool                        `json:"provisionVMAgent,omitempty"`
+	TimeZone                     *string                      `json:"timeZone,omitempty"`
+	WinRM                        *WinRMConfiguration          `json:"winRM,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_windowsvmguestpatchautomaticbyplatformsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_windowsvmguestpatchautomaticbyplatformsettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WindowsVMGuestPatchAutomaticByPlatformSettings struct {
+	BypassPlatformSafetyChecksOnUserSchedule *bool                                                `json:"bypassPlatformSafetyChecksOnUserSchedule,omitempty"`
+	RebootSetting                            *WindowsVMGuestPatchAutomaticByPlatformRebootSetting `json:"rebootSetting,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_winrmconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_winrmconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WinRMConfiguration struct {
+	Listeners *[]WinRMListener `json:"listeners,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_winrmlistener.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/model_winrmlistener.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WinRMListener struct {
+	CertificateUrl *string        `json:"certificateUrl,omitempty"`
+	Protocol       *ProtocolTypes `json:"protocol,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/predicates.go
@@ -1,0 +1,68 @@
+package virtualmachinescalesets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpgradeOperationHistoricalStatusInfoOperationPredicate struct {
+	Location *string
+	Type     *string
+}
+
+func (p UpgradeOperationHistoricalStatusInfoOperationPredicate) Matches(input UpgradeOperationHistoricalStatusInfo) bool {
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type VirtualMachineScaleSetOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p VirtualMachineScaleSetOperationPredicate) Matches(input VirtualMachineScaleSet) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type VirtualMachineScaleSetSkuOperationPredicate struct {
+	ResourceType *string
+}
+
+func (p VirtualMachineScaleSetSkuOperationPredicate) Matches(input VirtualMachineScaleSetSku) bool {
+
+	if p.ResourceType != nil && (input.ResourceType == nil || *p.ResourceType != *input.ResourceType) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets/version.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesets
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachinescalesets/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/README.md
@@ -1,0 +1,277 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms` Documentation
+
+The `virtualmachinescalesetvms` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachinescalesetvms.NewVirtualMachineScaleSetVMsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.ApproveRollingUpgrade`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.ApproveRollingUpgradeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.AttachDetachDataDisks`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+payload := virtualmachinescalesetvms.AttachDetachDataDisksRequest{
+	// ...
+}
+
+
+if err := client.AttachDetachDataDisksThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Deallocate`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.DeallocateThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.DeleteThenPoll(ctx, id, virtualmachinescalesetvms.DefaultDeleteOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+read, err := client.Get(ctx, id, virtualmachinescalesetvms.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.GetInstanceView`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+read, err := client.GetInstanceView(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.List`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+// alternatively `client.List(ctx, id, virtualmachinescalesetvms.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, virtualmachinescalesetvms.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.PerformMaintenance`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.PerformMaintenanceThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.PowerOff`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.PowerOffThenPoll(ctx, id, virtualmachinescalesetvms.DefaultPowerOffOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Redeploy`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.RedeployThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Reimage`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+payload := virtualmachinescalesetvms.VirtualMachineScaleSetVMReimageParameters{
+	// ...
+}
+
+
+if err := client.ReimageThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.ReimageAll`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.ReimageAllThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Restart`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.RestartThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.RetrieveBootDiagnosticsData`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+read, err := client.RetrieveBootDiagnosticsData(ctx, id, virtualmachinescalesetvms.DefaultRetrieveBootDiagnosticsDataOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.RunCommand`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+payload := virtualmachinescalesetvms.RunCommandInput{
+	// ...
+}
+
+
+if err := client.RunCommandThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.SimulateEviction`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+read, err := client.SimulateEviction(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Start`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+if err := client.StartThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetVMsClient.Update`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetvms.NewVirtualMachineScaleSetVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "instanceIdValue")
+
+payload := virtualmachinescalesetvms.VirtualMachineScaleSetVM{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload, virtualmachinescalesetvms.DefaultUpdateOperationOptions()); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/client.go
@@ -1,0 +1,26 @@
+package virtualmachinescalesetvms
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineScaleSetVMsClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineScaleSetVMsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachinescalesetvms", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineScaleSetVMsClient: %+v", err)
+	}
+
+	return &VirtualMachineScaleSetVMsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/constants.go
@@ -1,0 +1,2079 @@
+package virtualmachinescalesetvms
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CachingTypes string
+
+const (
+	CachingTypesNone      CachingTypes = "None"
+	CachingTypesReadOnly  CachingTypes = "ReadOnly"
+	CachingTypesReadWrite CachingTypes = "ReadWrite"
+)
+
+func PossibleValuesForCachingTypes() []string {
+	return []string{
+		string(CachingTypesNone),
+		string(CachingTypesReadOnly),
+		string(CachingTypesReadWrite),
+	}
+}
+
+func (s *CachingTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCachingTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCachingTypes(input string) (*CachingTypes, error) {
+	vals := map[string]CachingTypes{
+		"none":      CachingTypesNone,
+		"readonly":  CachingTypesReadOnly,
+		"readwrite": CachingTypesReadWrite,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CachingTypes(input)
+	return &out, nil
+}
+
+type ComponentNames string
+
+const (
+	ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup ComponentNames = "Microsoft-Windows-Shell-Setup"
+)
+
+func PossibleValuesForComponentNames() []string {
+	return []string{
+		string(ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup),
+	}
+}
+
+func (s *ComponentNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComponentNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComponentNames(input string) (*ComponentNames, error) {
+	vals := map[string]ComponentNames{
+		"microsoft-windows-shell-setup": ComponentNamesMicrosoftNegativeWindowsNegativeShellNegativeSetup,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComponentNames(input)
+	return &out, nil
+}
+
+type DeleteOptions string
+
+const (
+	DeleteOptionsDelete DeleteOptions = "Delete"
+	DeleteOptionsDetach DeleteOptions = "Detach"
+)
+
+func PossibleValuesForDeleteOptions() []string {
+	return []string{
+		string(DeleteOptionsDelete),
+		string(DeleteOptionsDetach),
+	}
+}
+
+func (s *DeleteOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeleteOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeleteOptions(input string) (*DeleteOptions, error) {
+	vals := map[string]DeleteOptions{
+		"delete": DeleteOptionsDelete,
+		"detach": DeleteOptionsDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeleteOptions(input)
+	return &out, nil
+}
+
+type DiffDiskOptions string
+
+const (
+	DiffDiskOptionsLocal DiffDiskOptions = "Local"
+)
+
+func PossibleValuesForDiffDiskOptions() []string {
+	return []string{
+		string(DiffDiskOptionsLocal),
+	}
+}
+
+func (s *DiffDiskOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiffDiskOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiffDiskOptions(input string) (*DiffDiskOptions, error) {
+	vals := map[string]DiffDiskOptions{
+		"local": DiffDiskOptionsLocal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiffDiskOptions(input)
+	return &out, nil
+}
+
+type DiffDiskPlacement string
+
+const (
+	DiffDiskPlacementCacheDisk    DiffDiskPlacement = "CacheDisk"
+	DiffDiskPlacementNVMeDisk     DiffDiskPlacement = "NvmeDisk"
+	DiffDiskPlacementResourceDisk DiffDiskPlacement = "ResourceDisk"
+)
+
+func PossibleValuesForDiffDiskPlacement() []string {
+	return []string{
+		string(DiffDiskPlacementCacheDisk),
+		string(DiffDiskPlacementNVMeDisk),
+		string(DiffDiskPlacementResourceDisk),
+	}
+}
+
+func (s *DiffDiskPlacement) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiffDiskPlacement(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiffDiskPlacement(input string) (*DiffDiskPlacement, error) {
+	vals := map[string]DiffDiskPlacement{
+		"cachedisk":    DiffDiskPlacementCacheDisk,
+		"nvmedisk":     DiffDiskPlacementNVMeDisk,
+		"resourcedisk": DiffDiskPlacementResourceDisk,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiffDiskPlacement(input)
+	return &out, nil
+}
+
+type DiskControllerTypes string
+
+const (
+	DiskControllerTypesNVMe DiskControllerTypes = "NVMe"
+	DiskControllerTypesSCSI DiskControllerTypes = "SCSI"
+)
+
+func PossibleValuesForDiskControllerTypes() []string {
+	return []string{
+		string(DiskControllerTypesNVMe),
+		string(DiskControllerTypesSCSI),
+	}
+}
+
+func (s *DiskControllerTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskControllerTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskControllerTypes(input string) (*DiskControllerTypes, error) {
+	vals := map[string]DiskControllerTypes{
+		"nvme": DiskControllerTypesNVMe,
+		"scsi": DiskControllerTypesSCSI,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskControllerTypes(input)
+	return &out, nil
+}
+
+type DiskCreateOptionTypes string
+
+const (
+	DiskCreateOptionTypesAttach    DiskCreateOptionTypes = "Attach"
+	DiskCreateOptionTypesCopy      DiskCreateOptionTypes = "Copy"
+	DiskCreateOptionTypesEmpty     DiskCreateOptionTypes = "Empty"
+	DiskCreateOptionTypesFromImage DiskCreateOptionTypes = "FromImage"
+	DiskCreateOptionTypesRestore   DiskCreateOptionTypes = "Restore"
+)
+
+func PossibleValuesForDiskCreateOptionTypes() []string {
+	return []string{
+		string(DiskCreateOptionTypesAttach),
+		string(DiskCreateOptionTypesCopy),
+		string(DiskCreateOptionTypesEmpty),
+		string(DiskCreateOptionTypesFromImage),
+		string(DiskCreateOptionTypesRestore),
+	}
+}
+
+func (s *DiskCreateOptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskCreateOptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskCreateOptionTypes(input string) (*DiskCreateOptionTypes, error) {
+	vals := map[string]DiskCreateOptionTypes{
+		"attach":    DiskCreateOptionTypesAttach,
+		"copy":      DiskCreateOptionTypesCopy,
+		"empty":     DiskCreateOptionTypesEmpty,
+		"fromimage": DiskCreateOptionTypesFromImage,
+		"restore":   DiskCreateOptionTypesRestore,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskCreateOptionTypes(input)
+	return &out, nil
+}
+
+type DiskDeleteOptionTypes string
+
+const (
+	DiskDeleteOptionTypesDelete DiskDeleteOptionTypes = "Delete"
+	DiskDeleteOptionTypesDetach DiskDeleteOptionTypes = "Detach"
+)
+
+func PossibleValuesForDiskDeleteOptionTypes() []string {
+	return []string{
+		string(DiskDeleteOptionTypesDelete),
+		string(DiskDeleteOptionTypesDetach),
+	}
+}
+
+func (s *DiskDeleteOptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskDeleteOptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskDeleteOptionTypes(input string) (*DiskDeleteOptionTypes, error) {
+	vals := map[string]DiskDeleteOptionTypes{
+		"delete": DiskDeleteOptionTypesDelete,
+		"detach": DiskDeleteOptionTypesDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskDeleteOptionTypes(input)
+	return &out, nil
+}
+
+type DiskDetachOptionTypes string
+
+const (
+	DiskDetachOptionTypesForceDetach DiskDetachOptionTypes = "ForceDetach"
+)
+
+func PossibleValuesForDiskDetachOptionTypes() []string {
+	return []string{
+		string(DiskDetachOptionTypesForceDetach),
+	}
+}
+
+func (s *DiskDetachOptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskDetachOptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskDetachOptionTypes(input string) (*DiskDetachOptionTypes, error) {
+	vals := map[string]DiskDetachOptionTypes{
+		"forcedetach": DiskDetachOptionTypesForceDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskDetachOptionTypes(input)
+	return &out, nil
+}
+
+type DomainNameLabelScopeTypes string
+
+const (
+	DomainNameLabelScopeTypesNoReuse            DomainNameLabelScopeTypes = "NoReuse"
+	DomainNameLabelScopeTypesResourceGroupReuse DomainNameLabelScopeTypes = "ResourceGroupReuse"
+	DomainNameLabelScopeTypesSubscriptionReuse  DomainNameLabelScopeTypes = "SubscriptionReuse"
+	DomainNameLabelScopeTypesTenantReuse        DomainNameLabelScopeTypes = "TenantReuse"
+)
+
+func PossibleValuesForDomainNameLabelScopeTypes() []string {
+	return []string{
+		string(DomainNameLabelScopeTypesNoReuse),
+		string(DomainNameLabelScopeTypesResourceGroupReuse),
+		string(DomainNameLabelScopeTypesSubscriptionReuse),
+		string(DomainNameLabelScopeTypesTenantReuse),
+	}
+}
+
+func (s *DomainNameLabelScopeTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDomainNameLabelScopeTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDomainNameLabelScopeTypes(input string) (*DomainNameLabelScopeTypes, error) {
+	vals := map[string]DomainNameLabelScopeTypes{
+		"noreuse":            DomainNameLabelScopeTypesNoReuse,
+		"resourcegroupreuse": DomainNameLabelScopeTypesResourceGroupReuse,
+		"subscriptionreuse":  DomainNameLabelScopeTypesSubscriptionReuse,
+		"tenantreuse":        DomainNameLabelScopeTypesTenantReuse,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DomainNameLabelScopeTypes(input)
+	return &out, nil
+}
+
+type HyperVGeneration string
+
+const (
+	HyperVGenerationVOne HyperVGeneration = "V1"
+	HyperVGenerationVTwo HyperVGeneration = "V2"
+)
+
+func PossibleValuesForHyperVGeneration() []string {
+	return []string{
+		string(HyperVGenerationVOne),
+		string(HyperVGenerationVTwo),
+	}
+}
+
+func (s *HyperVGeneration) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHyperVGeneration(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHyperVGeneration(input string) (*HyperVGeneration, error) {
+	vals := map[string]HyperVGeneration{
+		"v1": HyperVGenerationVOne,
+		"v2": HyperVGenerationVTwo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HyperVGeneration(input)
+	return &out, nil
+}
+
+type IPVersion string
+
+const (
+	IPVersionIPvFour IPVersion = "IPv4"
+	IPVersionIPvSix  IPVersion = "IPv6"
+)
+
+func PossibleValuesForIPVersion() []string {
+	return []string{
+		string(IPVersionIPvFour),
+		string(IPVersionIPvSix),
+	}
+}
+
+func (s *IPVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersion(input string) (*IPVersion, error) {
+	vals := map[string]IPVersion{
+		"ipv4": IPVersionIPvFour,
+		"ipv6": IPVersionIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersion(input)
+	return &out, nil
+}
+
+type IPVersions string
+
+const (
+	IPVersionsIPvFour IPVersions = "IPv4"
+	IPVersionsIPvSix  IPVersions = "IPv6"
+)
+
+func PossibleValuesForIPVersions() []string {
+	return []string{
+		string(IPVersionsIPvFour),
+		string(IPVersionsIPvSix),
+	}
+}
+
+func (s *IPVersions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersions(input string) (*IPVersions, error) {
+	vals := map[string]IPVersions{
+		"ipv4": IPVersionsIPvFour,
+		"ipv6": IPVersionsIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersions(input)
+	return &out, nil
+}
+
+type InstanceViewTypes string
+
+const (
+	InstanceViewTypesInstanceView InstanceViewTypes = "instanceView"
+	InstanceViewTypesUserData     InstanceViewTypes = "userData"
+)
+
+func PossibleValuesForInstanceViewTypes() []string {
+	return []string{
+		string(InstanceViewTypesInstanceView),
+		string(InstanceViewTypesUserData),
+	}
+}
+
+func (s *InstanceViewTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseInstanceViewTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseInstanceViewTypes(input string) (*InstanceViewTypes, error) {
+	vals := map[string]InstanceViewTypes{
+		"instanceview": InstanceViewTypesInstanceView,
+		"userdata":     InstanceViewTypesUserData,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InstanceViewTypes(input)
+	return &out, nil
+}
+
+type LinuxPatchAssessmentMode string
+
+const (
+	LinuxPatchAssessmentModeAutomaticByPlatform LinuxPatchAssessmentMode = "AutomaticByPlatform"
+	LinuxPatchAssessmentModeImageDefault        LinuxPatchAssessmentMode = "ImageDefault"
+)
+
+func PossibleValuesForLinuxPatchAssessmentMode() []string {
+	return []string{
+		string(LinuxPatchAssessmentModeAutomaticByPlatform),
+		string(LinuxPatchAssessmentModeImageDefault),
+	}
+}
+
+func (s *LinuxPatchAssessmentMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxPatchAssessmentMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxPatchAssessmentMode(input string) (*LinuxPatchAssessmentMode, error) {
+	vals := map[string]LinuxPatchAssessmentMode{
+		"automaticbyplatform": LinuxPatchAssessmentModeAutomaticByPlatform,
+		"imagedefault":        LinuxPatchAssessmentModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxPatchAssessmentMode(input)
+	return &out, nil
+}
+
+type LinuxVMGuestPatchAutomaticByPlatformRebootSetting string
+
+const (
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways     LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Always"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "IfRequired"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever      LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Never"
+	LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown    LinuxVMGuestPatchAutomaticByPlatformRebootSetting = "Unknown"
+)
+
+func PossibleValuesForLinuxVMGuestPatchAutomaticByPlatformRebootSetting() []string {
+	return []string{
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever),
+		string(LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown),
+	}
+}
+
+func (s *LinuxVMGuestPatchAutomaticByPlatformRebootSetting) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxVMGuestPatchAutomaticByPlatformRebootSetting(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxVMGuestPatchAutomaticByPlatformRebootSetting(input string) (*LinuxVMGuestPatchAutomaticByPlatformRebootSetting, error) {
+	vals := map[string]LinuxVMGuestPatchAutomaticByPlatformRebootSetting{
+		"always":     LinuxVMGuestPatchAutomaticByPlatformRebootSettingAlways,
+		"ifrequired": LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired,
+		"never":      LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever,
+		"unknown":    LinuxVMGuestPatchAutomaticByPlatformRebootSettingUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxVMGuestPatchAutomaticByPlatformRebootSetting(input)
+	return &out, nil
+}
+
+type LinuxVMGuestPatchMode string
+
+const (
+	LinuxVMGuestPatchModeAutomaticByPlatform LinuxVMGuestPatchMode = "AutomaticByPlatform"
+	LinuxVMGuestPatchModeImageDefault        LinuxVMGuestPatchMode = "ImageDefault"
+)
+
+func PossibleValuesForLinuxVMGuestPatchMode() []string {
+	return []string{
+		string(LinuxVMGuestPatchModeAutomaticByPlatform),
+		string(LinuxVMGuestPatchModeImageDefault),
+	}
+}
+
+func (s *LinuxVMGuestPatchMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLinuxVMGuestPatchMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLinuxVMGuestPatchMode(input string) (*LinuxVMGuestPatchMode, error) {
+	vals := map[string]LinuxVMGuestPatchMode{
+		"automaticbyplatform": LinuxVMGuestPatchModeAutomaticByPlatform,
+		"imagedefault":        LinuxVMGuestPatchModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinuxVMGuestPatchMode(input)
+	return &out, nil
+}
+
+type MaintenanceOperationResultCodeTypes string
+
+const (
+	MaintenanceOperationResultCodeTypesMaintenanceAborted   MaintenanceOperationResultCodeTypes = "MaintenanceAborted"
+	MaintenanceOperationResultCodeTypesMaintenanceCompleted MaintenanceOperationResultCodeTypes = "MaintenanceCompleted"
+	MaintenanceOperationResultCodeTypesNone                 MaintenanceOperationResultCodeTypes = "None"
+	MaintenanceOperationResultCodeTypesRetryLater           MaintenanceOperationResultCodeTypes = "RetryLater"
+)
+
+func PossibleValuesForMaintenanceOperationResultCodeTypes() []string {
+	return []string{
+		string(MaintenanceOperationResultCodeTypesMaintenanceAborted),
+		string(MaintenanceOperationResultCodeTypesMaintenanceCompleted),
+		string(MaintenanceOperationResultCodeTypesNone),
+		string(MaintenanceOperationResultCodeTypesRetryLater),
+	}
+}
+
+func (s *MaintenanceOperationResultCodeTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMaintenanceOperationResultCodeTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMaintenanceOperationResultCodeTypes(input string) (*MaintenanceOperationResultCodeTypes, error) {
+	vals := map[string]MaintenanceOperationResultCodeTypes{
+		"maintenanceaborted":   MaintenanceOperationResultCodeTypesMaintenanceAborted,
+		"maintenancecompleted": MaintenanceOperationResultCodeTypesMaintenanceCompleted,
+		"none":                 MaintenanceOperationResultCodeTypesNone,
+		"retrylater":           MaintenanceOperationResultCodeTypesRetryLater,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MaintenanceOperationResultCodeTypes(input)
+	return &out, nil
+}
+
+type Mode string
+
+const (
+	ModeAudit   Mode = "Audit"
+	ModeEnforce Mode = "Enforce"
+)
+
+func PossibleValuesForMode() []string {
+	return []string{
+		string(ModeAudit),
+		string(ModeEnforce),
+	}
+}
+
+func (s *Mode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMode(input string) (*Mode, error) {
+	vals := map[string]Mode{
+		"audit":   ModeAudit,
+		"enforce": ModeEnforce,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Mode(input)
+	return &out, nil
+}
+
+type NetworkApiVersion string
+
+const (
+	NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne NetworkApiVersion = "2020-11-01"
+)
+
+func PossibleValuesForNetworkApiVersion() []string {
+	return []string{
+		string(NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne),
+	}
+}
+
+func (s *NetworkApiVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkApiVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkApiVersion(input string) (*NetworkApiVersion, error) {
+	vals := map[string]NetworkApiVersion{
+		"2020-11-01": NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkApiVersion(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliaryMode string
+
+const (
+	NetworkInterfaceAuxiliaryModeAcceleratedConnections NetworkInterfaceAuxiliaryMode = "AcceleratedConnections"
+	NetworkInterfaceAuxiliaryModeFloating               NetworkInterfaceAuxiliaryMode = "Floating"
+	NetworkInterfaceAuxiliaryModeNone                   NetworkInterfaceAuxiliaryMode = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliaryMode() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+		string(NetworkInterfaceAuxiliaryModeFloating),
+		string(NetworkInterfaceAuxiliaryModeNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliaryMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliaryMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliaryMode(input string) (*NetworkInterfaceAuxiliaryMode, error) {
+	vals := map[string]NetworkInterfaceAuxiliaryMode{
+		"acceleratedconnections": NetworkInterfaceAuxiliaryModeAcceleratedConnections,
+		"floating":               NetworkInterfaceAuxiliaryModeFloating,
+		"none":                   NetworkInterfaceAuxiliaryModeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliaryMode(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliarySku string
+
+const (
+	NetworkInterfaceAuxiliarySkuAEight NetworkInterfaceAuxiliarySku = "A8"
+	NetworkInterfaceAuxiliarySkuAFour  NetworkInterfaceAuxiliarySku = "A4"
+	NetworkInterfaceAuxiliarySkuAOne   NetworkInterfaceAuxiliarySku = "A1"
+	NetworkInterfaceAuxiliarySkuATwo   NetworkInterfaceAuxiliarySku = "A2"
+	NetworkInterfaceAuxiliarySkuNone   NetworkInterfaceAuxiliarySku = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliarySku() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliarySkuAEight),
+		string(NetworkInterfaceAuxiliarySkuAFour),
+		string(NetworkInterfaceAuxiliarySkuAOne),
+		string(NetworkInterfaceAuxiliarySkuATwo),
+		string(NetworkInterfaceAuxiliarySkuNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliarySku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliarySku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliarySku(input string) (*NetworkInterfaceAuxiliarySku, error) {
+	vals := map[string]NetworkInterfaceAuxiliarySku{
+		"a8":   NetworkInterfaceAuxiliarySkuAEight,
+		"a4":   NetworkInterfaceAuxiliarySkuAFour,
+		"a1":   NetworkInterfaceAuxiliarySkuAOne,
+		"a2":   NetworkInterfaceAuxiliarySkuATwo,
+		"none": NetworkInterfaceAuxiliarySkuNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliarySku(input)
+	return &out, nil
+}
+
+type OperatingSystemTypes string
+
+const (
+	OperatingSystemTypesLinux   OperatingSystemTypes = "Linux"
+	OperatingSystemTypesWindows OperatingSystemTypes = "Windows"
+)
+
+func PossibleValuesForOperatingSystemTypes() []string {
+	return []string{
+		string(OperatingSystemTypesLinux),
+		string(OperatingSystemTypesWindows),
+	}
+}
+
+func (s *OperatingSystemTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOperatingSystemTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOperatingSystemTypes(input string) (*OperatingSystemTypes, error) {
+	vals := map[string]OperatingSystemTypes{
+		"linux":   OperatingSystemTypesLinux,
+		"windows": OperatingSystemTypesWindows,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperatingSystemTypes(input)
+	return &out, nil
+}
+
+type PassNames string
+
+const (
+	PassNamesOobeSystem PassNames = "OobeSystem"
+)
+
+func PossibleValuesForPassNames() []string {
+	return []string{
+		string(PassNamesOobeSystem),
+	}
+}
+
+func (s *PassNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePassNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePassNames(input string) (*PassNames, error) {
+	vals := map[string]PassNames{
+		"oobesystem": PassNamesOobeSystem,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PassNames(input)
+	return &out, nil
+}
+
+type ProtocolTypes string
+
+const (
+	ProtocolTypesHTTP  ProtocolTypes = "Http"
+	ProtocolTypesHTTPS ProtocolTypes = "Https"
+)
+
+func PossibleValuesForProtocolTypes() []string {
+	return []string{
+		string(ProtocolTypesHTTP),
+		string(ProtocolTypesHTTPS),
+	}
+}
+
+func (s *ProtocolTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProtocolTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProtocolTypes(input string) (*ProtocolTypes, error) {
+	vals := map[string]ProtocolTypes{
+		"http":  ProtocolTypesHTTP,
+		"https": ProtocolTypesHTTPS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtocolTypes(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuName string
+
+const (
+	PublicIPAddressSkuNameBasic    PublicIPAddressSkuName = "Basic"
+	PublicIPAddressSkuNameStandard PublicIPAddressSkuName = "Standard"
+)
+
+func PossibleValuesForPublicIPAddressSkuName() []string {
+	return []string{
+		string(PublicIPAddressSkuNameBasic),
+		string(PublicIPAddressSkuNameStandard),
+	}
+}
+
+func (s *PublicIPAddressSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuName(input string) (*PublicIPAddressSkuName, error) {
+	vals := map[string]PublicIPAddressSkuName{
+		"basic":    PublicIPAddressSkuNameBasic,
+		"standard": PublicIPAddressSkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuName(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuTier string
+
+const (
+	PublicIPAddressSkuTierGlobal   PublicIPAddressSkuTier = "Global"
+	PublicIPAddressSkuTierRegional PublicIPAddressSkuTier = "Regional"
+)
+
+func PossibleValuesForPublicIPAddressSkuTier() []string {
+	return []string{
+		string(PublicIPAddressSkuTierGlobal),
+		string(PublicIPAddressSkuTierRegional),
+	}
+}
+
+func (s *PublicIPAddressSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuTier(input string) (*PublicIPAddressSkuTier, error) {
+	vals := map[string]PublicIPAddressSkuTier{
+		"global":   PublicIPAddressSkuTierGlobal,
+		"regional": PublicIPAddressSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuTier(input)
+	return &out, nil
+}
+
+type PublicIPAllocationMethod string
+
+const (
+	PublicIPAllocationMethodDynamic PublicIPAllocationMethod = "Dynamic"
+	PublicIPAllocationMethodStatic  PublicIPAllocationMethod = "Static"
+)
+
+func PossibleValuesForPublicIPAllocationMethod() []string {
+	return []string{
+		string(PublicIPAllocationMethodDynamic),
+		string(PublicIPAllocationMethodStatic),
+	}
+}
+
+func (s *PublicIPAllocationMethod) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAllocationMethod(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAllocationMethod(input string) (*PublicIPAllocationMethod, error) {
+	vals := map[string]PublicIPAllocationMethod{
+		"dynamic": PublicIPAllocationMethodDynamic,
+		"static":  PublicIPAllocationMethodStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAllocationMethod(input)
+	return &out, nil
+}
+
+type SecurityEncryptionTypes string
+
+const (
+	SecurityEncryptionTypesDiskWithVMGuestState SecurityEncryptionTypes = "DiskWithVMGuestState"
+	SecurityEncryptionTypesNonPersistedTPM      SecurityEncryptionTypes = "NonPersistedTPM"
+	SecurityEncryptionTypesVMGuestStateOnly     SecurityEncryptionTypes = "VMGuestStateOnly"
+)
+
+func PossibleValuesForSecurityEncryptionTypes() []string {
+	return []string{
+		string(SecurityEncryptionTypesDiskWithVMGuestState),
+		string(SecurityEncryptionTypesNonPersistedTPM),
+		string(SecurityEncryptionTypesVMGuestStateOnly),
+	}
+}
+
+func (s *SecurityEncryptionTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityEncryptionTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityEncryptionTypes(input string) (*SecurityEncryptionTypes, error) {
+	vals := map[string]SecurityEncryptionTypes{
+		"diskwithvmgueststate": SecurityEncryptionTypesDiskWithVMGuestState,
+		"nonpersistedtpm":      SecurityEncryptionTypesNonPersistedTPM,
+		"vmgueststateonly":     SecurityEncryptionTypesVMGuestStateOnly,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityEncryptionTypes(input)
+	return &out, nil
+}
+
+type SecurityTypes string
+
+const (
+	SecurityTypesConfidentialVM SecurityTypes = "ConfidentialVM"
+	SecurityTypesTrustedLaunch  SecurityTypes = "TrustedLaunch"
+)
+
+func PossibleValuesForSecurityTypes() []string {
+	return []string{
+		string(SecurityTypesConfidentialVM),
+		string(SecurityTypesTrustedLaunch),
+	}
+}
+
+func (s *SecurityTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityTypes(input string) (*SecurityTypes, error) {
+	vals := map[string]SecurityTypes{
+		"confidentialvm": SecurityTypesConfidentialVM,
+		"trustedlaunch":  SecurityTypesTrustedLaunch,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityTypes(input)
+	return &out, nil
+}
+
+type SettingNames string
+
+const (
+	SettingNamesAutoLogon          SettingNames = "AutoLogon"
+	SettingNamesFirstLogonCommands SettingNames = "FirstLogonCommands"
+)
+
+func PossibleValuesForSettingNames() []string {
+	return []string{
+		string(SettingNamesAutoLogon),
+		string(SettingNamesFirstLogonCommands),
+	}
+}
+
+func (s *SettingNames) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSettingNames(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSettingNames(input string) (*SettingNames, error) {
+	vals := map[string]SettingNames{
+		"autologon":          SettingNamesAutoLogon,
+		"firstlogoncommands": SettingNamesFirstLogonCommands,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SettingNames(input)
+	return &out, nil
+}
+
+type StatusLevelTypes string
+
+const (
+	StatusLevelTypesError   StatusLevelTypes = "Error"
+	StatusLevelTypesInfo    StatusLevelTypes = "Info"
+	StatusLevelTypesWarning StatusLevelTypes = "Warning"
+)
+
+func PossibleValuesForStatusLevelTypes() []string {
+	return []string{
+		string(StatusLevelTypesError),
+		string(StatusLevelTypesInfo),
+		string(StatusLevelTypesWarning),
+	}
+}
+
+func (s *StatusLevelTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStatusLevelTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStatusLevelTypes(input string) (*StatusLevelTypes, error) {
+	vals := map[string]StatusLevelTypes{
+		"error":   StatusLevelTypesError,
+		"info":    StatusLevelTypesInfo,
+		"warning": StatusLevelTypesWarning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StatusLevelTypes(input)
+	return &out, nil
+}
+
+type StorageAccountTypes string
+
+const (
+	StorageAccountTypesPremiumLRS     StorageAccountTypes = "Premium_LRS"
+	StorageAccountTypesPremiumVTwoLRS StorageAccountTypes = "PremiumV2_LRS"
+	StorageAccountTypesPremiumZRS     StorageAccountTypes = "Premium_ZRS"
+	StorageAccountTypesStandardLRS    StorageAccountTypes = "Standard_LRS"
+	StorageAccountTypesStandardSSDLRS StorageAccountTypes = "StandardSSD_LRS"
+	StorageAccountTypesStandardSSDZRS StorageAccountTypes = "StandardSSD_ZRS"
+	StorageAccountTypesUltraSSDLRS    StorageAccountTypes = "UltraSSD_LRS"
+)
+
+func PossibleValuesForStorageAccountTypes() []string {
+	return []string{
+		string(StorageAccountTypesPremiumLRS),
+		string(StorageAccountTypesPremiumVTwoLRS),
+		string(StorageAccountTypesPremiumZRS),
+		string(StorageAccountTypesStandardLRS),
+		string(StorageAccountTypesStandardSSDLRS),
+		string(StorageAccountTypesStandardSSDZRS),
+		string(StorageAccountTypesUltraSSDLRS),
+	}
+}
+
+func (s *StorageAccountTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStorageAccountTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStorageAccountTypes(input string) (*StorageAccountTypes, error) {
+	vals := map[string]StorageAccountTypes{
+		"premium_lrs":     StorageAccountTypesPremiumLRS,
+		"premiumv2_lrs":   StorageAccountTypesPremiumVTwoLRS,
+		"premium_zrs":     StorageAccountTypesPremiumZRS,
+		"standard_lrs":    StorageAccountTypesStandardLRS,
+		"standardssd_lrs": StorageAccountTypesStandardSSDLRS,
+		"standardssd_zrs": StorageAccountTypesStandardSSDZRS,
+		"ultrassd_lrs":    StorageAccountTypesUltraSSDLRS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StorageAccountTypes(input)
+	return &out, nil
+}
+
+type VirtualMachineSizeTypes string
+
+const (
+	VirtualMachineSizeTypesBasicAFour                              VirtualMachineSizeTypes = "Basic_A4"
+	VirtualMachineSizeTypesBasicAOne                               VirtualMachineSizeTypes = "Basic_A1"
+	VirtualMachineSizeTypesBasicAThree                             VirtualMachineSizeTypes = "Basic_A3"
+	VirtualMachineSizeTypesBasicATwo                               VirtualMachineSizeTypes = "Basic_A2"
+	VirtualMachineSizeTypesBasicAZero                              VirtualMachineSizeTypes = "Basic_A0"
+	VirtualMachineSizeTypesStandardAEight                          VirtualMachineSizeTypes = "Standard_A8"
+	VirtualMachineSizeTypesStandardAEightVTwo                      VirtualMachineSizeTypes = "Standard_A8_v2"
+	VirtualMachineSizeTypesStandardAEightmVTwo                     VirtualMachineSizeTypes = "Standard_A8m_v2"
+	VirtualMachineSizeTypesStandardAFive                           VirtualMachineSizeTypes = "Standard_A5"
+	VirtualMachineSizeTypesStandardAFour                           VirtualMachineSizeTypes = "Standard_A4"
+	VirtualMachineSizeTypesStandardAFourVTwo                       VirtualMachineSizeTypes = "Standard_A4_v2"
+	VirtualMachineSizeTypesStandardAFourmVTwo                      VirtualMachineSizeTypes = "Standard_A4m_v2"
+	VirtualMachineSizeTypesStandardANine                           VirtualMachineSizeTypes = "Standard_A9"
+	VirtualMachineSizeTypesStandardAOne                            VirtualMachineSizeTypes = "Standard_A1"
+	VirtualMachineSizeTypesStandardAOneOne                         VirtualMachineSizeTypes = "Standard_A11"
+	VirtualMachineSizeTypesStandardAOneVTwo                        VirtualMachineSizeTypes = "Standard_A1_v2"
+	VirtualMachineSizeTypesStandardAOneZero                        VirtualMachineSizeTypes = "Standard_A10"
+	VirtualMachineSizeTypesStandardASeven                          VirtualMachineSizeTypes = "Standard_A7"
+	VirtualMachineSizeTypesStandardASix                            VirtualMachineSizeTypes = "Standard_A6"
+	VirtualMachineSizeTypesStandardAThree                          VirtualMachineSizeTypes = "Standard_A3"
+	VirtualMachineSizeTypesStandardATwo                            VirtualMachineSizeTypes = "Standard_A2"
+	VirtualMachineSizeTypesStandardATwoVTwo                        VirtualMachineSizeTypes = "Standard_A2_v2"
+	VirtualMachineSizeTypesStandardATwomVTwo                       VirtualMachineSizeTypes = "Standard_A2m_v2"
+	VirtualMachineSizeTypesStandardAZero                           VirtualMachineSizeTypes = "Standard_A0"
+	VirtualMachineSizeTypesStandardBEightms                        VirtualMachineSizeTypes = "Standard_B8ms"
+	VirtualMachineSizeTypesStandardBFourms                         VirtualMachineSizeTypes = "Standard_B4ms"
+	VirtualMachineSizeTypesStandardBOnems                          VirtualMachineSizeTypes = "Standard_B1ms"
+	VirtualMachineSizeTypesStandardBOnes                           VirtualMachineSizeTypes = "Standard_B1s"
+	VirtualMachineSizeTypesStandardBTwoms                          VirtualMachineSizeTypes = "Standard_B2ms"
+	VirtualMachineSizeTypesStandardBTwos                           VirtualMachineSizeTypes = "Standard_B2s"
+	VirtualMachineSizeTypesStandardDEightVThree                    VirtualMachineSizeTypes = "Standard_D8_v3"
+	VirtualMachineSizeTypesStandardDEightsVThree                   VirtualMachineSizeTypes = "Standard_D8s_v3"
+	VirtualMachineSizeTypesStandardDFiveVTwo                       VirtualMachineSizeTypes = "Standard_D5_v2"
+	VirtualMachineSizeTypesStandardDFour                           VirtualMachineSizeTypes = "Standard_D4"
+	VirtualMachineSizeTypesStandardDFourVThree                     VirtualMachineSizeTypes = "Standard_D4_v3"
+	VirtualMachineSizeTypesStandardDFourVTwo                       VirtualMachineSizeTypes = "Standard_D4_v2"
+	VirtualMachineSizeTypesStandardDFoursVThree                    VirtualMachineSizeTypes = "Standard_D4s_v3"
+	VirtualMachineSizeTypesStandardDOne                            VirtualMachineSizeTypes = "Standard_D1"
+	VirtualMachineSizeTypesStandardDOneFiveVTwo                    VirtualMachineSizeTypes = "Standard_D15_v2"
+	VirtualMachineSizeTypesStandardDOneFour                        VirtualMachineSizeTypes = "Standard_D14"
+	VirtualMachineSizeTypesStandardDOneFourVTwo                    VirtualMachineSizeTypes = "Standard_D14_v2"
+	VirtualMachineSizeTypesStandardDOneOne                         VirtualMachineSizeTypes = "Standard_D11"
+	VirtualMachineSizeTypesStandardDOneOneVTwo                     VirtualMachineSizeTypes = "Standard_D11_v2"
+	VirtualMachineSizeTypesStandardDOneSixVThree                   VirtualMachineSizeTypes = "Standard_D16_v3"
+	VirtualMachineSizeTypesStandardDOneSixsVThree                  VirtualMachineSizeTypes = "Standard_D16s_v3"
+	VirtualMachineSizeTypesStandardDOneThree                       VirtualMachineSizeTypes = "Standard_D13"
+	VirtualMachineSizeTypesStandardDOneThreeVTwo                   VirtualMachineSizeTypes = "Standard_D13_v2"
+	VirtualMachineSizeTypesStandardDOneTwo                         VirtualMachineSizeTypes = "Standard_D12"
+	VirtualMachineSizeTypesStandardDOneTwoVTwo                     VirtualMachineSizeTypes = "Standard_D12_v2"
+	VirtualMachineSizeTypesStandardDOneVTwo                        VirtualMachineSizeTypes = "Standard_D1_v2"
+	VirtualMachineSizeTypesStandardDSFiveVTwo                      VirtualMachineSizeTypes = "Standard_DS5_v2"
+	VirtualMachineSizeTypesStandardDSFour                          VirtualMachineSizeTypes = "Standard_DS4"
+	VirtualMachineSizeTypesStandardDSFourVTwo                      VirtualMachineSizeTypes = "Standard_DS4_v2"
+	VirtualMachineSizeTypesStandardDSOne                           VirtualMachineSizeTypes = "Standard_DS1"
+	VirtualMachineSizeTypesStandardDSOneFiveVTwo                   VirtualMachineSizeTypes = "Standard_DS15_v2"
+	VirtualMachineSizeTypesStandardDSOneFour                       VirtualMachineSizeTypes = "Standard_DS14"
+	VirtualMachineSizeTypesStandardDSOneFourNegativeEightVTwo      VirtualMachineSizeTypes = "Standard_DS14-8_v2"
+	VirtualMachineSizeTypesStandardDSOneFourNegativeFourVTwo       VirtualMachineSizeTypes = "Standard_DS14-4_v2"
+	VirtualMachineSizeTypesStandardDSOneFourVTwo                   VirtualMachineSizeTypes = "Standard_DS14_v2"
+	VirtualMachineSizeTypesStandardDSOneOne                        VirtualMachineSizeTypes = "Standard_DS11"
+	VirtualMachineSizeTypesStandardDSOneOneVTwo                    VirtualMachineSizeTypes = "Standard_DS11_v2"
+	VirtualMachineSizeTypesStandardDSOneThree                      VirtualMachineSizeTypes = "Standard_DS13"
+	VirtualMachineSizeTypesStandardDSOneThreeNegativeFourVTwo      VirtualMachineSizeTypes = "Standard_DS13-4_v2"
+	VirtualMachineSizeTypesStandardDSOneThreeNegativeTwoVTwo       VirtualMachineSizeTypes = "Standard_DS13-2_v2"
+	VirtualMachineSizeTypesStandardDSOneThreeVTwo                  VirtualMachineSizeTypes = "Standard_DS13_v2"
+	VirtualMachineSizeTypesStandardDSOneTwo                        VirtualMachineSizeTypes = "Standard_DS12"
+	VirtualMachineSizeTypesStandardDSOneTwoVTwo                    VirtualMachineSizeTypes = "Standard_DS12_v2"
+	VirtualMachineSizeTypesStandardDSOneVTwo                       VirtualMachineSizeTypes = "Standard_DS1_v2"
+	VirtualMachineSizeTypesStandardDSThree                         VirtualMachineSizeTypes = "Standard_DS3"
+	VirtualMachineSizeTypesStandardDSThreeVTwo                     VirtualMachineSizeTypes = "Standard_DS3_v2"
+	VirtualMachineSizeTypesStandardDSTwo                           VirtualMachineSizeTypes = "Standard_DS2"
+	VirtualMachineSizeTypesStandardDSTwoVTwo                       VirtualMachineSizeTypes = "Standard_DS2_v2"
+	VirtualMachineSizeTypesStandardDSixFourVThree                  VirtualMachineSizeTypes = "Standard_D64_v3"
+	VirtualMachineSizeTypesStandardDSixFoursVThree                 VirtualMachineSizeTypes = "Standard_D64s_v3"
+	VirtualMachineSizeTypesStandardDThree                          VirtualMachineSizeTypes = "Standard_D3"
+	VirtualMachineSizeTypesStandardDThreeTwoVThree                 VirtualMachineSizeTypes = "Standard_D32_v3"
+	VirtualMachineSizeTypesStandardDThreeTwosVThree                VirtualMachineSizeTypes = "Standard_D32s_v3"
+	VirtualMachineSizeTypesStandardDThreeVTwo                      VirtualMachineSizeTypes = "Standard_D3_v2"
+	VirtualMachineSizeTypesStandardDTwo                            VirtualMachineSizeTypes = "Standard_D2"
+	VirtualMachineSizeTypesStandardDTwoVThree                      VirtualMachineSizeTypes = "Standard_D2_v3"
+	VirtualMachineSizeTypesStandardDTwoVTwo                        VirtualMachineSizeTypes = "Standard_D2_v2"
+	VirtualMachineSizeTypesStandardDTwosVThree                     VirtualMachineSizeTypes = "Standard_D2s_v3"
+	VirtualMachineSizeTypesStandardEEightVThree                    VirtualMachineSizeTypes = "Standard_E8_v3"
+	VirtualMachineSizeTypesStandardEEightsVThree                   VirtualMachineSizeTypes = "Standard_E8s_v3"
+	VirtualMachineSizeTypesStandardEFourVThree                     VirtualMachineSizeTypes = "Standard_E4_v3"
+	VirtualMachineSizeTypesStandardEFoursVThree                    VirtualMachineSizeTypes = "Standard_E4s_v3"
+	VirtualMachineSizeTypesStandardEOneSixVThree                   VirtualMachineSizeTypes = "Standard_E16_v3"
+	VirtualMachineSizeTypesStandardEOneSixsVThree                  VirtualMachineSizeTypes = "Standard_E16s_v3"
+	VirtualMachineSizeTypesStandardESixFourNegativeOneSixsVThree   VirtualMachineSizeTypes = "Standard_E64-16s_v3"
+	VirtualMachineSizeTypesStandardESixFourNegativeThreeTwosVThree VirtualMachineSizeTypes = "Standard_E64-32s_v3"
+	VirtualMachineSizeTypesStandardESixFourVThree                  VirtualMachineSizeTypes = "Standard_E64_v3"
+	VirtualMachineSizeTypesStandardESixFoursVThree                 VirtualMachineSizeTypes = "Standard_E64s_v3"
+	VirtualMachineSizeTypesStandardEThreeTwoNegativeEightsVThree   VirtualMachineSizeTypes = "Standard_E32-8s_v3"
+	VirtualMachineSizeTypesStandardEThreeTwoNegativeOneSixVThree   VirtualMachineSizeTypes = "Standard_E32-16_v3"
+	VirtualMachineSizeTypesStandardEThreeTwoVThree                 VirtualMachineSizeTypes = "Standard_E32_v3"
+	VirtualMachineSizeTypesStandardEThreeTwosVThree                VirtualMachineSizeTypes = "Standard_E32s_v3"
+	VirtualMachineSizeTypesStandardETwoVThree                      VirtualMachineSizeTypes = "Standard_E2_v3"
+	VirtualMachineSizeTypesStandardETwosVThree                     VirtualMachineSizeTypes = "Standard_E2s_v3"
+	VirtualMachineSizeTypesStandardFEight                          VirtualMachineSizeTypes = "Standard_F8"
+	VirtualMachineSizeTypesStandardFEights                         VirtualMachineSizeTypes = "Standard_F8s"
+	VirtualMachineSizeTypesStandardFEightsVTwo                     VirtualMachineSizeTypes = "Standard_F8s_v2"
+	VirtualMachineSizeTypesStandardFFour                           VirtualMachineSizeTypes = "Standard_F4"
+	VirtualMachineSizeTypesStandardFFours                          VirtualMachineSizeTypes = "Standard_F4s"
+	VirtualMachineSizeTypesStandardFFoursVTwo                      VirtualMachineSizeTypes = "Standard_F4s_v2"
+	VirtualMachineSizeTypesStandardFOne                            VirtualMachineSizeTypes = "Standard_F1"
+	VirtualMachineSizeTypesStandardFOneSix                         VirtualMachineSizeTypes = "Standard_F16"
+	VirtualMachineSizeTypesStandardFOneSixs                        VirtualMachineSizeTypes = "Standard_F16s"
+	VirtualMachineSizeTypesStandardFOneSixsVTwo                    VirtualMachineSizeTypes = "Standard_F16s_v2"
+	VirtualMachineSizeTypesStandardFOnes                           VirtualMachineSizeTypes = "Standard_F1s"
+	VirtualMachineSizeTypesStandardFSevenTwosVTwo                  VirtualMachineSizeTypes = "Standard_F72s_v2"
+	VirtualMachineSizeTypesStandardFSixFoursVTwo                   VirtualMachineSizeTypes = "Standard_F64s_v2"
+	VirtualMachineSizeTypesStandardFThreeTwosVTwo                  VirtualMachineSizeTypes = "Standard_F32s_v2"
+	VirtualMachineSizeTypesStandardFTwo                            VirtualMachineSizeTypes = "Standard_F2"
+	VirtualMachineSizeTypesStandardFTwos                           VirtualMachineSizeTypes = "Standard_F2s"
+	VirtualMachineSizeTypesStandardFTwosVTwo                       VirtualMachineSizeTypes = "Standard_F2s_v2"
+	VirtualMachineSizeTypesStandardGFive                           VirtualMachineSizeTypes = "Standard_G5"
+	VirtualMachineSizeTypesStandardGFour                           VirtualMachineSizeTypes = "Standard_G4"
+	VirtualMachineSizeTypesStandardGOne                            VirtualMachineSizeTypes = "Standard_G1"
+	VirtualMachineSizeTypesStandardGSFive                          VirtualMachineSizeTypes = "Standard_GS5"
+	VirtualMachineSizeTypesStandardGSFiveNegativeEight             VirtualMachineSizeTypes = "Standard_GS5-8"
+	VirtualMachineSizeTypesStandardGSFiveNegativeOneSix            VirtualMachineSizeTypes = "Standard_GS5-16"
+	VirtualMachineSizeTypesStandardGSFour                          VirtualMachineSizeTypes = "Standard_GS4"
+	VirtualMachineSizeTypesStandardGSFourNegativeEight             VirtualMachineSizeTypes = "Standard_GS4-8"
+	VirtualMachineSizeTypesStandardGSFourNegativeFour              VirtualMachineSizeTypes = "Standard_GS4-4"
+	VirtualMachineSizeTypesStandardGSOne                           VirtualMachineSizeTypes = "Standard_GS1"
+	VirtualMachineSizeTypesStandardGSThree                         VirtualMachineSizeTypes = "Standard_GS3"
+	VirtualMachineSizeTypesStandardGSTwo                           VirtualMachineSizeTypes = "Standard_GS2"
+	VirtualMachineSizeTypesStandardGThree                          VirtualMachineSizeTypes = "Standard_G3"
+	VirtualMachineSizeTypesStandardGTwo                            VirtualMachineSizeTypes = "Standard_G2"
+	VirtualMachineSizeTypesStandardHEight                          VirtualMachineSizeTypes = "Standard_H8"
+	VirtualMachineSizeTypesStandardHEightm                         VirtualMachineSizeTypes = "Standard_H8m"
+	VirtualMachineSizeTypesStandardHOneSix                         VirtualMachineSizeTypes = "Standard_H16"
+	VirtualMachineSizeTypesStandardHOneSixm                        VirtualMachineSizeTypes = "Standard_H16m"
+	VirtualMachineSizeTypesStandardHOneSixmr                       VirtualMachineSizeTypes = "Standard_H16mr"
+	VirtualMachineSizeTypesStandardHOneSixr                        VirtualMachineSizeTypes = "Standard_H16r"
+	VirtualMachineSizeTypesStandardLEights                         VirtualMachineSizeTypes = "Standard_L8s"
+	VirtualMachineSizeTypesStandardLFours                          VirtualMachineSizeTypes = "Standard_L4s"
+	VirtualMachineSizeTypesStandardLOneSixs                        VirtualMachineSizeTypes = "Standard_L16s"
+	VirtualMachineSizeTypesStandardLThreeTwos                      VirtualMachineSizeTypes = "Standard_L32s"
+	VirtualMachineSizeTypesStandardMOneTwoEightNegativeSixFourms   VirtualMachineSizeTypes = "Standard_M128-64ms"
+	VirtualMachineSizeTypesStandardMOneTwoEightNegativeThreeTwoms  VirtualMachineSizeTypes = "Standard_M128-32ms"
+	VirtualMachineSizeTypesStandardMOneTwoEightms                  VirtualMachineSizeTypes = "Standard_M128ms"
+	VirtualMachineSizeTypesStandardMOneTwoEights                   VirtualMachineSizeTypes = "Standard_M128s"
+	VirtualMachineSizeTypesStandardMSixFourNegativeOneSixms        VirtualMachineSizeTypes = "Standard_M64-16ms"
+	VirtualMachineSizeTypesStandardMSixFourNegativeThreeTwoms      VirtualMachineSizeTypes = "Standard_M64-32ms"
+	VirtualMachineSizeTypesStandardMSixFourms                      VirtualMachineSizeTypes = "Standard_M64ms"
+	VirtualMachineSizeTypesStandardMSixFours                       VirtualMachineSizeTypes = "Standard_M64s"
+	VirtualMachineSizeTypesStandardNCOneTwo                        VirtualMachineSizeTypes = "Standard_NC12"
+	VirtualMachineSizeTypesStandardNCOneTwosVThree                 VirtualMachineSizeTypes = "Standard_NC12s_v3"
+	VirtualMachineSizeTypesStandardNCOneTwosVTwo                   VirtualMachineSizeTypes = "Standard_NC12s_v2"
+	VirtualMachineSizeTypesStandardNCSix                           VirtualMachineSizeTypes = "Standard_NC6"
+	VirtualMachineSizeTypesStandardNCSixsVThree                    VirtualMachineSizeTypes = "Standard_NC6s_v3"
+	VirtualMachineSizeTypesStandardNCSixsVTwo                      VirtualMachineSizeTypes = "Standard_NC6s_v2"
+	VirtualMachineSizeTypesStandardNCTwoFour                       VirtualMachineSizeTypes = "Standard_NC24"
+	VirtualMachineSizeTypesStandardNCTwoFourr                      VirtualMachineSizeTypes = "Standard_NC24r"
+	VirtualMachineSizeTypesStandardNCTwoFourrsVThree               VirtualMachineSizeTypes = "Standard_NC24rs_v3"
+	VirtualMachineSizeTypesStandardNCTwoFourrsVTwo                 VirtualMachineSizeTypes = "Standard_NC24rs_v2"
+	VirtualMachineSizeTypesStandardNCTwoFoursVThree                VirtualMachineSizeTypes = "Standard_NC24s_v3"
+	VirtualMachineSizeTypesStandardNCTwoFoursVTwo                  VirtualMachineSizeTypes = "Standard_NC24s_v2"
+	VirtualMachineSizeTypesStandardNDOneTwos                       VirtualMachineSizeTypes = "Standard_ND12s"
+	VirtualMachineSizeTypesStandardNDSixs                          VirtualMachineSizeTypes = "Standard_ND6s"
+	VirtualMachineSizeTypesStandardNDTwoFourrs                     VirtualMachineSizeTypes = "Standard_ND24rs"
+	VirtualMachineSizeTypesStandardNDTwoFours                      VirtualMachineSizeTypes = "Standard_ND24s"
+	VirtualMachineSizeTypesStandardNVOneTwo                        VirtualMachineSizeTypes = "Standard_NV12"
+	VirtualMachineSizeTypesStandardNVSix                           VirtualMachineSizeTypes = "Standard_NV6"
+	VirtualMachineSizeTypesStandardNVTwoFour                       VirtualMachineSizeTypes = "Standard_NV24"
+)
+
+func PossibleValuesForVirtualMachineSizeTypes() []string {
+	return []string{
+		string(VirtualMachineSizeTypesBasicAFour),
+		string(VirtualMachineSizeTypesBasicAOne),
+		string(VirtualMachineSizeTypesBasicAThree),
+		string(VirtualMachineSizeTypesBasicATwo),
+		string(VirtualMachineSizeTypesBasicAZero),
+		string(VirtualMachineSizeTypesStandardAEight),
+		string(VirtualMachineSizeTypesStandardAEightVTwo),
+		string(VirtualMachineSizeTypesStandardAEightmVTwo),
+		string(VirtualMachineSizeTypesStandardAFive),
+		string(VirtualMachineSizeTypesStandardAFour),
+		string(VirtualMachineSizeTypesStandardAFourVTwo),
+		string(VirtualMachineSizeTypesStandardAFourmVTwo),
+		string(VirtualMachineSizeTypesStandardANine),
+		string(VirtualMachineSizeTypesStandardAOne),
+		string(VirtualMachineSizeTypesStandardAOneOne),
+		string(VirtualMachineSizeTypesStandardAOneVTwo),
+		string(VirtualMachineSizeTypesStandardAOneZero),
+		string(VirtualMachineSizeTypesStandardASeven),
+		string(VirtualMachineSizeTypesStandardASix),
+		string(VirtualMachineSizeTypesStandardAThree),
+		string(VirtualMachineSizeTypesStandardATwo),
+		string(VirtualMachineSizeTypesStandardATwoVTwo),
+		string(VirtualMachineSizeTypesStandardATwomVTwo),
+		string(VirtualMachineSizeTypesStandardAZero),
+		string(VirtualMachineSizeTypesStandardBEightms),
+		string(VirtualMachineSizeTypesStandardBFourms),
+		string(VirtualMachineSizeTypesStandardBOnems),
+		string(VirtualMachineSizeTypesStandardBOnes),
+		string(VirtualMachineSizeTypesStandardBTwoms),
+		string(VirtualMachineSizeTypesStandardBTwos),
+		string(VirtualMachineSizeTypesStandardDEightVThree),
+		string(VirtualMachineSizeTypesStandardDEightsVThree),
+		string(VirtualMachineSizeTypesStandardDFiveVTwo),
+		string(VirtualMachineSizeTypesStandardDFour),
+		string(VirtualMachineSizeTypesStandardDFourVThree),
+		string(VirtualMachineSizeTypesStandardDFourVTwo),
+		string(VirtualMachineSizeTypesStandardDFoursVThree),
+		string(VirtualMachineSizeTypesStandardDOne),
+		string(VirtualMachineSizeTypesStandardDOneFiveVTwo),
+		string(VirtualMachineSizeTypesStandardDOneFour),
+		string(VirtualMachineSizeTypesStandardDOneFourVTwo),
+		string(VirtualMachineSizeTypesStandardDOneOne),
+		string(VirtualMachineSizeTypesStandardDOneOneVTwo),
+		string(VirtualMachineSizeTypesStandardDOneSixVThree),
+		string(VirtualMachineSizeTypesStandardDOneSixsVThree),
+		string(VirtualMachineSizeTypesStandardDOneThree),
+		string(VirtualMachineSizeTypesStandardDOneThreeVTwo),
+		string(VirtualMachineSizeTypesStandardDOneTwo),
+		string(VirtualMachineSizeTypesStandardDOneTwoVTwo),
+		string(VirtualMachineSizeTypesStandardDOneVTwo),
+		string(VirtualMachineSizeTypesStandardDSFiveVTwo),
+		string(VirtualMachineSizeTypesStandardDSFour),
+		string(VirtualMachineSizeTypesStandardDSFourVTwo),
+		string(VirtualMachineSizeTypesStandardDSOne),
+		string(VirtualMachineSizeTypesStandardDSOneFiveVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneFour),
+		string(VirtualMachineSizeTypesStandardDSOneFourNegativeEightVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneFourNegativeFourVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneFourVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneOne),
+		string(VirtualMachineSizeTypesStandardDSOneOneVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneThree),
+		string(VirtualMachineSizeTypesStandardDSOneThreeNegativeFourVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneThreeNegativeTwoVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneThreeVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneTwo),
+		string(VirtualMachineSizeTypesStandardDSOneTwoVTwo),
+		string(VirtualMachineSizeTypesStandardDSOneVTwo),
+		string(VirtualMachineSizeTypesStandardDSThree),
+		string(VirtualMachineSizeTypesStandardDSThreeVTwo),
+		string(VirtualMachineSizeTypesStandardDSTwo),
+		string(VirtualMachineSizeTypesStandardDSTwoVTwo),
+		string(VirtualMachineSizeTypesStandardDSixFourVThree),
+		string(VirtualMachineSizeTypesStandardDSixFoursVThree),
+		string(VirtualMachineSizeTypesStandardDThree),
+		string(VirtualMachineSizeTypesStandardDThreeTwoVThree),
+		string(VirtualMachineSizeTypesStandardDThreeTwosVThree),
+		string(VirtualMachineSizeTypesStandardDThreeVTwo),
+		string(VirtualMachineSizeTypesStandardDTwo),
+		string(VirtualMachineSizeTypesStandardDTwoVThree),
+		string(VirtualMachineSizeTypesStandardDTwoVTwo),
+		string(VirtualMachineSizeTypesStandardDTwosVThree),
+		string(VirtualMachineSizeTypesStandardEEightVThree),
+		string(VirtualMachineSizeTypesStandardEEightsVThree),
+		string(VirtualMachineSizeTypesStandardEFourVThree),
+		string(VirtualMachineSizeTypesStandardEFoursVThree),
+		string(VirtualMachineSizeTypesStandardEOneSixVThree),
+		string(VirtualMachineSizeTypesStandardEOneSixsVThree),
+		string(VirtualMachineSizeTypesStandardESixFourNegativeOneSixsVThree),
+		string(VirtualMachineSizeTypesStandardESixFourNegativeThreeTwosVThree),
+		string(VirtualMachineSizeTypesStandardESixFourVThree),
+		string(VirtualMachineSizeTypesStandardESixFoursVThree),
+		string(VirtualMachineSizeTypesStandardEThreeTwoNegativeEightsVThree),
+		string(VirtualMachineSizeTypesStandardEThreeTwoNegativeOneSixVThree),
+		string(VirtualMachineSizeTypesStandardEThreeTwoVThree),
+		string(VirtualMachineSizeTypesStandardEThreeTwosVThree),
+		string(VirtualMachineSizeTypesStandardETwoVThree),
+		string(VirtualMachineSizeTypesStandardETwosVThree),
+		string(VirtualMachineSizeTypesStandardFEight),
+		string(VirtualMachineSizeTypesStandardFEights),
+		string(VirtualMachineSizeTypesStandardFEightsVTwo),
+		string(VirtualMachineSizeTypesStandardFFour),
+		string(VirtualMachineSizeTypesStandardFFours),
+		string(VirtualMachineSizeTypesStandardFFoursVTwo),
+		string(VirtualMachineSizeTypesStandardFOne),
+		string(VirtualMachineSizeTypesStandardFOneSix),
+		string(VirtualMachineSizeTypesStandardFOneSixs),
+		string(VirtualMachineSizeTypesStandardFOneSixsVTwo),
+		string(VirtualMachineSizeTypesStandardFOnes),
+		string(VirtualMachineSizeTypesStandardFSevenTwosVTwo),
+		string(VirtualMachineSizeTypesStandardFSixFoursVTwo),
+		string(VirtualMachineSizeTypesStandardFThreeTwosVTwo),
+		string(VirtualMachineSizeTypesStandardFTwo),
+		string(VirtualMachineSizeTypesStandardFTwos),
+		string(VirtualMachineSizeTypesStandardFTwosVTwo),
+		string(VirtualMachineSizeTypesStandardGFive),
+		string(VirtualMachineSizeTypesStandardGFour),
+		string(VirtualMachineSizeTypesStandardGOne),
+		string(VirtualMachineSizeTypesStandardGSFive),
+		string(VirtualMachineSizeTypesStandardGSFiveNegativeEight),
+		string(VirtualMachineSizeTypesStandardGSFiveNegativeOneSix),
+		string(VirtualMachineSizeTypesStandardGSFour),
+		string(VirtualMachineSizeTypesStandardGSFourNegativeEight),
+		string(VirtualMachineSizeTypesStandardGSFourNegativeFour),
+		string(VirtualMachineSizeTypesStandardGSOne),
+		string(VirtualMachineSizeTypesStandardGSThree),
+		string(VirtualMachineSizeTypesStandardGSTwo),
+		string(VirtualMachineSizeTypesStandardGThree),
+		string(VirtualMachineSizeTypesStandardGTwo),
+		string(VirtualMachineSizeTypesStandardHEight),
+		string(VirtualMachineSizeTypesStandardHEightm),
+		string(VirtualMachineSizeTypesStandardHOneSix),
+		string(VirtualMachineSizeTypesStandardHOneSixm),
+		string(VirtualMachineSizeTypesStandardHOneSixmr),
+		string(VirtualMachineSizeTypesStandardHOneSixr),
+		string(VirtualMachineSizeTypesStandardLEights),
+		string(VirtualMachineSizeTypesStandardLFours),
+		string(VirtualMachineSizeTypesStandardLOneSixs),
+		string(VirtualMachineSizeTypesStandardLThreeTwos),
+		string(VirtualMachineSizeTypesStandardMOneTwoEightNegativeSixFourms),
+		string(VirtualMachineSizeTypesStandardMOneTwoEightNegativeThreeTwoms),
+		string(VirtualMachineSizeTypesStandardMOneTwoEightms),
+		string(VirtualMachineSizeTypesStandardMOneTwoEights),
+		string(VirtualMachineSizeTypesStandardMSixFourNegativeOneSixms),
+		string(VirtualMachineSizeTypesStandardMSixFourNegativeThreeTwoms),
+		string(VirtualMachineSizeTypesStandardMSixFourms),
+		string(VirtualMachineSizeTypesStandardMSixFours),
+		string(VirtualMachineSizeTypesStandardNCOneTwo),
+		string(VirtualMachineSizeTypesStandardNCOneTwosVThree),
+		string(VirtualMachineSizeTypesStandardNCOneTwosVTwo),
+		string(VirtualMachineSizeTypesStandardNCSix),
+		string(VirtualMachineSizeTypesStandardNCSixsVThree),
+		string(VirtualMachineSizeTypesStandardNCSixsVTwo),
+		string(VirtualMachineSizeTypesStandardNCTwoFour),
+		string(VirtualMachineSizeTypesStandardNCTwoFourr),
+		string(VirtualMachineSizeTypesStandardNCTwoFourrsVThree),
+		string(VirtualMachineSizeTypesStandardNCTwoFourrsVTwo),
+		string(VirtualMachineSizeTypesStandardNCTwoFoursVThree),
+		string(VirtualMachineSizeTypesStandardNCTwoFoursVTwo),
+		string(VirtualMachineSizeTypesStandardNDOneTwos),
+		string(VirtualMachineSizeTypesStandardNDSixs),
+		string(VirtualMachineSizeTypesStandardNDTwoFourrs),
+		string(VirtualMachineSizeTypesStandardNDTwoFours),
+		string(VirtualMachineSizeTypesStandardNVOneTwo),
+		string(VirtualMachineSizeTypesStandardNVSix),
+		string(VirtualMachineSizeTypesStandardNVTwoFour),
+	}
+}
+
+func (s *VirtualMachineSizeTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualMachineSizeTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualMachineSizeTypes(input string) (*VirtualMachineSizeTypes, error) {
+	vals := map[string]VirtualMachineSizeTypes{
+		"basic_a4":            VirtualMachineSizeTypesBasicAFour,
+		"basic_a1":            VirtualMachineSizeTypesBasicAOne,
+		"basic_a3":            VirtualMachineSizeTypesBasicAThree,
+		"basic_a2":            VirtualMachineSizeTypesBasicATwo,
+		"basic_a0":            VirtualMachineSizeTypesBasicAZero,
+		"standard_a8":         VirtualMachineSizeTypesStandardAEight,
+		"standard_a8_v2":      VirtualMachineSizeTypesStandardAEightVTwo,
+		"standard_a8m_v2":     VirtualMachineSizeTypesStandardAEightmVTwo,
+		"standard_a5":         VirtualMachineSizeTypesStandardAFive,
+		"standard_a4":         VirtualMachineSizeTypesStandardAFour,
+		"standard_a4_v2":      VirtualMachineSizeTypesStandardAFourVTwo,
+		"standard_a4m_v2":     VirtualMachineSizeTypesStandardAFourmVTwo,
+		"standard_a9":         VirtualMachineSizeTypesStandardANine,
+		"standard_a1":         VirtualMachineSizeTypesStandardAOne,
+		"standard_a11":        VirtualMachineSizeTypesStandardAOneOne,
+		"standard_a1_v2":      VirtualMachineSizeTypesStandardAOneVTwo,
+		"standard_a10":        VirtualMachineSizeTypesStandardAOneZero,
+		"standard_a7":         VirtualMachineSizeTypesStandardASeven,
+		"standard_a6":         VirtualMachineSizeTypesStandardASix,
+		"standard_a3":         VirtualMachineSizeTypesStandardAThree,
+		"standard_a2":         VirtualMachineSizeTypesStandardATwo,
+		"standard_a2_v2":      VirtualMachineSizeTypesStandardATwoVTwo,
+		"standard_a2m_v2":     VirtualMachineSizeTypesStandardATwomVTwo,
+		"standard_a0":         VirtualMachineSizeTypesStandardAZero,
+		"standard_b8ms":       VirtualMachineSizeTypesStandardBEightms,
+		"standard_b4ms":       VirtualMachineSizeTypesStandardBFourms,
+		"standard_b1ms":       VirtualMachineSizeTypesStandardBOnems,
+		"standard_b1s":        VirtualMachineSizeTypesStandardBOnes,
+		"standard_b2ms":       VirtualMachineSizeTypesStandardBTwoms,
+		"standard_b2s":        VirtualMachineSizeTypesStandardBTwos,
+		"standard_d8_v3":      VirtualMachineSizeTypesStandardDEightVThree,
+		"standard_d8s_v3":     VirtualMachineSizeTypesStandardDEightsVThree,
+		"standard_d5_v2":      VirtualMachineSizeTypesStandardDFiveVTwo,
+		"standard_d4":         VirtualMachineSizeTypesStandardDFour,
+		"standard_d4_v3":      VirtualMachineSizeTypesStandardDFourVThree,
+		"standard_d4_v2":      VirtualMachineSizeTypesStandardDFourVTwo,
+		"standard_d4s_v3":     VirtualMachineSizeTypesStandardDFoursVThree,
+		"standard_d1":         VirtualMachineSizeTypesStandardDOne,
+		"standard_d15_v2":     VirtualMachineSizeTypesStandardDOneFiveVTwo,
+		"standard_d14":        VirtualMachineSizeTypesStandardDOneFour,
+		"standard_d14_v2":     VirtualMachineSizeTypesStandardDOneFourVTwo,
+		"standard_d11":        VirtualMachineSizeTypesStandardDOneOne,
+		"standard_d11_v2":     VirtualMachineSizeTypesStandardDOneOneVTwo,
+		"standard_d16_v3":     VirtualMachineSizeTypesStandardDOneSixVThree,
+		"standard_d16s_v3":    VirtualMachineSizeTypesStandardDOneSixsVThree,
+		"standard_d13":        VirtualMachineSizeTypesStandardDOneThree,
+		"standard_d13_v2":     VirtualMachineSizeTypesStandardDOneThreeVTwo,
+		"standard_d12":        VirtualMachineSizeTypesStandardDOneTwo,
+		"standard_d12_v2":     VirtualMachineSizeTypesStandardDOneTwoVTwo,
+		"standard_d1_v2":      VirtualMachineSizeTypesStandardDOneVTwo,
+		"standard_ds5_v2":     VirtualMachineSizeTypesStandardDSFiveVTwo,
+		"standard_ds4":        VirtualMachineSizeTypesStandardDSFour,
+		"standard_ds4_v2":     VirtualMachineSizeTypesStandardDSFourVTwo,
+		"standard_ds1":        VirtualMachineSizeTypesStandardDSOne,
+		"standard_ds15_v2":    VirtualMachineSizeTypesStandardDSOneFiveVTwo,
+		"standard_ds14":       VirtualMachineSizeTypesStandardDSOneFour,
+		"standard_ds14-8_v2":  VirtualMachineSizeTypesStandardDSOneFourNegativeEightVTwo,
+		"standard_ds14-4_v2":  VirtualMachineSizeTypesStandardDSOneFourNegativeFourVTwo,
+		"standard_ds14_v2":    VirtualMachineSizeTypesStandardDSOneFourVTwo,
+		"standard_ds11":       VirtualMachineSizeTypesStandardDSOneOne,
+		"standard_ds11_v2":    VirtualMachineSizeTypesStandardDSOneOneVTwo,
+		"standard_ds13":       VirtualMachineSizeTypesStandardDSOneThree,
+		"standard_ds13-4_v2":  VirtualMachineSizeTypesStandardDSOneThreeNegativeFourVTwo,
+		"standard_ds13-2_v2":  VirtualMachineSizeTypesStandardDSOneThreeNegativeTwoVTwo,
+		"standard_ds13_v2":    VirtualMachineSizeTypesStandardDSOneThreeVTwo,
+		"standard_ds12":       VirtualMachineSizeTypesStandardDSOneTwo,
+		"standard_ds12_v2":    VirtualMachineSizeTypesStandardDSOneTwoVTwo,
+		"standard_ds1_v2":     VirtualMachineSizeTypesStandardDSOneVTwo,
+		"standard_ds3":        VirtualMachineSizeTypesStandardDSThree,
+		"standard_ds3_v2":     VirtualMachineSizeTypesStandardDSThreeVTwo,
+		"standard_ds2":        VirtualMachineSizeTypesStandardDSTwo,
+		"standard_ds2_v2":     VirtualMachineSizeTypesStandardDSTwoVTwo,
+		"standard_d64_v3":     VirtualMachineSizeTypesStandardDSixFourVThree,
+		"standard_d64s_v3":    VirtualMachineSizeTypesStandardDSixFoursVThree,
+		"standard_d3":         VirtualMachineSizeTypesStandardDThree,
+		"standard_d32_v3":     VirtualMachineSizeTypesStandardDThreeTwoVThree,
+		"standard_d32s_v3":    VirtualMachineSizeTypesStandardDThreeTwosVThree,
+		"standard_d3_v2":      VirtualMachineSizeTypesStandardDThreeVTwo,
+		"standard_d2":         VirtualMachineSizeTypesStandardDTwo,
+		"standard_d2_v3":      VirtualMachineSizeTypesStandardDTwoVThree,
+		"standard_d2_v2":      VirtualMachineSizeTypesStandardDTwoVTwo,
+		"standard_d2s_v3":     VirtualMachineSizeTypesStandardDTwosVThree,
+		"standard_e8_v3":      VirtualMachineSizeTypesStandardEEightVThree,
+		"standard_e8s_v3":     VirtualMachineSizeTypesStandardEEightsVThree,
+		"standard_e4_v3":      VirtualMachineSizeTypesStandardEFourVThree,
+		"standard_e4s_v3":     VirtualMachineSizeTypesStandardEFoursVThree,
+		"standard_e16_v3":     VirtualMachineSizeTypesStandardEOneSixVThree,
+		"standard_e16s_v3":    VirtualMachineSizeTypesStandardEOneSixsVThree,
+		"standard_e64-16s_v3": VirtualMachineSizeTypesStandardESixFourNegativeOneSixsVThree,
+		"standard_e64-32s_v3": VirtualMachineSizeTypesStandardESixFourNegativeThreeTwosVThree,
+		"standard_e64_v3":     VirtualMachineSizeTypesStandardESixFourVThree,
+		"standard_e64s_v3":    VirtualMachineSizeTypesStandardESixFoursVThree,
+		"standard_e32-8s_v3":  VirtualMachineSizeTypesStandardEThreeTwoNegativeEightsVThree,
+		"standard_e32-16_v3":  VirtualMachineSizeTypesStandardEThreeTwoNegativeOneSixVThree,
+		"standard_e32_v3":     VirtualMachineSizeTypesStandardEThreeTwoVThree,
+		"standard_e32s_v3":    VirtualMachineSizeTypesStandardEThreeTwosVThree,
+		"standard_e2_v3":      VirtualMachineSizeTypesStandardETwoVThree,
+		"standard_e2s_v3":     VirtualMachineSizeTypesStandardETwosVThree,
+		"standard_f8":         VirtualMachineSizeTypesStandardFEight,
+		"standard_f8s":        VirtualMachineSizeTypesStandardFEights,
+		"standard_f8s_v2":     VirtualMachineSizeTypesStandardFEightsVTwo,
+		"standard_f4":         VirtualMachineSizeTypesStandardFFour,
+		"standard_f4s":        VirtualMachineSizeTypesStandardFFours,
+		"standard_f4s_v2":     VirtualMachineSizeTypesStandardFFoursVTwo,
+		"standard_f1":         VirtualMachineSizeTypesStandardFOne,
+		"standard_f16":        VirtualMachineSizeTypesStandardFOneSix,
+		"standard_f16s":       VirtualMachineSizeTypesStandardFOneSixs,
+		"standard_f16s_v2":    VirtualMachineSizeTypesStandardFOneSixsVTwo,
+		"standard_f1s":        VirtualMachineSizeTypesStandardFOnes,
+		"standard_f72s_v2":    VirtualMachineSizeTypesStandardFSevenTwosVTwo,
+		"standard_f64s_v2":    VirtualMachineSizeTypesStandardFSixFoursVTwo,
+		"standard_f32s_v2":    VirtualMachineSizeTypesStandardFThreeTwosVTwo,
+		"standard_f2":         VirtualMachineSizeTypesStandardFTwo,
+		"standard_f2s":        VirtualMachineSizeTypesStandardFTwos,
+		"standard_f2s_v2":     VirtualMachineSizeTypesStandardFTwosVTwo,
+		"standard_g5":         VirtualMachineSizeTypesStandardGFive,
+		"standard_g4":         VirtualMachineSizeTypesStandardGFour,
+		"standard_g1":         VirtualMachineSizeTypesStandardGOne,
+		"standard_gs5":        VirtualMachineSizeTypesStandardGSFive,
+		"standard_gs5-8":      VirtualMachineSizeTypesStandardGSFiveNegativeEight,
+		"standard_gs5-16":     VirtualMachineSizeTypesStandardGSFiveNegativeOneSix,
+		"standard_gs4":        VirtualMachineSizeTypesStandardGSFour,
+		"standard_gs4-8":      VirtualMachineSizeTypesStandardGSFourNegativeEight,
+		"standard_gs4-4":      VirtualMachineSizeTypesStandardGSFourNegativeFour,
+		"standard_gs1":        VirtualMachineSizeTypesStandardGSOne,
+		"standard_gs3":        VirtualMachineSizeTypesStandardGSThree,
+		"standard_gs2":        VirtualMachineSizeTypesStandardGSTwo,
+		"standard_g3":         VirtualMachineSizeTypesStandardGThree,
+		"standard_g2":         VirtualMachineSizeTypesStandardGTwo,
+		"standard_h8":         VirtualMachineSizeTypesStandardHEight,
+		"standard_h8m":        VirtualMachineSizeTypesStandardHEightm,
+		"standard_h16":        VirtualMachineSizeTypesStandardHOneSix,
+		"standard_h16m":       VirtualMachineSizeTypesStandardHOneSixm,
+		"standard_h16mr":      VirtualMachineSizeTypesStandardHOneSixmr,
+		"standard_h16r":       VirtualMachineSizeTypesStandardHOneSixr,
+		"standard_l8s":        VirtualMachineSizeTypesStandardLEights,
+		"standard_l4s":        VirtualMachineSizeTypesStandardLFours,
+		"standard_l16s":       VirtualMachineSizeTypesStandardLOneSixs,
+		"standard_l32s":       VirtualMachineSizeTypesStandardLThreeTwos,
+		"standard_m128-64ms":  VirtualMachineSizeTypesStandardMOneTwoEightNegativeSixFourms,
+		"standard_m128-32ms":  VirtualMachineSizeTypesStandardMOneTwoEightNegativeThreeTwoms,
+		"standard_m128ms":     VirtualMachineSizeTypesStandardMOneTwoEightms,
+		"standard_m128s":      VirtualMachineSizeTypesStandardMOneTwoEights,
+		"standard_m64-16ms":   VirtualMachineSizeTypesStandardMSixFourNegativeOneSixms,
+		"standard_m64-32ms":   VirtualMachineSizeTypesStandardMSixFourNegativeThreeTwoms,
+		"standard_m64ms":      VirtualMachineSizeTypesStandardMSixFourms,
+		"standard_m64s":       VirtualMachineSizeTypesStandardMSixFours,
+		"standard_nc12":       VirtualMachineSizeTypesStandardNCOneTwo,
+		"standard_nc12s_v3":   VirtualMachineSizeTypesStandardNCOneTwosVThree,
+		"standard_nc12s_v2":   VirtualMachineSizeTypesStandardNCOneTwosVTwo,
+		"standard_nc6":        VirtualMachineSizeTypesStandardNCSix,
+		"standard_nc6s_v3":    VirtualMachineSizeTypesStandardNCSixsVThree,
+		"standard_nc6s_v2":    VirtualMachineSizeTypesStandardNCSixsVTwo,
+		"standard_nc24":       VirtualMachineSizeTypesStandardNCTwoFour,
+		"standard_nc24r":      VirtualMachineSizeTypesStandardNCTwoFourr,
+		"standard_nc24rs_v3":  VirtualMachineSizeTypesStandardNCTwoFourrsVThree,
+		"standard_nc24rs_v2":  VirtualMachineSizeTypesStandardNCTwoFourrsVTwo,
+		"standard_nc24s_v3":   VirtualMachineSizeTypesStandardNCTwoFoursVThree,
+		"standard_nc24s_v2":   VirtualMachineSizeTypesStandardNCTwoFoursVTwo,
+		"standard_nd12s":      VirtualMachineSizeTypesStandardNDOneTwos,
+		"standard_nd6s":       VirtualMachineSizeTypesStandardNDSixs,
+		"standard_nd24rs":     VirtualMachineSizeTypesStandardNDTwoFourrs,
+		"standard_nd24s":      VirtualMachineSizeTypesStandardNDTwoFours,
+		"standard_nv12":       VirtualMachineSizeTypesStandardNVOneTwo,
+		"standard_nv6":        VirtualMachineSizeTypesStandardNVSix,
+		"standard_nv24":       VirtualMachineSizeTypesStandardNVTwoFour,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualMachineSizeTypes(input)
+	return &out, nil
+}
+
+type WindowsPatchAssessmentMode string
+
+const (
+	WindowsPatchAssessmentModeAutomaticByPlatform WindowsPatchAssessmentMode = "AutomaticByPlatform"
+	WindowsPatchAssessmentModeImageDefault        WindowsPatchAssessmentMode = "ImageDefault"
+)
+
+func PossibleValuesForWindowsPatchAssessmentMode() []string {
+	return []string{
+		string(WindowsPatchAssessmentModeAutomaticByPlatform),
+		string(WindowsPatchAssessmentModeImageDefault),
+	}
+}
+
+func (s *WindowsPatchAssessmentMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsPatchAssessmentMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsPatchAssessmentMode(input string) (*WindowsPatchAssessmentMode, error) {
+	vals := map[string]WindowsPatchAssessmentMode{
+		"automaticbyplatform": WindowsPatchAssessmentModeAutomaticByPlatform,
+		"imagedefault":        WindowsPatchAssessmentModeImageDefault,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsPatchAssessmentMode(input)
+	return &out, nil
+}
+
+type WindowsVMGuestPatchAutomaticByPlatformRebootSetting string
+
+const (
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways     WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Always"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "IfRequired"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever      WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Never"
+	WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown    WindowsVMGuestPatchAutomaticByPlatformRebootSetting = "Unknown"
+)
+
+func PossibleValuesForWindowsVMGuestPatchAutomaticByPlatformRebootSetting() []string {
+	return []string{
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever),
+		string(WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown),
+	}
+}
+
+func (s *WindowsVMGuestPatchAutomaticByPlatformRebootSetting) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsVMGuestPatchAutomaticByPlatformRebootSetting(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsVMGuestPatchAutomaticByPlatformRebootSetting(input string) (*WindowsVMGuestPatchAutomaticByPlatformRebootSetting, error) {
+	vals := map[string]WindowsVMGuestPatchAutomaticByPlatformRebootSetting{
+		"always":     WindowsVMGuestPatchAutomaticByPlatformRebootSettingAlways,
+		"ifrequired": WindowsVMGuestPatchAutomaticByPlatformRebootSettingIfRequired,
+		"never":      WindowsVMGuestPatchAutomaticByPlatformRebootSettingNever,
+		"unknown":    WindowsVMGuestPatchAutomaticByPlatformRebootSettingUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsVMGuestPatchAutomaticByPlatformRebootSetting(input)
+	return &out, nil
+}
+
+type WindowsVMGuestPatchMode string
+
+const (
+	WindowsVMGuestPatchModeAutomaticByOS       WindowsVMGuestPatchMode = "AutomaticByOS"
+	WindowsVMGuestPatchModeAutomaticByPlatform WindowsVMGuestPatchMode = "AutomaticByPlatform"
+	WindowsVMGuestPatchModeManual              WindowsVMGuestPatchMode = "Manual"
+)
+
+func PossibleValuesForWindowsVMGuestPatchMode() []string {
+	return []string{
+		string(WindowsVMGuestPatchModeAutomaticByOS),
+		string(WindowsVMGuestPatchModeAutomaticByPlatform),
+		string(WindowsVMGuestPatchModeManual),
+	}
+}
+
+func (s *WindowsVMGuestPatchMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWindowsVMGuestPatchMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWindowsVMGuestPatchMode(input string) (*WindowsVMGuestPatchMode, error) {
+	vals := map[string]WindowsVMGuestPatchMode{
+		"automaticbyos":       WindowsVMGuestPatchModeAutomaticByOS,
+		"automaticbyplatform": WindowsVMGuestPatchModeAutomaticByPlatform,
+		"manual":              WindowsVMGuestPatchModeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WindowsVMGuestPatchMode(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/id_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/id_virtualmachinescaleset.go
@@ -1,0 +1,125 @@
+package virtualmachinescalesetvms
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetId{}
+
+// VirtualMachineScaleSetId is a struct representing the Resource ID for a Virtual Machine Scale Set
+type VirtualMachineScaleSetId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+}
+
+// NewVirtualMachineScaleSetID returns a new VirtualMachineScaleSetId struct
+func NewVirtualMachineScaleSetID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string) VirtualMachineScaleSetId {
+	return VirtualMachineScaleSetId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+	}
+}
+
+// ParseVirtualMachineScaleSetID parses 'input' into a VirtualMachineScaleSetId
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetIDInsensitively(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetID checks that 'input' can be parsed as a Virtual Machine Scale Set ID
+func ValidateVirtualMachineScaleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/id_virtualmachinescalesetvirtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/id_virtualmachinescalesetvirtualmachine.go
@@ -1,0 +1,134 @@
+package virtualmachinescalesetvms
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetVirtualMachineId{}
+
+// VirtualMachineScaleSetVirtualMachineId is a struct representing the Resource ID for a Virtual Machine Scale Set Virtual Machine
+type VirtualMachineScaleSetVirtualMachineId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+	InstanceId                 string
+}
+
+// NewVirtualMachineScaleSetVirtualMachineID returns a new VirtualMachineScaleSetVirtualMachineId struct
+func NewVirtualMachineScaleSetVirtualMachineID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, instanceId string) VirtualMachineScaleSetVirtualMachineId {
+	return VirtualMachineScaleSetVirtualMachineId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+		InstanceId:                 instanceId,
+	}
+}
+
+// ParseVirtualMachineScaleSetVirtualMachineID parses 'input' into a VirtualMachineScaleSetVirtualMachineId
+func ParseVirtualMachineScaleSetVirtualMachineID(input string) (*VirtualMachineScaleSetVirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetVirtualMachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetVirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetVirtualMachineIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetVirtualMachineId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetVirtualMachineIDInsensitively(input string) (*VirtualMachineScaleSetVirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetVirtualMachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetVirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetVirtualMachineId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	if id.InstanceId, ok = input.Parsed["instanceId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "instanceId", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetVirtualMachineID checks that 'input' can be parsed as a Virtual Machine Scale Set Virtual Machine ID
+func ValidateVirtualMachineScaleSetVirtualMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetVirtualMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set Virtual Machine ID
+func (id VirtualMachineScaleSetVirtualMachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.InstanceId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set Virtual Machine ID
+func (id VirtualMachineScaleSetVirtualMachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("instanceId", "instanceIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set Virtual Machine ID
+func (id VirtualMachineScaleSetVirtualMachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Instance: %q", id.InstanceId),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set Virtual Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_approverollingupgrade.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_approverollingupgrade.go
@@ -1,0 +1,69 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApproveRollingUpgradeOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ApproveRollingUpgrade ...
+func (c VirtualMachineScaleSetVMsClient) ApproveRollingUpgrade(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result ApproveRollingUpgradeOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/approveRollingUpgrade", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ApproveRollingUpgradeThenPoll performs ApproveRollingUpgrade then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) ApproveRollingUpgradeThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.ApproveRollingUpgrade(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ApproveRollingUpgrade: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ApproveRollingUpgrade: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_attachdetachdatadisks.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_attachdetachdatadisks.go
@@ -1,0 +1,75 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AttachDetachDataDisksOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *StorageProfile
+}
+
+// AttachDetachDataDisks ...
+func (c VirtualMachineScaleSetVMsClient) AttachDetachDataDisks(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input AttachDetachDataDisksRequest) (result AttachDetachDataDisksOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/attachDetachDataDisks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// AttachDetachDataDisksThenPoll performs AttachDetachDataDisks then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) AttachDetachDataDisksThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input AttachDetachDataDisksRequest) error {
+	result, err := c.AttachDetachDataDisks(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AttachDetachDataDisks: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after AttachDetachDataDisks: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_deallocate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_deallocate.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeallocateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Deallocate ...
+func (c VirtualMachineScaleSetVMsClient) Deallocate(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result DeallocateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/deallocate", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeallocateThenPoll performs Deallocate then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) DeallocateThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.Deallocate(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Deallocate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Deallocate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_delete.go
@@ -1,0 +1,99 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteOperationOptions struct {
+	ForceDeletion *bool
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeleteOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o DeleteOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ForceDeletion != nil {
+		out.Append("forceDeletion", fmt.Sprintf("%v", *o.ForceDeletion))
+	}
+	return &out
+}
+
+// Delete ...
+func (c VirtualMachineScaleSetVMsClient) Delete(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) DeleteThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options DeleteOperationOptions) error {
+	result, err := c.Delete(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_get.go
@@ -1,0 +1,83 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetVM
+}
+
+type GetOperationOptions struct {
+	Expand *InstanceViewTypes
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c VirtualMachineScaleSetVMsClient) Get(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineScaleSetVM
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_getinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_getinstanceview.go
@@ -1,0 +1,55 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetInstanceViewOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetVMInstanceView
+}
+
+// GetInstanceView ...
+func (c VirtualMachineScaleSetVMsClient) GetInstanceView(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result GetInstanceViewOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/instanceView", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineScaleSetVMInstanceView
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_list.go
@@ -1,0 +1,127 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSetVM
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSetVM
+}
+
+type ListOperationOptions struct {
+	Expand *string
+	Filter *string
+	Select *string
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Select != nil {
+		out.Append("$select", fmt.Sprintf("%v", *o.Select))
+	}
+	return &out
+}
+
+// List ...
+func (c VirtualMachineScaleSetVMsClient) List(ctx context.Context, id VirtualMachineScaleSetId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/virtualMachines", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSetVM `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetVMsClient) ListComplete(ctx context.Context, id VirtualMachineScaleSetId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, VirtualMachineScaleSetVMOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetVMsClient) ListCompleteMatchingPredicate(ctx context.Context, id VirtualMachineScaleSetId, options ListOperationOptions, predicate VirtualMachineScaleSetVMOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSetVM, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_performmaintenance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_performmaintenance.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PerformMaintenanceOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// PerformMaintenance ...
+func (c VirtualMachineScaleSetVMsClient) PerformMaintenance(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result PerformMaintenanceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/performMaintenance", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// PerformMaintenanceThenPoll performs PerformMaintenance then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) PerformMaintenanceThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.PerformMaintenance(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing PerformMaintenance: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after PerformMaintenance: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_poweroff.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_poweroff.go
@@ -1,0 +1,98 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PowerOffOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type PowerOffOperationOptions struct {
+	SkipShutdown *bool
+}
+
+func DefaultPowerOffOperationOptions() PowerOffOperationOptions {
+	return PowerOffOperationOptions{}
+}
+
+func (o PowerOffOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o PowerOffOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o PowerOffOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.SkipShutdown != nil {
+		out.Append("skipShutdown", fmt.Sprintf("%v", *o.SkipShutdown))
+	}
+	return &out
+}
+
+// PowerOff ...
+func (c VirtualMachineScaleSetVMsClient) PowerOff(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options PowerOffOperationOptions) (result PowerOffOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/poweroff", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// PowerOffThenPoll performs PowerOff then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) PowerOffThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options PowerOffOperationOptions) error {
+	result, err := c.PowerOff(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing PowerOff: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after PowerOff: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_redeploy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_redeploy.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RedeployOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Redeploy ...
+func (c VirtualMachineScaleSetVMsClient) Redeploy(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result RedeployOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/redeploy", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RedeployThenPoll performs Redeploy then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) RedeployThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.Redeploy(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Redeploy: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Redeploy: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_reimage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_reimage.go
@@ -1,0 +1,74 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReimageOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Reimage ...
+func (c VirtualMachineScaleSetVMsClient) Reimage(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input VirtualMachineScaleSetVMReimageParameters) (result ReimageOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/reimage", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReimageThenPoll performs Reimage then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) ReimageThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input VirtualMachineScaleSetVMReimageParameters) error {
+	result, err := c.Reimage(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Reimage: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Reimage: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_reimageall.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_reimageall.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReimageAllOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ReimageAll ...
+func (c VirtualMachineScaleSetVMsClient) ReimageAll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result ReimageAllOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/reimageall", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReimageAllThenPoll performs ReimageAll then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) ReimageAllThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.ReimageAll(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ReimageAll: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ReimageAll: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_restart.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_restart.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RestartOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Restart ...
+func (c VirtualMachineScaleSetVMsClient) Restart(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result RestartOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/restart", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RestartThenPoll performs Restart then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) RestartThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.Restart(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Restart: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Restart: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_retrievebootdiagnosticsdata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_retrievebootdiagnosticsdata.go
@@ -1,0 +1,83 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetrieveBootDiagnosticsDataOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RetrieveBootDiagnosticsDataResult
+}
+
+type RetrieveBootDiagnosticsDataOperationOptions struct {
+	SasUriExpirationTimeInMinutes *int64
+}
+
+func DefaultRetrieveBootDiagnosticsDataOperationOptions() RetrieveBootDiagnosticsDataOperationOptions {
+	return RetrieveBootDiagnosticsDataOperationOptions{}
+}
+
+func (o RetrieveBootDiagnosticsDataOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o RetrieveBootDiagnosticsDataOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o RetrieveBootDiagnosticsDataOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.SasUriExpirationTimeInMinutes != nil {
+		out.Append("sasUriExpirationTimeInMinutes", fmt.Sprintf("%v", *o.SasUriExpirationTimeInMinutes))
+	}
+	return &out
+}
+
+// RetrieveBootDiagnosticsData ...
+func (c VirtualMachineScaleSetVMsClient) RetrieveBootDiagnosticsData(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, options RetrieveBootDiagnosticsDataOperationOptions) (result RetrieveBootDiagnosticsDataOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		Path:          fmt.Sprintf("%s/retrieveBootDiagnosticsData", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RetrieveBootDiagnosticsDataResult
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_runcommand.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_runcommand.go
@@ -1,0 +1,75 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunCommandOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RunCommandResult
+}
+
+// RunCommand ...
+func (c VirtualMachineScaleSetVMsClient) RunCommand(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input RunCommandInput) (result RunCommandOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/runCommand", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RunCommandThenPoll performs RunCommand then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) RunCommandThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input RunCommandInput) error {
+	result, err := c.RunCommand(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RunCommand: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RunCommand: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_simulateeviction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_simulateeviction.go
@@ -1,0 +1,47 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SimulateEvictionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// SimulateEviction ...
+func (c VirtualMachineScaleSetVMsClient) SimulateEviction(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result SimulateEvictionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/simulateEviction", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_start.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_start.go
@@ -1,0 +1,70 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StartOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Start ...
+func (c VirtualMachineScaleSetVMsClient) Start(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) (result StartOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/start", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// StartThenPoll performs Start then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) StartThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId) error {
+	result, err := c.Start(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Start: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Start: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/method_update.go
@@ -1,0 +1,107 @@
+package virtualmachinescalesetvms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetVM
+}
+
+type UpdateOperationOptions struct {
+	IfMatch     *string
+	IfNoneMatch *string
+}
+
+func DefaultUpdateOperationOptions() UpdateOperationOptions {
+	return UpdateOperationOptions{}
+}
+
+func (o UpdateOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	if o.IfMatch != nil {
+		out.Append("If-Match", fmt.Sprintf("%v", *o.IfMatch))
+	}
+	if o.IfNoneMatch != nil {
+		out.Append("If-None-Match", fmt.Sprintf("%v", *o.IfNoneMatch))
+	}
+	return &out
+}
+
+func (o UpdateOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o UpdateOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+
+	return &out
+}
+
+// Update ...
+func (c VirtualMachineScaleSetVMsClient) Update(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input VirtualMachineScaleSetVM, options UpdateOperationOptions) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPut,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c VirtualMachineScaleSetVMsClient) UpdateThenPoll(ctx context.Context, id VirtualMachineScaleSetVirtualMachineId, input VirtualMachineScaleSetVM, options UpdateOperationOptions) error {
+	result, err := c.Update(ctx, id, input, options)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_additionalcapabilities.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_additionalcapabilities.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AdditionalCapabilities struct {
+	HibernationEnabled *bool `json:"hibernationEnabled,omitempty"`
+	UltraSSDEnabled    *bool `json:"ultraSSDEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_additionalunattendcontent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_additionalunattendcontent.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AdditionalUnattendContent struct {
+	ComponentName *ComponentNames `json:"componentName,omitempty"`
+	Content       *string         `json:"content,omitempty"`
+	PassName      *PassNames      `json:"passName,omitempty"`
+	SettingName   *SettingNames   `json:"settingName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_apientityreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_apientityreference.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApiEntityReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_attachdetachdatadisksrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_attachdetachdatadisksrequest.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AttachDetachDataDisksRequest struct {
+	DataDisksToAttach *[]DataDisksToAttach `json:"dataDisksToAttach,omitempty"`
+	DataDisksToDetach *[]DataDisksToDetach `json:"dataDisksToDetach,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_bootdiagnostics.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_bootdiagnostics.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BootDiagnostics struct {
+	Enabled    *bool   `json:"enabled,omitempty"`
+	StorageUri *string `json:"storageUri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_bootdiagnosticsinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_bootdiagnosticsinstanceview.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BootDiagnosticsInstanceView struct {
+	ConsoleScreenshotBlobUri *string             `json:"consoleScreenshotBlobUri,omitempty"`
+	SerialConsoleLogBlobUri  *string             `json:"serialConsoleLogBlobUri,omitempty"`
+	Status                   *InstanceViewStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadisk.go
@@ -1,0 +1,22 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataDisk struct {
+	Caching                 *CachingTypes          `json:"caching,omitempty"`
+	CreateOption            DiskCreateOptionTypes  `json:"createOption"`
+	DeleteOption            *DiskDeleteOptionTypes `json:"deleteOption,omitempty"`
+	DetachOption            *DiskDetachOptionTypes `json:"detachOption,omitempty"`
+	DiskIOPSReadWrite       *int64                 `json:"diskIOPSReadWrite,omitempty"`
+	DiskMBpsReadWrite       *int64                 `json:"diskMBpsReadWrite,omitempty"`
+	DiskSizeGB              *int64                 `json:"diskSizeGB,omitempty"`
+	Image                   *VirtualHardDisk       `json:"image,omitempty"`
+	Lun                     int64                  `json:"lun"`
+	ManagedDisk             *ManagedDiskParameters `json:"managedDisk,omitempty"`
+	Name                    *string                `json:"name,omitempty"`
+	SourceResource          *ApiEntityReference    `json:"sourceResource,omitempty"`
+	ToBeDetached            *bool                  `json:"toBeDetached,omitempty"`
+	Vhd                     *VirtualHardDisk       `json:"vhd,omitempty"`
+	WriteAcceleratorEnabled *bool                  `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadiskstoattach.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadiskstoattach.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataDisksToAttach struct {
+	Caching                 *CachingTypes          `json:"caching,omitempty"`
+	DeleteOption            *DiskDeleteOptionTypes `json:"deleteOption,omitempty"`
+	DiskEncryptionSet       *SubResource           `json:"diskEncryptionSet,omitempty"`
+	DiskId                  string                 `json:"diskId"`
+	Lun                     *int64                 `json:"lun,omitempty"`
+	WriteAcceleratorEnabled *bool                  `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadiskstodetach.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_datadiskstodetach.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataDisksToDetach struct {
+	DetachOption *DiskDetachOptionTypes `json:"detachOption,omitempty"`
+	DiskId       string                 `json:"diskId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diagnosticsprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diagnosticsprofile.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiagnosticsProfile struct {
+	BootDiagnostics *BootDiagnostics `json:"bootDiagnostics,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diffdisksettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diffdisksettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiffDiskSettings struct {
+	Option    *DiffDiskOptions   `json:"option,omitempty"`
+	Placement *DiffDiskPlacement `json:"placement,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diskencryptionsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diskencryptionsettings.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskEncryptionSettings struct {
+	DiskEncryptionKey *KeyVaultSecretReference `json:"diskEncryptionKey,omitempty"`
+	Enabled           *bool                    `json:"enabled,omitempty"`
+	KeyEncryptionKey  *KeyVaultKeyReference    `json:"keyEncryptionKey,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diskinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_diskinstanceview.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskInstanceView struct {
+	EncryptionSettings *[]DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	Name               *string                   `json:"name,omitempty"`
+	Statuses           *[]InstanceViewStatus     `json:"statuses,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_encryptionidentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_encryptionidentity.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EncryptionIdentity struct {
+	UserAssignedIdentityResourceId *string `json:"userAssignedIdentityResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_hardwareprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_hardwareprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HardwareProfile struct {
+	VMSize           *VirtualMachineSizeTypes `json:"vmSize,omitempty"`
+	VMSizeProperties *VMSizeProperties        `json:"vmSizeProperties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_imagereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_imagereference.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageReference struct {
+	CommunityGalleryImageId *string `json:"communityGalleryImageId,omitempty"`
+	ExactVersion            *string `json:"exactVersion,omitempty"`
+	Id                      *string `json:"id,omitempty"`
+	Offer                   *string `json:"offer,omitempty"`
+	Publisher               *string `json:"publisher,omitempty"`
+	SharedGalleryImageId    *string `json:"sharedGalleryImageId,omitempty"`
+	Sku                     *string `json:"sku,omitempty"`
+	Version                 *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_instanceviewstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_instanceviewstatus.go
@@ -1,0 +1,30 @@
+package virtualmachinescalesetvms
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstanceViewStatus struct {
+	Code          *string           `json:"code,omitempty"`
+	DisplayStatus *string           `json:"displayStatus,omitempty"`
+	Level         *StatusLevelTypes `json:"level,omitempty"`
+	Message       *string           `json:"message,omitempty"`
+	Time          *string           `json:"time,omitempty"`
+}
+
+func (o *InstanceViewStatus) GetTimeAsTime() (*time.Time, error) {
+	if o.Time == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.Time, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InstanceViewStatus) SetTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.Time = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_keyvaultkeyreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_keyvaultkeyreference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyVaultKeyReference struct {
+	KeyUrl      string      `json:"keyUrl"`
+	SourceVault SubResource `json:"sourceVault"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_keyvaultsecretreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_keyvaultsecretreference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyVaultSecretReference struct {
+	SecretUrl   string      `json:"secretUrl"`
+	SourceVault SubResource `json:"sourceVault"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxconfiguration.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxConfiguration struct {
+	DisablePasswordAuthentication *bool               `json:"disablePasswordAuthentication,omitempty"`
+	EnableVMAgentPlatformUpdates  *bool               `json:"enableVMAgentPlatformUpdates,omitempty"`
+	PatchSettings                 *LinuxPatchSettings `json:"patchSettings,omitempty"`
+	ProvisionVMAgent              *bool               `json:"provisionVMAgent,omitempty"`
+	Ssh                           *SshConfiguration   `json:"ssh,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxpatchsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxpatchsettings.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxPatchSettings struct {
+	AssessmentMode              *LinuxPatchAssessmentMode                     `json:"assessmentMode,omitempty"`
+	AutomaticByPlatformSettings *LinuxVMGuestPatchAutomaticByPlatformSettings `json:"automaticByPlatformSettings,omitempty"`
+	PatchMode                   *LinuxVMGuestPatchMode                        `json:"patchMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxvmguestpatchautomaticbyplatformsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_linuxvmguestpatchautomaticbyplatformsettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinuxVMGuestPatchAutomaticByPlatformSettings struct {
+	BypassPlatformSafetyChecksOnUserSchedule *bool                                              `json:"bypassPlatformSafetyChecksOnUserSchedule,omitempty"`
+	RebootSetting                            *LinuxVMGuestPatchAutomaticByPlatformRebootSetting `json:"rebootSetting,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_maintenanceredeploystatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_maintenanceredeploystatus.go
@@ -1,0 +1,68 @@
+package virtualmachinescalesetvms
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MaintenanceRedeployStatus struct {
+	IsCustomerInitiatedMaintenanceAllowed *bool                                `json:"isCustomerInitiatedMaintenanceAllowed,omitempty"`
+	LastOperationMessage                  *string                              `json:"lastOperationMessage,omitempty"`
+	LastOperationResultCode               *MaintenanceOperationResultCodeTypes `json:"lastOperationResultCode,omitempty"`
+	MaintenanceWindowEndTime              *string                              `json:"maintenanceWindowEndTime,omitempty"`
+	MaintenanceWindowStartTime            *string                              `json:"maintenanceWindowStartTime,omitempty"`
+	PreMaintenanceWindowEndTime           *string                              `json:"preMaintenanceWindowEndTime,omitempty"`
+	PreMaintenanceWindowStartTime         *string                              `json:"preMaintenanceWindowStartTime,omitempty"`
+}
+
+func (o *MaintenanceRedeployStatus) GetMaintenanceWindowEndTimeAsTime() (*time.Time, error) {
+	if o.MaintenanceWindowEndTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.MaintenanceWindowEndTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MaintenanceRedeployStatus) SetMaintenanceWindowEndTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.MaintenanceWindowEndTime = &formatted
+}
+
+func (o *MaintenanceRedeployStatus) GetMaintenanceWindowStartTimeAsTime() (*time.Time, error) {
+	if o.MaintenanceWindowStartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.MaintenanceWindowStartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MaintenanceRedeployStatus) SetMaintenanceWindowStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.MaintenanceWindowStartTime = &formatted
+}
+
+func (o *MaintenanceRedeployStatus) GetPreMaintenanceWindowEndTimeAsTime() (*time.Time, error) {
+	if o.PreMaintenanceWindowEndTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.PreMaintenanceWindowEndTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MaintenanceRedeployStatus) SetPreMaintenanceWindowEndTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.PreMaintenanceWindowEndTime = &formatted
+}
+
+func (o *MaintenanceRedeployStatus) GetPreMaintenanceWindowStartTimeAsTime() (*time.Time, error) {
+	if o.PreMaintenanceWindowStartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.PreMaintenanceWindowStartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MaintenanceRedeployStatus) SetPreMaintenanceWindowStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.PreMaintenanceWindowStartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_manageddiskparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_manageddiskparameters.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedDiskParameters struct {
+	DiskEncryptionSet  *SubResource           `json:"diskEncryptionSet,omitempty"`
+	Id                 *string                `json:"id,omitempty"`
+	SecurityProfile    *VMDiskSecurityProfile `json:"securityProfile,omitempty"`
+	StorageAccountType *StorageAccountTypes   `json:"storageAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkinterfacereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkinterfacereference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceReference struct {
+	Id         *string                              `json:"id,omitempty"`
+	Properties *NetworkInterfaceReferenceProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkinterfacereferenceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkinterfacereferenceproperties.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceReferenceProperties struct {
+	DeleteOption *DeleteOptions `json:"deleteOption,omitempty"`
+	Primary      *bool          `json:"primary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_networkprofile.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkProfile struct {
+	NetworkApiVersion              *NetworkApiVersion                             `json:"networkApiVersion,omitempty"`
+	NetworkInterfaceConfigurations *[]VirtualMachineNetworkInterfaceConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaces              *[]NetworkInterfaceReference                   `json:"networkInterfaces,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osdisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osdisk.go
@@ -1,0 +1,19 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSDisk struct {
+	Caching                 *CachingTypes           `json:"caching,omitempty"`
+	CreateOption            DiskCreateOptionTypes   `json:"createOption"`
+	DeleteOption            *DiskDeleteOptionTypes  `json:"deleteOption,omitempty"`
+	DiffDiskSettings        *DiffDiskSettings       `json:"diffDiskSettings,omitempty"`
+	DiskSizeGB              *int64                  `json:"diskSizeGB,omitempty"`
+	EncryptionSettings      *DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	Image                   *VirtualHardDisk        `json:"image,omitempty"`
+	ManagedDisk             *ManagedDiskParameters  `json:"managedDisk,omitempty"`
+	Name                    *string                 `json:"name,omitempty"`
+	OsType                  *OperatingSystemTypes   `json:"osType,omitempty"`
+	Vhd                     *VirtualHardDisk        `json:"vhd,omitempty"`
+	WriteAcceleratorEnabled *bool                   `json:"writeAcceleratorEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osprofile.go
@@ -1,0 +1,16 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSProfile struct {
+	AdminPassword               *string               `json:"adminPassword,omitempty"`
+	AdminUsername               *string               `json:"adminUsername,omitempty"`
+	AllowExtensionOperations    *bool                 `json:"allowExtensionOperations,omitempty"`
+	ComputerName                *string               `json:"computerName,omitempty"`
+	CustomData                  *string               `json:"customData,omitempty"`
+	LinuxConfiguration          *LinuxConfiguration   `json:"linuxConfiguration,omitempty"`
+	RequireGuestProvisionSignal *bool                 `json:"requireGuestProvisionSignal,omitempty"`
+	Secrets                     *[]VaultSecretGroup   `json:"secrets,omitempty"`
+	WindowsConfiguration        *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osprofileprovisioningdata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_osprofileprovisioningdata.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSProfileProvisioningData struct {
+	AdminPassword *string `json:"adminPassword,omitempty"`
+	CustomData    *string `json:"customData,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_patchsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_patchsettings.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PatchSettings struct {
+	AssessmentMode              *WindowsPatchAssessmentMode                     `json:"assessmentMode,omitempty"`
+	AutomaticByPlatformSettings *WindowsVMGuestPatchAutomaticByPlatformSettings `json:"automaticByPlatformSettings,omitempty"`
+	EnableHotpatching           *bool                                           `json:"enableHotpatching,omitempty"`
+	PatchMode                   *WindowsVMGuestPatchMode                        `json:"patchMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_plan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_plan.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Plan struct {
+	Name          *string `json:"name,omitempty"`
+	Product       *string `json:"product,omitempty"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     *string `json:"publisher,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_proxyagentsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_proxyagentsettings.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProxyAgentSettings struct {
+	Enabled          *bool  `json:"enabled,omitempty"`
+	KeyIncarnationId *int64 `json:"keyIncarnationId,omitempty"`
+	Mode             *Mode  `json:"mode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_publicipaddresssku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_publicipaddresssku.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressSku struct {
+	Name *PublicIPAddressSkuName `json:"name,omitempty"`
+	Tier *PublicIPAddressSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_retrievebootdiagnosticsdataresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_retrievebootdiagnosticsdataresult.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetrieveBootDiagnosticsDataResult struct {
+	ConsoleScreenshotBlobUri *string `json:"consoleScreenshotBlobUri,omitempty"`
+	SerialConsoleLogBlobUri  *string `json:"serialConsoleLogBlobUri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandinput.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunCommandInput struct {
+	CommandId  string                      `json:"commandId"`
+	Parameters *[]RunCommandInputParameter `json:"parameters,omitempty"`
+	Script     *[]string                   `json:"script,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandinputparameter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandinputparameter.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunCommandInputParameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_runcommandresult.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunCommandResult struct {
+	Value *[]InstanceViewStatus `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_securityprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_securityprofile.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityProfile struct {
+	EncryptionAtHost   *bool               `json:"encryptionAtHost,omitempty"`
+	EncryptionIdentity *EncryptionIdentity `json:"encryptionIdentity,omitempty"`
+	ProxyAgentSettings *ProxyAgentSettings `json:"proxyAgentSettings,omitempty"`
+	SecurityType       *SecurityTypes      `json:"securityType,omitempty"`
+	UefiSettings       *UefiSettings       `json:"uefiSettings,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sku.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Capacity *int64  `json:"capacity,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Tier     *string `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sshconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sshconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SshConfiguration struct {
+	PublicKeys *[]SshPublicKey `json:"publicKeys,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sshpublickey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_sshpublickey.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SshPublicKey struct {
+	KeyData *string `json:"keyData,omitempty"`
+	Path    *string `json:"path,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_storageprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_storageprofile.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StorageProfile struct {
+	DataDisks          *[]DataDisk          `json:"dataDisks,omitempty"`
+	DiskControllerType *DiskControllerTypes `json:"diskControllerType,omitempty"`
+	ImageReference     *ImageReference      `json:"imageReference,omitempty"`
+	OsDisk             *OSDisk              `json:"osDisk,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_subresource.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_uefisettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_uefisettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UefiSettings struct {
+	SecureBootEnabled *bool `json:"secureBootEnabled,omitempty"`
+	VTpmEnabled       *bool `json:"vTpmEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vaultcertificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vaultcertificate.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCertificate struct {
+	CertificateStore *string `json:"certificateStore,omitempty"`
+	CertificateUrl   *string `json:"certificateUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vaultsecretgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vaultsecretgroup.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSecretGroup struct {
+	SourceVault       *SubResource        `json:"sourceVault,omitempty"`
+	VaultCertificates *[]VaultCertificate `json:"vaultCertificates,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualharddisk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualharddisk.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualHardDisk struct {
+	Uri *string `json:"uri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineagentinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineagentinstanceview.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineAgentInstanceView struct {
+	ExtensionHandlers *[]VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
+	Statuses          *[]InstanceViewStatus                         `json:"statuses,omitempty"`
+	VMAgentVersion    *string                                       `json:"vmAgentVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextension.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtension struct {
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualMachineExtensionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensionhandlerinstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensionhandlerinstanceview.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionHandlerInstanceView struct {
+	Status             *InstanceViewStatus `json:"status,omitempty"`
+	Type               *string             `json:"type,omitempty"`
+	TypeHandlerVersion *string             `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensioninstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensioninstanceview.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionInstanceView struct {
+	Name               *string               `json:"name,omitempty"`
+	Statuses           *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Substatuses        *[]InstanceViewStatus `json:"substatuses,omitempty"`
+	Type               *string               `json:"type,omitempty"`
+	TypeHandlerVersion *string               `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineextensionproperties.go
@@ -1,0 +1,20 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionProperties struct {
+	AutoUpgradeMinorVersion       *bool                                `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                                `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                              `json:"forceUpdateTag,omitempty"`
+	InstanceView                  *VirtualMachineExtensionInstanceView `json:"instanceView,omitempty"`
+	ProtectedSettings             *interface{}                         `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference             `json:"protectedSettingsFromKeyVault,omitempty"`
+	ProvisionAfterExtensions      *[]string                            `json:"provisionAfterExtensions,omitempty"`
+	ProvisioningState             *string                              `json:"provisioningState,omitempty"`
+	Publisher                     *string                              `json:"publisher,omitempty"`
+	Settings                      *interface{}                         `json:"settings,omitempty"`
+	SuppressFailures              *bool                                `json:"suppressFailures,omitempty"`
+	Type                          *string                              `json:"type,omitempty"`
+	TypeHandlerVersion            *string                              `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinehealthstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinehealthstatus.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineHealthStatus struct {
+	Status *InstanceViewStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineiptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachineiptag.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineIPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineNetworkInterfaceConfiguration struct {
+	Name       string                                                 `json:"name"`
+	Properties *VirtualMachineNetworkInterfaceConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceconfigurationproperties.go
@@ -1,0 +1,19 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineNetworkInterfaceConfigurationProperties struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode                          `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku                           `json:"auxiliarySku,omitempty"`
+	DeleteOption                *DeleteOptions                                          `json:"deleteOption,omitempty"`
+	DisableTcpStateTracking     *bool                                                   `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *VirtualMachineNetworkInterfaceDnsSettingsConfiguration `json:"dnsSettings,omitempty"`
+	DscpConfiguration           *SubResource                                            `json:"dscpConfiguration,omitempty"`
+	EnableAcceleratedNetworking *bool                                                   `json:"enableAcceleratedNetworking,omitempty"`
+	EnableFpga                  *bool                                                   `json:"enableFpga,omitempty"`
+	EnableIPForwarding          *bool                                                   `json:"enableIPForwarding,omitempty"`
+	IPConfigurations            []VirtualMachineNetworkInterfaceIPConfiguration         `json:"ipConfigurations"`
+	NetworkSecurityGroup        *SubResource                                            `json:"networkSecurityGroup,omitempty"`
+	Primary                     *bool                                                   `json:"primary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfacednssettingsconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfacednssettingsconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineNetworkInterfaceDnsSettingsConfiguration struct {
+	DnsServers *[]string `json:"dnsServers,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceipconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineNetworkInterfaceIPConfiguration struct {
+	Name       string                                                   `json:"name"`
+	Properties *VirtualMachineNetworkInterfaceIPConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinenetworkinterfaceipconfigurationproperties.go
@@ -1,0 +1,14 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineNetworkInterfaceIPConfigurationProperties struct {
+	ApplicationGatewayBackendAddressPools *[]SubResource                              `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]SubResource                              `json:"applicationSecurityGroups,omitempty"`
+	LoadBalancerBackendAddressPools       *[]SubResource                              `json:"loadBalancerBackendAddressPools,omitempty"`
+	Primary                               *bool                                       `json:"primary,omitempty"`
+	PrivateIPAddressVersion               *IPVersions                                 `json:"privateIPAddressVersion,omitempty"`
+	PublicIPAddressConfiguration          *VirtualMachinePublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	Subnet                                *SubResource                                `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressconfiguration.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachinePublicIPAddressConfiguration struct {
+	Name       string                                                `json:"name"`
+	Properties *VirtualMachinePublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+	Sku        *PublicIPAddressSku                                   `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressconfigurationproperties.go
@@ -1,0 +1,14 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachinePublicIPAddressConfigurationProperties struct {
+	DeleteOption             *DeleteOptions                                         `json:"deleteOption,omitempty"`
+	DnsSettings              *VirtualMachinePublicIPAddressDnsSettingsConfiguration `json:"dnsSettings,omitempty"`
+	IPTags                   *[]VirtualMachineIPTag                                 `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes     *int64                                                 `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPAddressVersion   *IPVersions                                            `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAllocationMethod *PublicIPAllocationMethod                              `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPPrefix           *SubResource                                           `json:"publicIPPrefix,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressdnssettingsconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinepublicipaddressdnssettingsconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachinePublicIPAddressDnsSettingsConfiguration struct {
+	DomainNameLabel      string                     `json:"domainNameLabel"`
+	DomainNameLabelScope *DomainNameLabelScopeTypes `json:"domainNameLabelScope,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetipconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPConfiguration struct {
+	Name       string                                           `json:"name"`
+	Properties *VirtualMachineScaleSetIPConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetipconfigurationproperties.go
@@ -1,0 +1,15 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPConfigurationProperties struct {
+	ApplicationGatewayBackendAddressPools *[]SubResource                                      `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]SubResource                                      `json:"applicationSecurityGroups,omitempty"`
+	LoadBalancerBackendAddressPools       *[]SubResource                                      `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatPools           *[]SubResource                                      `json:"loadBalancerInboundNatPools,omitempty"`
+	Primary                               *bool                                               `json:"primary,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                          `json:"privateIPAddressVersion,omitempty"`
+	PublicIPAddressConfiguration          *VirtualMachineScaleSetPublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	Subnet                                *ApiEntityReference                                 `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetiptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetiptag.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetIPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfiguration.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfiguration struct {
+	Name       string                                                `json:"name"`
+	Properties *VirtualMachineScaleSetNetworkConfigurationProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfigurationdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfigurationdnssettings.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfigurationDnsSettings struct {
+	DnsServers *[]string `json:"dnsServers,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetnetworkconfigurationproperties.go
@@ -1,0 +1,18 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetNetworkConfigurationProperties struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode                         `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku                          `json:"auxiliarySku,omitempty"`
+	DeleteOption                *DeleteOptions                                         `json:"deleteOption,omitempty"`
+	DisableTcpStateTracking     *bool                                                  `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *VirtualMachineScaleSetNetworkConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	EnableAcceleratedNetworking *bool                                                  `json:"enableAcceleratedNetworking,omitempty"`
+	EnableFpga                  *bool                                                  `json:"enableFpga,omitempty"`
+	EnableIPForwarding          *bool                                                  `json:"enableIPForwarding,omitempty"`
+	IPConfigurations            []VirtualMachineScaleSetIPConfiguration                `json:"ipConfigurations"`
+	NetworkSecurityGroup        *SubResource                                           `json:"networkSecurityGroup,omitempty"`
+	Primary                     *bool                                                  `json:"primary,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfiguration.go
@@ -1,0 +1,10 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfiguration struct {
+	Name       string                                                        `json:"name"`
+	Properties *VirtualMachineScaleSetPublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+	Sku        *PublicIPAddressSku                                           `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfigurationdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfigurationdnssettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings struct {
+	DomainNameLabel      string                     `json:"domainNameLabel"`
+	DomainNameLabelScope *DomainNameLabelScopeTypes `json:"domainNameLabelScope,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetpublicipaddressconfigurationproperties.go
@@ -1,0 +1,13 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
+	DeleteOption           *DeleteOptions                                                 `json:"deleteOption,omitempty"`
+	DnsSettings            *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings `json:"dnsSettings,omitempty"`
+	IPTags                 *[]VirtualMachineScaleSetIPTag                                 `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes   *int64                                                         `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPAddressVersion *IPVersion                                                     `json:"publicIPAddressVersion,omitempty"`
+	PublicIPPrefix         *SubResource                                                   `json:"publicIPPrefix,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvm.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvm.go
@@ -1,0 +1,25 @@
+package virtualmachinescalesetvms
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVM struct {
+	Etag       *string                             `json:"etag,omitempty"`
+	Id         *string                             `json:"id,omitempty"`
+	Identity   *identity.SystemAndUserAssignedMap  `json:"identity,omitempty"`
+	InstanceId *string                             `json:"instanceId,omitempty"`
+	Location   string                              `json:"location"`
+	Name       *string                             `json:"name,omitempty"`
+	Plan       *Plan                               `json:"plan,omitempty"`
+	Properties *VirtualMachineScaleSetVMProperties `json:"properties,omitempty"`
+	Resources  *[]VirtualMachineExtension          `json:"resources,omitempty"`
+	Sku        *Sku                                `json:"sku,omitempty"`
+	Tags       *map[string]string                  `json:"tags,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+	Zones      *zones.Schema                       `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvminstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvminstanceview.go
@@ -1,0 +1,23 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMInstanceView struct {
+	AssignedHost              *string                                `json:"assignedHost,omitempty"`
+	BootDiagnostics           *BootDiagnosticsInstanceView           `json:"bootDiagnostics,omitempty"`
+	ComputerName              *string                                `json:"computerName,omitempty"`
+	Disks                     *[]DiskInstanceView                    `json:"disks,omitempty"`
+	Extensions                *[]VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	HyperVGeneration          *HyperVGeneration                      `json:"hyperVGeneration,omitempty"`
+	MaintenanceRedeployStatus *MaintenanceRedeployStatus             `json:"maintenanceRedeployStatus,omitempty"`
+	OsName                    *string                                `json:"osName,omitempty"`
+	OsVersion                 *string                                `json:"osVersion,omitempty"`
+	PlacementGroupId          *string                                `json:"placementGroupId,omitempty"`
+	PlatformFaultDomain       *int64                                 `json:"platformFaultDomain,omitempty"`
+	PlatformUpdateDomain      *int64                                 `json:"platformUpdateDomain,omitempty"`
+	RdpThumbPrint             *string                                `json:"rdpThumbPrint,omitempty"`
+	Statuses                  *[]InstanceViewStatus                  `json:"statuses,omitempty"`
+	VMAgent                   *VirtualMachineAgentInstanceView       `json:"vmAgent,omitempty"`
+	VMHealth                  *VirtualMachineHealthStatus            `json:"vmHealth,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmnetworkprofileconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmnetworkprofileconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMNetworkProfileConfiguration struct {
+	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmproperties.go
@@ -1,0 +1,43 @@
+package virtualmachinescalesetvms
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMProperties struct {
+	AdditionalCapabilities      *AdditionalCapabilities                              `json:"additionalCapabilities,omitempty"`
+	AvailabilitySet             *SubResource                                         `json:"availabilitySet,omitempty"`
+	DiagnosticsProfile          *DiagnosticsProfile                                  `json:"diagnosticsProfile,omitempty"`
+	HardwareProfile             *HardwareProfile                                     `json:"hardwareProfile,omitempty"`
+	InstanceView                *VirtualMachineScaleSetVMInstanceView                `json:"instanceView,omitempty"`
+	LatestModelApplied          *bool                                                `json:"latestModelApplied,omitempty"`
+	LicenseType                 *string                                              `json:"licenseType,omitempty"`
+	ModelDefinitionApplied      *string                                              `json:"modelDefinitionApplied,omitempty"`
+	NetworkProfile              *NetworkProfile                                      `json:"networkProfile,omitempty"`
+	NetworkProfileConfiguration *VirtualMachineScaleSetVMNetworkProfileConfiguration `json:"networkProfileConfiguration,omitempty"`
+	OsProfile                   *OSProfile                                           `json:"osProfile,omitempty"`
+	ProtectionPolicy            *VirtualMachineScaleSetVMProtectionPolicy            `json:"protectionPolicy,omitempty"`
+	ProvisioningState           *string                                              `json:"provisioningState,omitempty"`
+	SecurityProfile             *SecurityProfile                                     `json:"securityProfile,omitempty"`
+	StorageProfile              *StorageProfile                                      `json:"storageProfile,omitempty"`
+	TimeCreated                 *string                                              `json:"timeCreated,omitempty"`
+	UserData                    *string                                              `json:"userData,omitempty"`
+	VMId                        *string                                              `json:"vmId,omitempty"`
+}
+
+func (o *VirtualMachineScaleSetVMProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *VirtualMachineScaleSetVMProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmprotectionpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmprotectionpolicy.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMProtectionPolicy struct {
+	ProtectFromScaleIn         *bool `json:"protectFromScaleIn,omitempty"`
+	ProtectFromScaleSetActions *bool `json:"protectFromScaleSetActions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmreimageparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_virtualmachinescalesetvmreimageparameters.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMReimageParameters struct {
+	ExactVersion                  *string                    `json:"exactVersion,omitempty"`
+	ForceUpdateOSDiskForEphemeral *bool                      `json:"forceUpdateOSDiskForEphemeral,omitempty"`
+	OsProfile                     *OSProfileProvisioningData `json:"osProfile,omitempty"`
+	TempDisk                      *bool                      `json:"tempDisk,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vmdisksecurityprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vmdisksecurityprofile.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMDiskSecurityProfile struct {
+	DiskEncryptionSet      *SubResource             `json:"diskEncryptionSet,omitempty"`
+	SecurityEncryptionType *SecurityEncryptionTypes `json:"securityEncryptionType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vmsizeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_vmsizeproperties.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMSizeProperties struct {
+	VCPUsAvailable *int64 `json:"vCPUsAvailable,omitempty"`
+	VCPUsPerCore   *int64 `json:"vCPUsPerCore,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_windowsconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_windowsconfiguration.go
@@ -1,0 +1,14 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WindowsConfiguration struct {
+	AdditionalUnattendContent    *[]AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
+	EnableAutomaticUpdates       *bool                        `json:"enableAutomaticUpdates,omitempty"`
+	EnableVMAgentPlatformUpdates *bool                        `json:"enableVMAgentPlatformUpdates,omitempty"`
+	PatchSettings                *PatchSettings               `json:"patchSettings,omitempty"`
+	ProvisionVMAgent             *bool                        `json:"provisionVMAgent,omitempty"`
+	TimeZone                     *string                      `json:"timeZone,omitempty"`
+	WinRM                        *WinRMConfiguration          `json:"winRM,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_windowsvmguestpatchautomaticbyplatformsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_windowsvmguestpatchautomaticbyplatformsettings.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WindowsVMGuestPatchAutomaticByPlatformSettings struct {
+	BypassPlatformSafetyChecksOnUserSchedule *bool                                                `json:"bypassPlatformSafetyChecksOnUserSchedule,omitempty"`
+	RebootSetting                            *WindowsVMGuestPatchAutomaticByPlatformRebootSetting `json:"rebootSetting,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_winrmconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_winrmconfiguration.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WinRMConfiguration struct {
+	Listeners *[]WinRMListener `json:"listeners,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_winrmlistener.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/model_winrmlistener.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WinRMListener struct {
+	CertificateUrl *string        `json:"certificateUrl,omitempty"`
+	Protocol       *ProtocolTypes `json:"protocol,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/predicates.go
@@ -1,0 +1,42 @@
+package virtualmachinescalesetvms
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetVMOperationPredicate struct {
+	Etag       *string
+	Id         *string
+	InstanceId *string
+	Location   *string
+	Name       *string
+	Type       *string
+}
+
+func (p VirtualMachineScaleSetVMOperationPredicate) Matches(input VirtualMachineScaleSetVM) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.InstanceId != nil && (input.InstanceId == nil || *p.InstanceId != *input.InstanceId) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms/version.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetvms
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachinescalesetvms/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -341,7 +341,9 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedh
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms
 github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger
 github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/certificates

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -341,6 +341,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedh
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets
 github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger
 github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/certificates

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -339,6 +339,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/availabili
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhostgroups
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhosts
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines
 github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger
 github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Following resources have been updated to use `hashicorp/go-azure-sdk`
- `azurerm_linux_virtual_machine`
- `azurerm_linux_virtual_machine_scale_set`
- `azurerm_orchestrated_machine_scale_set`
- `azurerm_virtual_machine_scale_set`
- `azurerm_windows_virtual_machine`
- `azurerm_windows_virtual_machine_scale_set`

Following data sources have been updated to use `hashicorp/go-azure-sdk`
- `azurerm_virtual_machine`
- `azurerm_virtual_machine_scale_set`

In addition:
- Swapped all references to `utils.String/Bool/...` to `pointer.To`
- Moved the SSHKey diff suppress func to the `suppress` package

## Testing 

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/ea52a3db-a0d6-466b-b8ab-df90dc9a6e83)

2 of the failing tests have been fixed by the last commit https://github.com/hashicorp/terraform-provider-azurerm/pull/25533/commits/1a60a6f8856da464fcfa7d328bbb4484151baa39

The remaining 9 failing tests are flaky and failing because of an unstable connection from TC with the following error: `HTTP response was nil; connection may have been reset` but have passed on previous runs.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
