### PR TITLE
azurerm_container_app - support:  allows IP restrictions without requiring CIDR

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -484,7 +484,7 @@ func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {
 				"ip_address_range": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ValidateFunc: validation.IsIPAddressOrCIDR,
+					ValidateFunc: validation.Any(validation.IsCIDR, validation.IsIPAddress),
 					Description:  "CIDR notation to match incoming IP address.",
 				},
 

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -484,7 +484,7 @@ func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {
 				"ip_address_range": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ValidateFunc: validation.IsCIDR,
+					ValidateFunc: validation.IsIPAddressOrCIDR,
 					Description:  "CIDR notation to match incoming IP address.",
 				},
 

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -485,7 +485,7 @@ func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
 					ValidateFunc: validation.Any(validation.IsCIDR, validation.IsIPAddress),
-					Description:  "CIDR notation to match incoming IP address.",
+					Description:  "The incoming IP address or range of IP addresses (in CIDR notation).",
 				},
 
 				"name": {

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -143,21 +143,6 @@ func IsIPv6Address(i interface{}, k string) ([]string, []error) {
 	return validation.IsIPv6Address(i, k)
 }
 
-// IsIPAddressOrCIDR validates if the input is either a valid IP address or a CIDR notation
-func IsIPAddressOrCIDR(i interface{}, k string) ([]string, []error) {
-	warningsIP, errorsIP := IsIPAddress(i, k)
-	if len(errorsIP) == 0 {
-		return warningsIP, nil
-	}
-
-	warningsCIDR, errorsCIDR := IsCIDR(i, k)
-	if len(errorsCIDR) == 0 {
-		return warningsCIDR, nil
-	}
-
-	return append(warningsIP, warningsCIDR...), append(errorsIP, errorsCIDR...)
-}
-
 // IsMonth id a SchemaValidateFunc which tests if the provided value is of type string and a valid english month
 func IsMonth(ignoreCase bool) func(interface{}, string) ([]string, []error) {
 	return validation.IsMonth(ignoreCase)

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -143,6 +143,21 @@ func IsIPv6Address(i interface{}, k string) ([]string, []error) {
 	return validation.IsIPv6Address(i, k)
 }
 
+// IsIPAddressOrCIDR validates if the input is either a valid IP address or a CIDR notation
+func IsIPAddressOrCIDR(i interface{}, k string) ([]string, []error) {
+	warningsIP, errorsIP := IsIPAddress(i, k)
+	if len(errorsIP) == 0 {
+		return warningsIP, nil
+	}
+
+	warningsCIDR, errorsCIDR := IsCIDR(i, k)
+	if len(errorsCIDR) == 0 {
+		return warningsCIDR, nil
+	}
+
+	return append(warningsIP, warningsCIDR...), append(errorsIP, errorsCIDR...)
+}
+
 // IsMonth id a SchemaValidateFunc which tests if the provided value is of type string and a valid english month
 func IsMonth(ignoreCase bool) func(interface{}, string) ([]string, []error) {
 	return validation.IsMonth(ignoreCase)

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -413,7 +413,7 @@ A `ip_security_restriction` block supports the following:
 
 * `description` - (Optional) Describe the IP restriction rule that is being sent to the container-app.
 
-* `ip_address_range` - (Required) CIDR notation to match incoming IP address.
+* `ip_address_range` - (Required) The incoming IP address or range of IP addresses (in CIDR notation).
 
 * `name` - (Required) Name for the IP restriction rule.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
When setting IP restrictions for Azure Container Apps using the Azure Portal or CLI, it appears that the CIDR notation is not always necessary for a single host (no errors are reported).
[IP restrictions for Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/ip-restrictions?pivots=azure-cli#create-or-update-rules).

```bash
az containerapp ingress access-restriction set --name example-app --resource-group example-app-rg --rule-name "my allow rule" --description "example of rule allowing access" --ip-address 192.168.0.1 --action Allow
```
Given that the native Azure behavior allows IP restrictions without requiring CIDR notation, should we not update the Terraform provider to align with this functionality? This would simplify configuration processes and reduce potential discrepancies between direct Azure usage and Terraform configurations.



<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1236" alt="CleanShot 2024-04-14 at 01 40 03@2x" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/69241625/5652f61e-f576-4d27-b97b-20b116542ef5">


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25608 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
