### PR TITLE
`azurerm_storage_container` and `azurerm_storage_blob`: support for encryption scope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9
 	github.com/sergi/go-diff v1.2.0
-	github.com/tombuildsstuff/giovanni v0.25.5
+	github.com/tombuildsstuff/giovanni v0.26.1
 	github.com/tombuildsstuff/kermit v0.20240122.1123108
 	golang.org/x/crypto v0.18.0
 	golang.org/x/tools v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tombuildsstuff/giovanni v0.25.5 h1:YjVuiurzRAZDwTsWtelYOJV3373fMHXEazirh6h7nhU=
-github.com/tombuildsstuff/giovanni v0.25.5/go.mod h1:s7xbU2lN5Iz9MBglmDDv9p2QPbn6x3UkJBtpCfUerLs=
+github.com/tombuildsstuff/giovanni v0.26.1 h1:RZgnpyIHtgw0GXYpw3xttNk35obJNoI1hztCZsh/Djo=
+github.com/tombuildsstuff/giovanni v0.26.1/go.mod h1:s7xbU2lN5Iz9MBglmDDv9p2QPbn6x3UkJBtpCfUerLs=
 github.com/tombuildsstuff/kermit v0.20240122.1123108 h1:icQaxsv/ANv/KC4Sr0V1trrWA/XIL+3QAVBDpiSTgj8=
 github.com/tombuildsstuff/kermit v0.20240122.1123108/go.mod h1:T3YBVFhRV4qA7SbnRaNE6eapIMpKDA9rG/V7Ocsjlno=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/services/storage/shim/containers.go
+++ b/internal/services/storage/shim/containers.go
@@ -19,8 +19,10 @@ type StorageContainerWrapper interface {
 }
 
 type StorageContainerProperties struct {
-	AccessLevel           containers.AccessLevel
-	MetaData              map[string]string
-	HasImmutabilityPolicy bool
-	HasLegalHold          bool
+	AccessLevel                     containers.AccessLevel
+	DefaultEncryptionScope          string
+	EncryptionScopeOverrideDisabled bool
+	MetaData                        map[string]string
+	HasImmutabilityPolicy           bool
+	HasLegalHold                    bool
 }

--- a/internal/services/storage/shim/containers_data_plane.go
+++ b/internal/services/storage/shim/containers_data_plane.go
@@ -60,10 +60,12 @@ func (w DataPlaneStorageContainerWrapper) Get(ctx context.Context, containerName
 	}
 
 	return &StorageContainerProperties{
-		AccessLevel:           props.AccessLevel,
-		MetaData:              props.MetaData,
-		HasImmutabilityPolicy: props.HasImmutabilityPolicy,
-		HasLegalHold:          props.HasLegalHold,
+		AccessLevel:                     props.AccessLevel,
+		DefaultEncryptionScope:          props.DefaultEncryptionScope,
+		EncryptionScopeOverrideDisabled: props.EncryptionScopeOverrideDisabled,
+		MetaData:                        props.MetaData,
+		HasImmutabilityPolicy:           props.HasImmutabilityPolicy,
+		HasLegalHold:                    props.HasLegalHold,
 	}, nil
 }
 

--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -63,6 +63,11 @@ func dataSourceStorageBlob() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"encryption_scope": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"url": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -135,6 +140,8 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 	d.Set("content_md5", contentMD5)
+
+	d.Set("encryption_scope", props.EncryptionScope)
 
 	d.Set("type", strings.TrimSuffix(string(props.BlobType), "Blob"))
 

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -111,6 +111,13 @@ func resourceStorageBlob() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"encryption_scope": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageEncryptionScopeName,
+			},
+
 			"source": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
@@ -239,6 +246,11 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		SourceContent: d.Get("source_content").(string),
 		SourceUri:     d.Get("source_uri").(string),
 	}
+
+	if encryptionScope := d.Get("encryption_scope"); encryptionScope.(string) != "" {
+		blobInput.EncryptionScope = encryptionScope.(string)
+	}
+
 	if err = blobInput.Create(ctx); err != nil {
 		return fmt.Errorf("creating %s: %v", id, err)
 	}
@@ -379,6 +391,8 @@ func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		}
 	}
 	d.Set("content_md5", contentMD5)
+
+	d.Set("encryption_scope", props.EncryptionScope)
 
 	d.Set("type", strings.TrimSuffix(string(props.BlobType), "Blob"))
 	d.Set("url", d.Id())

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/accounts"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/blobs"
 )
@@ -285,11 +285,24 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("building Blobs Client: %v", err)
 	}
 
+	log.Printf("[INFO] Retrieving %s", id)
+	input := blobs.GetPropertiesInput{}
+	props, err := blobsClient.GetProperties(ctx, id.ContainerName, id.BlobName, input)
+	if err != nil {
+		if response.WasNotFound(props.HttpResponse) {
+			log.Printf("[INFO] Blob %q was not found in Container %q / Account %q - assuming removed & removing from state...", id.BlobName, id.ContainerName, id.AccountId.AccountName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving properties for %s: %v", id, err)
+	}
+
 	if d.HasChange("content_type") || d.HasChange("cache_control") {
 		log.Printf("[DEBUG] Updating Properties for %s...", id)
 		input := blobs.SetPropertiesInput{
-			ContentType:  utils.String(d.Get("content_type").(string)),
-			CacheControl: utils.String(d.Get("cache_control").(string)),
+			ContentType:  pointer.To(d.Get("content_type").(string)),
+			CacheControl: pointer.To(d.Get("cache_control").(string)),
 		}
 
 		// `content_md5` is `ForceNew` but must be included in the `SetPropertiesInput` update payload, or it will be zeroed on the blob.
@@ -298,10 +311,8 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			if err != nil {
 				return fmt.Errorf("converting hex to base64 encoding for content_md5: %v", err)
 			}
-
-			input.ContentMD5 = utils.String(data)
+			input.ContentMD5 = pointer.To(data)
 		}
-
 		if _, err = blobsClient.SetProperties(ctx, id.ContainerName, id.BlobName, input); err != nil {
 			return fmt.Errorf("updating Properties for %s: %v", id, err)
 		}
@@ -313,6 +324,10 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		metaDataRaw := d.Get("metadata").(map[string]interface{})
 		input := blobs.SetMetaDataInput{
 			MetaData: ExpandMetaData(metaDataRaw),
+		}
+		// Encryption Scope must be specified when updating metadata
+		if props.EncryptionScope != "" {
+			input.EncryptionScope = pointer.To(props.EncryptionScope)
 		}
 		if _, err = blobsClient.SetMetaData(ctx, id.ContainerName, id.BlobName, input); err != nil {
 			return fmt.Errorf("updating MetaData for %s: %v", id, err)

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -344,6 +344,43 @@ func TestAccStorageBlob_encryptionScope(t *testing.T) {
 	})
 }
 
+func TestAccStorageBlob_encryptionScopeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_blob", "test")
+	r := StorageBlobResource{}
+	content := "Wubba Lubba Dub Dub"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.encryptionScope(data, content),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "source_content", "type"),
+		{
+			Config: r.encryptionScopeUpdateMetadata(data, content),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "source_content", "type"),
+		{
+			Config: r.encryptionScopeUpdateProperties(data, content),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "source_content", "type"),
+		{
+			Config: r.encryptionScopeUpdateAccessTier(data, content),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "source_content", "type"),
+	})
+}
+
 func TestAccStorageBlob_pageEmpty(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_blob", "test")
 	r := StorageBlobResource{}
@@ -985,6 +1022,107 @@ resource "azurerm_storage_blob" "test" {
   source_content         = <<EOT
 %[3]s
 EOT
+}
+`, template, data.RandomInteger, content)
+}
+
+func (r StorageBlobResource) encryptionScopeUpdateMetadata(data acceptance.TestData, content string) string {
+	template := r.template(data, "blob")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_storage_encryption_scope" "test" {
+  name               = "acctestEScontainer%[2]d"
+  storage_account_id = azurerm_storage_account.test.id
+  source             = "Microsoft.Storage"
+}
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "rick.morty"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  encryption_scope       = azurerm_storage_encryption_scope.test.name
+  source_content         = <<EOT
+%[3]s
+EOT
+
+  metadata = {
+    hello = "world"
+  }
+}
+`, template, data.RandomInteger, content)
+}
+
+func (r StorageBlobResource) encryptionScopeUpdateProperties(data acceptance.TestData, content string) string {
+	template := r.template(data, "blob")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_storage_encryption_scope" "test" {
+  name               = "acctestEScontainer%[2]d"
+  storage_account_id = azurerm_storage_account.test.id
+  source             = "Microsoft.Storage"
+}
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "rick.morty"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  encryption_scope       = azurerm_storage_encryption_scope.test.name
+  source_content         = <<EOT
+%[3]s
+EOT
+
+  metadata = {
+    hello = "world"
+  }
+
+  content_type = "text/plain"
+}
+`, template, data.RandomInteger, content)
+}
+
+func (r StorageBlobResource) encryptionScopeUpdateAccessTier(data acceptance.TestData, content string) string {
+	template := r.template(data, "blob")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_storage_encryption_scope" "test" {
+  name               = "acctestEScontainer%[2]d"
+  storage_account_id = azurerm_storage_account.test.id
+  source             = "Microsoft.Storage"
+}
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "rick.morty"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  encryption_scope       = azurerm_storage_encryption_scope.test.name
+  source_content         = <<EOT
+%[3]s
+EOT
+
+  metadata = {
+    hello = "world"
+  }
+
+  content_type = "text/plain"
+  access_tier  = "Hot"
 }
 `, template, data.RandomInteger, content)
 }

--- a/internal/services/storage/storage_container_data_source.go
+++ b/internal/services/storage/storage_container_data_source.go
@@ -40,6 +40,16 @@ func dataSourceStorageContainer() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"default_encryption_scope": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"encryption_scope_override_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"metadata": MetaDataComputedSchema(),
 
 			// TODO: support for ACL's, Legal Holds and Immutability Policies
@@ -110,6 +120,9 @@ func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{})
 	d.Set("name", containerName)
 	d.Set("storage_account_name", accountName)
 	d.Set("container_access_type", flattenStorageContainerAccessLevel(props.AccessLevel))
+
+	d.Set("default_encryption_scope", props.DefaultEncryptionScope)
+	d.Set("encryption_scope_override_enabled", !props.EncryptionScopeOverrideDisabled)
 
 	if err = d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
 		return fmt.Errorf("setting `metadata`: %v", err)

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/blobs/metadata_set.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/blobs/metadata_set.go
@@ -18,6 +18,9 @@ type SetMetaDataInput struct {
 
 	// Any metadata which should be added to this blob
 	MetaData map[string]string
+
+	// The encryption scope for the blob.
+	EncryptionScope *string
 }
 
 type SetMetaDataResponse struct {
@@ -84,6 +87,9 @@ func (s setMetadataOptions) ToHeaders() *client.Headers {
 	headers := &client.Headers{}
 	if s.input.LeaseID != nil {
 		headers.Append("x-ms-lease-id", *s.input.LeaseID)
+	}
+	if s.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *s.input.EncryptionScope)
 	}
 	headers.Merge(metadata.SetMetaDataHeaders(s.input.MetaData))
 	return headers

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/datalakestore/filesystems/create.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/datalakestore/filesystems/create.go
@@ -10,6 +10,9 @@ import (
 )
 
 type CreateInput struct {
+	// The encryption scope to set as the default on the filesystem.
+	DefaultEncryptionScope string
+
 	// A map of base64-encoded strings to store as user-defined properties with the File System
 	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
 	// This automatically gets converted to a comma-separated list of name and
@@ -35,7 +38,7 @@ func (c Client) Create(ctx context.Context, fileSystemName string, input CreateI
 		},
 		HttpMethod: http.MethodPut,
 		OptionsObject: createOptions{
-			properties: input.Properties,
+			input: input,
 		},
 
 		Path: fmt.Sprintf("/%s", fileSystemName),
@@ -61,12 +64,17 @@ func (c Client) Create(ctx context.Context, fileSystemName string, input CreateI
 }
 
 type createOptions struct {
-	properties map[string]string
+	input CreateInput
 }
 
 func (o createOptions) ToHeaders() *client.Headers {
 	headers := &client.Headers{}
-	props := buildProperties(o.properties)
+
+	if o.input.DefaultEncryptionScope != "" {
+		headers.Append("x-ms-default-encryption-scope", o.input.DefaultEncryptionScope)
+	}
+
+	props := buildProperties(o.input.Properties)
 	if props != "" {
 		headers.Append("x-ms-properties", props)
 	}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/datalakestore/filesystems/properties_get.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2023-11-03/datalakestore/filesystems/properties_get.go
@@ -12,6 +12,9 @@ import (
 type GetPropertiesResponse struct {
 	HttpResponse *http.Response
 
+	// The default encryption scope for the filesystem.
+	DefaultEncryptionScope string
+
 	// A map of base64-encoded strings to store as user-defined properties with the File System
 	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
 	// This automatically gets converted to a comma-separated list of name and
@@ -51,6 +54,8 @@ func (c Client) GetProperties(ctx context.Context, fileSystemName string) (resul
 		result.HttpResponse = resp.Response
 
 		if resp.Header != nil {
+			result.DefaultEncryptionScope = resp.Header.Get("x-ms-default-encryption-scope")
+
 			propertiesRaw := resp.Header.Get("x-ms-properties")
 			var properties *map[string]string
 			properties, err = parseProperties(propertiesRaw)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1277,7 +1277,7 @@ github.com/rickb777/plural
 # github.com/sergi/go-diff v1.2.0
 ## explicit; go 1.12
 github.com/sergi/go-diff/diffmatchpatch
-# github.com/tombuildsstuff/giovanni v0.25.5
+# github.com/tombuildsstuff/giovanni v0.26.1
 ## explicit; go 1.21
 github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/accounts
 github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/blobs

--- a/website/docs/d/storage_blob.html.markdown
+++ b/website/docs/d/storage_blob.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `content_md5` - The MD5 sum of the blob contents.
 
+* `encryption_scope` - The encryption scope for this blob.
+
 * `metadata` - A map of custom blob metadata.
 
 ## Timeouts

--- a/website/docs/d/storage_container.html.markdown
+++ b/website/docs/d/storage_container.html.markdown
@@ -31,6 +31,10 @@ The following arguments are supported:
 
 * `container_access_type` - The Access Level configured for this Container.
 
+* `default_encryption_scope` - The default encryption scope in use for blobs uploaded to this container.
+
+* `encryption_scope_override_enabled` - Whether blobs are allowed to override the default encryption scope for this container.
+
 * `has_immutability_policy` - Is there an Immutability Policy configured on this Storage Container?
 
 * `has_legal_hold` - Is there a Legal Hold configured on this Storage Container?

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 ~> **NOTE:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` or `source_content`, respectively, are defined.
 
+* `encryption_scope` - (Optional) The encryption scope to use for this blob.
+
 * `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified. Changing this forces a new resource to be created.
 
 * `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified. Changing this forces a new resource to be created.

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -49,6 +49,10 @@ The following arguments are supported:
 
 ~> **Note** When updating `container_access_type` for an existing storage container resource, Shared Key authentication will always be used, as AzureAD authentication is not supported.
 
+* `default_encryption_scope` - (Optional) The default encryption scope to use for blobs uploaded to this container. Changing this forces a new resource to be created.
+
+* `encryption_scope_override_enabled` - (Optional) Whether to allow blobs to override the default encryption scope for this container. Can only be set when specifying `default_encryption_scope`. Defaults to `true`. Changing this forces a new resource to be created.
+
 * `metadata` - (Optional) A mapping of MetaData for this Container. All metadata keys should be lowercase.
 
 ## Attributes Reference

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
 
+* `default_encryption_scope` - (Optional) The default encryption scope to use for this filesystem. Changing this forces a new resource to be created.
+
 * `properties` - (Optional) A mapping of Key to Base64-Encoded Values which should be assigned to this Data Lake Gen2 File System.
 
 * `ace` - (Optional) One or more `ace` blocks as defined below to specify the entries for the ACL for the path.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for setting encryption scope when creating a storage container, blob, or datalake gen2 filesystem.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

ENHANCEMENTS:

* dependencies: updating to `v0.26.1` of `github.com/tombuildsstuff/giovanni`
* `azurerm_storage_blob` - support for the `encryption_scope` property
* `azurerm_storage_container` - support for the `default_encryption_scope` and `encryption_scope_override_enabled` properties
* `azurerm_storage_data_lake_gen2_filesystem` - support for the `default_encryption_scope` property

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes: #12055
Closes: #17272
Closes: #23232

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
