### PR TITLE
new datasource `azurerm_custom_location`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -141,6 +141,9 @@ service/event-grid:
 service/event-hubs:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_eventhub((.|\n)*)###'
 
+service/extendedlocation:
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_custom_location((.|\n)*)###'
+
 service/firewall:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_firewall((.|\n)*)###'
 

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -239,6 +239,11 @@ service/event-hubs:
   - any-glob-to-any-file:
     - internal/services/eventhub/**/*
 
+service/extendedlocation:
+- changed-files:
+  - any-glob-to-any-file:
+    - internal/services/extendedlocation/**/*
+
 service/firewall:
 - changed-files:
   - any-glob-to-any-file:

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -53,6 +53,7 @@ var services = mapOf(
         "elasticsan" to "ElasticSan",
         "eventgrid" to "EventGrid",
         "eventhub" to "EventHub",
+        "extendedlocation" to "ExtendedLocation",
         "firewall" to "Firewall",
         "fluidrelay" to "Fluid Relay",
         "frontdoor" to "FrontDoor",

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -211,7 +211,7 @@ type Client struct {
 	ElasticSan                        *elasticsan.Client
 	EventGrid                         *eventgrid_v2022_06_15.Client
 	Eventhub                          *eventhub.Client
-	ExtendedLocation				  *extendedlocation.Client
+	ExtendedLocation                  *extendedlocation.Client
 	FluidRelay                        *fluidrelay_2022_05_26.Client
 	Frontdoor                         *frontdoor.Client
 	Graph                             *graph.Client

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -73,6 +73,7 @@ import (
 	elasticsan "github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan/client"
 	eventgrid "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid/client"
 	eventhub "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/client"
+	extendedlocation "github.com/hashicorp/terraform-provider-azurerm/internal/services/extendedlocation/client"
 	fluidrelay "github.com/hashicorp/terraform-provider-azurerm/internal/services/fluidrelay/client"
 	frontdoor "github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor/client"
 	graph "github.com/hashicorp/terraform-provider-azurerm/internal/services/graphservices/client"
@@ -210,6 +211,7 @@ type Client struct {
 	ElasticSan                        *elasticsan.Client
 	EventGrid                         *eventgrid_v2022_06_15.Client
 	Eventhub                          *eventhub.Client
+	ExtendedLocation				  *extendedlocation.Client
 	FluidRelay                        *fluidrelay_2022_05_26.Client
 	Frontdoor                         *frontdoor.Client
 	Graph                             *graph.Client
@@ -446,6 +448,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	}
 	if client.Eventhub, err = eventhub.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Eventhub: %+v", err)
+	}
+	if client.ExtendedLocation, err = extendedlocation.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for ExtendedLocation: %+v", err)
 	}
 	if client.FluidRelay, err = fluidrelay.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for FluidRelay: %+v", err)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -53,6 +53,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/extendedlocation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/fluidrelay"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor"
@@ -170,6 +171,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		domainservices.Registration{},
 		elasticsan.Registration{},
 		eventhub.Registration{},
+		extendedlocation.Registration{},
 		fluidrelay.Registration{},
 		graphservices.Registration{},
 		storagecache.Registration{},

--- a/internal/services/extendedlocation/client/client.go
+++ b/internal/services/extendedlocation/client/client.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"fmt"
+
+	extendedLocation20210815 "github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+type Client struct {
+	*extendedLocation20210815.Client
+}
+
+func NewClient(o *common.ClientOptions) (*Client, error) {
+	client, err := extendedLocation20210815.NewClientWithBaseURI(o.Environment.ResourceManager, func(c *resourcemanager.Client) {
+		o.Configure(c, o.Authorizers.ResourceManager)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building clients for Network: %+v", err)
+	}
+
+	return &Client{
+		Client: client,
+	}, nil
+}

--- a/internal/services/extendedlocation/custom_location_data_source.go
+++ b/internal/services/extendedlocation/custom_location_data_source.go
@@ -21,7 +21,7 @@ type CustomLocationDataSource struct{}
 
 var _ sdk.DataSource = CustomLocationDataSource{}
 
-type CustomLocationModel struct {
+type CustomLocationDataSourceModel struct {
 	ClusterExtensionIds []string                       `tfschema:"cluster_extension_ids"`
 	DisplayName         string                         `tfschema:"display_name"`
 	HostResourceId      string                         `tfschema:"host_resource_id"`
@@ -38,7 +38,7 @@ func (r CustomLocationDataSource) ResourceType() string {
 }
 
 func (r CustomLocationDataSource) ModelObject() interface{} {
-	return &CustomLocationModel{}
+	return &CustomLocationDataSourceModel{}
 }
 
 func (r CustomLocationDataSource) Arguments() map[string]*pluginsdk.Schema {
@@ -96,7 +96,7 @@ func (r CustomLocationDataSource) Read() sdk.ResourceFunc {
 			client := metadata.Client.ExtendedLocation.CustomLocations
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			var model CustomLocationModel
+			var model CustomLocationDataSourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -112,7 +112,7 @@ func (r CustomLocationDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			state := CustomLocationModel{
+			state := CustomLocationDataSourceModel{
 				Name:              model.Name,
 				ResourceGroupName: model.ResourceGroupName,
 			}

--- a/internal/services/extendedlocation/custom_location_data_source.go
+++ b/internal/services/extendedlocation/custom_location_data_source.go
@@ -1,0 +1,138 @@
+package extendedlocation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type CustomLocationDataSource struct{}
+
+var _ sdk.DataSource = CustomLocationDataSource{}
+
+type CustomLocationModel struct {
+	ClusterExtensionIds []string                       `tfschema:"cluster_extension_ids"`
+	DisplayName         string                         `tfschema:"display_name"`
+	HostResourceId      string                         `tfschema:"host_resource_id"`
+	Identities          []identity.ModelSystemAssigned `tfschema:"identities"`
+	Location            string                         `tfschema:"location"`
+	Name                string                         `tfschema:"name"`
+	Namespace           string                         `tfschema:"namespace"`
+	ResourceGroupName   string                         `tfschema:"resource_group_name"`
+	Tags                map[string]interface{}         `tfschema:"tags"`
+}
+
+func (r CustomLocationDataSource) ResourceType() string {
+	return "azurerm_custom_location"
+}
+
+func (r CustomLocationDataSource) ModelObject() interface{} {
+	return &CustomLocationModel{}
+}
+
+func (r CustomLocationDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (r CustomLocationDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"cluster_extension_ids": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"display_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"host_resource_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"identities": commonschema.SystemAssignedIdentityComputed(),
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"namespace": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (r CustomLocationDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ExtendedLocation.CustomLocations
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model CustomLocationModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := customlocations.NewCustomLocationID(subscriptionId, model.ResourceGroupName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("%s does not exist", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := CustomLocationModel{
+				Name:              model.Name,
+				ResourceGroupName: model.ResourceGroupName,
+			}
+
+			if model := existing.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Tags = tags.Flatten(model.Tags)
+				state.Identities = identity.FlattenSystemAssignedToModel(model.Identity)
+
+				if props := model.Properties; props != nil {
+					state.ClusterExtensionIds = pointer.From(props.ClusterExtensionIds)
+					state.DisplayName = pointer.From(props.DisplayName)
+					state.HostResourceId = pointer.From(props.HostResourceId)
+					state.Namespace = pointer.From(props.Namespace)
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/extendedlocation/custom_location_data_source_test.go
+++ b/internal/services/extendedlocation/custom_location_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-type ManagerDataSource struct{}
+type CustomLocationDataSource struct{}
 
 const (
 	customLocationName              = "ARM_TEST_CUSTOM_LOCATION_NAME"
@@ -18,7 +18,7 @@ const (
 
 func TestAccCustomLocationDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_custom_location", "test")
-	d := ManagerDataSource{}
+	d := CustomLocationDataSource{}
 
 	if os.Getenv(customLocationName) == "" || os.Getenv(customLocationResourceGroupName) == "" {
 		t.Skipf("Skipping test due to missing environment variables: %s, %s", customLocationName, customLocationResourceGroupName)
@@ -38,7 +38,7 @@ func TestAccCustomLocationDataSource_basic(t *testing.T) {
 	})
 }
 
-func (d ManagerDataSource) basic() string {
+func (d CustomLocationDataSource) basic() string {
 	return fmt.Sprintf(`
 provider azurerm {
   features {}

--- a/internal/services/extendedlocation/custom_location_data_source_test.go
+++ b/internal/services/extendedlocation/custom_location_data_source_test.go
@@ -1,0 +1,52 @@
+package extendedlocation_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ManagerDataSource struct{}
+
+const (
+	customLocationName              = "ARM_TEST_CUSTOM_LOCATION_NAME"
+	customLocationResourceGroupName = "ARM_TEST_CUSTOM_LOCATION_RESOURCE_GROUP_NAME"
+)
+
+func TestAccCustomLocationDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_custom_location", "test")
+	d := ManagerDataSource{}
+
+	if os.Getenv(customLocationName) == "" || os.Getenv(customLocationResourceGroupName) == "" {
+		t.Skipf("Skipping test due to missing environment variables: %s, %s", customLocationName, customLocationResourceGroupName)
+	}
+
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.basic(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").IsNotEmpty(),
+				check.That(data.ResourceName).Key("host_resource_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("display_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("namespace").IsNotEmpty(),
+				check.That(data.ResourceName).Key("cluster_extension_ids.#").HasValue("2"),
+			),
+		},
+	})
+}
+
+func (d ManagerDataSource) basic() string {
+	return fmt.Sprintf(`
+provider azurerm {
+  features {}
+}
+
+data "azurerm_custom_location" "test" {
+  name                = %q
+  resource_group_name = %q
+}
+`, os.Getenv(customLocationName), os.Getenv(customLocationResourceGroupName))
+}

--- a/internal/services/extendedlocation/registration.go
+++ b/internal/services/extendedlocation/registration.go
@@ -1,0 +1,31 @@
+package extendedlocation
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+var _ sdk.TypedServiceRegistration = Registration{}
+
+type Registration struct{}
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/extendedlocation"
+}
+
+func (Registration) Name() string {
+	return "ExtendedLocation"
+}
+
+func (Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{
+		CustomLocationDataSource{},
+	}
+}
+
+func (Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{}
+}
+
+func (Registration) WebsiteCategories() []string {
+	return []string{
+		"Extended Location",
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/client.go
@@ -1,0 +1,28 @@
+package v2021_08_15
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+type Client struct {
+	CustomLocations *customlocations.CustomLocationsClient
+}
+
+func NewClientWithBaseURI(sdkApi sdkEnv.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
+	customLocationsClient, err := customlocations.NewCustomLocationsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building CustomLocations client: %+v", err)
+	}
+	configureFunc(customLocationsClient.Client)
+
+	return &Client{
+		CustomLocations: customLocationsClient,
+	}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -519,6 +519,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespace
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/schemaregistry
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces
+github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15
 github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations
 github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26
 github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelaycontainers

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -51,6 +51,7 @@ Digital Twins
 Disks
 Elastic
 Elastic SAN
+Extended Location
 Fluid Relay
 Graph Services
 HDInsight

--- a/website/docs/d/custom_location.html.markdown
+++ b/website/docs/d/custom_location.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Extended Location"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_custom_location"
+description: |-
+  Gets information about an existing Custom Location.
+---
+
+# Data Source: azurerm_custom_location
+
+Use this data source to access information about an existing Custom Location.
+
+## Example Usage
+
+```hcl
+data "azurerm_custom_location" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_custom_location.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Custom Location.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Custom Location exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Custom Location.
+
+* `cluster_extension_ids` - A `cluster_extension_ids` block as defined below.
+
+* `display_name` - The display name of the Custom Location.
+
+* `host_resource_id` - The ID of the host resource of the Custom Location.
+
+* `identities` - A `identities` block as defined below.
+
+* `location` - The geo-location where the Custom Location exists.
+
+* `namespace` - Kubernetes namespace that is created on the specified cluster for the Custom Location.
+
+* `tags` - A mapping of tags assigned to the Custom Location.
+
+---
+
+A `identities` block exports the following:
+
+* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Custom Location.
+
+* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Custom Location.
+
+* `type` - The type of Managed Service Identity that is configured on this Custom Location.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Custom Location.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Concept of Azure Custom Location: https://learn.microsoft.com/en-us/azure/azure-arc/platform/conceptual-custom-locations
How to create a custom location on your Azure Arc-enabled Kubernetes cluster: https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/custom-locations
REST API: https://learn.microsoft.com/en-us/rest/api/extendedlocation/custom-locations/get?view=rest-extendedlocation-2021-08-15&tabs=HTTP
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The custom location is created during with Azure Stack HCI deployment or an Arc-enabled Kubernetes. Below test is based on an existing custom location, which is created by Azure Stack HCI deployment, and the deployment steps are included in the acctest of PR #25646 which is quite complicated.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/104055472/85d80ca4-26d9-4892-988f-9ef87fd453d5)

```
ARM_TEST_CUSTOM_LOCATION_NAME=customlocationnsm6h ARM_TEST_CUSTOM_LOCATION_RESOURCE_GROUP_NAME=acctest-hci-nsm6h TF_ACC=1 go test -v ./internal/services/extendedlocation -run TestAccCustomLocationDataSource_basic -timeout 24h
=== RUN   TestAccCustomLocationDataSource_basic
--- PASS: TestAccCustomLocationDataSource_basic (25.72s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/extendedlocation      25.755s
```

Acc test debug log:
```
2024/04/22 07:59:20 [DEBUG] GET https://management.azure.com/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ExtendedLocation/customLocations/customlocationnsm6h?api-version=2021-08-15
2024/04/22 07:59:21 [DEBUG] AzureRM Response for https://management.azure.com/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ExtendedLocation/customLocations/customlocationnsm6h?api-version=2021-08-15:
HTTP/2.0 200 OK
Content-Length: 1323
Cache-Control: no-cache
Content-Type: application/json
Date: Mon, 22 Apr 2024 07:59:20 GMT
Expires: -1
Pragma: no-cache
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Cache: CONFIG_NOCACHE
X-Content-Type-Options: nosniff
X-Ms-Correlation-Request-Id: b2362b51-fb37-3b72-915f-7a1b2d43c68e
X-Ms-Ratelimit-Remaining-Subscription-Reads: 11999
X-Ms-Request-Id: 1652766e-28e1-40eb-b2c3-5411f694d877
X-Ms-Routing-Request-Id: JAPANWEST:20240422T075921Z:06e976e3-6677-4a7a-ad0f-e41d813b0a37
X-Msedge-Ref: Ref A: A7533555A12C4B36895EA62796964C53 Ref B: TYO201151005029 Ref C: 2024-04-22T07:59:20Z

{"id":"/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ExtendedLocation/customLocations/customlocationnsm6h","name":"customlocationnsm6h","location":"eastus","type":"Microsoft.ExtendedLocation/customLocations","systemData":{"createdBy":"XXXX","createdByType":"Application","createdAt":"2024-04-19T05:08:12.6009417Z","lastModifiedBy":"XXXX","lastModifiedByType":"Application","lastModifiedAt":"2024-04-19T05:12:14.1923853Z"},"properties":{"hostResourceId":"/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ResourceConnector/appliances/hcinsm6h-cl-arcbridge","namespace":"default","displayName":"customlocationnsm6h","provisioningState":"Succeeded","clusterExtensionIds":["/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ResourceConnector/appliances/hcinsm6h-cl-arcbridge/providers/Microsoft.KubernetesConfiguration/extensions/hybridaksextension","/subscriptions/XXXX/resourceGroups/acctest-hci-nsm6h/providers/Microsoft.ResourceConnector/appliances/hcinsm6h-cl-arcbridge/providers/Microsoft.KubernetesConfiguration/extensions/vmss-hci"],"authentication":{}}}
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* new datasource `azurerm_custom_location`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
