### PR TITLE
`azurerm_storage_account` - Further check replication type when evaluating support level of share/queue for Storage(V1) accounts

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1626,13 +1626,13 @@ func TestAccStorageAccount_StorageV1_blobProperties(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_StorageV1_queueProperties(t *testing.T) {
+func TestAccStorageAccount_StorageV1_queuePropertiesLRS(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageV1QueueProperties(data),
+			Config: r.storageV1QueueProperties(data, "LRS"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1641,13 +1641,13 @@ func TestAccStorageAccount_StorageV1_queueProperties(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_StorageV1_shareProperties(t *testing.T) {
+func TestAccStorageAccount_StorageV1_queuePropertiesGRS(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageV1ShareProperties(data),
+			Config: r.storageV1QueueProperties(data, "GRS"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1655,6 +1655,67 @@ func TestAccStorageAccount_StorageV1_shareProperties(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+
+func TestAccStorageAccount_StorageV1_queuePropertiesRAGRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageV1QueueProperties(data, "RAGRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_StorageV1_sharePropertiesLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageV1ShareProperties(data, "LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_StorageV1_sharePropertiesGRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageV1ShareProperties(data, "GRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_StorageV1_sharePropertiesRAGRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageV1ShareProperties(data, "RAGRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseStorageAccountID(state.ID)
 	if err != nil {
@@ -4788,7 +4849,7 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountResource) storageV1QueueProperties(data acceptance.TestData) string {
+func (r StorageAccountResource) storageV1QueueProperties(data acceptance.TestData, repl string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -4806,7 +4867,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_kind             = "Storage"
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "%s"
 
   queue_properties {
     cors_rule {
@@ -4838,10 +4899,10 @@ resource "azurerm_storage_account" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, repl)
 }
 
-func (r StorageAccountResource) storageV1ShareProperties(data acceptance.TestData) string {
+func (r StorageAccountResource) storageV1ShareProperties(data acceptance.TestData, repl string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -4859,7 +4920,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_kind             = "Storage"
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "%s"
 
   share_properties {
     cors_rule {
@@ -4881,5 +4942,5 @@ resource "azurerm_storage_account" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, repl)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fix [this](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_STORAGE/130628?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true) AccTest failure, which is introduced by #25427.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_storageV1StandardZRS|TestAccStorageAccount_StorageV1_queueProperties|TestAccStorageAccount_StorageV1_shareProperties'                                         === RUN   TestAccStorageAccount_storageV1StandardZRS
=== PAUSE TestAccStorageAccount_storageV1StandardZRS
=== RUN   TestAccStorageAccount_StorageV1_queuePropertiesLRS
=== PAUSE TestAccStorageAccount_StorageV1_queuePropertiesLRS
=== RUN   TestAccStorageAccount_StorageV1_queuePropertiesGRS
=== PAUSE TestAccStorageAccount_StorageV1_queuePropertiesGRS
=== RUN   TestAccStorageAccount_StorageV1_queuePropertiesRAGRS
=== PAUSE TestAccStorageAccount_StorageV1_queuePropertiesRAGRS
=== RUN   TestAccStorageAccount_StorageV1_sharePropertiesLRS
=== PAUSE TestAccStorageAccount_StorageV1_sharePropertiesLRS
=== RUN   TestAccStorageAccount_StorageV1_sharePropertiesGRS
=== PAUSE TestAccStorageAccount_StorageV1_sharePropertiesGRS
=== RUN   TestAccStorageAccount_StorageV1_sharePropertiesRAGRS
=== PAUSE TestAccStorageAccount_StorageV1_sharePropertiesRAGRS
=== CONT  TestAccStorageAccount_storageV1StandardZRS
=== CONT  TestAccStorageAccount_StorageV1_sharePropertiesLRS
=== CONT  TestAccStorageAccount_StorageV1_queuePropertiesGRS
=== CONT  TestAccStorageAccount_StorageV1_sharePropertiesRAGRS
=== CONT  TestAccStorageAccount_StorageV1_queuePropertiesRAGRS
=== CONT  TestAccStorageAccount_StorageV1_queuePropertiesLRS
=== CONT  TestAccStorageAccount_StorageV1_sharePropertiesGRS
--- PASS: TestAccStorageAccount_storageV1StandardZRS (147.31s)
--- PASS: TestAccStorageAccount_StorageV1_queuePropertiesRAGRS (156.35s)
--- PASS: TestAccStorageAccount_StorageV1_sharePropertiesRAGRS (156.51s)
--- PASS: TestAccStorageAccount_StorageV1_sharePropertiesGRS (156.79s)
--- PASS: TestAccStorageAccount_StorageV1_sharePropertiesLRS (168.54s)
--- PASS: TestAccStorageAccount_StorageV1_queuePropertiesGRS (172.05s)
--- PASS: TestAccStorageAccount_StorageV1_queuePropertiesLRS (178.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       178.109s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - Further check replication type when evaluating support level of share/queue for Storage(V1) accounts [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
