### PR TITLE
`azurerm_key_vault_certificate_contacts` - in v4.0 make the `contact` field optional to allow for deletion of contacts from the key vault. / `azurerm_key_vault` - deprecate the `contact` field from v3.x provider and update properties to `Computed` `Optional`.

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_contacts_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource.go
@@ -44,11 +44,10 @@ func (r KeyVaultCertificateContactsResource) Arguments() map[string]*pluginsdk.S
 		"key_vault_id": commonschema.ResourceIDReferenceRequiredForceNew(&commonids.KeyVaultId{}),
 	}
 
-	if !features.FourPointOhBeta() {
+	if features.FourPointOhBeta() {
 		schema["contact"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeSet,
-			Required: true,
-			MinItems: 1,
+			Optional: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"email": {
@@ -74,7 +73,8 @@ func (r KeyVaultCertificateContactsResource) Arguments() map[string]*pluginsdk.S
 	} else {
 		schema["contact"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeSet,
-			Optional: true,
+			Required: true,
+			MinItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"email": {
@@ -163,11 +163,7 @@ func (r KeyVaultCertificateContactsResource) Create() sdk.ResourceFunc {
 				ContactList: expandKeyVaultCertificateContactsContact(state.Contact),
 			}
 
-			if !features.FourPointOhBeta() {
-				if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
-					return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
-				}
-			} else {
+			if features.FourPointOhBeta() {
 				if len(*contacts.ContactList) == 0 {
 					if _, err := client.DeleteCertificateContacts(ctx, id.KeyVaultBaseUrl); err != nil {
 						return fmt.Errorf("removing Key Vault Certificate Contacts %s: %+v", id, err)
@@ -176,6 +172,10 @@ func (r KeyVaultCertificateContactsResource) Create() sdk.ResourceFunc {
 					if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
 						return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
 					}
+				}
+			} else {
+				if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
+					return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
 				}
 			}
 
@@ -259,11 +259,7 @@ func (r KeyVaultCertificateContactsResource) Update() sdk.ResourceFunc {
 				existing.ContactList = expandKeyVaultCertificateContactsContact(state.Contact)
 			}
 
-			if !features.FourPointOhBeta() {
-				if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
-					return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
-				}
-			} else {
+			if features.FourPointOhBeta() {
 				if len(*existing.ContactList) == 0 {
 					if _, err := client.DeleteCertificateContacts(ctx, id.KeyVaultBaseUrl); err != nil {
 						return fmt.Errorf("removing Key Vault Certificate Contacts %s: %+v", id, err)
@@ -272,6 +268,10 @@ func (r KeyVaultCertificateContactsResource) Update() sdk.ResourceFunc {
 					if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
 						return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
 					}
+				}
+			} else {
+				if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
+					return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/keyvault/key_vault_certificate_contacts_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
@@ -39,10 +40,12 @@ type Contact struct {
 }
 
 func (r KeyVaultCertificateContactsResource) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"key_vault_id": commonschema.ResourceIDReferenceRequiredForceNew(&commonids.KeyVaultId{}),
+	}
 
-		"contact": {
+	if !features.FourPointOhBeta() {
+		schema["contact"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeSet,
 			Required: true,
 			MinItems: 1,
@@ -67,8 +70,36 @@ func (r KeyVaultCertificateContactsResource) Arguments() map[string]*pluginsdk.S
 					},
 				},
 			},
-		},
+		}
+	} else {
+		schema["contact"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"email": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"phone": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		}
 	}
+
+	return schema
 }
 
 func (r KeyVaultCertificateContactsResource) Attributes() map[string]*pluginsdk.Schema {
@@ -132,8 +163,20 @@ func (r KeyVaultCertificateContactsResource) Create() sdk.ResourceFunc {
 				ContactList: expandKeyVaultCertificateContactsContact(state.Contact),
 			}
 
-			if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
-				return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
+			if !features.FourPointOhBeta() {
+				if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
+					return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
+				}
+			} else {
+				if len(*contacts.ContactList) == 0 {
+					if _, err := client.DeleteCertificateContacts(ctx, id.KeyVaultBaseUrl); err != nil {
+						return fmt.Errorf("removing Key Vault Certificate Contacts %s: %+v", id, err)
+					}
+				} else {
+					if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
+						return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
+					}
+				}
 			}
 
 			metadata.SetID(id)
@@ -216,8 +259,20 @@ func (r KeyVaultCertificateContactsResource) Update() sdk.ResourceFunc {
 				existing.ContactList = expandKeyVaultCertificateContactsContact(state.Contact)
 			}
 
-			if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
-				return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
+			if !features.FourPointOhBeta() {
+				if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
+					return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
+				}
+			} else {
+				if len(*existing.ContactList) == 0 {
+					if _, err := client.DeleteCertificateContacts(ctx, id.KeyVaultBaseUrl); err != nil {
+						return fmt.Errorf("removing Key Vault Certificate Contacts %s: %+v", id, err)
+					}
+				} else {
+					if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
+						return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
+					}
+				}
 			}
 
 			return nil

--- a/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -99,6 +100,41 @@ func TestAccKeyVaultCertificateContacts_nonExistentVault(t *testing.T) {
 			ExpectNonEmptyPlan: true,
 			ExpectError:        regexp.MustCompile(`not found`),
 		},
+	})
+}
+
+func TestAccKeyVaultCertificateContacts_remove(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		t.Skipf("Skippped as test is not valid in 3.x")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.remove(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("contact").IsEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("contact").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -254,4 +290,19 @@ resource "azurerm_key_vault_access_policy" "test" {
   ]
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (r KeyVaultCertificateContactsResource) remove(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_certificate_contacts" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test
+  ]
+}
+`, template)
 }

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -218,7 +218,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 			Type:       pluginsdk.TypeSet,
 			Optional:   true,
 			Computed:   true,
-			Deprecated: "As the `contact` property requires reaching out to the dataplane to better support private endpoints and keyvaults with public network access disabled, `contact` will be removed in favour of the `azurerm_key_vault_certificate_contacts` resource in version 4.0 of the AzureRM Provider.",
+			Deprecated: "As the `contact` property requires reaching out to the dataplane, to better support private endpoints and keyvaults with public network access disabled, `contact` will be removed in favour of the `azurerm_key_vault_certificate_contacts` resource in version 4.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"email": {

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -218,7 +218,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 			Type:       pluginsdk.TypeSet,
 			Optional:   true,
 			Computed:   true,
-			Deprecated: "`contact` will be removed in favour of the `azurerm_key_vault_certificate_contacts` resource in version 4.0 of the AzureRM Provider.",
+			Deprecated: "As the `contact` property requires reaching out to the dataplane to better support private endpoints and keyvaults with public network access disabled, `contact` will be removed in favour of the `azurerm_key_vault_certificate_contacts` resource in version 4.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"email": {

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	commonValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -30,13 +31,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	dataplane "github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+	dataplane "github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault" // TODO: Remove in 4.0
 )
 
 var keyVaultResourceName = "azurerm_key_vault"
 
 func resourceKeyVault() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := pluginsdk.Resource{
 		Create: resourceKeyVaultCreate,
 		Read:   resourceKeyVaultRead,
 		Update: resourceKeyVaultUpdate,
@@ -202,27 +203,6 @@ func resourceKeyVault() *pluginsdk.Resource {
 				ValidateFunc: validation.IntBetween(7, 90),
 			},
 
-			"contact": {
-				Type:     pluginsdk.TypeSet,
-				Optional: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"email": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-						},
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
-						"phone": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-
 			"tags": commonschema.Tags(),
 
 			// Computed
@@ -232,12 +212,39 @@ func resourceKeyVault() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["contact"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeSet,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "`contact` will be removed in favour of the `azurerm_key_vault_certificate_contacts` resource in version 4.0 of the AzureRM Provider.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"email": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"phone": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		}
+	}
+
+	return &resource
 }
 
 func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).KeyVault.VaultsClient
-	dataPlaneClient := meta.(*clients.Client).KeyVault.ManagementClient
+	dataPlaneClient := meta.(*clients.Client).KeyVault.ManagementClient // TODO: Remove in 4.0
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -283,9 +290,12 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	isPublic := d.Get("public_network_access_enabled").(bool)
-	contactRaw := d.Get("contact").(*pluginsdk.Set).List()
-	if !isPublic && len(contactRaw) > 0 {
-		return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
+	contactRaw := d.Get("contact").(*pluginsdk.Set).List() // TODO: Remove in 4.0
+
+	if !features.FourPointOhBeta() {
+		if !isPublic && len(contactRaw) > 0 {
+			return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
+		}
 	}
 
 	tenantUUID := d.Get("tenant_id").(string)
@@ -413,16 +423,18 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if len(contactRaw) > 0 {
-		if !isPublic {
-			return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
-		}
+	if !features.FourPointOhBeta() {
+		if len(contactRaw) > 0 {
+			if !isPublic {
+				return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
+			}
 
-		contacts := dataplane.Contacts{
-			ContactList: expandKeyVaultCertificateContactList(contactRaw),
-		}
-		if _, err := dataPlaneClient.SetCertificateContacts(ctx, vaultUri, contacts); err != nil {
-			return fmt.Errorf("failed to set Contacts for %s: %+v", id, err)
+			contacts := dataplane.Contacts{
+				ContactList: expandKeyVaultCertificateContactList(contactRaw),
+			}
+			if _, err := dataPlaneClient.SetCertificateContacts(ctx, vaultUri, contacts); err != nil {
+				return fmt.Errorf("failed to set Contacts for %s: %+v", id, err)
+			}
 		}
 	}
 
@@ -623,30 +635,32 @@ func resourceKeyVaultUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
-	if d.HasChange("contact") {
-		if !isPublic {
-			return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
-		}
-		contacts := dataplane.Contacts{
-			ContactList: expandKeyVaultCertificateContactList(d.Get("contact").(*pluginsdk.Set).List()),
-		}
-		vaultUri := ""
-		if existing.Model != nil && existing.Model.Properties.VaultUri != nil {
-			vaultUri = *existing.Model.Properties.VaultUri
-		}
-		if vaultUri == "" {
-			return fmt.Errorf("failed to get vault base url for %s: %s", *id, err)
-		}
+	if !features.FourPointOhBeta() {
+		if d.HasChange("contact") {
+			if !isPublic {
+				return fmt.Errorf("`contact` cannot be specified when `public_network_access_enabled` is set to `false`")
+			}
+			contacts := dataplane.Contacts{
+				ContactList: expandKeyVaultCertificateContactList(d.Get("contact").(*pluginsdk.Set).List()),
+			}
+			vaultUri := ""
+			if existing.Model != nil && existing.Model.Properties.VaultUri != nil {
+				vaultUri = *existing.Model.Properties.VaultUri
+			}
+			if vaultUri == "" {
+				return fmt.Errorf("failed to get vault base url for %s: %s", *id, err)
+			}
 
-		var err error
-		if len(*contacts.ContactList) == 0 {
-			_, err = managementClient.DeleteCertificateContacts(ctx, vaultUri)
-		} else {
-			_, err = managementClient.SetCertificateContacts(ctx, vaultUri, contacts)
-		}
+			var err error
+			if len(*contacts.ContactList) == 0 {
+				_, err = managementClient.DeleteCertificateContacts(ctx, vaultUri)
+			} else {
+				_, err = managementClient.SetCertificateContacts(ctx, vaultUri, contacts)
+			}
 
-		if err != nil {
-			return fmt.Errorf("setting Contacts for %s: %+v", *id, err)
+			if err != nil {
+				return fmt.Errorf("setting Contacts for %s: %+v", *id, err)
+			}
 		}
 	}
 
@@ -657,7 +671,7 @@ func resourceKeyVaultUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).KeyVault.VaultsClient
-	dataplaneClient := meta.(*clients.Client).KeyVault.ManagementClient
+	dataplaneClient := meta.(*clients.Client).KeyVault.ManagementClient // TODO: Remove in 4.0
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -690,15 +704,17 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		meta.(*clients.Client).KeyVault.AddToCache(*id, vaultUri)
 	}
 
-	var contactsResp *dataplane.Contacts
-	if isPublic {
-		contacts, err := dataplaneClient.GetCertificateContacts(ctx, vaultUri)
-		if err != nil {
-			if !utils.ResponseWasForbidden(contacts.Response) && !utils.ResponseWasNotFound(contacts.Response) {
-				return fmt.Errorf("retrieving `contact` for KeyVault: %+v", err)
+	var contactsResp *dataplane.Contacts // TODO: Remove in 4.0
+	if !features.FourPointOhBeta() {
+		if isPublic {
+			contacts, err := dataplaneClient.GetCertificateContacts(ctx, vaultUri)
+			if err != nil {
+				if !utils.ResponseWasForbidden(contacts.Response) && !utils.ResponseWasNotFound(contacts.Response) {
+					return fmt.Errorf("retrieving `contact` for KeyVault: %+v", err)
+				}
 			}
+			contactsResp = &contacts
 		}
-		contactsResp = &contacts
 	}
 
 	d.Set("name", id.VaultName)
@@ -749,8 +765,10 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			return fmt.Errorf("setting `access_policy`: %+v", err)
 		}
 
-		if err := d.Set("contact", flattenKeyVaultCertificateContactList(contactsResp)); err != nil {
-			return fmt.Errorf("setting `contact` for KeyVault: %+v", err)
+		if !features.FourPointOhBeta() {
+			if err := d.Set("contact", flattenKeyVaultCertificateContactList(contactsResp)); err != nil {
+				return fmt.Errorf("setting `contact` for KeyVault: %+v", err)
+			}
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
@@ -916,6 +934,7 @@ func expandKeyVaultNetworkAcls(input []interface{}) (*vaults.NetworkRuleSet, []s
 	return &ruleSet, subnetIds
 }
 
+// TODO: Remove in 4.0
 func expandKeyVaultCertificateContactList(input []interface{}) *[]dataplane.Contact {
 	results := make([]dataplane.Contact, 0)
 	if len(input) == 0 || input[0] == nil {

--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -203,6 +204,10 @@ func TestAccKeyVault_upgradeSKU(t *testing.T) {
 }
 
 func TestAccKeyVault_updateContacts(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skipf("Skippped as deprecated property removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
 	r := KeyVaultResource{}
 
@@ -1159,6 +1164,7 @@ resource "azurerm_key_vault" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
+// TODO: Remove in 4.0
 func (KeyVaultResource) updateContacts(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -14,6 +14,7 @@ Manages a Key Vault.
 
 ~> **Note:** It's possible to define Key Vault Access Policies both within [the `azurerm_key_vault` resource](key_vault.html) via the `access_policy` block and by using [the `azurerm_key_vault_access_policy` resource](key_vault_access_policy.html). However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
 
+<!-- TODO: Remove Note in 4.0 -->
 ~> **Note:** It's possible to define Key Vault Certificate Contacts both within [the `azurerm_key_vault` resource](key_vault.html) via the `contact` block and by using [the `azurerm_key_vault_certificate_contacts` resource](key_vault_certificate_contacts.html). However it's not possible to use both methods to manage Certificate Contacts within a KeyVault, since there'll be conflicts.
 
 ~> **Note:** Terraform will automatically recover a soft-deleted Key Vault during Creation if one is found - you can opt out of this using the `features` block within the Provider block.
@@ -107,6 +108,7 @@ The following arguments are supported:
 
 ~> **Note:** This field can only be configured one time and cannot be updated.
 
+<!-- TODO: Remove `contact` and Notes in 4.0 -->
 * `contact` - (Optional) One or more `contact` block as defined below.
 
 ~> **Note:** This field can only be set once user has `managecontacts` certificate permission.

--- a/website/docs/r/key_vault_certificate_contacts.html.markdown
+++ b/website/docs/r/key_vault_certificate_contacts.html.markdown
@@ -12,6 +12,7 @@ Manages Key Vault Certificate Contacts.
 
 ## Disclaimers
 
+<!-- TODO: Remove Note in 4.0 -->
 ~> **Note:** It's possible to define Key Vault Certificate Contacts both within [the `azurerm_key_vault` resource](key_vault.html) via the `contact` block and by using [the `azurerm_key_vault_certificate_contacts` resource](key_vault_certificate_contacts.html). However it's not possible to use both methods to manage Certificate Contacts within a KeyVault, since there'll be conflicts.
 
 ## Example Usage
@@ -77,6 +78,9 @@ The following arguments are supported:
 * `key_vault_id` - (Required) The ID of the Key Vault. Changing this forces a new resource to be created.
 
 * `contact` - (Required) One or more `contact` blocks as defined below.
+<!-- TODO: Update in 4.0
+* `contact` - (Optional) One or more `contact` blocks as defined below.
+-->
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

* `azurerm_key_vault` - deprecate the `contact` field from v3.x provider and update properties to `Computed` `Optional`.
* `azurerm_key_vault_certificate_contacts` - in v4.0 make the `contact` field optional to allow for deletion of contacts from the key vault.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="383" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/20408400/9fd71a02-8b9f-4f75-a2cb-c79ecc547cb8">


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_key_vault` - deprecate the `contact` field from v3.x provider and update properties to `Computed` `Optional`.
* `azurerm_key_vault_certificate_contacts` - in v4.0 make the `contact` field optional to allow for deletion of contacts from the key vault.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #22301

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
