### PR TITLE
Add optional `EnablePrivateLinkFastPath` to Virtual Network Gateway Connection resource

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_data_source.go
+++ b/internal/services/network/virtual_network_gateway_connection_data_source.go
@@ -119,6 +119,11 @@ func dataSourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"private_link_fast_path_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"resource_guid": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -227,6 +232,7 @@ func dataSourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, me
 		d.Set("egress_bytes_transferred", gwc.EgressBytesTransferred)
 		d.Set("use_policy_based_traffic_selectors", gwc.UsePolicyBasedTrafficSelectors)
 		d.Set("express_route_gateway_bypass", gwc.ExpressRouteGatewayBypass)
+		d.Set("private_link_fast_path_enabled", gwc.EnablePrivateLinkFastPath)
 		d.Set("type", string(gwc.ConnectionType))
 		d.Set("connection_protocol", string(gwc.ConnectionProtocol))
 		d.Set("routing_weight", gwc.RoutingWeight)

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -161,6 +161,12 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"private_link_fast_path_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"connection_protocol": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -521,6 +527,10 @@ func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta
 		d.Set("express_route_gateway_bypass", conn.ExpressRouteGatewayBypass)
 	}
 
+	if conn.EnablePrivateLinkFastPath != nil {
+		d.Set("private_link_fast_path_enabled", conn.EnablePrivateLinkFastPath)
+	}
+
 	if conn.IpsecPolicies != nil {
 		ipsecPolicies := flattenVirtualNetworkGatewayConnectionIpsecPolicies(conn.IpsecPolicies)
 
@@ -586,6 +596,7 @@ func getVirtualNetworkGatewayConnectionProperties(d *pluginsdk.ResourceData, vir
 		ConnectionType:                 connectionType,
 		ConnectionMode:                 connectionMode,
 		EnableBgp:                      utils.Bool(d.Get("enable_bgp").(bool)),
+		EnablePrivateLinkFastPath:      utils.Bool(d.Get("private_link_fast_path_enabled").(bool)),
 		ExpressRouteGatewayBypass:      utils.Bool(d.Get("express_route_gateway_bypass").(bool)),
 		UsePolicyBasedTrafficSelectors: utils.Bool(d.Get("use_policy_based_traffic_selectors").(bool)),
 	}
@@ -698,6 +709,9 @@ func getVirtualNetworkGatewayConnectionProperties(d *pluginsdk.ResourceData, vir
 	if props.ConnectionType == network.VirtualNetworkGatewayConnectionTypeExpressRoute {
 		if props.Peer == nil || props.Peer.ID == nil {
 			return nil, fmt.Errorf("`express_route_circuit_id` must be specified when `type` is set to `ExpressRoute`")
+		}
+		if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
+			return nil, fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
 		}
 	}
 

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -65,6 +65,21 @@ func TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey(t *testin
 	})
 }
 
+func TestAccVirtualNetworkGatewayConnection_expressroute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
+	r := VirtualNetworkGatewayConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.expressroute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("shared_key"),
+	})
+}
+
 func TestAccVirtualNetworkGatewayConnection_vnettonet(t *testing.T) {
 	data1 := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test_1")
 	data2 := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test_2")
@@ -426,6 +441,112 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
   local_network_gateway_id   = azurerm_local_network_gateway.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkGatewayConnectionResource) expressroute(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+variable "random" {
+  default = "%d"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-${var.random}"
+  location = "%s"
+}
+
+resource "azurerm_express_route_circuit" "test" {
+  name                  = "acctest-erc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  service_provider_name = "Equinix"
+  peering_location      = "Silicon Valley"
+  bandwidth_in_mbps     = 50
+
+  sku {
+    tier   = "Standard"
+    family = "MeteredData"
+  }
+
+  allow_classic_operations = false
+
+  tags = {
+    Environment = "production"
+    Purpose     = "AcceptanceTests"
+  }
+}
+
+resource "azurerm_express_route_circuit_authorization" "test" {
+  name                       = "acctestauth%d"
+  express_route_circuit_name = azurerm_express_route_circuit.test.name
+  resource_group_name        = azurerm_resource_group.test.name
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type       = "ExpressRoute"
+  sku        = "UltraPerformance"
+  vpn_type   = "PolicyBased"
+  enable_bgp = false
+  remote_vnet_traffic_enabled = true
+  virtual_wan_traffic_enabled = true
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+  address_space   = ["10.1.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  lifecycle {
+    ignore_changes = ["authorization_key"]
+  }
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "ExpressRoute"
+
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.test.id
+  express_route_circuit_id   = azurerm_express_route_circuit.test.id
+  authorization_key          = azurerm_express_route_circuit_authorization.test.authorization_key
+  routing_weight             = "0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (r VirtualNetworkGatewayConnectionResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -80,6 +80,21 @@ func TestAccVirtualNetworkGatewayConnection_expressroute(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkGatewayConnection_expressrouteWithFastPath(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
+	r := VirtualNetworkGatewayConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.expressrouteWithFastPath(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("shared_key"),
+	})
+}
+
 func TestAccVirtualNetworkGatewayConnection_vnettonet(t *testing.T) {
 	data1 := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test_1")
 	data2 := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test_2")
@@ -545,6 +560,114 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
   express_route_circuit_id   = azurerm_express_route_circuit.test.id
   authorization_key          = azurerm_express_route_circuit_authorization.test.authorization_key
   routing_weight             = "0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayConnectionResource) expressrouteWithFastPath(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+variable "random" {
+  default = "%d"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-${var.random}"
+  location = "%s"
+}
+
+resource "azurerm_express_route_circuit" "test" {
+  name                  = "acctest-erc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  service_provider_name = "Equinix"
+  peering_location      = "Silicon Valley"
+  bandwidth_in_mbps     = 50
+
+  sku {
+    tier   = "Standard"
+    family = "MeteredData"
+  }
+
+  allow_classic_operations = false
+
+  tags = {
+    Environment = "production"
+    Purpose     = "AcceptanceTests"
+  }
+}
+
+resource "azurerm_express_route_circuit_authorization" "test" {
+  name                       = "acctestauth%d"
+  express_route_circuit_name = azurerm_express_route_circuit.test.name
+  resource_group_name        = azurerm_resource_group.test.name
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type       = "ExpressRoute"
+  sku        = "UltraPerformance"
+  vpn_type   = "PolicyBased"
+  enable_bgp = false
+  remote_vnet_traffic_enabled = true
+  virtual_wan_traffic_enabled = true
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+  address_space   = ["10.1.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  lifecycle {
+    ignore_changes = ["authorization_key"]
+  }
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "ExpressRoute"
+
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.test.id
+  express_route_circuit_id   = azurerm_express_route_circuit.test.id
+  authorization_key          = azurerm_express_route_circuit_authorization.test.authorization_key
+  routing_weight             = "0"
+  express_route_gateway_bypass   = true
+  private_link_fast_path_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -242,6 +242,8 @@ The following arguments are supported:
 
 * `express_route_gateway_bypass` - (Optional) If `true`, data packets will bypass ExpressRoute Gateway for data forwarding This is only valid for ExpressRoute connections.
 
+* `private_link_fast_path_enabled` - (Optional) Bypass the Express Route gateway when accessing private-links. When enabled `express_route_gateway_bypass` must be set to `true`. Defaults to `false`.
+
 * `egress_nat_rule_ids` - (Optional) A list of the egress NAT Rule Ids.
 
 * `ingress_nat_rule_ids` - (Optional) A list of the ingress NAT Rule Ids.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

In line with https://github.com/hashicorp/terraform-provider-azurerm/pull/25596, this PR adds support for `EnablePrivateLinkFastPath` on Virtual Network Gateway Connections.

The prior implementation was just for Express Route Circuit Connections, but this one specifically is needed as well.

I've also added tests for expressroute scenarios and another one with FastPath enabled.

This feature is optional, but `ExpressRouteGatewayBypass` is required to be enabled and the VirtualNetworkGateway type must be a ExpressRoute gateway.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network_gateway_connection ` - support for `private_link_fast_path_enabled` property on expressroute type connections.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Relates to https://github.com/hashicorp/terraform-provider-azurerm/pull/25596
cc/ @stephybun 