### PR TITLE
`azzurerm_application_insights` - set correct AppID in data source

### DIFF
--- a/internal/services/applicationinsights/application_insights_data_source.go
+++ b/internal/services/applicationinsights/application_insights_data_source.go
@@ -106,7 +106,7 @@ func dataSourceArmApplicationInsightsRead(d *pluginsdk.ResourceData, meta interf
 			return fmt.Errorf("flattening `tags`: %+v", err)
 		}
 		if props := model.Properties; props != nil {
-			d.Set("app_id", props.ApplicationId)
+			d.Set("app_id", props.AppId)
 			d.Set("application_type", props.ApplicationType)
 			d.Set("connection_string", props.ConnectionString)
 			d.Set("instrumentation_key", props.InstrumentationKey)

--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -401,7 +401,15 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 	d.Set("kind", resp.Model.Kind)
 
 	if props := resp.Model.Properties; props != nil {
-		d.Set("application_insights_id", props.ApplicationInsights)
+		appInsightsId := ""
+		if props.ApplicationInsights != nil {
+			applicationInsightsId, err := components.ParseComponentIDInsensitively(*props.ApplicationInsights)
+			if err != nil {
+				return err
+			}
+			appInsightsId = applicationInsightsId.ID()
+		}
+		d.Set("application_insights_id", appInsightsId)
 		d.Set("storage_account_id", props.StorageAccount)
 		d.Set("container_registry_id", props.ContainerRegistry)
 		d.Set("description", props.Description)


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes #25684 and also fixes the Machine Learning Workspace `requiresImport` test, the API returns the Application Insights ID with the wrong casing.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Data Source: `azurerm_application_insights` - set correct AppID into state [GH-00000]
* `azurerm_machine_learning_workspace` - insensitively parse Application Insights resource ID before setting into state [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
