### PR TITLE
`azurerm_monitor_smart_detector_alert_rule` - Normalize `action_group.ids`

### DIFF
--- a/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
+++ b/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
@@ -19,6 +19,7 @@ import (
 	commonValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/migration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
@@ -251,7 +252,11 @@ func resourceMonitorSmartDetectorAlertRuleRead(d *pluginsdk.ResourceData, meta i
 			}
 			d.Set("throttling_duration", throttlingDuration)
 
-			if err := d.Set("action_group", flattenMonitorSmartDetectorAlertRuleActionGroup(&props.ActionGroups)); err != nil {
+			actionGroup, err := flattenMonitorSmartDetectorAlertRuleActionGroup(&props.ActionGroups)
+			if err != nil {
+				return fmt.Errorf("flatten `action_group`: %+v", err)
+			}
+			if err := d.Set("action_group", actionGroup); err != nil {
 				return fmt.Errorf("setting `action_group`: %+v", err)
 			}
 		}
@@ -288,9 +293,9 @@ func expandMonitorSmartDetectorAlertRuleActionGroup(input []interface{}) *smartd
 	}
 }
 
-func flattenMonitorSmartDetectorAlertRuleActionGroup(input *smartdetectoralertrules.ActionGroupsInformation) []interface{} {
+func flattenMonitorSmartDetectorAlertRuleActionGroup(input *smartdetectoralertrules.ActionGroupsInformation) ([]interface{}, error) {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{}, nil
 	}
 
 	var customEmailSubject, CustomWebhookPayload string
@@ -301,11 +306,20 @@ func flattenMonitorSmartDetectorAlertRuleActionGroup(input *smartdetectoralertru
 		CustomWebhookPayload = *input.CustomWebhookPayload
 	}
 
+	var groupIds []string
+	for _, idRaw := range input.GroupIds {
+		id, err := parse.ActionGroupIDInsensitively(idRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %v", idRaw, err)
+		}
+		groupIds = append(groupIds, id.ID())
+	}
+
 	return []interface{}{
 		map[string]interface{}{
-			"ids":             input.GroupIds,
+			"ids":             groupIds,
 			"email_subject":   customEmailSubject,
 			"webhook_payload": CustomWebhookPayload,
 		},
-	}
+	}, nil
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

In most cases, the `action_group` is a reference from an `azurerm_monitor_action_group`, which is fine. Whilst for other cases, where the action group of this alert rule is referenced from other means, the resource id might be not of the expected form (especially the `actionGroup` section can be `actiongroup`), which violates the validation defined in https://github.com/hashicorp/terraform-provider-azurerm/blob/4b72a21e86224698854dc1375f3bff3abd54f367/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go#L118.

One live example can be found at https://github.com/Azure/aztfexport/issues/259

This PR normalizes the `action_group.ids` during `Read`.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
