### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20240409.1113035`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-azure-helpers v0.67.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240409.1113035
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-azure-helpers v0.67.0
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240408.1091446
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.67.0 h1:0RY6mY3W3Ym2I+jExLtyLx96fh6p5n9vidqisAKGUSE=
 github.com/hashicorp/go-azure-helpers v0.67.0/go.mod h1:S4Bu66vyJvHA0trqHQB0YVGsISuF7HMH9tyEsMVlx8A=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446 h1:29AGSyAgyhkPLT/+lF6gdkAgjlSvVxY+I920qPvxl9s=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446/go.mod h1:XBU+P3RiAw5behcmYMOEYU9yc0iDOFrFk48gzlHrDkU=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240409.1113035 h1:Qd0g2XnvfXekdsjFHiSa/4tAcLpnJAYdiVY5xhO8Ad4=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240409.1113035/go.mod h1:Pc8LAwXacrZMdmrXh94BPhQww1GysHnHvHeWo9LfhJA=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035 h1:EvMlT8eKPv0p7szyWHR9bt/tyBD7P92hzRLAXILwfdg=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035/go.mod h1:POOjeoqNp+mvlLBuibJTziUAkBZ7FxXGeGestwemL/w=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/hashicorp/go-azure-helpers v0.67.0 h1:0RY6mY3W3Ym2I+jExLtyLx96fh6p5n9
 github.com/hashicorp/go-azure-helpers v0.67.0/go.mod h1:S4Bu66vyJvHA0trqHQB0YVGsISuF7HMH9tyEsMVlx8A=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446 h1:29AGSyAgyhkPLT/+lF6gdkAgjlSvVxY+I920qPvxl9s=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446/go.mod h1:XBU+P3RiAw5behcmYMOEYU9yc0iDOFrFk48gzlHrDkU=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240408.1091446 h1:9eGMTbem0I+7r6pZAkgcl93oi4DdO0cE6i7LUA71xvM=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240408.1091446/go.mod h1:POOjeoqNp+mvlLBuibJTziUAkBZ7FxXGeGestwemL/w=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035 h1:EvMlT8eKPv0p7szyWHR9bt/tyBD7P92hzRLAXILwfdg=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035/go.mod h1:POOjeoqNp+mvlLBuibJTziUAkBZ7FxXGeGestwemL/w=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
@@ -20,8 +20,8 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 
 	originalRequestUri := response.Request.URL.String()
 
-	// If this is a LRO we should either have a 201/202 with a Polling URI header
-	isLroStatus := response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted
+	// If this is a LRO we should either have a 200/201/202 with a Polling URI header
+	isLroStatus := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted
 	methodIsDelete := strings.EqualFold(response.Request.Method, "DELETE")
 	lroPollingUri := pollingUriForLongRunningOperation(response)
 	lroIsSelfReference := isLROSelfReference(lroPollingUri, originalRequestUri)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,7 +151,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240408.1091446
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240409.1113035
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1078,7 +1078,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saplands
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saprecommendations
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapsupportedsku
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240408.1091446
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240409.1113035
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20240409.1113035` - further details can be found in a comment.