### PR TITLE
`azurerm_sentinel_alert_rule_scheduled` - remove `forcenew` for `alert_rule_template_version`

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -73,7 +73,6 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 			"alert_rule_template_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"description": {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -33,6 +33,28 @@ func TestAccSentinelAlertRuleScheduled_basic(t *testing.T) {
 	})
 }
 
+func TestAccSentinelAlertRuleScheduled_upgrade(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_scheduled", "test")
+	r := SentinelAlertRuleScheduledResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.upgradeVersion(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.upgradeVersion(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSentinelAlertRuleScheduled_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_scheduled", "test")
 	r := SentinelAlertRuleScheduledResource{}
@@ -337,6 +359,32 @@ QUERY
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r SentinelAlertRuleScheduledResource) upgradeVersion(data acceptance.TestData, update bool) string {
+	version := "1.0.4"
+	if update {
+		version = "1.0.5"
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_alert_rule_scheduled" "test" {
+  name                        = "acctest-SentinelAlertRule-Sche-%d"
+  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
+  display_name                = "Some Rule"
+  alert_rule_template_guid    = "173f8699-6af5-484a-8b06-8c47ba89b380"
+  alert_rule_template_version = "%[3]s"
+  severity                    = "Medium"
+  query                       = <<QUERY
+AzureActivity |
+  where OperationName == "Create or Update Virtual Machine" or OperationName =="Create Deployment" |
+  where ActivityStatus == "Succeeded" |
+  make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
+QUERY
+
+}
+`, r.template(data), data.RandomInteger, version)
 }
 
 func (SentinelAlertRuleScheduledResource) template(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -39,14 +39,14 @@ func TestAccSentinelAlertRuleScheduled_upgrade(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeVersion(data, false),
+			Config: r.upgradeVersion(data, "1.0.4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeVersion(data, true),
+			Config: r.upgradeVersion(data, "1.0.5"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -361,11 +361,7 @@ QUERY
 `, r.template(data), data.RandomInteger)
 }
 
-func (r SentinelAlertRuleScheduledResource) upgradeVersion(data acceptance.TestData, update bool) string {
-	version := "1.0.4"
-	if update {
-		version = "1.0.5"
-	}
+func (r SentinelAlertRuleScheduledResource) upgradeVersion(data acceptance.TestData, version string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `alert_rule_template_guid` - (Optional) The GUID of the alert rule template which is used for this Sentinel Scheduled Alert Rule. Changing this forces a new Sentinel Scheduled Alert Rule to be created.
 
-* `alert_rule_template_version` - (Optional) The version of the alert rule template which is used for this Sentinel Scheduled Alert Rule. Changing this forces a new Sentinel Scheduled Alert Rule to be created.
+* `alert_rule_template_version` - (Optional) The version of the alert rule template which is used for this Sentinel Scheduled Alert Rule.
 
 * `custom_details` - (Optional) A map of string key-value pairs of columns to be attached to this Sentinel Scheduled Alert Rule. The key will appear as the field name in alerts and the value is the event parameter you wish to surface in the alerts.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

remove the `forcenew` property for `alert_rule_template_version`. As per testing it's not required now.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
❯❯ tftest sentinel TestAccSentinelAlertRuleScheduled        
=== RUN   TestAccSentinelAlertRuleScheduled_basic
=== PAUSE TestAccSentinelAlertRuleScheduled_basic
=== RUN   TestAccSentinelAlertRuleScheduled_upgrade
=== PAUSE TestAccSentinelAlertRuleScheduled_upgrade
=== RUN   TestAccSentinelAlertRuleScheduled_complete
=== PAUSE TestAccSentinelAlertRuleScheduled_complete
=== RUN   TestAccSentinelAlertRuleScheduled_update
=== PAUSE TestAccSentinelAlertRuleScheduled_update
=== RUN   TestAccSentinelAlertRuleScheduled_requiresImport
=== PAUSE TestAccSentinelAlertRuleScheduled_requiresImport
=== RUN   TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== PAUSE TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== RUN   TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== PAUSE TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== CONT  TestAccSentinelAlertRuleScheduled_basic
=== CONT  TestAccSentinelAlertRuleScheduled_requiresImport
=== CONT  TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== CONT  TestAccSentinelAlertRuleScheduled_complete
=== CONT  TestAccSentinelAlertRuleScheduled_upgrade
=== CONT  TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleScheduled_update
=== NAME  TestAccSentinelAlertRuleScheduled_requiresImport
    testing_new.go:90: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Solution (Subscription: "*****"
        Resource Group Name: "acctestRG-sentinel-240422142804380013"
        Solution Name: "SecurityInsights(acctestLAW-240422142804380013)"): performing Delete: unexpected status 204 (204 No Content) received with no body
        
        deleting Solution (Subscription: "*****"
        Resource Group Name: "acctestRG-sentinel-240422142804380013"
        Solution Name: "SecurityInsights(acctestLAW-240422142804380013)"): performing
        Delete: unexpected status 204 (204 No Content) received with no body
--- FAIL: TestAccSentinelAlertRuleScheduled_requiresImport (143.33s)
--- PASS: TestAccSentinelAlertRuleScheduled_complete (287.05s)
--- PASS: TestAccSentinelAlertRuleScheduled_basic (289.01s)
--- PASS: TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid (289.63s)
--- PASS: TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting (362.60s)
--- PASS: TestAccSentinelAlertRuleScheduled_upgrade (370.77s)
--- PASS: TestAccSentinelAlertRuleScheduled_update (429.31s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel	429.385s
FAIL
```
rerun the failed one
```
❯❯ tftest sentinel TestAccSentinelAlertRuleScheduled_requiresImport
=== RUN   TestAccSentinelAlertRuleScheduled_requiresImport
=== PAUSE TestAccSentinelAlertRuleScheduled_requiresImport
=== CONT  TestAccSentinelAlertRuleScheduled_requiresImport
--- PASS: TestAccSentinelAlertRuleScheduled_requiresImport (206.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel	207.060s
```
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

`azurerm_sentinel_alert_rule_scheduled` - remove `forcenew` for `alert_rule_template_version` [GH-25688]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25564


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
