### PR TITLE
data/resource: azurerm_management_group - now exports tenant_scoped_id

### DIFF
--- a/internal/services/eventgrid/eventgrid_system_topic_resource.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_resource.go
@@ -71,7 +71,7 @@ func resourceEventGridSystemTopic() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.Any(
 					azure.ValidateResourceID,
-					mgmtGroupValidate.ManagementGroupIDForSystemTopic,
+					mgmtGroupValidate.TenantScopedManagementGroupID,
 				),
 			},
 

--- a/internal/services/eventgrid/eventgrid_system_topic_resource.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_resource.go
@@ -71,7 +71,7 @@ func resourceEventGridSystemTopic() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.Any(
 					azure.ValidateResourceID,
-					mgmtGroupValidate.ManagementGroupID,
+					mgmtGroupValidate.ManagementGroupIDForSystemTopic,
 				),
 			},
 

--- a/internal/services/managementgroup/management_group_data_source.go
+++ b/internal/services/managementgroup/management_group_data_source.go
@@ -114,8 +114,8 @@ func dataSourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) 
 	d.Set("name", groupName)
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, groupName)
-	d.Set("management_group_id", idForSystemTopic)
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, id.Name)
+	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	if props := resp.Properties; props != nil {
 		d.Set("display_name", props.DisplayName)

--- a/internal/services/managementgroup/management_group_data_source.go
+++ b/internal/services/managementgroup/management_group_data_source.go
@@ -41,7 +41,7 @@ func dataSourceManagementGroup() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"name", "display_name"},
 			},
 
-			"management_group_id": {
+			"tenant_scoped_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -114,8 +114,8 @@ func dataSourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) 
 	d.Set("name", groupName)
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
-	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
+	tenantScopedID := parse.NewTenantScopedManagementGroupID(tenantID, id.Name)
+	d.Set("tenant_scoped_id", tenantScopedID.TenantScopedID())
 
 	if props := resp.Properties; props != nil {
 		d.Set("display_name", props.DisplayName)

--- a/internal/services/managementgroup/management_group_data_source.go
+++ b/internal/services/managementgroup/management_group_data_source.go
@@ -114,7 +114,7 @@ func dataSourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) 
 	d.Set("name", groupName)
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, id.Name)
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
 	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	if props := resp.Properties; props != nil {

--- a/internal/services/managementgroup/management_group_data_source.go
+++ b/internal/services/managementgroup/management_group_data_source.go
@@ -41,6 +41,11 @@ func dataSourceManagementGroup() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"name", "display_name"},
 			},
 
+			"management_group_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"parent_management_group_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -75,6 +80,7 @@ func dataSourceManagementGroup() *pluginsdk.Resource {
 
 func dataSourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).ManagementGroups.GroupsClient
+	accountClient := meta.(*clients.Client)
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -106,6 +112,10 @@ func dataSourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) 
 	id := parse.NewManagementGroupId(groupName)
 	d.SetId(id.ID())
 	d.Set("name", groupName)
+
+	tenantID := accountClient.Account.TenantId
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, groupName)
+	d.Set("management_group_id", idForSystemTopic)
 
 	if props := resp.Properties; props != nil {
 		d.Set("display_name", props.DisplayName)

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -59,6 +59,11 @@ func resourceManagementGroup() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"management_group_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"parent_management_group_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -83,6 +88,7 @@ func resourceManagementGroup() *pluginsdk.Resource {
 func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).ManagementGroups.GroupsClient
 	subscriptionsClient := meta.(*clients.Client).ManagementGroups.SubscriptionClient
+	accountClient := meta.(*clients.Client)
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 	armTenantID := meta.(*clients.Client).Account.TenantId
@@ -97,6 +103,10 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	id := parse.NewManagementGroupId(groupName)
+
+	tenantID := accountClient.Account.TenantId
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, groupName)
+	d.Set("management_group_id", idForSystemTopic)
 
 	parentManagementGroupId := d.Get("parent_management_group_id").(string)
 	if parentManagementGroupId == "" {

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -105,7 +105,7 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	id := parse.NewManagementGroupId(groupName)
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, groupName)
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
 	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	parentManagementGroupId := d.Get("parent_management_group_id").(string)
@@ -226,7 +226,7 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, id.Name)
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
 	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	recurse := utils.Bool(true)

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -216,6 +216,7 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).ManagementGroups.GroupsClient
+	accountClient := meta.(*clients.Client)
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -223,6 +224,10 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
+
+	tenantID := accountClient.Account.TenantId
+	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, id.Name)
+	d.Set("management_group_id", idForSystemTopic)
 
 	recurse := utils.Bool(true)
 	resp, err := client.Get(ctx, id.Name, "children", recurse, "", managementGroupCacheControl)

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -59,12 +59,12 @@ func resourceManagementGroup() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"management_group_id": {
+			"tenant_scoped_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
-			"parent_management_group_id": {
+			"parent_tenant_scoped_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				Computed:     true,
@@ -105,10 +105,10 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	id := parse.NewManagementGroupId(groupName)
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
-	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
+	tenantScopedID := parse.NewTenantScopedManagementGroupID(tenantID, id.Name)
+	d.Set("tenant_scoped_id", tenantScopedID.TenantScopedID())
 
-	parentManagementGroupId := d.Get("parent_management_group_id").(string)
+	parentManagementGroupId := d.Get("parent_tenant_scoped_id").(string)
 	if parentManagementGroupId == "" {
 		parentManagementGroupId = fmt.Sprintf("/providers/Microsoft.Management/managementGroups/%s", armTenantID)
 	}
@@ -226,8 +226,8 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	tenantID := accountClient.Account.TenantId
-	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(id.Name, tenantID)
-	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
+	tenantScopedID := parse.NewTenantScopedManagementGroupID(tenantID, id.Name)
+	d.Set("tenant_scoped_id", tenantScopedID.TenantScopedID())
 
 	recurse := utils.Bool(true)
 	resp, err := client.Get(ctx, id.Name, "children", recurse, "", managementGroupCacheControl)
@@ -260,7 +260,7 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 				}
 			}
 		}
-		d.Set("parent_management_group_id", parentId)
+		d.Set("parent_tenant_scoped_id", parentId)
 	}
 
 	return nil

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -106,7 +106,7 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	tenantID := accountClient.Account.TenantId
 	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, groupName)
-	d.Set("management_group_id", idForSystemTopic)
+	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	parentManagementGroupId := d.Get("parent_management_group_id").(string)
 	if parentManagementGroupId == "" {
@@ -227,7 +227,7 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 
 	tenantID := accountClient.Account.TenantId
 	idForSystemTopic := parse.NewManagementGroupIDForSystemTopic(tenantID, id.Name)
-	d.Set("management_group_id", idForSystemTopic)
+	d.Set("management_group_id", idForSystemTopic.IDForSystemTopic())
 
 	recurse := utils.Bool(true)
 	resp, err := client.Get(ctx, id.Name, "children", recurse, "", managementGroupCacheControl)

--- a/internal/services/managementgroup/parse/management_group.go
+++ b/internal/services/managementgroup/parse/management_group.go
@@ -40,6 +40,33 @@ func ManagementGroupID(input string) (*ManagementGroupId, error) {
 	return &id, nil
 }
 
+func ManagementGroupIDForSystemTopic(input string) (*ManagementGroupId, error) {
+	regex := regexp.MustCompile(`^/tenants/.+/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
+	if !regex.MatchString(input) {
+		return nil, fmt.Errorf("Unable to parse Management Group ID for System Topic %q, format should look like '/tenants/<tenantID>/providers/Microsoft.Management/managementGroups/<management_group_name>'", input)
+	}
+
+	// Split the input ID by the regex
+	segments := regex.Split(input, -1)
+	if len(segments) != 2 {
+		return nil, fmt.Errorf("Unable to parse Management Group ID %q: expected id to have two segments after splitting", input)
+	}
+
+	groupID := segments[1]
+	if groupID == "" {
+		return nil, fmt.Errorf("unable to parse Management Group ID %q: management group name is empty", input)
+	}
+	if segments := strings.Split(groupID, "/"); len(segments) != 1 {
+		return nil, fmt.Errorf("unable to parse Management Group ID %q: ID has extra segments", input)
+	}
+
+	id := ManagementGroupId{
+		Name: groupID,
+	}
+
+	return &id, nil
+}
+
 func NewManagementGroupId(managementGroupName string) ManagementGroupId {
 	return ManagementGroupId{
 		Name: managementGroupName,

--- a/internal/services/managementgroup/parse/management_group.go
+++ b/internal/services/managementgroup/parse/management_group.go
@@ -41,8 +41,8 @@ func ManagementGroupID(input string) (*ManagementGroupId, error) {
 	return &id, nil
 }
 
-func ManagementGroupIDForSystemTopic(input string) (*ManagementGroupId, error) {
-	regex := regexp.MustCompile(`^/tenants/.*-.*-.*-.*-.*/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
+func TenantScopedManagementGroupID(input string) (*ManagementGroupId, error) {
+	regex := regexp.MustCompile(`^/tenants/.*-.*-.*-.*-.*/providers/Microsoft\.Management/managementGroups/`)
 	if !regex.MatchString(input) {
 		return nil, fmt.Errorf("Unable to parse Management Group ID for System Topic %q, format should look like '/tenants/<tenantID>/providers/Microsoft.Management/managementGroups/<management_group_name>'", input)
 	}
@@ -76,7 +76,7 @@ func NewManagementGroupId(managementGroupName string) ManagementGroupId {
 	}
 }
 
-func NewManagementGroupIDForSystemTopic(groupName string, tenantID string) ManagementGroupId {
+func NewTenantScopedManagementGroupID(tenantID, groupName string) ManagementGroupId {
 	return ManagementGroupId{
 		Name:     groupName,
 		TenantID: tenantID,
@@ -88,7 +88,7 @@ func (r ManagementGroupId) ID() string {
 	return fmt.Sprintf(managementGroupIdFmt, r.Name)
 }
 
-func (r ManagementGroupId) IDForSystemTopic() string {
+func (r ManagementGroupId) TenantScopedID() string {
 	managementGroupIDForSystemTopicFormat := "/tenants/%s/providers/Microsoft.Management/managementGroups/%s"
 
 	return fmt.Sprintf(managementGroupIDForSystemTopicFormat, r.TenantID, r.Name)

--- a/internal/services/managementgroup/parse/management_group.go
+++ b/internal/services/managementgroup/parse/management_group.go
@@ -42,7 +42,7 @@ func ManagementGroupID(input string) (*ManagementGroupId, error) {
 }
 
 func ManagementGroupIDForSystemTopic(input string) (*ManagementGroupId, error) {
-	regex := regexp.MustCompile(`^/tenants/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
+	regex := regexp.MustCompile(`^/tenants/.*-.*-.*-.*-.*/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
 	if !regex.MatchString(input) {
 		return nil, fmt.Errorf("Unable to parse Management Group ID for System Topic %q, format should look like '/tenants/<tenantID>/providers/Microsoft.Management/managementGroups/<management_group_name>'", input)
 	}

--- a/internal/services/managementgroup/parse/management_group.go
+++ b/internal/services/managementgroup/parse/management_group.go
@@ -10,7 +10,8 @@ import (
 )
 
 type ManagementGroupId struct {
-	Name string
+	Name     string
+	TenantID string
 }
 
 func ManagementGroupID(input string) (*ManagementGroupId, error) {
@@ -62,6 +63,7 @@ func ManagementGroupIDForSystemTopic(input string) (*ManagementGroupId, error) {
 
 	id := ManagementGroupId{
 		Name: groupID,
+		// TODO: Add in the TenantID
 	}
 
 	return &id, nil
@@ -73,7 +75,20 @@ func NewManagementGroupId(managementGroupName string) ManagementGroupId {
 	}
 }
 
+func NewManagementGroupIDForSystemTopic(groupName string, tenantID string) *ManagementGroupId {
+	return &ManagementGroupId{
+		Name:     groupName,
+		TenantID: tenantID,
+	}
+}
+
 func (r ManagementGroupId) ID() string {
 	managementGroupIdFmt := "/providers/Microsoft.Management/managementGroups/%s"
 	return fmt.Sprintf(managementGroupIdFmt, r.Name)
+}
+
+func (r ManagementGroupId) IDForSystemTopic() string {
+	managementGroupIDForSystemTopicFormat := "/tenants/%s/providers/Microsoft.Management/managementGroups/%s"
+
+	return fmt.Sprintf(managementGroupIDForSystemTopicFormat, r.TenantID, r.Name)
 }

--- a/internal/services/managementgroup/parse/management_group_test.go
+++ b/internal/services/managementgroup/parse/management_group_test.go
@@ -119,7 +119,7 @@ func TestManagementGroupIDForSystemTopic(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Name)
 
-		actual, err := ManagementGroupIDForSystemTopic(v.Input)
+		actual, err := TenantScopedManagementGroupID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/internal/services/managementgroup/parse/management_group_test.go
+++ b/internal/services/managementgroup/parse/management_group_test.go
@@ -98,3 +98,42 @@ func TestManagementGroupID(t *testing.T) {
 		}
 	}
 }
+
+func TestManagementGroupIDForSystemTopic(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Error    bool
+		Expected *ManagementGroupId
+	}{
+		{
+			Name:  "Management Group ID for System Topic",
+			Input: "/tenants/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000",
+			Expected: &ManagementGroupId{
+				Name:     "00000000-0000-0000-0000-000000000000",
+				TenantID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ManagementGroupIDForSystemTopic(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.TenantID != v.Expected.TenantID {
+			t.Fatalf("Expected %q but got %q for TenantID", v.Expected.TenantID, actual.TenantID)
+		}
+	}
+}

--- a/internal/services/managementgroup/validate/management_group_id.go
+++ b/internal/services/managementgroup/validate/management_group_id.go
@@ -24,14 +24,14 @@ func ManagementGroupID(i interface{}, k string) (warnings []string, errors []err
 	return
 }
 
-func ManagementGroupIDForSystemTopic(i interface{}, k string) (warnings []string, errors []error) {
+func TenantScopedManagementGroupID(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
 		return
 	}
 
-	if _, err := parse.ManagementGroupIDForSystemTopic(v); err != nil {
+	if _, err := parse.TenantScopedManagementGroupID(v); err != nil {
 		errors = append(errors, fmt.Errorf("Can not parse %q as a management group id: %v", k, err))
 		return
 	}

--- a/internal/services/managementgroup/validate/management_group_id.go
+++ b/internal/services/managementgroup/validate/management_group_id.go
@@ -23,3 +23,18 @@ func ManagementGroupID(i interface{}, k string) (warnings []string, errors []err
 
 	return
 }
+
+func ManagementGroupIDForSystemTopic(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.ManagementGroupIDForSystemTopic(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a management group id: %v", k, err))
+		return
+	}
+
+	return
+}

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -30,13 +30,15 @@ The following arguments are supported:
 
 * `display_name` - Specifies the display name of this Management Group.
 
-~> **NOTE** Whilst multiple management groups may share the same display name, when filtering Terraform expects a single management group to be found with this name.  
+~> **NOTE** Whilst multiple management groups may share the same display name, when filtering Terraform expects a single management group to be found with this name.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID of the Management Group.
+
+* `management_group_id` - The Management Group ID with the Tenant ID prefix.
 
 * `parent_management_group_id` - The ID of any Parent Management Group.
 

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -38,7 +38,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Management Group.
 
-* `management_group_id` - The Management Group ID with the Tenant ID prefix.
+* `tenant_scoped_id` - The Management Group ID with the Tenant ID prefix.
 
 * `parent_management_group_id` - The ID of any Parent Management Group.
 

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `display_name` - (Optional) A friendly name for this Management Group. If not specified, this will be the same as the `name`.
 
-* `parent_management_group_id` - (Optional) The ID of the Parent Management Group. 
+* `parent_management_group_id` - (Optional) The ID of the Parent Management Group.
 
 * `subscription_ids` - (Optional) A list of Subscription GUIDs which should be assigned to the Management Group.
 
@@ -56,6 +56,8 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Management Group.
+
+* `management_group_id` - The Management Group ID with the Tenant ID prefix.
 
 ## Timeouts
 

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -57,7 +57,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Management Group.
 
-* `management_group_id` - The Management Group ID with the Tenant ID prefix.
+* `tenant_scoped_id` - The Management Group ID with the Tenant ID prefix.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Currently when trying to create a System Topic on a Management Group using the described and validated Management Group ID as per below an error is received:
```
resource "azurerm_eventgrid_system_topic" "this" {
  name                   = "policy-insights"
  resource_group_name    = "resource-group"
  location               = "Global"
  source_arm_resource_id = "/providers/Microsoft.Management/managementGroups/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
  topic_type             = "Microsoft.PolicyInsights.PolicyStates"
}
```

This yields the following error:
```
╷
│ Error: creating/updating System Topic (Subscription: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
│ Resource Group Name: "resource-group"
│ System Topic Name: "policy-insights"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: InvalidRequest: ResourceID is not in the expected format: /providers/Microsoft.Management/managementGroups/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (Parameter 'GetSourceScope')
│ 
│   with azurerm_eventgrid_system_topic.this,
│   on main.tf line 14, in resource "azurerm_eventgrid_system_topic" "this":
│   14: resource "azurerm_eventgrid_system_topic" "this" {
│ 
╵
```

This error looks to be coming from the Azure API, which means the current `validate.ManagementGroupID` function from the `github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate` package is only checking for valid format on the above and not what is expected by the API.

As shown in the following documentation the resource ID format changes specifically for Management Group IDs when creating a System Topic. 

https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/governance/policy/tutorials/route-state-change-events.md#create-an-event-grid-system-topic

The resolution to this is to create a validator and parser for Management Group IDs based on that format.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_eventgrid_system_topic` - support for using a correctly formatted Management Group ID as the `source_arm_resource_id` [GH-25555]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24548


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
