### PR TITLE
`azurerm_mssql_server` - fix 400 error when updating resource when the `type` of `identity` is set to `SystemAssigned, UserAssigned` 

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -340,6 +341,11 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
 			payload.Identity = expanded
+		} else {
+			// switch out the legacy API value (no space) for the value used in the Schema (w/space for consistency)
+			if strings.EqualFold(string(payload.Identity.Type), "SystemAssigned,UserAssigned") {
+				payload.Identity.Type = identity.TypeSystemAssignedUserAssigned
+			}
 		}
 
 		if d.HasChange("transparent_data_encryption_key_vault_key_id") {

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -341,11 +341,9 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
 			payload.Identity = expanded
-		} else {
+		} else if strings.EqualFold(string(payload.Identity.Type), "SystemAssigned,UserAssigned") {
 			// switch out the legacy API value (no space) for the value used in the Schema (w/space for consistency)
-			if strings.EqualFold(string(payload.Identity.Type), "SystemAssigned,UserAssigned") {
-				payload.Identity.Type = identity.TypeSystemAssignedUserAssigned
-			}
+			payload.Identity.Type = identity.TypeSystemAssignedUserAssigned
 		}
 
 		if d.HasChange("transparent_data_encryption_key_vault_key_id") {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

If the `type` of `identity` is set to `SystemAssigned, UserAssigned`(w/space), Terraform will return the following 400 error if the `type` has not changed when updating the resource.  It is caused by an internal error (internal error: the legacy `SystemAssigned,UserAssigned` identity type should be being converted to the schema type - this is a bug). In this case, the `type` value returned from API is `SystemAssigned,UserAssigned`(no space) causing this internal error to occur. I assume that we should replace the legacy API value (no space) with the value used in the Schema (w/space for consistency) when updating resource w/o change for `type` to fix #24390.

`performing CreateOrUpdate: unexpected status 400 with error: InvalidResource: The resource definition is invalid.`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

 PASS: TestAccMsSqlServer_systemAndUserAssignedIdentity (513.94s)

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24390


