### PR TITLE
`azurerm_linux_web_app` - `site_config.0.application_stack.0.java_version` must be specified with `java_server` and `java_server_version`

### DIFF
--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -538,6 +538,9 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					"17",
 				}, false),
 				ExactlyOneOf: linuxApplicationStackConstraint,
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_server_version", "site_config.0.application_stack.0.java_server",
+				},
 			},
 
 			"java_server": {
@@ -549,7 +552,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					"JBOSSEAP",
 				}, false),
 				RequiredWith: []string{
-					"site_config.0.application_stack.0.java_version",
+					"site_config.0.application_stack.0.java_version", "site_config.0.application_stack.0.java_server_version",
 				},
 			},
 
@@ -557,7 +560,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				RequiredWith: []string{
-					"site_config.0.application_stack.0.java_server",
+					"site_config.0.application_stack.0.java_version", "site_config.0.application_stack.0.java_server",
 				},
 			},
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -170,6 +170,8 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** The valid version combinations for `java_version`, `java_server` and `java_server_version` can be checked from the command line via `az webapp list-runtimes --linux`.
 
+~> **NOTE:** `java_server`, `java_server_version`, and `java_version` must all be specified if building a java app
+
 * `node_version` - (Optional) The version of Node to run. Possible values include `12-lts`, `14-lts`, `16-lts`, `18-lts` and `20-lts`. This property conflicts with `java_version`.
 
 ~> **NOTE:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes a bug where `site_config.0.application_stack.0.java_version` could be passed in without any of the other java elements. Terraform would run but would not actually do anything. 

This could be considered a breaking change but it wasn't working before so it should be ok to add this in


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_web_app` - `site_config.0.application_stack.0.java_version` must be specified with `java_server` and `java_server_version` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
