### PR TITLE
internal/sdk: add struct tag for properties that should only be introduced in 4.0

### DIFF
--- a/internal/features/four_point_oh.go
+++ b/internal/features/four_point_oh.go
@@ -9,9 +9,9 @@ package features
 // DeprecatedInFourPointOh returns the deprecation message if the provider
 // is running in 4.0 mode - otherwise is returns an empty string (such that
 // this deprecation should be ignored).
-//
-// This will be used to signify resources which will be Deprecated in 4.0,
-// but not Removed (which will happen in a later, presumably 5.0 release).
+// This can be used for the following scenarios:
+//   - Signify resources which will be Deprecated in 4.0, but not Removed (which will happen in a later release).
+//   - For properties undergoing a rename, where the renamed property will only be introduced in the next release
 func DeprecatedInFourPointOh(deprecationMessage string) string {
 	if !FourPointOhBeta() {
 		return ""
@@ -26,10 +26,6 @@ func DeprecatedInFourPointOh(deprecationMessage string) string {
 // This exists to allow breaking changes to be piped through the provider
 // during the development of 3.x until 4.0 is ready.
 func FourPointOh() bool {
-	// WodansSon: Added for testing 4.0 functionality,
-	// will comment out in final check-in...
-	// return !(os.Getenv("TF_FOUR_POINT_OH_BETA") == "")
-
 	return false
 }
 

--- a/internal/sdk/resource_encode.go
+++ b/internal/sdk/resource_encode.go
@@ -66,7 +66,7 @@ func recurse(objType reflect.Type, objVal reflect.Value, debugLogger Logger) (ou
 			}
 
 			if structTags.addedInNextMajorVersion && !features.FourPointOh() {
-				debugLogger.Infof("The HCL Path %q is marked as removed - skipping", structTags.hclPath)
+				debugLogger.Infof("The HCL Path %q is marked as not yet present - skipping", structTags.hclPath)
 				continue
 			}
 

--- a/internal/sdk/resource_encode.go
+++ b/internal/sdk/resource_encode.go
@@ -65,6 +65,11 @@ func recurse(objType reflect.Type, objVal reflect.Value, debugLogger Logger) (ou
 				continue
 			}
 
+			if structTags.addedInNextMajorVersion && !features.FourPointOh() {
+				debugLogger.Infof("The HCL Path %q is marked as removed - skipping", structTags.hclPath)
+				continue
+			}
+
 			switch field.Type.Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				iv := fieldVal.Int()

--- a/internal/sdk/resource_helpers_test.go
+++ b/internal/sdk/resource_helpers_test.go
@@ -38,6 +38,7 @@ func TestParseStructTags_WithValue(t *testing.T) {
 			input: `tfschema:"hello"`,
 			expected: &decodedStructTags{
 				hclPath:                   "hello",
+				addedInNextMajorVersion:   false,
 				removedInNextMajorVersion: false,
 			},
 		},
@@ -46,6 +47,7 @@ func TestParseStructTags_WithValue(t *testing.T) {
 			input: `tfschema:"hello,removedInNextMajorVersion"`,
 			expected: &decodedStructTags{
 				hclPath:                   "hello",
+				addedInNextMajorVersion:   false,
 				removedInNextMajorVersion: true,
 			},
 		},
@@ -54,6 +56,7 @@ func TestParseStructTags_WithValue(t *testing.T) {
 			input: `tfschema:"hello, removedInNextMajorVersion"`,
 			expected: &decodedStructTags{
 				hclPath:                   "hello",
+				addedInNextMajorVersion:   false,
 				removedInNextMajorVersion: true,
 			},
 		},
@@ -65,6 +68,7 @@ func TestParseStructTags_WithValue(t *testing.T) {
 			input: `tfschema:"hello ,removedInNextMajorVersion"`,
 			expected: &decodedStructTags{
 				hclPath:                   "hello",
+				addedInNextMajorVersion:   false,
 				removedInNextMajorVersion: true,
 			},
 		},
@@ -76,8 +80,30 @@ func TestParseStructTags_WithValue(t *testing.T) {
 			input: `tfschema:"hello , removedInNextMajorVersion"`,
 			expected: &decodedStructTags{
 				hclPath:                   "hello",
+				addedInNextMajorVersion:   false,
 				removedInNextMajorVersion: true,
 			},
+		},
+		{
+			// valid, with addedInNextMajorVersion and a space before the comma
+			input: `tfschema:"hello, addedInNextMajorVersion"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				addedInNextMajorVersion:   true,
+				removedInNextMajorVersion: false,
+			},
+		},
+		{
+			// valid, with addedInNextMajorVersion and a space before the comma
+			input:    `tfschema:"hello, removedInNextMajorVersion, addedInNextMajorVersion"`,
+			expected: nil,
+			error:    pointer.To("the struct-tags `removedInNextMajorVersion` and `addedInNextMajorVersion` cannot be set together"),
+		},
+		{
+			// valid, with addedInNextMajorVersion and a space before the comma
+			input:    `tfschema:"hello, addedInNextMajorVersion, removedInNextMajorVersion"`,
+			expected: nil,
+			error:    pointer.To("the struct-tags `removedInNextMajorVersion` and `addedInNextMajorVersion` cannot be set together"),
 		},
 		{
 			// invalid, unknown struct tags

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -304,7 +304,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty),
 							AtLeastOneOf: []string{
 								"azure_active_directory_role_based_access_control.0.tenant_id",
-								"azure_active_directory_role_based_access_control.0.managed",
 								"azure_active_directory_role_based_access_control.0.admin_group_object_ids",
 							},
 						},
@@ -323,7 +322,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							},
 							AtLeastOneOf: []string{
 								"azure_active_directory_role_based_access_control.0.tenant_id",
-								"azure_active_directory_role_based_access_control.0.managed",
 								"azure_active_directory_role_based_access_control.0.admin_group_object_ids",
 							},
 						},

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -223,17 +223,17 @@ func resourceSubnet() *pluginsdk.Resource {
 			"private_link_service_network_policies_enabled": {
 				Type: pluginsdk.TypeBool,
 				Computed: func() bool {
-					return !features.FourPointOh()
+					return !features.FourPointOhBeta()
 				}(),
 				Optional: true,
 				Default: func() interface{} {
-					if !features.FourPointOh() {
+					if !features.FourPointOhBeta() {
 						return nil
 					}
-					return features.FourPointOh()
+					return features.FourPointOhBeta()
 				}(),
 				ConflictsWith: func() []string {
-					if !features.FourPointOh() {
+					if !features.FourPointOhBeta() {
 						return []string{"enforce_private_link_service_network_policies"}
 					}
 					return []string{}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- adds a struct tag for properties that are only introduced in 4.0
- fixes some 4.0 changes that break the providers internal validation


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
