### PR TITLE
`compute` - migrate remaining non-legacy compute resources

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource_test.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource_test.go
@@ -144,6 +144,7 @@ resource "azurerm_aadb2c_directory" "test" {
   domain_name             = "acctest%[2]d.onmicrosoft.com"
   resource_group_name     = azurerm_resource_group.test.name
   sku_name                = "PremiumP1"
+  test                    = "test"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/ssh"
@@ -332,19 +332,17 @@ func (ImageResource) virtualMachineExists(ctx context.Context, client *clients.C
 }
 
 func (ImageResource) virtualMachineScaleSetExists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	id, err := commonids.ParseVirtualMachineScaleSetID(state.ID)
+	id, err := virtualmachinescalesets.ParseVirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroupName, id.VirtualMachineScaleSetName, "")
+	resp, err := client.Compute.VirtualMachineScaleSetsClient.Get(ctx, *id, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("%s does not exist", *id)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
 		}
-
-		return fmt.Errorf("Bad: Get on client: %+v", err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -8,9 +8,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func TestAccLinuxVirtualMachine_otherAllowExtensionOperationsDefault(t *testing.T) {
@@ -824,7 +824,7 @@ func TestAccLinuxVirtualMachine_otherPatchModeAutomaticByPlatform(t *testing.T) 
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherPatchMode(data, string(compute.LinuxVMGuestPatchModeAutomaticByPlatform)),
+			Config: r.otherPatchMode(data, string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -839,21 +839,21 @@ func TestAccLinuxVirtualMachine_otherPatchModeUpdate(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherPatchMode(data, string(compute.LinuxVMGuestPatchModeImageDefault)),
+			Config: r.otherPatchMode(data, string(virtualmachines.LinuxVMGuestPatchModeImageDefault)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.otherPatchMode(data, string(compute.LinuxVMGuestPatchModeAutomaticByPlatform)),
+			Config: r.otherPatchMode(data, string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.otherPatchMode(data, string(compute.LinuxVMGuestPatchModeImageDefault)),
+			Config: r.otherPatchMode(data, string(virtualmachines.LinuxVMGuestPatchModeImageDefault)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func OrchestratedVirtualMachineScaleSetOSProfileSchema() *pluginsdk.Schema {
@@ -93,21 +92,21 @@ func OrchestratedVirtualMachineScaleSetWindowsConfigurationSchema() *pluginsdk.S
 				"patch_assessment_mode": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  string(compute.WindowsPatchAssessmentModeImageDefault),
+					Default:  string(virtualmachinescalesets.WindowsPatchAssessmentModeImageDefault),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.WindowsPatchAssessmentModeAutomaticByPlatform),
-						string(compute.WindowsPatchAssessmentModeImageDefault),
+						string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform),
+						string(virtualmachinescalesets.WindowsPatchAssessmentModeImageDefault),
 					}, false),
 				},
 
 				"patch_mode": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  string(compute.WindowsVMGuestPatchModeAutomaticByOS),
+					Default:  string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByOS),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.WindowsVMGuestPatchModeAutomaticByOS),
-						string(compute.WindowsVMGuestPatchModeAutomaticByPlatform),
-						string(compute.WindowsVMGuestPatchModeManual),
+						string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByOS),
+						string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform),
+						string(virtualmachinescalesets.WindowsVMGuestPatchModeManual),
 					}, false),
 				},
 
@@ -167,20 +166,20 @@ func OrchestratedVirtualMachineScaleSetLinuxConfigurationSchema() *pluginsdk.Sch
 				"patch_assessment_mode": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  string(compute.LinuxPatchAssessmentModeImageDefault),
+					Default:  string(virtualmachinescalesets.LinuxPatchAssessmentModeImageDefault),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.LinuxPatchAssessmentModeAutomaticByPlatform),
-						string(compute.LinuxPatchAssessmentModeImageDefault),
+						string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform),
+						string(virtualmachinescalesets.LinuxPatchAssessmentModeImageDefault),
 					}, false),
 				},
 
 				"patch_mode": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  string(compute.LinuxVMGuestPatchModeImageDefault),
+					Default:  string(virtualmachinescalesets.LinuxVMGuestPatchModeImageDefault),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.LinuxVMGuestPatchModeImageDefault),
-						string(compute.LinuxVMGuestPatchModeAutomaticByPlatform),
+						string(virtualmachinescalesets.LinuxVMGuestPatchModeImageDefault),
+						string(virtualmachinescalesets.LinuxVMGuestPatchModeAutomaticByPlatform),
 					}, false),
 				},
 
@@ -377,10 +376,10 @@ func orchestratedVirtualMachineScaleSetIPConfigurationSchema() *pluginsdk.Schema
 				"version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  string(compute.IPVersionIPv4),
+					Default:  string(virtualmachinescalesets.IPVersionIPvFour),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.IPVersionIPv4),
-						string(compute.IPVersionIPv6),
+						string(virtualmachinescalesets.IPVersionIPvFour),
+						string(virtualmachinescalesets.IPVersionIPvSix),
 					}, false),
 				},
 			},
@@ -454,10 +453,10 @@ func orchestratedVirtualMachineScaleSetPublicIPAddressSchema() *pluginsdk.Schema
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ForceNew: true,
-					Default:  string(compute.IPVersionIPv4),
+					Default:  string(virtualmachinescalesets.IPVersionIPvFour),
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.IPVersionIPv4),
-						string(compute.IPVersionIPv6),
+						string(virtualmachinescalesets.IPVersionIPvFour),
+						string(virtualmachinescalesets.IPVersionIPvSix),
 					}, false),
 				},
 			},
@@ -499,9 +498,9 @@ func OrchestratedVirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.CachingTypesNone),
-						string(compute.CachingTypesReadOnly),
-						string(compute.CachingTypesReadWrite),
+						string(virtualmachinescalesets.CachingTypesNone),
+						string(virtualmachinescalesets.CachingTypesReadOnly),
+						string(virtualmachinescalesets.CachingTypesReadWrite),
 					}, false),
 				},
 
@@ -509,10 +508,10 @@ func OrchestratedVirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.DiskCreateOptionTypesEmpty),
-						string(compute.DiskCreateOptionTypesFromImage),
+						string(virtualmachinescalesets.DiskCreateOptionTypesEmpty),
+						string(virtualmachinescalesets.DiskCreateOptionTypesFromImage),
 					}, false),
-					Default: string(compute.DiskCreateOptionTypesEmpty),
+					Default: string(virtualmachinescalesets.DiskCreateOptionTypesEmpty),
 				},
 
 				"disk_encryption_set_id": {
@@ -543,13 +542,13 @@ func OrchestratedVirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.StorageAccountTypesPremiumLRS),
-						string(compute.StorageAccountTypesPremiumV2LRS),
-						string(compute.StorageAccountTypesPremiumZRS),
-						string(compute.StorageAccountTypesStandardLRS),
-						string(compute.StorageAccountTypesStandardSSDLRS),
-						string(compute.StorageAccountTypesStandardSSDZRS),
-						string(compute.StorageAccountTypesUltraSSDLRS),
+						string(virtualmachinescalesets.StorageAccountTypesPremiumLRS),
+						string(virtualmachinescalesets.StorageAccountTypesPremiumVTwoLRS),
+						string(virtualmachinescalesets.StorageAccountTypesPremiumZRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardLRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardSSDLRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardSSDZRS),
+						string(virtualmachinescalesets.StorageAccountTypesUltraSSDLRS),
 					}, false),
 				},
 
@@ -608,9 +607,9 @@ func OrchestratedVirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.CachingTypesNone),
-						string(compute.CachingTypesReadOnly),
-						string(compute.CachingTypesReadWrite),
+						string(virtualmachinescalesets.CachingTypesNone),
+						string(virtualmachinescalesets.CachingTypesReadOnly),
+						string(virtualmachinescalesets.CachingTypesReadWrite),
 					}, false),
 				},
 				"storage_account_type": {
@@ -621,11 +620,11 @@ func OrchestratedVirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						// NOTE: OS Disks don't support Ultra SSDs or PremiumV2_LRS
-						string(compute.StorageAccountTypesPremiumLRS),
-						string(compute.StorageAccountTypesPremiumZRS),
-						string(compute.StorageAccountTypesStandardLRS),
-						string(compute.StorageAccountTypesStandardSSDLRS),
-						string(compute.StorageAccountTypesStandardSSDZRS),
+						string(virtualmachinescalesets.StorageAccountTypesPremiumLRS),
+						string(virtualmachinescalesets.StorageAccountTypesPremiumZRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardLRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardSSDLRS),
+						string(virtualmachinescalesets.StorageAccountTypesStandardSSDZRS),
 					}, false),
 				},
 
@@ -641,17 +640,17 @@ func OrchestratedVirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 								Required: true,
 								ForceNew: true,
 								ValidateFunc: validation.StringInSlice([]string{
-									string(compute.DiffDiskOptionsLocal),
+									string(virtualmachinescalesets.DiffDiskOptionsLocal),
 								}, false),
 							},
 							"placement": {
 								Type:     pluginsdk.TypeString,
 								Optional: true,
 								ForceNew: true,
-								Default:  string(compute.DiffDiskPlacementCacheDisk),
+								Default:  string(virtualmachinescalesets.DiffDiskPlacementCacheDisk),
 								ValidateFunc: validation.StringInSlice([]string{
-									string(compute.DiffDiskPlacementCacheDisk),
-									string(compute.DiffDiskPlacementResourceDisk),
+									string(virtualmachinescalesets.DiffDiskPlacementCacheDisk),
+									string(virtualmachinescalesets.DiffDiskPlacementResourceDisk),
 								}, false),
 							}},
 					},
@@ -1450,7 +1449,7 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 			extensionProps.Settings = pointer.To(result)
 		}
 
-		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVault(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
+		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVaultVMSS(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
 		extensionProps.ProtectedSettingsFromKeyVault = (protectedSettingsFromKeyVault)
 
 		if val, ok := extensionRaw["protected_settings"]; ok && val.(string) != "" {
@@ -1580,7 +1579,7 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *virtualmachinesc
 			"failure_suppression_enabled":               suppressFailures,
 			"extensions_to_provision_after_vm_creation": provisionAfterExtension,
 			"protected_settings":                        protectedSettings,
-			"protected_settings_from_key_vault":         flattenProtectedSettingsFromKeyVault(protectedSettingsFromKeyVault),
+			"protected_settings_from_key_vault":         flattenProtectedSettingsFromKeyVaultVMSS(protectedSettingsFromKeyVault),
 			"publisher":                                 extPublisher,
 			"settings":                                  extSettings,
 			"type":                                      extType,
@@ -1736,8 +1735,8 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *virtua
 		output["timezone"] = v
 	}
 
-	output["patch_mode"] = string(compute.WindowsVMGuestPatchModeAutomaticByOS)
-	output["patch_assessment_mode"] = string(compute.WindowsPatchAssessmentModeAutomaticByPlatform)
+	output["patch_mode"] = string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByOS)
+	output["patch_assessment_mode"] = string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 	output["hotpatching_enabled"] = false
 
 	if patchSettings != nil {

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -51,7 +51,7 @@ func dataSourcePlatformImage() *pluginsdk.Resource {
 }
 
 func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMImageClient
+	client := meta.(*clients.Client).Compute.VirtualMachineImagesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func protectedSettingsFromKeyVaultSchema(conflictsWithProtectedSettings bool) *pluginsdk.Schema {
@@ -39,22 +39,22 @@ func protectedSettingsFromKeyVaultSchema(conflictsWithProtectedSettings bool) *p
 	}
 }
 
-func expandProtectedSettingsFromKeyVaultOld(input []interface{}) *compute.KeyVaultSecretReference {
+func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachineextensions.KeyVaultSecretReference {
 	if len(input) == 0 {
 		return nil
 	}
 
 	v := input[0].(map[string]interface{})
 
-	return &compute.KeyVaultSecretReference{
-		SecretURL: pointer.To(v["secret_url"].(string)),
-		SourceVault: &compute.SubResource{
-			ID: utils.String(v["source_vault_id"].(string)),
+	return &virtualmachineextensions.KeyVaultSecretReference{
+		SecretUrl: v["secret_url"].(string),
+		SourceVault: virtualmachineextensions.SubResource{
+			Id: pointer.To(v["source_vault_id"].(string)),
 		},
 	}
 }
 
-func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachinescalesets.KeyVaultSecretReference {
+func expandProtectedSettingsFromKeyVaultVMSS(input []interface{}) *virtualmachinescalesets.KeyVaultSecretReference {
 	if len(input) == 0 {
 		return nil
 	}
@@ -64,32 +64,65 @@ func expandProtectedSettingsFromKeyVault(input []interface{}) *virtualmachinesca
 	return &virtualmachinescalesets.KeyVaultSecretReference{
 		SecretUrl: v["secret_url"].(string),
 		SourceVault: virtualmachinescalesets.SubResource{
-			Id: utils.String(v["source_vault_id"].(string)),
+			Id: pointer.To(v["source_vault_id"].(string)),
 		},
 	}
 }
 
-func flattenProtectedSettingsFromKeyVaultOld(input *compute.KeyVaultSecretReference) []interface{} {
-	if input == nil {
+func expandProtectedSettingsFromKeyVaultOldVMSSExtension(input []interface{}) *virtualmachinescalesetextensions.KeyVaultSecretReference {
+	if len(input) == 0 {
 		return nil
 	}
 
+	v := input[0].(map[string]interface{})
+
+	return &virtualmachinescalesetextensions.KeyVaultSecretReference{
+		SecretUrl: v["secret_url"].(string),
+		SourceVault: virtualmachinescalesetextensions.SubResource{
+			Id: pointer.To(v["source_vault_id"].(string)),
+		},
+	}
+}
+
+func flattenProtectedSettingsFromKeyVault(input *virtualmachineextensions.KeyVaultSecretReference) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
 	sourceVaultId := ""
-	if input.SourceVault.ID != nil {
-		sourceVaultId = *input.SourceVault.ID
+	if input.SourceVault.Id != nil {
+		sourceVaultId = *input.SourceVault.Id
 	}
 
 	return []interface{}{
 		map[string]interface{}{
-			"secret_url":      input.SecretURL,
+			"secret_url":      input.SecretUrl,
 			"source_vault_id": sourceVaultId,
 		},
 	}
 }
 
-func flattenProtectedSettingsFromKeyVault(input *virtualmachinescalesets.KeyVaultSecretReference) []interface{} {
+func flattenProtectedSettingsFromKeyVaultVMSS(input *virtualmachinescalesets.KeyVaultSecretReference) []interface{} {
 	if input == nil {
 		return []interface{}{}
+	}
+
+	sourceVaultId := ""
+	if input.SourceVault.Id != nil {
+		sourceVaultId = *input.SourceVault.Id
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"secret_url":      input.SecretUrl,
+			"source_vault_id": sourceVaultId,
+		},
+	}
+}
+
+func flattenProtectedSettingsFromKeyVaultOldVMSSExtension(input *virtualmachinescalesetextensions.KeyVaultSecretReference) []interface{} {
+	if input == nil {
+		return nil
 	}
 
 	sourceVaultId := ""

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryimages"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryimageversions"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceSharedImage() *pluginsdk.Resource {
@@ -92,8 +92,8 @@ func resourceSharedImage() *pluginsdk.Resource {
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.DiskStorageAccountTypesStandardLRS),
-						string(compute.DiskStorageAccountTypesPremiumLRS),
+						string(galleryimageversions.StorageAccountTypeStandardLRS),
+						string(galleryimageversions.StorageAccountTypePremiumLRS),
 					}, false),
 				},
 			},

--- a/internal/services/compute/validate/orchestrated_vmss_public_ip_sku.go
+++ b/internal/services/compute/validate/orchestrated_vmss_public_ip_sku.go
@@ -6,7 +6,7 @@ package validate
 import (
 	"fmt"
 
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 )
 
 func OrchestratedVirtualMachineScaleSetPublicIPSku(input interface{}, key string) (warnings []string, errors []error) {
@@ -17,10 +17,10 @@ func OrchestratedVirtualMachineScaleSetPublicIPSku(input interface{}, key string
 	}
 
 	publicIpSkus := []string{
-		fmt.Sprintf("%s_%s", string(compute.PublicIPAddressSkuNameBasic), string(compute.PublicIPAddressSkuTierRegional)),
-		fmt.Sprintf("%s_%s", string(compute.PublicIPAddressSkuNameStandard), string(compute.PublicIPAddressSkuTierRegional)),
-		fmt.Sprintf("%s_%s", string(compute.PublicIPAddressSkuNameBasic), string(compute.PublicIPAddressSkuTierGlobal)),
-		fmt.Sprintf("%s_%s", string(compute.PublicIPAddressSkuNameStandard), string(compute.PublicIPAddressSkuTierGlobal)),
+		fmt.Sprintf("%s_%s", string(virtualmachinescalesets.PublicIPAddressSkuNameBasic), string(virtualmachinescalesets.PublicIPAddressSkuTierRegional)),
+		fmt.Sprintf("%s_%s", string(virtualmachinescalesets.PublicIPAddressSkuNameStandard), string(virtualmachinescalesets.PublicIPAddressSkuTierRegional)),
+		fmt.Sprintf("%s_%s", string(virtualmachinescalesets.PublicIPAddressSkuNameBasic), string(virtualmachinescalesets.PublicIPAddressSkuTierGlobal)),
+		fmt.Sprintf("%s_%s", string(virtualmachinescalesets.PublicIPAddressSkuNameStandard), string(virtualmachinescalesets.PublicIPAddressSkuTierGlobal)),
 	}
 
 	for _, sku := range publicIpSkus {

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func virtualMachineAdditionalCapabilitiesSchema() *pluginsdk.Schema {
@@ -117,9 +116,9 @@ func virtualMachineOSDiskSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.CachingTypesNone),
-						string(compute.CachingTypesReadOnly),
-						string(compute.CachingTypesReadWrite),
+						string(virtualmachines.CachingTypesNone),
+						string(virtualmachines.CachingTypesReadOnly),
+						string(virtualmachines.CachingTypesReadWrite),
 					}, false),
 				},
 				"storage_account_type": {
@@ -130,11 +129,11 @@ func virtualMachineOSDiskSchema() *pluginsdk.Schema {
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						// note: OS Disks don't support Ultra SSDs or PremiumV2_LRS
-						string(compute.StorageAccountTypesPremiumLRS),
-						string(compute.StorageAccountTypesStandardLRS),
-						string(compute.StorageAccountTypesStandardSSDLRS),
-						string(compute.StorageAccountTypesStandardSSDZRS),
-						string(compute.StorageAccountTypesPremiumZRS),
+						string(virtualmachines.StorageAccountTypesPremiumLRS),
+						string(virtualmachines.StorageAccountTypesStandardLRS),
+						string(virtualmachines.StorageAccountTypesStandardSSDLRS),
+						string(virtualmachines.StorageAccountTypesStandardSSDZRS),
+						string(virtualmachines.StorageAccountTypesPremiumZRS),
 					}, false),
 				},
 
@@ -151,17 +150,17 @@ func virtualMachineOSDiskSchema() *pluginsdk.Schema {
 								Required: true,
 								ForceNew: true,
 								ValidateFunc: validation.StringInSlice([]string{
-									string(compute.DiffDiskOptionsLocal),
+									string(virtualmachines.DiffDiskOptionsLocal),
 								}, false),
 							},
 							"placement": {
 								Type:     pluginsdk.TypeString,
 								Optional: true,
 								ForceNew: true,
-								Default:  string(compute.DiffDiskPlacementCacheDisk),
+								Default:  string(virtualmachines.DiffDiskPlacementCacheDisk),
 								ValidateFunc: validation.StringInSlice([]string{
-									string(compute.DiffDiskPlacementCacheDisk),
-									string(compute.DiffDiskPlacementResourceDisk),
+									string(virtualmachines.DiffDiskPlacementCacheDisk),
+									string(virtualmachines.DiffDiskPlacementResourceDisk),
 								}, false),
 							},
 						},
@@ -204,8 +203,8 @@ func virtualMachineOSDiskSchema() *pluginsdk.Schema {
 					Optional: true,
 					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.SecurityEncryptionTypesVMGuestStateOnly),
-						string(compute.SecurityEncryptionTypesDiskWithVMGuestState),
+						string(virtualmachines.SecurityEncryptionTypesVMGuestStateOnly),
+						string(virtualmachines.SecurityEncryptionTypesDiskWithVMGuestState),
 					}, false),
 				},
 

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
@@ -8,9 +8,11 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -19,8 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceVirtualMachineDataDiskAttachment() *pluginsdk.Resource {
@@ -68,9 +68,9 @@ func resourceVirtualMachineDataDiskAttachment() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.CachingTypesNone),
-					string(compute.CachingTypesReadOnly),
-					string(compute.CachingTypesReadWrite),
+					string(virtualmachines.CachingTypesNone),
+					string(virtualmachines.CachingTypesReadOnly),
+					string(virtualmachines.CachingTypesReadWrite),
 				}, false),
 			},
 
@@ -78,10 +78,10 @@ func resourceVirtualMachineDataDiskAttachment() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(compute.DiskCreateOptionTypesAttach),
+				Default:  string(virtualmachines.DiskCreateOptionTypesAttach),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.DiskCreateOptionTypesAttach),
-					string(compute.DiskCreateOptionTypesEmpty),
+					string(virtualmachines.DiskCreateOptionTypesAttach),
+					string(virtualmachines.DiskCreateOptionTypesEmpty),
 				}, false),
 			},
 
@@ -95,25 +95,34 @@ func resourceVirtualMachineDataDiskAttachment() *pluginsdk.Resource {
 }
 
 func resourceVirtualMachineDataDiskAttachmentCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	parsedVirtualMachineId, err := commonids.ParseVirtualMachineID(d.Get("virtual_machine_id").(string))
+	parsedVirtualMachineId, err := virtualmachines.ParseVirtualMachineID(d.Get("virtual_machine_id").(string))
 	if err != nil {
-		return fmt.Errorf("parsing Virtual Machine ID %q: %+v", parsedVirtualMachineId.ID(), err)
+		return err
 	}
 
 	locks.ByName(parsedVirtualMachineId.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(parsedVirtualMachineId.VirtualMachineName, VirtualMachineResourceName)
 
-	virtualMachine, err := client.Get(ctx, parsedVirtualMachineId.ResourceGroupName, parsedVirtualMachineId.VirtualMachineName, "")
+	virtualMachine, err := client.Get(ctx, *parsedVirtualMachineId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(virtualMachine.Response) {
-			return fmt.Errorf("Virtual Machine %q  was not found", parsedVirtualMachineId.String())
+		if response.WasNotFound(virtualMachine.HttpResponse) {
+			return fmt.Errorf("%s was not found", parsedVirtualMachineId)
 		}
+		return fmt.Errorf("retrieving %s: %+v", parsedVirtualMachineId, err)
+	}
 
-		return fmt.Errorf("loading Virtual Machine %q : %+v", parsedVirtualMachineId.String(), err)
+	if virtualMachine.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", parsedVirtualMachineId)
+	}
+	if virtualMachine.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", parsedVirtualMachineId)
+	}
+	if virtualMachine.Model.Properties.StorageProfile == nil {
+		return fmt.Errorf("retrieving %s: `storageprofile` was nil", parsedVirtualMachineId)
 	}
 
 	managedDiskId := d.Get("managed_disk_id").(string)
@@ -123,29 +132,29 @@ func resourceVirtualMachineDataDiskAttachmentCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	if managedDisk.Sku == nil {
-		return fmt.Errorf("Error: unable to determine Storage Account Type for Managed Disk %q: %+v", managedDiskId, err)
+		return fmt.Errorf("unable to determine Storage Account Type for Managed Disk %q: %+v", managedDiskId, err)
 	}
 
 	name := *managedDisk.Name
 	resourceId := fmt.Sprintf("%s/dataDisks/%s", parsedVirtualMachineId.ID(), name)
 	lun := int32(d.Get("lun").(int))
 	caching := d.Get("caching").(string)
-	createOption := compute.DiskCreateOptionTypes(d.Get("create_option").(string))
+	createOption := virtualmachines.DiskCreateOptionTypes(d.Get("create_option").(string))
 	writeAcceleratorEnabled := d.Get("write_accelerator_enabled").(bool)
 
-	expandedDisk := compute.DataDisk{
-		Name:         utils.String(name),
-		Caching:      compute.CachingTypes(caching),
+	expandedDisk := virtualmachines.DataDisk{
+		Name:         pointer.To(name),
+		Caching:      pointer.To(virtualmachines.CachingTypes(caching)),
 		CreateOption: createOption,
-		Lun:          utils.Int32(lun),
-		ManagedDisk: &compute.ManagedDiskParameters{
-			ID:                 utils.String(managedDiskId),
-			StorageAccountType: compute.StorageAccountTypes(string(*managedDisk.Sku.Name)),
+		Lun:          int64(lun),
+		ManagedDisk: &virtualmachines.ManagedDiskParameters{
+			Id:                 pointer.To(managedDiskId),
+			StorageAccountType: pointer.To(virtualmachines.StorageAccountTypes(*managedDisk.Sku.Name)),
 		},
-		WriteAcceleratorEnabled: utils.Bool(writeAcceleratorEnabled),
+		WriteAcceleratorEnabled: pointer.To(writeAcceleratorEnabled),
 	}
 
-	disks := *virtualMachine.StorageProfile.DataDisks
+	disks := *virtualMachine.Model.Properties.StorageProfile.DataDisks
 
 	existingIndex := -1
 	for i, disk := range disks {
@@ -169,25 +178,20 @@ func resourceVirtualMachineDataDiskAttachmentCreateUpdate(d *pluginsdk.ResourceD
 		disks[existingIndex] = expandedDisk
 	}
 
-	virtualMachine.StorageProfile.DataDisks = &disks
+	virtualMachine.Model.Properties.StorageProfile.DataDisks = &disks
 
 	// fixes #2485
-	virtualMachine.Identity = nil
+	virtualMachine.Model.Identity = nil
 	// fixes #1600
-	virtualMachine.Resources = nil
+	virtualMachine.Model.Resources = nil
 	// fixes #24145
-	virtualMachine.ApplicationProfile = nil
+	virtualMachine.Model.Properties.ApplicationProfile = nil
 
 	// if there's too many disks we get a 409 back with:
 	//   `The maximum number of data disks allowed to be attached to a VM of this size is 1.`
 	// which we're intentionally not wrapping, since the errors good.
-	future, err := client.CreateOrUpdate(ctx, parsedVirtualMachineId.ResourceGroupName, parsedVirtualMachineId.VirtualMachineName, virtualMachine)
-	if err != nil {
-		return fmt.Errorf("updating Virtual Machine %q  with Disk %q: %+v", parsedVirtualMachineId.String(), name, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for Virtual Machine %q to finish updating Disk %q: %+v", parsedVirtualMachineId.String(), name, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *parsedVirtualMachineId, *virtualMachine.Model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+		return fmt.Errorf("updating %s with Disk %q: %+v", parsedVirtualMachineId, name, err)
 	}
 
 	d.SetId(resourceId)
@@ -195,7 +199,7 @@ func resourceVirtualMachineDataDiskAttachmentCreateUpdate(d *pluginsdk.ResourceD
 }
 
 func resourceVirtualMachineDataDiskAttachmentRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -204,54 +208,58 @@ func resourceVirtualMachineDataDiskAttachmentRead(d *pluginsdk.ResourceData, met
 		return err
 	}
 
-	virtualMachine, err := client.Get(ctx, id.ResourceGroup, id.VirtualMachineName, "")
+	virtualMachineId := virtualmachines.NewVirtualMachineID(id.SubscriptionId, id.ResourceGroup, id.VirtualMachineName)
+
+	virtualMachine, err := client.Get(ctx, virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(virtualMachine.Response) {
-			log.Printf("[DEBUG] Virtual Machine %q was not found (Resource Group %q) therefore Data Disk Attachment cannot exist - removing from state", id.VirtualMachineName, id.ResourceGroup)
+		if response.WasNotFound(virtualMachine.HttpResponse) {
+			log.Printf("[DEBUG] %s was not found therefore Data Disk Attachment cannot exist - removing from state", virtualMachineId)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("loading Virtual Machine %q : %+v", id.String(), err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	var disk *compute.DataDisk
-	if profile := virtualMachine.StorageProfile; profile != nil {
-		if dataDisks := profile.DataDisks; dataDisks != nil {
-			for _, dataDisk := range *dataDisks {
-				// since this field isn't (and shouldn't be) case-sensitive; we're deliberately not using `strings.EqualFold`
-				if *dataDisk.Name == id.Name {
-					disk = &dataDisk
-					break
+	var disk *virtualmachines.DataDisk
+	if model := virtualMachine.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if profile := props.StorageProfile; profile != nil {
+				if dataDisks := profile.DataDisks; dataDisks != nil {
+					for _, dataDisk := range *dataDisks {
+						// since this field isn't (and shouldn't be) case-sensitive; we're deliberately not using `strings.EqualFold`
+						if *dataDisk.Name == id.Name {
+							disk = &dataDisk
+							break
+						}
+					}
 				}
 			}
 		}
 	}
 
 	if disk == nil {
-		log.Printf("[DEBUG] Data Disk %q was not found on Virtual Machine %q  - removing from state", id.Name, id.String())
+		log.Printf("[DEBUG] %s was not found on Virtual Machine %q  - removing from state", id, id.VirtualMachineName)
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("virtual_machine_id", virtualMachine.ID)
-	d.Set("caching", string(disk.Caching))
+	d.Set("virtual_machine_id", virtualMachineId.ID())
+	d.Set("caching", string(pointer.From(disk.Caching)))
 	d.Set("create_option", string(disk.CreateOption))
 	d.Set("write_accelerator_enabled", disk.WriteAcceleratorEnabled)
 
 	if managedDisk := disk.ManagedDisk; managedDisk != nil {
-		d.Set("managed_disk_id", managedDisk.ID)
+		d.Set("managed_disk_id", managedDisk.Id)
 	}
 
-	if lun := disk.Lun; lun != nil {
-		d.Set("lun", int(*lun))
-	}
+	d.Set("lun", int(disk.Lun))
 
 	return nil
 }
 
 func resourceVirtualMachineDataDiskAttachmentDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -260,42 +268,49 @@ func resourceVirtualMachineDataDiskAttachmentDelete(d *pluginsdk.ResourceData, m
 		return err
 	}
 
+	virtualMachineId := virtualmachines.NewVirtualMachineID(id.SubscriptionId, id.ResourceGroup, id.VirtualMachineName)
+
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	virtualMachine, err := client.Get(ctx, id.ResourceGroup, id.VirtualMachineName, "")
+	virtualMachine, err := client.Get(ctx, virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(virtualMachine.Response) {
-			return fmt.Errorf("Virtual Machine %q was not found", id.String())
+		if response.WasNotFound(virtualMachine.HttpResponse) {
+			return fmt.Errorf("%s was not found", virtualMachineId)
 		}
 
-		return fmt.Errorf("loading Virtual Machine %q : %+v", id.String(), err)
+		return fmt.Errorf("retrieving %s: %+v", virtualMachineId, err)
 	}
 
-	dataDisks := make([]compute.DataDisk, 0)
-	for _, dataDisk := range *virtualMachine.StorageProfile.DataDisks {
+	if virtualMachine.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", virtualMachineId)
+	}
+	if virtualMachine.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", virtualMachineId)
+	}
+	if virtualMachine.Model.Properties.StorageProfile == nil {
+		return fmt.Errorf("retrieving %s: `storageprofile` was nil", virtualMachineId)
+	}
+
+	dataDisks := make([]virtualmachines.DataDisk, 0)
+	for _, dataDisk := range *virtualMachine.Model.Properties.StorageProfile.DataDisks {
 		// since this field isn't (and shouldn't be) case-sensitive; we're deliberately not using `strings.EqualFold`
 		if *dataDisk.Name != id.Name {
 			dataDisks = append(dataDisks, dataDisk)
 		}
 	}
 
-	virtualMachine.StorageProfile.DataDisks = &dataDisks
+	virtualMachine.Model.Properties.StorageProfile.DataDisks = &dataDisks
 
 	// fixes #2485
-	virtualMachine.Identity = nil
+	virtualMachine.Model.Identity = nil
 	// fixes #1600
-	virtualMachine.Resources = nil
+	virtualMachine.Model.Resources = nil
 	// fixes #24145
-	virtualMachine.ApplicationProfile = nil
+	virtualMachine.Model.Properties.ApplicationProfile = nil
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineName, virtualMachine)
-	if err != nil {
-		return fmt.Errorf("removing Disk %q from Virtual Machine %q : %+v", id.Name, id.String(), err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for Disk %q to be removed from Virtual Machine %q : %+v", id.Name, id.String(), err)
+	if err := client.CreateOrUpdateThenPoll(ctx, virtualMachineId, *virtualMachine.Model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+		return fmt.Errorf("removing %s from Virtual Machine %q : %+v", id, id.VirtualMachineName, err)
 	}
 
 	return nil

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -239,7 +240,7 @@ func (t VirtualMachineDataDiskAttachmentResource) Exists(ctx context.Context, cl
 		}
 	}
 
-	return utils.Bool(disk != nil), nil
+	return pointer.To(disk != nil), nil
 }
 
 func (VirtualMachineDataDiskAttachmentResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -4,20 +4,23 @@
 package compute
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 func resourceVirtualMachineExtension() *pluginsdk.Resource {
@@ -28,7 +31,7 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 		Delete: resourceVirtualMachineExtensionsDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.VirtualMachineExtensionID(id)
+			_, err := virtualmachineextensions.ParseExtensionID(id)
 			return err
 		}),
 
@@ -117,42 +120,46 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 		},
 	}
 }
 
 func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	vmExtensionClient := meta.(*clients.Client).Compute.VMExtensionClient
-	vmClient := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachineExtensionsClient
+	vmClient := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtualMachineId, err := commonids.ParseVirtualMachineID(d.Get("virtual_machine_id").(string))
+	virtualMachineId, err := virtualmachines.ParseVirtualMachineID(d.Get("virtual_machine_id").(string))
 	if err != nil {
-		return fmt.Errorf("parsing Virtual Machine ID %q: %+v", virtualMachineId, err)
+		return err
 	}
-	id := parse.NewVirtualMachineExtensionID(virtualMachineId.SubscriptionId, virtualMachineId.ResourceGroupName, virtualMachineId.VirtualMachineName, d.Get("name").(string))
+	id := virtualmachineextensions.NewExtensionID(virtualMachineId.SubscriptionId, virtualMachineId.ResourceGroupName, virtualMachineId.VirtualMachineName, d.Get("name").(string))
 
-	virtualMachine, err := vmClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName, "")
+	virtualMachine, err := vmClient.Get(ctx, *virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("getting %s: %+v", virtualMachineId, err)
+		return fmt.Errorf("retrieving %s: %+v", virtualMachineId, err)
 	}
 
-	location := *virtualMachine.Location
+	if virtualMachine.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", virtualMachineId)
+	}
+
+	location := virtualMachine.Model.Location
 	if location == "" {
 		return fmt.Errorf("reading location of %s", virtualMachineId)
 	}
 
 	if d.IsNewResource() {
-		existing, err := vmExtensionClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName, "")
+		existing, err := client.Get(ctx, id, virtualmachineextensions.DefaultGetOperationOptions())
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_machine_extension", id.ID())
 		}
 	}
@@ -165,47 +172,44 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 	suppressFailure := d.Get("failure_suppression_enabled").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
-	extension := compute.VirtualMachineExtension{
+	extension := virtualmachineextensions.VirtualMachineExtension{
 		Location: &location,
-		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
+		Properties: &virtualmachineextensions.VirtualMachineExtensionProperties{
 			Publisher:                     &publisher,
 			Type:                          &extensionType,
 			TypeHandlerVersion:            &typeHandlerVersion,
 			AutoUpgradeMinorVersion:       &autoUpgradeMinor,
 			EnableAutomaticUpgrade:        &enableAutomaticUpgrade,
-			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{})),
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
 			SuppressFailures:              &suppressFailure,
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if settingsString := d.Get("settings").(string); settingsString != "" {
-		settings, err := pluginsdk.ExpandJsonFromString(settingsString)
+		var result interface{}
+		err := json.Unmarshal([]byte(settingsString), &result)
 		if err != nil {
-			return fmt.Errorf("unable to parse settings: %s", err)
+			return fmt.Errorf("unmarshaling `settings`: %+v", err)
 		}
-		extension.VirtualMachineExtensionProperties.Settings = &settings
+		extension.Properties.Settings = pointer.To(result)
 	}
 
 	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
-		protectedSettings, err := pluginsdk.ExpandJsonFromString(protectedSettingsString)
+		var result interface{}
+		err := json.Unmarshal([]byte(protectedSettingsString), &result)
 		if err != nil {
-			return fmt.Errorf("unable to parse protected_settings: %s", err)
+			return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 		}
-		extension.VirtualMachineExtensionProperties.ProtectedSettings = &protectedSettings
+		extension.Properties.ProtectedSettings = pointer.To(result)
 	}
 
 	if provisionAfterExtensionsValue, exists := d.GetOk("provision_after_extensions"); exists {
-		extension.ProvisionAfterExtensions = utils.ExpandStringSlice(provisionAfterExtensionsValue.([]interface{}))
+		extension.Properties.ProvisionAfterExtensions = utils.ExpandStringSlice(provisionAfterExtensionsValue.([]interface{}))
 	}
 
-	future, err := vmExtensionClient.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName, extension)
-	if err != nil {
-		return err
-	}
-
-	if err = future.WaitForCompletionRef(ctx, vmExtensionClient.Client); err != nil {
-		return err
+	if err := client.CreateOrUpdateThenPoll(ctx, id, extension); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -214,80 +218,82 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 }
 
 func resourceVirtualMachineExtensionsRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	vmExtensionClient := meta.(*clients.Client).Compute.VMExtensionClient
-	vmClient := meta.(*clients.Client).Compute.VMClient
+	client := meta.(*clients.Client).Compute.VirtualMachineExtensionsClient
+	vmClient := meta.(*clients.Client).Compute.VirtualMachinesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineExtensionID(d.Id())
+	id, err := virtualmachineextensions.ParseExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	virtualMachine, err := vmClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName, "")
+	virtualMachineId := virtualmachines.NewVirtualMachineID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineName)
+
+	virtualMachine, err := vmClient.Get(ctx, virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(virtualMachine.Response) {
+		if response.WasNotFound(virtualMachine.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("making Read request on Virtual Machine %s: %s", id.ExtensionName, err)
+		return fmt.Errorf("retrieving %s: %+v", virtualMachineId, err)
 	}
 
-	d.Set("virtual_machine_id", virtualMachine.ID)
+	d.Set("virtual_machine_id", virtualMachineId.ID())
 
-	resp, err := vmExtensionClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName, "")
+	resp, err := client.Get(ctx, *id, virtualmachineextensions.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("making Read request on Virtual Machine Extension %s: %s", id.ExtensionName, err)
+		return fmt.Errorf("retrieving %s: %s", id.ExtensionName, err)
 	}
 
-	d.Set("name", resp.Name)
+	d.Set("name", id.ExtensionName)
 
-	if props := resp.VirtualMachineExtensionProperties; props != nil {
-		d.Set("publisher", props.Publisher)
-		d.Set("type", props.Type)
-		d.Set("type_handler_version", props.TypeHandlerVersion)
-		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
-		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
-		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVaultOld(props.ProtectedSettingsFromKeyVault))
-		d.Set("provision_after_extensions", pointer.From(props.ProvisionAfterExtensions))
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("publisher", props.Publisher)
+			d.Set("type", props.Type)
+			d.Set("type_handler_version", props.TypeHandlerVersion)
+			d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
+			d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
+			d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
+			d.Set("provision_after_extensions", pointer.From(props.ProvisionAfterExtensions))
 
-		suppressFailure := false
-		if props.SuppressFailures != nil {
-			suppressFailure = *props.SuppressFailures
-		}
-		d.Set("failure_suppression_enabled", suppressFailure)
-
-		if settings := props.Settings; settings != nil {
-			settingsVal := settings.(map[string]interface{})
-			settingsJson, err := pluginsdk.FlattenJsonToString(settingsVal)
-			if err != nil {
-				return fmt.Errorf("unable to parse settings from response: %s", err)
+			suppressFailure := false
+			if props.SuppressFailures != nil {
+				suppressFailure = *props.SuppressFailures
 			}
-			d.Set("settings", settingsJson)
-		}
-	}
+			d.Set("failure_suppression_enabled", suppressFailure)
 
-	return tags.FlattenAndSet(d, resp.Tags)
+			if props.Settings != nil {
+				settings, err := json.Marshal(props.Settings)
+				if err != nil {
+					return fmt.Errorf("unmarshaling `settings`: %+v", err)
+				}
+				d.Set("settings", string(settings))
+			}
+		}
+		return tags.FlattenAndSet(d, model.Tags)
+	}
+	return nil
 }
 
 func resourceVirtualMachineExtensionsDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMExtensionClient
+	client := meta.(*clients.Client).Compute.VirtualMachineExtensionsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineExtensionID(d.Id())
+	id, err := virtualmachineextensions.ParseExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName)
-	if err != nil {
-		return err
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
-	return future.WaitForCompletionRef(ctx, client.Client)
+	return nil
 }

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineExtensionResource struct{}
@@ -141,17 +141,17 @@ func TestAccVirtualMachineExtension_protectedSettingsFromKeyVault(t *testing.T) 
 }
 
 func (t VirtualMachineExtensionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualMachineExtensionID(state.ID)
+	id, err := virtualmachineextensions.ParseExtensionID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMExtensionClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName, "")
+	resp, err := clients.Compute.VirtualMachineExtensionsClient.Get(ctx, *id, virtualmachineextensions.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Compute Virtual Machine Extension %q", id.String())
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualMachineExtensionResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -2141,7 +2141,7 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfi
 			extensionProps.Settings = pointer.To(result)
 		}
 
-		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVault(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
+		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVaultVMSS(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
 		extensionProps.ProtectedSettingsFromKeyVault = protectedSettingsFromKeyVault
 
 		if val, ok := extensionRaw["protected_settings"]; ok && val.(string) != "" {
@@ -2257,7 +2257,7 @@ func flattenVirtualMachineScaleSetExtensions(input *virtualmachinescalesets.Virt
 			"force_update_tag":                  forceUpdateTag,
 			"provision_after_extensions":        provisionAfterExtension,
 			"protected_settings":                protectedSettings,
-			"protected_settings_from_key_vault": flattenProtectedSettingsFromKeyVault(protectedSettingsFromKeyVault),
+			"protected_settings_from_key_vault": flattenProtectedSettingsFromKeyVaultVMSS(protectedSettingsFromKeyVault),
 			"publisher":                         extPublisher,
 			"settings":                          extSettings,
 			"type":                              extType,

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -4,19 +4,22 @@
 package compute
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
 )
 
 // NOTE (also in the docs): this is not intended to be used with the `azurerm_virtual_machine_scale_set` resource
@@ -29,7 +32,7 @@ func resourceVirtualMachineScaleSetExtension() *pluginsdk.Resource {
 		Delete: resourceVirtualMachineScaleSetExtensionDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.VirtualMachineScaleSetExtensionID(id)
+			_, err := virtualmachinescalesetextensions.ParseVirtualMachineScaleSetExtensionID(id)
 			return err
 		}),
 
@@ -129,7 +132,7 @@ func resourceVirtualMachineScaleSetExtension() *pluginsdk.Resource {
 }
 
 func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetExtensionsClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetExtensionsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -137,64 +140,61 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 	if err != nil {
 		return err
 	}
-	id := parse.NewVirtualMachineScaleSetExtensionID(virtualMachineScaleSetId.SubscriptionId, virtualMachineScaleSetId.ResourceGroupName, virtualMachineScaleSetId.VirtualMachineScaleSetName, d.Get("name").(string))
+	id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionID(virtualMachineScaleSetId.SubscriptionId, virtualMachineScaleSetId.ResourceGroupName, virtualMachineScaleSetId.VirtualMachineScaleSetName, d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, "")
+	resp, err := client.Get(ctx, id, virtualmachinescalesetextensions.DefaultGetOperationOptions())
 	if err != nil {
-		if !utils.ResponseWasNotFound(resp.Response) {
+		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("checking for existing %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(resp.Response) {
-		return tf.ImportAsExistsError("azurerm_virtual_machine_scale_set_extension", *resp.ID)
+	if !response.WasNotFound(resp.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_virtual_machine_scale_set_extension", id.ID())
 	}
 
-	settings := map[string]interface{}{}
+	var settings *interface{}
 	if settingsString := d.Get("settings").(string); settingsString != "" {
-		s, err := pluginsdk.ExpandJsonFromString(settingsString)
+		var result interface{}
+		err := json.Unmarshal([]byte(settingsString), &result)
 		if err != nil {
-			return fmt.Errorf("unable to parse `settings`: %s", err)
+			return fmt.Errorf("unmarshaling `settings`: %+v", err)
 		}
-		settings = s
+		settings = pointer.To(result)
 	}
 
 	provisionAfterExtensionsRaw := d.Get("provision_after_extensions").([]interface{})
 	provisionAfterExtensions := utils.ExpandStringSlice(provisionAfterExtensionsRaw)
 
-	props := compute.VirtualMachineScaleSetExtension{
-		Name: utils.String(id.ExtensionName),
-		VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:                     utils.String(d.Get("publisher").(string)),
-			Type:                          utils.String(d.Get("type").(string)),
-			TypeHandlerVersion:            utils.String(d.Get("type_handler_version").(string)),
-			AutoUpgradeMinorVersion:       utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
-			EnableAutomaticUpgrade:        utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
-			SuppressFailures:              utils.Bool(d.Get("failure_suppression_enabled").(bool)),
-			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{})),
+	props := virtualmachinescalesetextensions.VirtualMachineScaleSetExtension{
+		Name: pointer.To(id.ExtensionName),
+		Properties: &virtualmachinescalesetextensions.VirtualMachineScaleSetExtensionProperties{
+			Publisher:                     pointer.To(d.Get("publisher").(string)),
+			Type:                          pointer.To(d.Get("type").(string)),
+			TypeHandlerVersion:            pointer.To(d.Get("type_handler_version").(string)),
+			AutoUpgradeMinorVersion:       pointer.To(d.Get("auto_upgrade_minor_version").(bool)),
+			EnableAutomaticUpgrade:        pointer.To(d.Get("automatic_upgrade_enabled").(bool)),
+			SuppressFailures:              pointer.To(d.Get("failure_suppression_enabled").(bool)),
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVaultOldVMSSExtension(d.Get("protected_settings_from_key_vault").([]interface{})),
 			ProvisionAfterExtensions:      provisionAfterExtensions,
 			Settings:                      settings,
 		},
 	}
 	if v, ok := d.GetOk("force_update_tag"); ok {
-		props.VirtualMachineScaleSetExtensionProperties.ForceUpdateTag = utils.String(v.(string))
+		props.Properties.ForceUpdateTag = pointer.To(v.(string))
 	}
 
 	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
-		protectedSettings, err := pluginsdk.ExpandJsonFromString(protectedSettingsString)
+		var result interface{}
+		err := json.Unmarshal([]byte(protectedSettingsString), &result)
 		if err != nil {
-			return fmt.Errorf("unable to parse `protected_settings`: %s", err)
+			return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 		}
-		props.VirtualMachineScaleSetExtensionProperties.ProtectedSettings = &protectedSettings
+		props.Properties.ProtectedSettings = pointer.To(result)
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, props)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, props); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -203,44 +203,45 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 }
 
 func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetExtensionsClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetExtensionsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineScaleSetExtensionID(d.Id())
+	id, err := virtualmachinescalesetextensions.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	props := compute.VirtualMachineScaleSetExtensionProperties{
+	props := virtualmachinescalesetextensions.VirtualMachineScaleSetExtensionProperties{
 		// if this isn't specified it defaults to false
-		AutoUpgradeMinorVersion: utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
-		EnableAutomaticUpgrade:  utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
+		AutoUpgradeMinorVersion: pointer.To(d.Get("auto_upgrade_minor_version").(bool)),
+		EnableAutomaticUpgrade:  pointer.To(d.Get("automatic_upgrade_enabled").(bool)),
 	}
 
 	if d.HasChange("failure_suppression_enabled") {
-		props.SuppressFailures = utils.Bool(d.Get("failure_suppression_enabled").(bool))
+		props.SuppressFailures = pointer.To(d.Get("failure_suppression_enabled").(bool))
 	}
 
 	if d.HasChange("force_update_tag") {
-		props.ForceUpdateTag = utils.String(d.Get("force_update_tag").(string))
+		props.ForceUpdateTag = pointer.To(d.Get("force_update_tag").(string))
 	}
 
 	if d.HasChange("protected_settings") {
-		protectedSettings := map[string]interface{}{}
+		var protectedSettings interface{}
 		if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
-			ps, err := pluginsdk.ExpandJsonFromString(protectedSettingsString)
+			var result interface{}
+			err := json.Unmarshal([]byte(protectedSettingsString), &result)
 			if err != nil {
-				return fmt.Errorf("unable to parse `protected_settings`: %s", err)
+				return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
-			protectedSettings = ps
-		}
 
-		props.ProtectedSettings = protectedSettings
+			protectedSettings = result
+		}
+		props.ProtectedSettings = pointer.To(protectedSettings)
 	}
 
 	if d.HasChange("protected_settings_from_key_vault") {
-		props.ProtectedSettingsFromKeyVault = expandProtectedSettingsFromKeyVaultOld(d.Get("protected_settings_from_key_vault").([]interface{}))
+		props.ProtectedSettingsFromKeyVault = expandProtectedSettingsFromKeyVaultOldVMSSExtension(d.Get("protected_settings_from_key_vault").([]interface{}))
 	}
 
 	if d.HasChange("provision_after_extensions") {
@@ -249,134 +250,124 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if d.HasChange("publisher") {
-		props.Publisher = utils.String(d.Get("publisher").(string))
+		props.Publisher = pointer.To(d.Get("publisher").(string))
 	}
 
 	if d.HasChange("settings") {
-		settings := map[string]interface{}{}
-
+		var settings interface{}
 		if settingsString := d.Get("settings").(string); settingsString != "" {
-			s, err := pluginsdk.ExpandJsonFromString(settingsString)
+			var result interface{}
+			err := json.Unmarshal([]byte(settingsString), &result)
 			if err != nil {
-				return fmt.Errorf("unable to parse `settings`: %s", err)
+				return fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
-			settings = s
+			settings = result
 		}
 
-		props.Settings = settings
+		props.Settings = pointer.To(settings)
 	}
 
 	if d.HasChange("type") {
-		props.Type = utils.String(d.Get("type").(string))
+		props.Type = pointer.To(d.Get("type").(string))
 	}
 
 	if d.HasChange("type_handler_version") {
-		props.TypeHandlerVersion = utils.String(d.Get("type_handler_version").(string))
+		props.TypeHandlerVersion = pointer.To(d.Get("type_handler_version").(string))
 	}
 
-	extension := compute.VirtualMachineScaleSetExtension{
-		Name: utils.String(id.ExtensionName),
-		VirtualMachineScaleSetExtensionProperties: &props,
+	extension := virtualmachinescalesetextensions.VirtualMachineScaleSetExtension{
+		Name:       pointer.To(id.ExtensionName),
+		Properties: &props,
 	}
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, extension)
-	if err != nil {
-		return fmt.Errorf("updating Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, extension); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return resourceVirtualMachineScaleSetExtensionRead(d, meta)
 }
 
 func resourceVirtualMachineScaleSetExtensionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	vmssClient := meta.(*clients.Client).Compute.VMScaleSetClient
-	client := meta.(*clients.Client).Compute.VMScaleSetExtensionsClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetExtensionsClient
+	vmssClient := meta.(*clients.Client).Compute.VirtualMachineScaleSetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineScaleSetExtensionID(d.Id())
+	id, err := virtualmachinescalesetextensions.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	vmss, err := vmssClient.Get(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, "")
+	virtualMachineScaleSetId := virtualmachinescalesets.NewVirtualMachineScaleSetID(id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+
+	vmss, err := vmssClient.Get(ctx, virtualMachineScaleSetId, virtualmachinescalesets.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(vmss.Response) {
-			log.Printf("Virtual Machine Scale Set %q was not found in Resource Group %q - removing Extension from state!", id.VirtualMachineScaleSetName, id.ResourceGroup)
+		if response.WasNotFound(vmss.HttpResponse) {
+			log.Printf("%s was not found - removing Extension from state!", virtualMachineScaleSetId)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.VirtualMachineScaleSetName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", virtualMachineScaleSetId, err)
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, "")
+	resp, err := client.Get(ctx, *id, virtualmachinescalesetextensions.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("Extension %q (Virtual Machine Scale Set %q / Resource Group %q) was not found - removing from state!", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup)
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("%s was not found - removing from state!", id)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.Set("name", id.ExtensionName)
-	d.Set("virtual_machine_scale_set_id", vmss.ID)
+	d.Set("virtual_machine_scale_set_id", virtualMachineScaleSetId.ID())
 
-	if props := resp.VirtualMachineScaleSetExtensionProperties; props != nil {
-		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
-		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
-		d.Set("force_update_tag", props.ForceUpdateTag)
-		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVaultOld(props.ProtectedSettingsFromKeyVault))
-		d.Set("provision_after_extensions", utils.FlattenStringSlice(props.ProvisionAfterExtensions))
-		d.Set("publisher", props.Publisher)
-		d.Set("type", props.Type)
-		d.Set("type_handler_version", props.TypeHandlerVersion)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
+			d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
+			d.Set("force_update_tag", props.ForceUpdateTag)
+			d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVaultOldVMSSExtension(props.ProtectedSettingsFromKeyVault))
+			d.Set("provision_after_extensions", utils.FlattenStringSlice(props.ProvisionAfterExtensions))
+			d.Set("publisher", props.Publisher)
+			d.Set("type", props.Type)
+			d.Set("type_handler_version", props.TypeHandlerVersion)
 
-		suppressFailure := false
-		if props.SuppressFailures != nil {
-			suppressFailure = *props.SuppressFailures
-		}
-		d.Set("failure_suppression_enabled", suppressFailure)
-
-		settings := ""
-		if props.Settings != nil {
-			settingsVal, ok := props.Settings.(map[string]interface{})
-			if ok {
-				settingsJson, err := pluginsdk.FlattenJsonToString(settingsVal)
-				if err != nil {
-					return fmt.Errorf("unable to parse settings from response: %s", err)
-				}
-				settings = settingsJson
+			suppressFailure := false
+			if props.SuppressFailures != nil {
+				suppressFailure = *props.SuppressFailures
 			}
+			d.Set("failure_suppression_enabled", suppressFailure)
+
+			settings := ""
+			if props.Settings != nil {
+				settingsRaw, err := json.Marshal(props.Settings)
+				if err != nil {
+					return fmt.Errorf("unmarshaling `settings`: %+v", err)
+				}
+				settings = string(settingsRaw)
+			}
+			d.Set("settings", settings)
 		}
-		d.Set("settings", settings)
 	}
 
 	return nil
 }
 
 func resourceVirtualMachineScaleSetExtensionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMScaleSetExtensionsClient
+	client := meta.(*clients.Client).Compute.VirtualMachineScaleSetExtensionsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineScaleSetExtensionID(d.Id())
+	id, err := virtualmachinescalesetextensions.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName)
-	if err != nil {
-		return fmt.Errorf("deleting Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.ExtensionName, id.VirtualMachineScaleSetName, id.ResourceGroup, err)
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineScaleSetExtensionResource struct{}
@@ -223,17 +223,17 @@ func TestAccVirtualMachineScaleSetExtension_updateVersion(t *testing.T) {
 }
 
 func (t VirtualMachineScaleSetExtensionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualMachineScaleSetExtensionID(state.ID)
+	id, err := virtualmachinescalesetextensions.ParseVirtualMachineScaleSetExtensionID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMScaleSetExtensionsClient.Get(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, "")
+	resp, err := clients.Compute.VirtualMachineScaleSetExtensionsClient.Get(ctx, *id, virtualmachinescalesetextensions.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Compute Virtual Machine Scale Set Extension %q", id.String())
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualMachineScaleSetExtensionResource) basicLinux(data acceptance.TestData) string {

--- a/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
+++ b/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
@@ -699,7 +699,7 @@ func (LegacyVMSSV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		// however it existed in the legacy migration so even though this is
 		//  essentially a noop there's no reason this shouldn't be the same I guess
 
-		client := meta.(*clients.Client).Compute.VMScaleSetClient
+		client := meta.(*clients.Client).Legacy.VMScaleSetClient
 
 		resGroup := rawState["resource_group_name"].(string)
 		name := rawState["name"].(string)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/README.md
@@ -1,0 +1,98 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions` Documentation
+
+The `virtualmachineextensions` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachineextensions.NewVirtualMachineExtensionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineExtensionsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualmachineextensions.NewExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "extensionValue")
+
+payload := virtualmachineextensions.VirtualMachineExtension{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineExtensionsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualmachineextensions.NewExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "extensionValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineExtensionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachineextensions.NewExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "extensionValue")
+
+read, err := client.Get(ctx, id, virtualmachineextensions.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineExtensionsClient.List`
+
+```go
+ctx := context.TODO()
+id := virtualmachineextensions.NewVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue")
+
+read, err := client.List(ctx, id, virtualmachineextensions.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineExtensionsClient.Update`
+
+```go
+ctx := context.TODO()
+id := virtualmachineextensions.NewExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineValue", "extensionValue")
+
+payload := virtualmachineextensions.VirtualMachineExtensionUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/client.go
@@ -1,0 +1,26 @@
+package virtualmachineextensions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineExtensionsClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineExtensionsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachineextensions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineExtensionsClient: %+v", err)
+	}
+
+	return &VirtualMachineExtensionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/constants.go
@@ -1,0 +1,54 @@
+package virtualmachineextensions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StatusLevelTypes string
+
+const (
+	StatusLevelTypesError   StatusLevelTypes = "Error"
+	StatusLevelTypesInfo    StatusLevelTypes = "Info"
+	StatusLevelTypesWarning StatusLevelTypes = "Warning"
+)
+
+func PossibleValuesForStatusLevelTypes() []string {
+	return []string{
+		string(StatusLevelTypesError),
+		string(StatusLevelTypesInfo),
+		string(StatusLevelTypesWarning),
+	}
+}
+
+func (s *StatusLevelTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStatusLevelTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStatusLevelTypes(input string) (*StatusLevelTypes, error) {
+	vals := map[string]StatusLevelTypes{
+		"error":   StatusLevelTypesError,
+		"info":    StatusLevelTypesInfo,
+		"warning": StatusLevelTypesWarning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StatusLevelTypes(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/id_extension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/id_extension.go
@@ -1,0 +1,139 @@
+package virtualmachineextensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ExtensionId{})
+}
+
+var _ resourceids.ResourceId = &ExtensionId{}
+
+// ExtensionId is a struct representing the Resource ID for a Extension
+type ExtensionId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	VirtualMachineName string
+	ExtensionName      string
+}
+
+// NewExtensionID returns a new ExtensionId struct
+func NewExtensionID(subscriptionId string, resourceGroupName string, virtualMachineName string, extensionName string) ExtensionId {
+	return ExtensionId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		VirtualMachineName: virtualMachineName,
+		ExtensionName:      extensionName,
+	}
+}
+
+// ParseExtensionID parses 'input' into a ExtensionId
+func ParseExtensionID(input string) (*ExtensionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExtensionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExtensionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseExtensionIDInsensitively parses 'input' case-insensitively into a ExtensionId
+// note: this method should only be used for API response data and not user input
+func ParseExtensionIDInsensitively(input string) (*ExtensionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExtensionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExtensionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ExtensionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineName, ok = input.Parsed["virtualMachineName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", input)
+	}
+
+	if id.ExtensionName, ok = input.Parsed["extensionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "extensionName", input)
+	}
+
+	return nil
+}
+
+// ValidateExtensionID checks that 'input' can be parsed as a Extension ID
+func ValidateExtensionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseExtensionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Extension ID
+func (id ExtensionId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s/extensions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineName, id.ExtensionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Extension ID
+func (id ExtensionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("virtualMachineName", "virtualMachineValue"),
+		resourceids.StaticSegment("staticExtensions", "extensions", "extensions"),
+		resourceids.UserSpecifiedSegment("extensionName", "extensionValue"),
+	}
+}
+
+// String returns a human-readable description of this Extension ID
+func (id ExtensionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Name: %q", id.VirtualMachineName),
+		fmt.Sprintf("Extension Name: %q", id.ExtensionName),
+	}
+	return fmt.Sprintf("Extension (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/id_virtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/id_virtualmachine.go
@@ -1,0 +1,130 @@
+package virtualmachineextensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&VirtualMachineId{})
+}
+
+var _ resourceids.ResourceId = &VirtualMachineId{}
+
+// VirtualMachineId is a struct representing the Resource ID for a Virtual Machine
+type VirtualMachineId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	VirtualMachineName string
+}
+
+// NewVirtualMachineID returns a new VirtualMachineId struct
+func NewVirtualMachineID(subscriptionId string, resourceGroupName string, virtualMachineName string) VirtualMachineId {
+	return VirtualMachineId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		VirtualMachineName: virtualMachineName,
+	}
+}
+
+// ParseVirtualMachineID parses 'input' into a VirtualMachineId
+func ParseVirtualMachineID(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineIDInsensitively parses 'input' case-insensitively into a VirtualMachineId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineIDInsensitively(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineName, ok = input.Parsed["virtualMachineName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineID checks that 'input' can be parsed as a Virtual Machine ID
+func ValidateVirtualMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine ID
+func (id VirtualMachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine ID
+func (id VirtualMachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("virtualMachineName", "virtualMachineValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine ID
+func (id VirtualMachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Name: %q", id.VirtualMachineName),
+	}
+	return fmt.Sprintf("Virtual Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_createorupdate.go
@@ -1,0 +1,75 @@
+package virtualmachineextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineExtension
+}
+
+// CreateOrUpdate ...
+func (c VirtualMachineExtensionsClient) CreateOrUpdate(ctx context.Context, id ExtensionId, input VirtualMachineExtension) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualMachineExtensionsClient) CreateOrUpdateThenPoll(ctx context.Context, id ExtensionId, input VirtualMachineExtension) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_delete.go
@@ -1,0 +1,71 @@
+package virtualmachineextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VirtualMachineExtensionsClient) Delete(ctx context.Context, id ExtensionId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualMachineExtensionsClient) DeleteThenPoll(ctx context.Context, id ExtensionId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_get.go
@@ -1,0 +1,83 @@
+package virtualmachineextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineExtension
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c VirtualMachineExtensionsClient) Get(ctx context.Context, id ExtensionId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineExtension
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_list.go
@@ -1,0 +1,83 @@
+package virtualmachineextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineExtensionsListResult
+}
+
+type ListOperationOptions struct {
+	Expand *string
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// List ...
+func (c VirtualMachineExtensionsClient) List(ctx context.Context, id VirtualMachineId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/extensions", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineExtensionsListResult
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/method_update.go
@@ -1,0 +1,74 @@
+package virtualmachineextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineExtension
+}
+
+// Update ...
+func (c VirtualMachineExtensionsClient) Update(ctx context.Context, id ExtensionId, input VirtualMachineExtensionUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c VirtualMachineExtensionsClient) UpdateThenPoll(ctx context.Context, id ExtensionId, input VirtualMachineExtensionUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_instanceviewstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_instanceviewstatus.go
@@ -1,0 +1,30 @@
+package virtualmachineextensions
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstanceViewStatus struct {
+	Code          *string           `json:"code,omitempty"`
+	DisplayStatus *string           `json:"displayStatus,omitempty"`
+	Level         *StatusLevelTypes `json:"level,omitempty"`
+	Message       *string           `json:"message,omitempty"`
+	Time          *string           `json:"time,omitempty"`
+}
+
+func (o *InstanceViewStatus) GetTimeAsTime() (*time.Time, error) {
+	if o.Time == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.Time, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InstanceViewStatus) SetTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.Time = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_keyvaultsecretreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_keyvaultsecretreference.go
@@ -1,0 +1,9 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyVaultSecretReference struct {
+	SecretUrl   string      `json:"secretUrl"`
+	SourceVault SubResource `json:"sourceVault"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_subresource.go
@@ -1,0 +1,8 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextension.go
@@ -1,0 +1,13 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtension struct {
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualMachineExtensionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensioninstanceview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensioninstanceview.go
@@ -1,0 +1,12 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionInstanceView struct {
+	Name               *string               `json:"name,omitempty"`
+	Statuses           *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Substatuses        *[]InstanceViewStatus `json:"substatuses,omitempty"`
+	Type               *string               `json:"type,omitempty"`
+	TypeHandlerVersion *string               `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionproperties.go
@@ -1,0 +1,20 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionProperties struct {
+	AutoUpgradeMinorVersion       *bool                                `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                                `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                              `json:"forceUpdateTag,omitempty"`
+	InstanceView                  *VirtualMachineExtensionInstanceView `json:"instanceView,omitempty"`
+	ProtectedSettings             *interface{}                         `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference             `json:"protectedSettingsFromKeyVault,omitempty"`
+	ProvisionAfterExtensions      *[]string                            `json:"provisionAfterExtensions,omitempty"`
+	ProvisioningState             *string                              `json:"provisioningState,omitempty"`
+	Publisher                     *string                              `json:"publisher,omitempty"`
+	Settings                      *interface{}                         `json:"settings,omitempty"`
+	SuppressFailures              *bool                                `json:"suppressFailures,omitempty"`
+	Type                          *string                              `json:"type,omitempty"`
+	TypeHandlerVersion            *string                              `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionslistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionslistresult.go
@@ -1,0 +1,8 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionsListResult struct {
+	Value *[]VirtualMachineExtension `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionupdate.go
@@ -1,0 +1,9 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionUpdate struct {
+	Properties *VirtualMachineExtensionUpdateProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/model_virtualmachineextensionupdateproperties.go
@@ -1,0 +1,17 @@
+package virtualmachineextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineExtensionUpdateProperties struct {
+	AutoUpgradeMinorVersion       *bool                    `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                    `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                  `json:"forceUpdateTag,omitempty"`
+	ProtectedSettings             *interface{}             `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference `json:"protectedSettingsFromKeyVault,omitempty"`
+	Publisher                     *string                  `json:"publisher,omitempty"`
+	Settings                      *interface{}             `json:"settings,omitempty"`
+	SuppressFailures              *bool                    `json:"suppressFailures,omitempty"`
+	Type                          *string                  `json:"type,omitempty"`
+	TypeHandlerVersion            *string                  `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions/version.go
@@ -1,0 +1,12 @@
+package virtualmachineextensions
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachineextensions/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/README.md
@@ -1,0 +1,99 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions` Documentation
+
+The `virtualmachinescalesetextensions` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2024-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineScaleSetExtensionsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "extensionValue")
+
+payload := virtualmachinescalesetextensions.VirtualMachineScaleSetExtension{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetExtensionsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "extensionValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetExtensionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "extensionValue")
+
+read, err := client.Get(ctx, id, virtualmachinescalesetextensions.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetExtensionsClient.List`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineScaleSetExtensionsClient.Update`
+
+```go
+ctx := context.TODO()
+id := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "extensionValue")
+
+payload := virtualmachinescalesetextensions.VirtualMachineScaleSetExtensionUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/client.go
@@ -1,0 +1,26 @@
+package virtualmachinescalesetextensions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineScaleSetExtensionsClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineScaleSetExtensionsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "virtualmachinescalesetextensions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineScaleSetExtensionsClient: %+v", err)
+	}
+
+	return &VirtualMachineScaleSetExtensionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/id_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/id_virtualmachinescaleset.go
@@ -1,0 +1,130 @@
+package virtualmachinescalesetextensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&VirtualMachineScaleSetId{})
+}
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetId{}
+
+// VirtualMachineScaleSetId is a struct representing the Resource ID for a Virtual Machine Scale Set
+type VirtualMachineScaleSetId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+}
+
+// NewVirtualMachineScaleSetID returns a new VirtualMachineScaleSetId struct
+func NewVirtualMachineScaleSetID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string) VirtualMachineScaleSetId {
+	return VirtualMachineScaleSetId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+	}
+}
+
+// ParseVirtualMachineScaleSetID parses 'input' into a VirtualMachineScaleSetId
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetIDInsensitively(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetID checks that 'input' can be parsed as a Virtual Machine Scale Set ID
+func ValidateVirtualMachineScaleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/id_virtualmachinescalesetextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/id_virtualmachinescalesetextension.go
@@ -1,0 +1,139 @@
+package virtualmachinescalesetextensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&VirtualMachineScaleSetExtensionId{})
+}
+
+var _ resourceids.ResourceId = &VirtualMachineScaleSetExtensionId{}
+
+// VirtualMachineScaleSetExtensionId is a struct representing the Resource ID for a Virtual Machine Scale Set Extension
+type VirtualMachineScaleSetExtensionId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+	ExtensionName              string
+}
+
+// NewVirtualMachineScaleSetExtensionID returns a new VirtualMachineScaleSetExtensionId struct
+func NewVirtualMachineScaleSetExtensionID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, extensionName string) VirtualMachineScaleSetExtensionId {
+	return VirtualMachineScaleSetExtensionId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+		ExtensionName:              extensionName,
+	}
+}
+
+// ParseVirtualMachineScaleSetExtensionID parses 'input' into a VirtualMachineScaleSetExtensionId
+func ParseVirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleSetExtensionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetExtensionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetExtensionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetExtensionIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetExtensionId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetExtensionIDInsensitively(input string) (*VirtualMachineScaleSetExtensionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualMachineScaleSetExtensionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualMachineScaleSetExtensionId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualMachineScaleSetExtensionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = input.Parsed["virtualMachineScaleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", input)
+	}
+
+	if id.ExtensionName, ok = input.Parsed["extensionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "extensionName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualMachineScaleSetExtensionID checks that 'input' can be parsed as a Virtual Machine Scale Set Extension ID
+func ValidateVirtualMachineScaleSetExtensionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetExtensionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set Extension ID
+func (id VirtualMachineScaleSetExtensionId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/extensions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.ExtensionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set Extension ID
+func (id VirtualMachineScaleSetExtensionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+		resourceids.StaticSegment("staticExtensions", "extensions", "extensions"),
+		resourceids.UserSpecifiedSegment("extensionName", "extensionValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set Extension ID
+func (id VirtualMachineScaleSetExtensionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Extension Name: %q", id.ExtensionName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set Extension (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_createorupdate.go
@@ -1,0 +1,75 @@
+package virtualmachinescalesetextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetExtension
+}
+
+// CreateOrUpdate ...
+func (c VirtualMachineScaleSetExtensionsClient) CreateOrUpdate(ctx context.Context, id VirtualMachineScaleSetExtensionId, input VirtualMachineScaleSetExtension) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualMachineScaleSetExtensionsClient) CreateOrUpdateThenPoll(ctx context.Context, id VirtualMachineScaleSetExtensionId, input VirtualMachineScaleSetExtension) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_delete.go
@@ -1,0 +1,71 @@
+package virtualmachinescalesetextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VirtualMachineScaleSetExtensionsClient) Delete(ctx context.Context, id VirtualMachineScaleSetExtensionId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualMachineScaleSetExtensionsClient) DeleteThenPoll(ctx context.Context, id VirtualMachineScaleSetExtensionId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_get.go
@@ -1,0 +1,83 @@
+package virtualmachinescalesetextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetExtension
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c VirtualMachineScaleSetExtensionsClient) Get(ctx context.Context, id VirtualMachineScaleSetExtensionId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualMachineScaleSetExtension
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_list.go
@@ -1,0 +1,91 @@
+package virtualmachinescalesetextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualMachineScaleSetExtension
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualMachineScaleSetExtension
+}
+
+// List ...
+func (c VirtualMachineScaleSetExtensionsClient) List(ctx context.Context, id VirtualMachineScaleSetId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/extensions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualMachineScaleSetExtension `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VirtualMachineScaleSetExtensionsClient) ListComplete(ctx context.Context, id VirtualMachineScaleSetId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, VirtualMachineScaleSetExtensionOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineScaleSetExtensionsClient) ListCompleteMatchingPredicate(ctx context.Context, id VirtualMachineScaleSetId, predicate VirtualMachineScaleSetExtensionOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]VirtualMachineScaleSetExtension, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/method_update.go
@@ -1,0 +1,75 @@
+package virtualmachinescalesetextensions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualMachineScaleSetExtension
+}
+
+// Update ...
+func (c VirtualMachineScaleSetExtensionsClient) Update(ctx context.Context, id VirtualMachineScaleSetExtensionId, input VirtualMachineScaleSetExtensionUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c VirtualMachineScaleSetExtensionsClient) UpdateThenPoll(ctx context.Context, id VirtualMachineScaleSetExtensionId, input VirtualMachineScaleSetExtensionUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_keyvaultsecretreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_keyvaultsecretreference.go
@@ -1,0 +1,9 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyVaultSecretReference struct {
+	SecretUrl   string      `json:"secretUrl"`
+	SourceVault SubResource `json:"sourceVault"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_subresource.go
@@ -1,0 +1,8 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextension.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtension struct {
+	Id         *string                                    `json:"id,omitempty"`
+	Name       *string                                    `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetExtensionProperties `json:"properties,omitempty"`
+	Type       *string                                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextensionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextensionproperties.go
@@ -1,0 +1,19 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionProperties struct {
+	AutoUpgradeMinorVersion       *bool                    `json:"autoUpgradeMinorVersion,omitempty"`
+	EnableAutomaticUpgrade        *bool                    `json:"enableAutomaticUpgrade,omitempty"`
+	ForceUpdateTag                *string                  `json:"forceUpdateTag,omitempty"`
+	ProtectedSettings             *interface{}             `json:"protectedSettings,omitempty"`
+	ProtectedSettingsFromKeyVault *KeyVaultSecretReference `json:"protectedSettingsFromKeyVault,omitempty"`
+	ProvisionAfterExtensions      *[]string                `json:"provisionAfterExtensions,omitempty"`
+	ProvisioningState             *string                  `json:"provisioningState,omitempty"`
+	Publisher                     *string                  `json:"publisher,omitempty"`
+	Settings                      *interface{}             `json:"settings,omitempty"`
+	SuppressFailures              *bool                    `json:"suppressFailures,omitempty"`
+	Type                          *string                  `json:"type,omitempty"`
+	TypeHandlerVersion            *string                  `json:"typeHandlerVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextensionupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/model_virtualmachinescalesetextensionupdate.go
@@ -1,0 +1,11 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionUpdate struct {
+	Id         *string                                    `json:"id,omitempty"`
+	Name       *string                                    `json:"name,omitempty"`
+	Properties *VirtualMachineScaleSetExtensionProperties `json:"properties,omitempty"`
+	Type       *string                                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/predicates.go
@@ -1,0 +1,27 @@
+package virtualmachinescalesetextensions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineScaleSetExtensionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p VirtualMachineScaleSetExtensionOperationPredicate) Matches(input VirtualMachineScaleSetExtension) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions/version.go
@@ -1,0 +1,12 @@
+package virtualmachinescalesetextensions
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-03-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/virtualmachinescalesetextensions/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -340,8 +340,10 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/availabili
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhostgroups
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhosts
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineextensions
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachineimages
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetextensions
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesets
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This migrates the remaining non-legacy compute resources over to using `hashicorp/go-azure-sdk`

## Testing

In Progress..

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `compute` - update remaining non-legacy compute resources to use `hashicorp/go-azure-sdk` [GH-00000]


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
