### PR TITLE
`azurerm_storage_share_file` - Post hex decode then base64 encode the value of `content_md5`, to align with Azure expectation

### DIFF
--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -159,7 +159,12 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("content_md5"); ok {
-		input.ContentMD5 = utils.String(v.(string))
+		// Azure uses a Base64 encoded representation of the standard MD5 sum of the file
+		contentMD5, err := convertHexToBase64Encoding(v.(string))
+		if err != nil {
+			return fmt.Errorf("failed to hex decode then base64 encode `content_md5` value: %s", err)
+		}
+		input.ContentMD5 = &contentMD5
 	}
 
 	var file *os.File
@@ -237,7 +242,12 @@ func resourceStorageShareFileUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if v, ok := d.GetOk("content_md5"); ok {
-			input.ContentMD5 = utils.String(v.(string))
+			// Azure uses a Base64 encoded representation of the standard MD5 sum of the file
+			contentMD5, err := convertHexToBase64Encoding(v.(string))
+			if err != nil {
+				return fmt.Errorf("failed to hex decode then base64 encode `content_md5` value: %s", err)
+			}
+			input.ContentMD5 = &contentMD5
 		}
 
 		if _, err = client.SetProperties(ctx, id.ShareName, id.DirectoryPath, id.FileName, input); err != nil {

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.
 
+~> **NOTE:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` is defined.
+
 * `content_encoding` - (Optional) Specifies which content encodings have been applied to the file.
 
 * `content_disposition` - (Optional) Sets the file’s Content-Disposition header.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR changes added post processs (i.e. hex decode then base64 encode the value) for the `content_md5`, to align with [Azure expectation](https://github.com/Azure/azure-storage-azcopy/wiki/Data-integrity-and-validation#:~:text=A%20note%20on%20hash%20formats).

The current implementation of the `content_md5` (i.e. plainly set the value to API) will fail the post md5 check when users try to download the file via `azcopy`, e.g.

> 2024/04/23 05:57:33 ERR: [P#0-T#0] DOWNLOADFAILED: https://mgdtestshare.file.core.windows.net/test/test : 000 : the MD5 hash of the data, as we received it, did not match the expected value, as found in the Blob/File Service. This means that either there is a data integrity error OR another tool has failed to keep the stored hash up to date. (NOTE In the specific case of downloading a Page Blob that has been used as a VM disk, the VM has probably changed the content since the hash was set. That's normal, and in that specific case you can simply disable the MD5 check. See the documentation for the check-md5 parameter.). When Checking MD5 hash. X-Ms-Request-Id: 


Though this is technically a breaking change (for users who manually do the conversion before setting it in TF config), I still submit this change for two reasons:

1. Currently there is no trivial way to get the correct value natively in Terraform - mostly because there is a lack of way to convert from hex to byte (also terraform has no native representation for byte type), so most users are using this incorrectly
2. The `azurerm_storage_blob` resource has the same behavior that post-processes the `content_md5`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

By uploading the `CHANGELOG.md` file at this branch:

*before* (uploaded as `test`)

Failed to download the file as it failed the md5sum check:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/7970698/da49caea-0bc6-4268-af5b-b27f286f2cf8)

*after* (uploaded as `test2`)

It is donwloaded successfully:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/7970698/3a520588-b8f5-4f6a-bcb3-fc761643e2e3)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share_file` - Post hex decode then base64 encode the value of `content_md5`, to align with Azure expectation [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25704

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
