### PR TITLE
`azurerm_mssql_managed_database` - allow RestorableDatabaseID to be used for point in time restore

### DIFF
--- a/internal/services/mssqlmanagedinstance/parse/restorable_dropped_database.go
+++ b/internal/services/mssqlmanagedinstance/parse/restorable_dropped_database.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+// note: this can't be automated today due to the comma in the Resource ID
+
+type RestorableDroppedDatabaseId struct {
+	Name                 string
+	MsSqlManagedInstance string
+	ResourceGroup        string
+	RestoreName          string
+}
+
+func RestorableDroppedDatabaseID(input string) (*RestorableDroppedDatabaseId, error) {
+	inputList := strings.Split(input, ",")
+
+	if len(inputList) != 2 {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Microsoft Sql Managed Instance Restorable DB ID %q, please refer to '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/managedInstance1/restorableDroppedDatabases/miDB1,000000000000000000'", input)
+	}
+
+	restorableDBId := RestorableDroppedDatabaseId{
+		RestoreName: inputList[1],
+	}
+
+	id, err := azure.ParseAzureResourceID(inputList[0])
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Microsoft Sql Managed Instance Restorable DB ID %q: %+v", input, err)
+	}
+
+	restorableDBId.ResourceGroup = id.ResourceGroup
+
+	if restorableDBId.MsSqlManagedInstance, err = id.PopSegment("managedInstances"); err != nil {
+		return nil, err
+	}
+
+	if restorableDBId.Name, err = id.PopSegment("restorableDroppedDatabases"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(inputList[0]); err != nil {
+		return nil, err
+	}
+
+	return &restorableDBId, nil
+}

--- a/internal/services/mssqlmanagedinstance/parse/restorable_dropped_database_test.go
+++ b/internal/services/mssqlmanagedinstance/parse/restorable_dropped_database_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import "testing"
+
+func TestMsSqlRestoreDBID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *RestorableDroppedDatabaseId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Restore Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Managed Instance Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Managed Instance Restorable Database",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/managedInstance1,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Managed Instance Restorable Database Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/managedInstance1/restorableDroppedDatabases,000000000000000000",
+			Expected: nil,
+		},
+		{
+			Name:  "Sql Managed Instance Restorable Database ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/managedInstance1/restorableDroppedDatabases/miDB1,000000000000000000",
+			Expected: &RestorableDroppedDatabaseId{
+				Name:                 "miDB1",
+				MsSqlManagedInstance: "managedInstance1",
+				ResourceGroup:        "resGroup1",
+				RestoreName:          "000000000000000000",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/managedInstances/managedInstance1/RestorableDroppedDatabases/miDB1,000000000000000000",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := RestorableDroppedDatabaseID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.RestoreName != v.Expected.RestoreName {
+			t.Fatalf("Expected %q but got %q for Restore Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.MsSqlManagedInstance != v.Expected.MsSqlManagedInstance {
+			t.Fatalf("Expected %q but got %q for Sql Server", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/internal/services/mssqlmanagedinstance/validate/restorable_dropped_database_id.go
+++ b/internal/services/mssqlmanagedinstance/validate/restorable_dropped_database_id.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
+)
+
+func RestorableDatabaseID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := parse.RestorableDroppedDatabaseID(v); err != nil {
+		errors = append(errors, fmt.Errorf("cannot parse %q as a MsSql Managed Instance Restorable Database resource id: %v", k, err))
+	}
+
+	return warnings, errors
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This pr adds validation for RestorableDatabaseID and allows them to be used for point in time restores of mssql_managed_database

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

Tested this manually:

* Create an azurem_mssql_managed_database using tf
* Destroy the azurem_mssql_managed_database using tf
* Retrieve restorable db id and point in time restore time from backups in mssql_managed_instance and populate `point_in_time_restore` block with these and apply

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_managed_database_resource` - allow RestorableDatabaseID to be used for point in time restore [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change
