### PR TITLE
`azurerm_function_app_hybrid_connection` and `azurerm_web_app_hybrid_connection`: allow use of an authorization rule for a relay in a different resource group

### DIFF
--- a/internal/services/appservice/function_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource.go
@@ -162,7 +162,7 @@ func (r FunctionAppHybridConnectionResource) Create() sdk.ResourceFunc {
 				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
 			}
 
-			sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, id, appHybridConn.SendKeyName)
+			sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, *relayId, appHybridConn.SendKeyName)
 			if err != nil {
 				return err
 			}
@@ -312,7 +312,12 @@ func (r FunctionAppHybridConnectionResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("send_key_name") {
-				key, err := helpers.GetSendKeyValue(ctx, metadata, *id, appHybridConn.SendKeyName)
+				relayId, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				if err != nil {
+					return err
+				}
+
+				key, err := helpers.GetSendKeyValue(ctx, metadata, *relayId, appHybridConn.SendKeyName)
 				if err != nil {
 					return err
 				}

--- a/internal/services/appservice/function_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource_test.go
@@ -254,6 +254,63 @@ resource "azurerm_windows_function_app" "test" {
 `, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
 }
 
+func (r FunctionAppHybridConnectionResource) templateRelayInOtherResourceGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  os_type             = "Windows"
+  sku_name            = "%[3]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[4]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_resource_group" "rg-test-relay" {
+  name     = "acctestRG-relay-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_relay_namespace" "test" {
+  name                = "acctest-RN-%[1]d"
+  location            = azurerm_resource_group.rg-test-relay.location
+  resource_group_name = azurerm_resource_group.rg-test-relay.name
+
+  sku_name = "Standard"
+}
+
+resource "azurerm_relay_hybrid_connection" "test" {
+  name                 = "acctest-RHC-%[1]d"
+  resource_group_name  = azurerm_resource_group.rg-test-relay.name
+  relay_namespace_name = azurerm_relay_namespace.test.name
+  user_metadata        = "metadatatest"
+}
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {}
+}
+`, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
+}
+
 func (r FunctionAppHybridConnectionResource) authRuleTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -276,14 +333,9 @@ func (r FunctionAppHybridConnectionResource) authRuleInRemoteResourceGroupTempla
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_resource_group" "relay" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
 resource "azurerm_relay_hybrid_connection_authorization_rule" "test" {
   name                   = "sendKey"
-  resource_group_name    = azurerm_resource_group.relay.name
+  resource_group_name    = azurerm_resource_group.rg-test-relay.name
   hybrid_connection_name = azurerm_relay_hybrid_connection.test.name
   namespace_name         = azurerm_relay_namespace.test.name
 
@@ -292,5 +344,5 @@ resource "azurerm_relay_hybrid_connection_authorization_rule" "test" {
   manage = false
 }
 
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, r.templateRelayInOtherResourceGroup(data))
 }

--- a/internal/services/appservice/function_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource_test.go
@@ -254,58 +254,6 @@ resource "azurerm_windows_function_app" "test" {
 `, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
 }
 
-func (r FunctionAppHybridConnectionResource) templateFunctionApp(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_service_plan" "test" {
-  name                = "acctestASP-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  os_type             = "Windows"
-  sku_name            = "%[3]s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%[4]s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_relay_namespace" "test" {
-  name                = "acctest-RN-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "Standard"
-}
-
-resource "azurerm_relay_hybrid_connection" "test" {
-  name                 = "acctest-RHC-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  relay_namespace_name = azurerm_relay_namespace.test.name
-  user_metadata        = "metadatatest"
-}
-
-resource "azurerm_windows_function_app" "test" {
-  name                = "acctest-WFA-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  service_plan_id     = azurerm_service_plan.test.id
-
-  storage_account_name       = azurerm_storage_account.test.name
-  storage_account_access_key = azurerm_storage_account.test.primary_access_key
-
-  site_config {}
-}
-`, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
-}
-
 func (r FunctionAppHybridConnectionResource) templateRelayInOtherResourceGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/internal/services/appservice/function_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource_test.go
@@ -254,6 +254,58 @@ resource "azurerm_windows_function_app" "test" {
 `, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
 }
 
+func (r FunctionAppHybridConnectionResource) templateFunctionApp(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  os_type             = "Windows"
+  sku_name            = "%[3]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[4]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_relay_namespace" "test" {
+  name                = "acctest-RN-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "Standard"
+}
+
+resource "azurerm_relay_hybrid_connection" "test" {
+  name                 = "acctest-RHC-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  relay_namespace_name = azurerm_relay_namespace.test.name
+  user_metadata        = "metadatatest"
+}
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {}
+}
+`, data.RandomInteger, data.Locations.Primary, SkuBasicPlan, data.RandomString)
+}
+
 func (r FunctionAppHybridConnectionResource) templateRelayInOtherResourceGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/internal/services/appservice/helpers/hybrid_connection.go
+++ b/internal/services/appservice/helpers/hybrid_connection.go
@@ -10,13 +10,12 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 )
 
-func GetSendKeyValue(ctx context.Context, metadata sdk.ResourceMetaData, id webapps.RelayId, sendKeyName string) (*string, error) {
+func GetSendKeyValue(ctx context.Context, metadata sdk.ResourceMetaData, id hybridconnections.HybridConnectionId, sendKeyName string) (*string, error) {
 	relayNamespaceClient := metadata.Client.Relay.NamespacesClient
-	relayConnectionId := namespaces.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.HybridConnectionNamespaceName, sendKeyName)
+	relayConnectionId := namespaces.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, sendKeyName)
 	relayKeys, err := relayNamespaceClient.ListKeys(ctx, relayConnectionId)
 	if err != nil && !response.WasNotFound(relayKeys.HttpResponse) {
 		return nil, fmt.Errorf("listing Send Keys for name %s for %s in %s: %+v", sendKeyName, relayConnectionId, id, err)
@@ -26,7 +25,7 @@ func GetSendKeyValue(ctx context.Context, metadata sdk.ResourceMetaData, id weba
 	}
 
 	hybridConnectionsClient := metadata.Client.Relay.HybridConnectionsClient
-	connectionId := hybridconnections.NewHybridConnectionAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.HybridConnectionNamespaceName, id.RelayName, sendKeyName)
+	connectionId := hybridconnections.NewHybridConnectionAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.HybridConnectionName, sendKeyName)
 	keys, err := hybridConnectionsClient.ListKeys(ctx, connectionId)
 	if err != nil {
 		return nil, fmt.Errorf("listing Send Keys for name %s for %s in %s: %+v", sendKeyName, connectionId, id, err)

--- a/internal/services/appservice/web_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource.go
@@ -162,7 +162,7 @@ func (r WebAppHybridConnectionResource) Create() sdk.ResourceFunc {
 				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
 			}
 
-			sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, id, appHybridConn.SendKeyName)
+			sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, *relayId, appHybridConn.SendKeyName)
 			if err != nil {
 				return err
 			}
@@ -311,7 +311,12 @@ func (r WebAppHybridConnectionResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("send_key_name") {
-				sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, *id, appHybridConn.SendKeyName)
+				relayId, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				if err != nil {
+					return err
+				}
+	
+				sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, *relayId, appHybridConn.SendKeyName)
 				if err != nil {
 					return err
 				}

--- a/internal/services/appservice/web_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource.go
@@ -315,7 +315,7 @@ func (r WebAppHybridConnectionResource) Update() sdk.ResourceFunc {
 				if err != nil {
 					return err
 				}
-	
+
 				sendKeyValue, err := helpers.GetSendKeyValue(ctx, metadata, *relayId, appHybridConn.SendKeyName)
 				if err != nil {
 					return err

--- a/internal/services/appservice/web_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource_test.go
@@ -269,8 +269,8 @@ resource "azurerm_relay_hybrid_connection" "test" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
- }
-  
+}
+
 resource "azurerm_service_plan" "test" {
   name                = "acctestASP-%[1]d"
   location            = azurerm_resource_group.test.location
@@ -278,7 +278,7 @@ resource "azurerm_service_plan" "test" {
   os_type             = "Windows"
   sku_name            = "%[3]s"
 }
-  
+
 resource "azurerm_windows_web_app" "test" {
   name                = "acctestWA-%[1]d"
   location            = azurerm_resource_group.test.location

--- a/internal/services/appservice/web_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource_test.go
@@ -244,6 +244,52 @@ resource "azurerm_windows_web_app" "test" {
 `, data.RandomInteger, data.Locations.Primary, SkuBasicPlan)
 }
 
+func (r WebAppHybridConnectionResource) templateRelayInOtherResourceGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "rg-test-relay" {
+  name     = "acctestRG-%[1]d-relay"
+  location = "%[2]s"
+}
+
+resource "azurerm_relay_namespace" "test" {
+  name                = "acctest-RN-%[1]d"
+  location            = azurerm_resource_group.rg-test-relay.location
+  resource_group_name = azurerm_resource_group.rg-test-relay.name
+
+  sku_name = "Standard"
+}
+
+resource "azurerm_relay_hybrid_connection" "test" {
+  name                 = "acctest-RHC-%[1]d"
+  resource_group_name  = azurerm_resource_group.rg-test-relay.name
+  relay_namespace_name = azurerm_relay_namespace.test.name
+  user_metadata        = "metadatatest"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+ }
+  
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  os_type             = "Windows"
+  sku_name            = "%[3]s"
+}
+  
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+}
+`, data.RandomInteger, data.Locations.Primary, SkuBasicPlan)
+}
+
 func (r WebAppHybridConnectionResource) authRuleTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -266,14 +312,9 @@ func (r WebAppHybridConnectionResource) authRuleInRemoteResourceGroupTemplate(da
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_resource_group" "relay" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
 resource "azurerm_relay_hybrid_connection_authorization_rule" "test" {
   name                   = "sendKey"
-  resource_group_name    = azurerm_resource_group.relay.name
+  resource_group_name    = azurerm_resource_group.rg-test-relay.name
   hybrid_connection_name = azurerm_relay_hybrid_connection.test.name
   namespace_name         = azurerm_relay_namespace.test.name
 
@@ -282,5 +323,5 @@ resource "azurerm_relay_hybrid_connection_authorization_rule" "test" {
   manage = false
 }
 
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, r.templateRelayInOtherResourceGroup(data))
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

The hybrid connection `send_key_name` argument and associated retrieval of the `send_key_value` assumed that the relay/hybrid connection/authorization rule existed in the same resource group as the web app / function app.  This is often not the case and this PR fixes that and includes updated/fixed acceptance tests (the `_complete` tests) for the same


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_function_app_hybrid_connection` and  `azurerm_web_app_hybrid_connection` - fix the case where the relay and hybrid connection are in a different resource group to the web/function app.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
