### PR TITLE
``azurerm_windows_web_app_slot``, ``azurerm_windows_function_app_slot`` - Fix error 500/409 when using virtual network subnet

### DIFF
--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -548,8 +548,6 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 			if functionAppSlot.VirtualNetworkSubnetID != "" {
 				siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(functionAppSlot.VirtualNetworkSubnetID)
-				// (@apokalypt) Azure requires this property to be set when VirtualNetworkSubnetId is set
-				// https://github.com/hashicorp/terraform-provider-azurerm/issues/24618#issuecomment-2058710360
 				siteEnvelope.Properties.ServerFarmId = pointer.To(servicePlanId.ID())
 			}
 

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -548,6 +548,9 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 			if functionAppSlot.VirtualNetworkSubnetID != "" {
 				siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(functionAppSlot.VirtualNetworkSubnetID)
+				// (@apokalypt) Azure requires this property to be set when VirtualNetworkSubnetId is set
+				// https://github.com/hashicorp/terraform-provider-azurerm/issues/24618#issuecomment-2058710360
+				siteEnvelope.Properties.ServerFarmId = pointer.To(servicePlanId.ID())
 			}
 
 			if functionAppSlot.KeyVaultReferenceIdentityID != "" {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -374,8 +374,6 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 
 			if webAppSlot.VirtualNetworkSubnetID != "" {
 				siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(webAppSlot.VirtualNetworkSubnetID)
-				// (@apokalypt) Azure requires this property to be set when VirtualNetworkSubnetId is set
-				// https://github.com/hashicorp/terraform-provider-azurerm/issues/24618#issuecomment-2058710360
 				siteEnvelope.Properties.ServerFarmId = pointer.To(servicePlanId.ID())
 			}
 

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -374,6 +374,9 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 
 			if webAppSlot.VirtualNetworkSubnetID != "" {
 				siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(webAppSlot.VirtualNetworkSubnetID)
+				// (@apokalypt) Azure requires this property to be set when VirtualNetworkSubnetId is set
+				// https://github.com/hashicorp/terraform-provider-azurerm/issues/24618#issuecomment-2058710360
+				siteEnvelope.Properties.ServerFarmId = pointer.To(servicePlanId.ID())
 			}
 
 			if err := client.CreateOrUpdateSlotThenPoll(ctx, id, siteEnvelope); err != nil {


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
Since the release `3.88.0`, Azure reject the creation of web app slot and function app slot when there is a virtual network subnet. Initially the API rejects all calls with an error 500 but since this morning the error is clearer and validate analysis perform by few users in the issue linked :
<img width="775" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/165187852/e91cb780-347e-4a6c-a5c8-3775dd7f2d65">


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
> I could only run local test and not acceptance tests see below the explanation...


## Testing 
> Sorry, but I couldn't run acceptance tests because I don't have enough permissions in my team to make them run properly. However, some tests were run manually and some checks/tests were run directly with the API to make sure everything worked despite my technical limitations.
>
> One thing to note is that a acceptance test is failing ``TestAccWindowsWebAppSlot_completeUpdate `` but this fail comes from another change since the test fails without my code!


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_web_app_slot` - Force "serverFarmId" to be set when "virtualNetworkSubnetId" is set as requested by Azure API #24618 
* `azurerm_windows_function_app_slot` - Force "serverFarmId" to be set when "virtualNetworkSubnetId" is set as requested by Azure API #24618 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24618 
