### PR TITLE
`azurerm_web_pubsub`, `azurerm_signalr_service` - add `Premium_P2` to SKU property

### DIFF
--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -828,13 +828,15 @@ func resourceArmSignalRServiceSchema() map[string]*pluginsdk.Schema {
 							"Free_F1",
 							"Standard_S1",
 							"Premium_P1",
+							"Premium_P2",
 						}, false),
 					},
 
 					"capacity": {
-						Type:         pluginsdk.TypeInt,
-						Required:     true,
-						ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100}),
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+						ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200,
+							300, 400, 500, 600, 700, 800, 900, 1000}),
 					},
 				},
 			},

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -108,13 +108,36 @@ func TestAccSignalRService_identity(t *testing.T) {
 	})
 }
 
-func TestAccSignalRService_premium(t *testing.T) {
+func TestAccSignalRService_premiumP1(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
 	r := SignalRServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.premium(data),
+			Config: r.premium(data, "Premium_P1", 1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("hostname").Exists(),
+				check.That(data.ResourceName).Key("ip_address").Exists(),
+				check.That(data.ResourceName).Key("public_port").Exists(),
+				check.That(data.ResourceName).Key("server_port").Exists(),
+				check.That(data.ResourceName).Key("primary_access_key").Exists(),
+				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSignalRService_premiumP2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
+	r := SignalRServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.premium(data, "Premium_P2", 100),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("hostname").Exists(),
@@ -690,7 +713,7 @@ resource "azurerm_signalr_service" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r SignalRServiceResource) premium(data acceptance.TestData) string {
+func (r SignalRServiceResource) premium(data acceptance.TestData, planSku string, capacity int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -707,11 +730,11 @@ resource "azurerm_signalr_service" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    name     = "Premium_P1"
-    capacity = 1
+    name     = "%s"
+    capacity = %d
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, planSku, capacity)
 }
 
 func (r SignalRServiceResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -70,17 +70,18 @@ func resourceWebPubSub() *pluginsdk.Resource {
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Premium_P1",
+					"Premium_P2",
 					"Standard_S1",
 					"Free_F1",
 				}, false),
 			},
 
 			"capacity": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ValidateFunc: validation.IntInSlice([]int{1, 2, 5, 10, 20, 50, 100}),
-			},
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Default:  1,
+				ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200,
+					300, 400, 500, 600, 700, 800, 900, 1000})},
 
 			"live_trace": {
 				Type:     pluginsdk.TypeList,

--- a/internal/services/signalr/web_pubsub_resource_test.go
+++ b/internal/services/signalr/web_pubsub_resource_test.go
@@ -41,6 +41,50 @@ func TestAccWebPubsub_basic(t *testing.T) {
 	})
 }
 
+func TestAccWebPubsub_premiumP1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub", "test")
+	r := WebPubsubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.premium(data, "Premium_P1", 1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("hostname").Exists(),
+				check.That(data.ResourceName).Key("public_port").Exists(),
+				check.That(data.ResourceName).Key("server_port").Exists(),
+				check.That(data.ResourceName).Key("primary_access_key").Exists(),
+				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWebPubsub_premiumP2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub", "test")
+	r := WebPubsubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.premium(data, "Premium_P2", 100),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("hostname").Exists(),
+				check.That(data.ResourceName).Key("public_port").Exists(),
+				check.That(data.ResourceName).Key("server_port").Exists(),
+				check.That(data.ResourceName).Key("primary_access_key").Exists(),
+				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccWebPubsub_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub", "test")
 	r := WebPubsubResource{}
@@ -262,6 +306,20 @@ resource "azurerm_web_pubsub" "test" {
   capacity            = 1
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r WebPubsubResource) premium(data acceptance.TestData, sku string, capacity int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_web_pubsub" "test" {
+  name                = "acctestWebPubsub-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "%s"
+  capacity            = %d
+}
+`, r.template(data), data.RandomInteger, sku, capacity)
 }
 
 func (r WebPubsubResource) complete(data acceptance.TestData) string {

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -133,7 +133,7 @@ A `sku` block supports the following:
 
 * `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` and `1000`.
 
-~> **NOTE:** The valid unit range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for `Standard_S1` and `Premium_P1` .
+~> **NOTE:** The valid capacity range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for sku `Standard_S1` and `Premium_P1`.
 
 ---
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -129,9 +129,11 @@ A `live_trace` block supports the following:
 
 A `sku` block supports the following:
 
-* `name` - (Required) Specifies which tier to use. Valid values are `Free_F1`, `Standard_S1` and `Premium_P1`.
+* `name` - (Required) Specifies which tier to use. Valid values are `Free_F1`, `Standard_S1`, `Premium_P1` and `Premium_P2`.
 
-* `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90` and `100`.
+* `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` and `1000`.
+
+~> **NOTE:** The valid unit range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for `Standard_S1` and `Premium_P1` .
 
 ---
 

--- a/website/docs/r/web_pubsub.html.markdown
+++ b/website/docs/r/web_pubsub.html.markdown
@@ -50,9 +50,11 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Web PubSub service exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Specifies which SKU to use. Possible values are `Free_F1`, `Standard_S1`, and `Premium_P1`.
+* `sku` - (Required) Specifies which SKU to use. Possible values are `Free_F1`, `Standard_S1`, `Premium_P1` and `Premium_P2`.
 
-* `capacity` - (Optional) Specifies the number of units associated with this Web PubSub resource. Valid values are: Free: `1`, Standard: `1`, `2`, `5`, `10`, `20`, `50`, `100`.
+* `capacity` - (Optional) Specifies the number of units associated with this Web PubSub resource. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` and `1000`.
+
+~> **NOTE:** The valid capacity range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for `Standard_S1` and `Premium_P1` .
 
 * `public_network_access_enabled` - (Optional) Whether to enable public network access? Defaults to `true`.
 

--- a/website/docs/r/web_pubsub.html.markdown
+++ b/website/docs/r/web_pubsub.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `capacity` - (Optional) Specifies the number of units associated with this Web PubSub resource. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` and `1000`.
 
-~> **NOTE:** The valid capacity range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for `Standard_S1` and `Premium_P1` .
+~> **NOTE:** The valid capacity range for sku `Free_F1` is `1`, for sku `Premium_P2` is from `100` to `1000`, and from `1` to `100` for sku `Standard_S1` and `Premium_P1`.
 
 * `public_network_access_enabled` - (Optional) Whether to enable public network access? Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
--- PASS: TestAccWebPubsub_premiumP1 (166.50s)
--- PASS: TestAccWebPubsub_premiumP2 (480.98s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr       484.923s
--- PASS: TestAccSignalRService_premiumP1 (357.49s)
--- PASS: TestAccSignalRService_premiumP2 (996.81s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr       1013.449s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_web_pubsub`, `azurerm_signalr_service` - add `Premium_P2` to SKU property
* `azurerm_web_pubsub` - updated the accept value list of `capacity`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
