### PR TITLE
`azurerm_mysql_flexible_server` - Validation rule fix (regex) `sku_name` property

### DIFF
--- a/internal/services/mysql/validate/flexible_server_sku_name.go
+++ b/internal/services/mysql/validate/flexible_server_sku_name.go
@@ -16,7 +16,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 	}
 
 	// See all available sku names from https://docs.microsoft.com/en-us/azure/mysql/flexible-server/concepts-compute-storage#compute-tiers-size-and-server-types
-	if !regexp.MustCompile(`^(B|GP|MO)_((Standard_E(2|4|8|16|20|32|48|64|80i)ds_v4)|(Standard_E(2|2a|4|4a|8|8a|16|16a|20|20a|32|32a|48|48a|64|64a|96)ds_v5)|(Standard_B(1|1m|2|2m|4m|8m|12m|16m|20m)s)|(Standard_D(2|4|8|16|32|48|64)ds_v4)|(Standard_D(2|4|8|16|32|48|64)ads_v5))$`).MatchString(v) {
+	if !regexp.MustCompile(`^(B_(Standard_B(1|1m|2|2m|4m|8m|12m|16m|20m)s))|(GP_(Standard_D(2|4|8|16|32|48|64)ds_v4)|(Standard_D(2|4|8|16|32|48|64)ads_v5))|(MO_((Standard_E(2|4|8|16|20|32|48|64|80i)ds_v4)|(Standard_E(2|2a|4|4a|8|8a|16|16a|20|20a|32|32a|48|48a|64|64a|96)ds_v5)))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/mysql/validate/flexible_server_sku_name_test.go
+++ b/internal/services/mysql/validate/flexible_server_sku_name_test.go
@@ -76,6 +76,16 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			input: "GP_Standard_D64ds_v4",
 			valid: true,
 		},
+		{
+			name:  "B_Standard_D64ds_v4",
+			input: "B_Standard_D64ds_v4",
+			valid: false,
+		},
+		{
+			name:  "MO_Standard_B2s",
+			input: "MO_Standard_B2s",
+			valid: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

With the current Regular Expression in the code, it is possible create a `azurerm_mysql_flexible_server` with `sku_name` equals B_Standard_D64ds_v4, which is not a valid name, as Standard_D64ds_v4 is a General Purpose (GP) machine. Without this validation, the API throws an Internal Server Error when trying to create the resource.

Following the official documentation for [Service tiers, size, and server types](https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#compute-tiers-size-and-server-types), I noticed that the Burstable should follow B_Standard_B* pattern, General Purpose should follow GP_Standard_D* and Memory Optimized should follow the MO_Standard_E* pattern. I limited the options in the regex to avoid using a `sku_name` that is not available in Azure documentation.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mysql_flexible_server` - fix `sku_name` regex validation [GH-23427]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23427


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
