### PR TITLE
`HDInsight` clusters: add support for `private_link_configuration`

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -1795,11 +1795,7 @@ resource "azurerm_storage_container" "test" {
 func (HDInsightHadoopClusterResource) gen2template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -1507,6 +1507,17 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     is_default                   = true
   }
 
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
   roles {
     head_node {
       vm_size  = "Standard_D3_V2"
@@ -1784,7 +1795,11 @@ resource "azurerm_storage_container" "test" {
 func (HDInsightHadoopClusterResource) gen2template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -834,6 +834,17 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
     is_default                   = true
   }
 
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
   roles {
     head_node {
       vm_size  = "Standard_D3_V2"

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -120,6 +120,8 @@ func resourceHDInsightInteractiveQueryCluster() *pluginsdk.Resource {
 
 			"storage_account_gen2": SchemaHDInsightsGen2StorageAccounts(),
 
+			"private_link_configuration": SchemaHDInsightPrivateLinkConfigurations(),
+
 			"tags": commonschema.Tags(),
 
 			"https_endpoint": {
@@ -205,6 +207,9 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 	networkPropertiesRaw := d.Get("network").([]interface{})
 	networkProperties := ExpandHDInsightsNetwork(networkPropertiesRaw)
 
+	privateLinkConfigurationsRaw := d.Get("private_link_configuration").([]interface{})
+	privateLinkConfigurations := ExpandHDInsightPrivateLinkConfigurations(privateLinkConfigurationsRaw)
+
 	storageAccountsRaw := d.Get("storage_account").([]interface{})
 	storageAccountsGen2Raw := d.Get("storage_account_gen2").([]interface{})
 	storageAccounts, expandedIdentity, err := ExpandHDInsightsStorageAccounts(storageAccountsRaw, storageAccountsGen2Raw)
@@ -242,11 +247,12 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 	params := clusters.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &clusters.ClusterCreateProperties{
-			Tier:                   pointer.To(tier),
-			OsType:                 pointer.To(clusters.OSTypeLinux),
-			ClusterVersion:         utils.String(clusterVersion),
-			MinSupportedTlsVersion: utils.String(tls),
-			NetworkProperties:      networkProperties,
+			Tier:                      pointer.To(tier),
+			OsType:                    pointer.To(clusters.OSTypeLinux),
+			ClusterVersion:            utils.String(clusterVersion),
+			MinSupportedTlsVersion:    utils.String(tls),
+			NetworkProperties:         networkProperties,
+			PrivateLinkConfigurations: privateLinkConfigurations,
 			EncryptionInTransitProperties: &clusters.EncryptionInTransitProperties{
 				IsEncryptionInTransitEnabled: &encryptionInTransit,
 			},
@@ -398,6 +404,10 @@ func resourceHDInsightInteractiveQueryClusterRead(d *pluginsdk.ResourceData, met
 
 			if err := d.Set("network", flattenHDInsightsNetwork(props.NetworkProperties)); err != nil {
 				return fmt.Errorf("flattening `network`: %+v", err)
+			}
+
+			if err := d.Set("private_link_configuration", flattenHDInsightPrivateLinkConfigurations(props.PrivateLinkConfigurations)); err != nil {
+				return fmt.Errorf("flattening `private_link_configuration`: %+v", err)
 			}
 
 			interactiveQueryRoles := hdInsightRoleDefinition{

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -881,6 +881,17 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     is_default                   = true
   }
 
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
   roles {
     head_node {
       vm_size  = "Standard_D13_V2"

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -62,6 +62,26 @@ func TestAccHDInsightKafkaCluster_gen2storage(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightKafkaCluster_privateLink(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	r := HDInsightKafkaClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateLink(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightKafkaCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
 	r := HDInsightKafkaClusterResource{}
@@ -710,6 +730,135 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
 `, r.gen2template(data), data.RandomInteger)
 }
 
+func (r HDInsightKafkaClusterResource) privateLink(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.16.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.16.11.0/26"]
+
+  enforce_private_link_service_network_policies = true
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  zones               = ["1"]
+}
+
+resource "azurerm_nat_gateway" "test" {
+  name                    = "acctestnat%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  sku_name                = "Standard"
+  idle_timeout_in_minutes = 10
+  zones                   = ["1"]
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "test" {
+  nat_gateway_id       = azurerm_nat_gateway.test.id
+  public_ip_address_id = azurerm_public_ip.test.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "test" {
+  subnet_id      = azurerm_subnet.test.id
+  nat_gateway_id = azurerm_nat_gateway.test.id
+}
+
+resource "azurerm_subnet_network_security_group_association" "test" {
+  subnet_id                 = azurerm_subnet.test.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+
+resource "azurerm_hdinsight_kafka_cluster" "test" {
+  depends_on = [azurerm_role_assignment.test, azurerm_nat_gateway.test, azurerm_subnet_network_security_group_association.test]
+
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    hadoop = "3.1"
+  }
+
+  network {
+    connection_direction = "Outbound"
+    private_link_enabled = true
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account_gen2 {
+    storage_resource_id          = azurerm_storage_account.gen2test.id
+    filesystem_id                = azurerm_storage_data_lake_gen2_filesystem.gen2test.id
+    managed_identity_resource_id = azurerm_user_assigned_identity.test.id
+    is_default                   = true
+  }
+
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+
+      subnet_id          = azurerm_subnet.test.id
+      virtual_network_id = azurerm_virtual_network.test.id
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+
+      subnet_id          = azurerm_subnet.test.id
+      virtual_network_id = azurerm_virtual_network.test.id
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+
+      subnet_id          = azurerm_subnet.test.id
+      virtual_network_id = azurerm_virtual_network.test.id
+    }
+  }
+}
+
+%s
+`, r.gen2template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, r.nsgTemplate(data))
+}
+
 func (r HDInsightKafkaClusterResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -1037,6 +1186,218 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (HDInsightKafkaClusterResource) nsgTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  security_rule = [
+    {
+      access                                     = "Allow"
+      description                                = "Rule can be deleted but do not change source ips."
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = "443"
+      destination_port_ranges                    = []
+      direction                                  = "Inbound"
+      name                                       = "Rule-101"
+      priority                                   = 101
+      protocol                                   = "Tcp"
+      source_address_prefix                      = "VirtualNetwork"
+      source_address_prefixes                    = []
+      source_application_security_group_ids      = []
+      source_port_range                          = "*"
+      source_port_ranges                         = []
+    },
+    {
+      access                                     = "Allow"
+      description                                = "Rule can be deleted but do not change source ips."
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = "*"
+      destination_port_ranges                    = []
+      direction                                  = "Inbound"
+      name                                       = "Rule-103"
+      priority                                   = 103
+      protocol                                   = "*"
+      source_address_prefix                      = "CorpNetPublic"
+      source_address_prefixes                    = []
+      source_application_security_group_ids      = []
+      source_port_range                          = "*"
+      source_port_ranges                         = []
+    },
+    {
+      access                                     = "Allow"
+      description                                = "Rule can be deleted but do not change source ips."
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = "*"
+      destination_port_ranges                    = []
+      direction                                  = "Inbound"
+      name                                       = "Rule-104"
+      priority                                   = 104
+      protocol                                   = "*"
+      source_address_prefix                      = "CorpNetSaw"
+      source_address_prefixes                    = []
+      source_application_security_group_ids      = []
+      source_port_range                          = "*"
+      source_port_ranges                         = []
+    },
+    {
+      access                                     = "Deny"
+      description                                = "DO NOT DELETE"
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = ""
+      destination_port_ranges = [
+        "111",
+        "11211",
+        "123",
+        "13",
+        "17",
+        "19",
+        "1900",
+        "512",
+        "514",
+        "53",
+        "5353",
+        "593",
+        "69",
+        "873",
+      ]
+      direction                             = "Inbound"
+      name                                  = "Rule-108"
+      priority                              = 108
+      protocol                              = "*"
+      source_address_prefix                 = "Internet"
+      source_address_prefixes               = []
+      source_application_security_group_ids = []
+      source_port_range                     = "*"
+      source_port_ranges                    = []
+    },
+    {
+      access                                     = "Deny"
+      description                                = "DO NOT DELETE"
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = ""
+      destination_port_ranges = [
+        "119",
+        "137",
+        "138",
+        "139",
+        "161",
+        "162",
+        "2049",
+        "2301",
+        "2381",
+        "3268",
+        "389",
+        "5800",
+        "5900",
+        "636",
+      ]
+      direction                             = "Inbound"
+      name                                  = "Rule-109"
+      priority                              = 109
+      protocol                              = "*"
+      source_address_prefix                 = "Internet"
+      source_address_prefixes               = []
+      source_application_security_group_ids = []
+      source_port_range                     = "*"
+      source_port_ranges                    = []
+    },
+    {
+      access                                     = "Deny"
+      description                                = "DO NOT DELETE"
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = ""
+      destination_port_ranges = [
+        "135",
+        "23",
+        "445",
+        "5985",
+        "5986",
+      ]
+      direction                             = "Inbound"
+      name                                  = "Rule-107"
+      priority                              = 107
+      protocol                              = "Tcp"
+      source_address_prefix                 = "Internet"
+      source_address_prefixes               = []
+      source_application_security_group_ids = []
+      source_port_range                     = "*"
+      source_port_ranges                    = []
+    },
+    {
+      access                                     = "Deny"
+      description                                = "DO NOT DELETE"
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = ""
+      destination_port_ranges = [
+        "1433",
+        "1434",
+        "16379",
+        "26379",
+        "27017",
+        "3306",
+        "4333",
+        "5432",
+        "6379",
+        "7000",
+        "7001",
+        "7199",
+        "9042",
+        "9160",
+        "9300",
+      ]
+      direction                             = "Inbound"
+      name                                  = "Rule-105"
+      priority                              = 105
+      protocol                              = "*"
+      source_address_prefix                 = "Internet"
+      source_address_prefixes               = []
+      source_application_security_group_ids = []
+      source_port_range                     = "*"
+      source_port_ranges                    = []
+    },
+    {
+      access                                     = "Deny"
+      description                                = "DO NOT DELETE"
+      destination_address_prefix                 = "*"
+      destination_address_prefixes               = []
+      destination_application_security_group_ids = []
+      destination_port_range                     = ""
+      destination_port_ranges = [
+        "22",
+        "3389",
+      ]
+      direction                             = "Inbound"
+      name                                  = "Rule-106"
+      priority                              = 106
+      protocol                              = "Tcp"
+      source_address_prefix                 = "Internet"
+      source_address_prefixes               = []
+      source_application_security_group_ids = []
+      source_port_range                     = "*"
+      source_port_ranges                    = []
+    },
+  ]
+}
+`, data.RandomInteger)
 }
 
 func (HDInsightKafkaClusterResource) template(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -793,7 +793,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   tier                = "Standard"
 
   component_version {
-    hadoop = "3.1"
+    kafka = "2.1"
   }
 
   network {
@@ -835,10 +835,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_D4_V2"
-      username              = "acctestusrvm"
-      password              = "AccTestvdSC4daf986!"
-      target_instance_count = 3
+      vm_size                  = "Standard_D4_V2"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+      number_of_disks_per_node = 2
 
       subnet_id          = azurerm_subnet.test.id
       virtual_network_id = azurerm_virtual_network.test.id

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -933,6 +933,17 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     is_default                   = true
   }
 
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
   roles {
     head_node {
       vm_size  = "Standard_D13_V2"

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
 
 * `network` - (Optional) A `network` block as defined below.
 
+* `private_link_configuration` - (Optional) A `private_link_configuration` block as defined below.
+
 * `disk_encryption` - (Optional) One or more `disk_encryption` block as defined below.
 
 * `compute_isolation` - (Optional) A `compute_isolation` block as defined below.
@@ -232,6 +234,30 @@ A `storage_account_gen2` block supports the following:
 * `managed_identity_resource_id` - (Required) The ID of Managed Identity to use for accessing the Gen2 filesystem. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
+
+---
+
+A `private_link_configuration` block supports the following:
+
+* `name` - (Required) The name of the private link configuration.
+
+* `group_id` - (Required) The ID of the private link service group.
+
+* `private_link_service_connection` - (Required) A `private_link_service_connection` block as defined below.
+
+---
+
+A `private_link_service_connection` block supports the following:
+
+* `name` - (Required) The name of the private link service connection.
+
+* `primary` - (Optional) Indicates whether this IP configuration is primary.
+
+* `private_ip_allocation_method` - (Optional) The private IP allocation method. The only possible value now is `Dynamic`.
+
+* `private_ip_address` - (Optional) The private IP address of the IP configuration.
+
+* `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the private link service connection should be provisioned within.
 
 ---
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
 
 * `network` - (Optional) A `network` block as defined below.
 
+* `private_link_configuration` - (Optional) A `private_link_configuration` block as defined below.
+
 * `compute_isolation` - (Optional) A `compute_isolation` block as defined below.
 
 * `storage_account` - (Optional) One or more `storage_account` block as defined below.
@@ -230,6 +232,30 @@ A `storage_account_gen2` block supports the following:
 * `managed_identity_resource_id` - (Required) The ID of Managed Identity to use for accessing the Gen2 filesystem. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
+
+---
+
+A `private_link_configuration` block supports the following:
+
+* `name` - (Required) The name of the private link configuration.
+
+* `group_id` - (Required) The ID of the private link service group.
+
+* `private_link_service_connection` - (Required) A `private_link_service_connection` block as defined below.
+
+---
+
+A `private_link_service_connection` block supports the following:
+
+* `name` - (Required) The name of the private link service connection.
+
+* `primary` - (Optional) Indicates whether this IP configuration is primary.
+
+* `private_ip_allocation_method` - (Optional) The private IP allocation method. The only possible value now is `Dynamic`.
+
+* `private_ip_address` - (Optional) The private IP address of the IP configuration.
+
+* `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the private link service connection should be provisioned within.
 
 ---
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `network` - (Optional) A `network` block as defined below.
 
+* `private_link_configuration` - (Optional) A `private_link_configuration` block as defined below.
+
 * `compute_isolation` - (Optional) A `compute_isolation` block as defined below.
 
 * `storage_account` - (Optional) One or more `storage_account` block as defined below.
@@ -234,6 +236,30 @@ A `storage_account_gen2` block supports the following:
 * `managed_identity_resource_id` - (Required) The ID of Managed Identity to use for accessing the Gen2 filesystem. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
+
+---
+
+A `private_link_configuration` block supports the following:
+
+* `name` - (Required) The name of the private link configuration.
+
+* `group_id` - (Required) The ID of the private link service group.
+
+* `private_link_service_connection` - (Required) A `private_link_service_connection` block as defined below.
+
+---
+
+A `private_link_service_connection` block supports the following:
+
+* `name` - (Required) The name of the private link service connection.
+
+* `primary` - (Optional) Indicates whether this IP configuration is primary.
+
+* `private_ip_allocation_method` - (Optional) The private IP allocation method. The only possible value now is `Dynamic`.
+
+* `private_ip_address` - (Optional) The private IP address of the IP configuration.
+
+* `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the private link service connection should be provisioned within.
 
 ---
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -98,6 +98,8 @@ The following arguments are supported:
 
 * `network` - (Optional) A `network` block as defined below.
 
+* `private_link_configuration` - (Optional) A `private_link_configuration` block as defined below.
+
 * `storage_account` - (Optional) One or more `storage_account` block as defined below.
 
 * `storage_account_gen2` - (Optional) A `storage_account_gen2` block as defined below.
@@ -229,6 +231,30 @@ A `storage_account_gen2` block supports the following:
 * `managed_identity_resource_id` - (Required) The ID of Managed Identity to use for accessing the Gen2 filesystem. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
+
+---
+
+A `private_link_configuration` block supports the following:
+
+* `name` - (Required) The name of the private link configuration.
+
+* `group_id` - (Required) The ID of the private link service group.
+
+* `private_link_service_connection` - (Required) A `private_link_service_connection` block as defined below.
+
+---
+
+A `private_link_service_connection` block supports the following:
+
+* `name` - (Required) The name of the private link service connection.
+
+* `primary` - (Optional) Indicates whether this IP configuration is primary.
+
+* `private_ip_allocation_method` - (Optional) The private IP allocation method. The only possible value now is `Dynamic`.
+
+* `private_ip_address` - (Optional) The private IP address of the IP configuration.
+
+* `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the private link service connection should be provisioned within.
 
 ---
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `network` - (Optional) A `network` block as defined below.
 
+* `private_link_configuration` - (Optional) A `private_link_configuration` block as defined below.
+
 * `compute_isolation` - (Optional) A `compute_isolation` block as defined below.
 
 * `storage_account` - (Optional) One or more `storage_account` block as defined below.
@@ -232,6 +234,30 @@ A `storage_account_gen2` block supports the following:
 * `managed_identity_resource_id` - (Required) The ID of Managed Identity to use for accessing the Gen2 filesystem. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
+
+---
+
+A `private_link_configuration` block supports the following:
+
+* `name` - (Required) The name of the private link configuration.
+
+* `group_id` - (Required) The ID of the private link service group.
+
+* `private_link_service_connection` - (Required) A `private_link_service_connection` block as defined below.
+
+---
+
+A `private_link_service_connection` block supports the following:
+
+* `name` - (Required) The name of the private link service connection.
+
+* `primary` - (Optional) Indicates whether this IP configuration is primary.
+
+* `private_ip_allocation_method` - (Optional) The private IP allocation method. The only possible value now is `Dynamic`.
+
+* `private_ip_address` - (Optional) The private IP address of the IP configuration.
+
+* `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the private link service connection should be provisioned within.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Add support for `private_link_configuration` to `HDInsight` cluster resources.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![Screenshot 2024-04-17 135333](https://github.com/hashicorp/terraform-provider-azurerm/assets/100274846/e6f40c77-f4f5-4b13-8ed8-fdb8cfe4ad19)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `hdinsight_hadoop_cluster_resource`, `hdinsight_hbase_cluster_resource`, `hdinsight_interactive_query_cluster_resource`, `hdinsight_kafka_cluster_resource`, `hdinsight_spark_cluster_resource` - support for the `private_link_configuration` property.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
