### PR TITLE
fix duplicate prop in `azurerm_bot_service_azure_bot` docs

### DIFF
--- a/website/docs/r/bot_service_azure_bot.html.markdown
+++ b/website/docs/r/bot_service_azure_bot.html.markdown
@@ -96,8 +96,6 @@ The following arguments are supported:
 
 * `streaming_endpoint_enabled` - (Optional) Is the streaming endpoint enabled for this Azure Bot Service. Defaults to `false`.
 
-* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
-
 * `tags` - (Optional) A mapping of tags which should be assigned to this Azure Bot Service.
 
 ## Attributes Reference


### PR DESCRIPTION
This removes a duplicate `public_network_access_enabled` property in the docs for `azurerm_bot_service_azure_bot`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
