### PR TITLE
`azurerm_subnet` - the private_endpoint_network_policies_enabled property has been deprecated in favour of the `private_endpoint_network_policies` property

### DIFF
--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -87,7 +87,7 @@ func dataSourceSubnet() *pluginsdk.Resource {
 		resource.Schema["private_endpoint_network_policies_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Computed:   true,
-			Deprecated: "This is deprecated in favor of `private_endpoint_network_policies`",
+			Deprecated: "This property has been superseded by `private_endpoint_network_policies` and will be removed in v4.0 of the AzureRM Provider.",
 		}
 
 		resource.Schema["enforce_private_link_endpoint_network_policies"] = &pluginsdk.Schema{

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -85,8 +85,9 @@ func dataSourceSubnet() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		resource.Schema["private_endpoint_network_policies_enabled"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "This is deprecated in favor of `private_endpoint_network_policies`",
 		}
 
 		resource.Schema["enforce_private_link_endpoint_network_policies"] = &pluginsdk.Schema{

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -70,8 +71,8 @@ func dataSourceSubnet() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
-			"private_endpoint_network_policies_enabled": {
-				Type:     pluginsdk.TypeBool,
+			"private_endpoint_network_policies": {
+				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
@@ -83,6 +84,11 @@ func dataSourceSubnet() *pluginsdk.Resource {
 	}
 
 	if !features.FourPointOhBeta() {
+		resource.Schema["private_endpoint_network_policies_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		}
+
 		resource.Schema["enforce_private_link_endpoint_network_policies"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
@@ -132,10 +138,11 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 			if !features.FourPointOhBeta() {
 				d.Set("enforce_private_link_endpoint_network_policies", flattenEnforceSubnetNetworkPolicy(string(*props.PrivateEndpointNetworkPolicies)))
+				d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(*props.PrivateEndpointNetworkPolicies)))
 				d.Set("enforce_private_link_service_network_policies", flattenEnforceSubnetNetworkPolicy(string(*props.PrivateLinkServiceNetworkPolicies)))
 			}
 
-			d.Set("private_endpoint_network_policies_enabled", flattenSubnetNetworkPolicy(string(*props.PrivateEndpointNetworkPolicies)))
+			d.Set("private_endpoint_network_policies", string(pointer.From(props.PrivateEndpointNetworkPolicies)))
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(*props.PrivateLinkServiceNetworkPolicies)))
 
 			networkSecurityGroupId := ""

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -5,9 +5,9 @@ package network
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -806,6 +806,9 @@ func expandSubnetNetworkPolicy(enabled bool) string {
 
 // TODO 4.0: Remove flattenEnforceSubnetPrivateLinkNetworkPolicy function
 func flattenEnforceSubnetNetworkPolicy(input string) bool {
+	// This is strange logic, but to get the schema to make sense for the end user
+	// I exposed it with the same name that the Azure CLI does to be consistent
+	// between the tool sets, which means true == Disabled.
 	return strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled))
 }
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -201,8 +201,8 @@ func resourceSubnet() *pluginsdk.Resource {
 				},
 			},
 
-			"private_endpoint_network_policies_enabled": {
-				Type: pluginsdk.TypeBool,
+			"private_endpoint_network_policies": {
+				Type: pluginsdk.TypeString,
 				Computed: func() bool {
 					return !features.FourPointOh()
 				}(),
@@ -213,9 +213,10 @@ func resourceSubnet() *pluginsdk.Resource {
 					}
 					return !features.FourPointOh()
 				}(),
+				ValidateFunc: validation.StringInSlice(subnets.PossibleValuesForVirtualNetworkPrivateEndpointNetworkPolicies(), false),
 				ConflictsWith: func() []string {
 					if !features.FourPointOhBeta() {
-						return []string{"enforce_private_link_endpoint_network_policies"}
+						return []string{"enforce_private_link_endpoint_network_policies", "private_endpoint_network_policies_enabled"}
 					}
 					return []string{}
 				}(),
@@ -244,12 +245,20 @@ func resourceSubnet() *pluginsdk.Resource {
 	}
 
 	if !features.FourPointOhBeta() {
+		resource.Schema["private_endpoint_network_policies_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Computed:      true,
+			Optional:      true,
+			Deprecated:    "`private_endpoint_network_policies_enabled` will be removed in favour of the property `private_endpoint_network_policies` in version 4.0 of the AzureRM Provider",
+			ConflictsWith: []string{"enforce_private_link_endpoint_network_policies", "private_endpoint_network_policies"},
+		}
+
 		resource.Schema["enforce_private_link_endpoint_network_policies"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeBool,
 			Computed:      true,
 			Optional:      true,
-			Deprecated:    "`enforce_private_link_endpoint_network_policies` will be removed in favour of the property `private_endpoint_network_policies_enabled` in version 4.0 of the AzureRM Provider",
-			ConflictsWith: []string{"private_endpoint_network_policies_enabled"},
+			Deprecated:    "`enforce_private_link_endpoint_network_policies` will be removed in favour of the property `private_endpoint_network_policies` in version 4.0 of the AzureRM Provider",
+			ConflictsWith: []string{"private_endpoint_network_policies_enabled", "private_endpoint_network_policies"},
 		}
 
 		resource.Schema["enforce_private_link_service_network_policies"] = &pluginsdk.Schema{

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -803,27 +803,12 @@ func expandSubnetNetworkPolicy(enabled bool) string {
 }
 
 // TODO 4.0: Remove flattenEnforceSubnetPrivateLinkNetworkPolicy function
-func flattenEnforceSubnetNetworkPolicy(input string) interface{} {
-	// This is strange logic, but to get the schema to make sense for the end user
-	// I exposed it with the same name that the Azure CLI does to be consistent
-	// between the tool sets, which means true == Disabled.
-	if strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)) {
-		return true
-	} else if strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)) {
-		return false
-	}
-
-	return nil
+func flattenEnforceSubnetNetworkPolicy(input string) bool {
+	return strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled))
 }
 
-func flattenSubnetNetworkPolicy(input string) interface{} {
-	if strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled)) {
-		return true
-	} else if strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled)) {
-		return false
-	}
-
-	return nil
+func flattenSubnetNetworkPolicy(input string) bool {
+	return strings.EqualFold(input, string(subnets.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled))
 }
 
 func expandSubnetServiceEndpointPolicies(input []interface{}) *[]subnets.ServiceEndpointPolicy {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -367,12 +367,15 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		// Only one of these values can be set since they conflict with each other
 		// if neither of them are set use the default values
-		if enforceOk {
-			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
-		} else if enableOk {
-			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
-		} else if privateEndpointNetworkPoliciesOk {
-			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
+		if enforceOk || enableOk || privateEndpointNetworkPoliciesOk {
+			switch {
+			case enforceOk:
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
+			case enableOk:
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+			case privateEndpointNetworkPoliciesOk:
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
+			}
 		}
 
 		if enforceServiceOk || enableServiceOk {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -493,9 +493,9 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if features.FourPointOhBeta() {
-		if d.HasChange("private_endpoint_network_policies_enabled") {
-			v := d.Get("private_endpoint_network_policies_enabled").(bool)
-			props.PrivateEndpointNetworkPolicies = pointer.To(subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(v)))
+		if d.HasChange("private_endpoint_network_policies") {
+			v := d.Get("private_endpoint_network_policies").(string)
+			props.PrivateEndpointNetworkPolicies = pointer.To(subnets.VirtualNetworkPrivateEndpointNetworkPolicies(v))
 		}
 
 		if d.HasChange("private_link_service_network_policies_enabled") {
@@ -511,14 +511,17 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		var privateEndpointNetworkPolicies subnets.VirtualNetworkPrivateEndpointNetworkPolicies
 		var privateLinkServiceNetworkPolicies subnets.VirtualNetworkPrivateLinkServiceNetworkPolicies
 
-		if d.HasChange("enforce_private_link_endpoint_network_policies") || d.HasChange("private_endpoint_network_policies_enabled") {
+		if d.HasChange("enforce_private_link_endpoint_network_policies") || d.HasChange("private_endpoint_network_policies_enabled") || d.HasChange("private_endpoint_network_policies") {
 			enforcePrivateEndpointNetworkPoliciesRaw := d.Get("enforce_private_link_endpoint_network_policies").(bool)
 			privateEndpointNetworkPoliciesRaw := d.Get("private_endpoint_network_policies_enabled").(bool)
+			privateEndpointNetworkPoliciesStringRaw := d.Get("private_endpoint_network_policies").(string)
 
 			if d.HasChange("enforce_private_link_endpoint_network_policies") {
 				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
 			} else if d.HasChange("private_endpoint_network_policies_enabled") {
 				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+			} else if d.HasChange("private_endpoint_network_policies") {
+				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
 			}
 
 			props.PrivateEndpointNetworkPolicies = pointer.To(privateEndpointNetworkPolicies)

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -517,11 +517,12 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			privateEndpointNetworkPoliciesRaw := d.Get("private_endpoint_network_policies_enabled").(bool)
 			privateEndpointNetworkPoliciesStringRaw := d.Get("private_endpoint_network_policies").(string)
 
-			if d.HasChange("enforce_private_link_endpoint_network_policies") {
+			switch {
+			case d.HasChange("enforce_private_link_endpoint_network_policies"):
 				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
-			} else if d.HasChange("private_endpoint_network_policies_enabled") {
+			case d.HasChange("private_endpoint_network_policies_enabled"):
 				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
-			} else if d.HasChange("private_endpoint_network_policies") {
+			case d.HasChange("private_endpoint_network_policies"):
 				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
 			}
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -367,14 +367,12 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		// Only one of these values can be set since they conflict with each other
 		// if neither of them are set use the default values
-		if enforceOk || enableOk || privateEndpointNetworkPoliciesOk {
-			if enforceOk {
-				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
-			} else if enableOk {
-				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
-			} else if privateEndpointNetworkPoliciesOk {
-				privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
-			}
+		if enforceOk {
+			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandEnforceSubnetNetworkPolicy(enforcePrivateEndpointNetworkPoliciesRaw))
+		} else if enableOk {
+			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(expandSubnetNetworkPolicy(privateEndpointNetworkPoliciesRaw))
+		} else if privateEndpointNetworkPoliciesOk {
+			privateEndpointNetworkPolicies = subnets.VirtualNetworkPrivateEndpointNetworkPolicies(privateEndpointNetworkPoliciesStringRaw)
 		}
 
 		if enforceServiceOk || enableServiceOk {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -216,7 +216,14 @@ func TestAccSubnet_privateEndpointNetworkPolicies(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
+			Config: r.privateEndpointNetworkPolicies(data, "NetworkSecurityGroupEnabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.privateEndpointNetworkPolicies(data, "RouteTableEnabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -337,12 +344,12 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
+				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
 				Check: acceptance.ComposeTestCheckFunc(
 					check.That(data.ResourceName).ExistsInAzure(r),
 					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
@@ -354,7 +361,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 			},
 			data.ImportStep(),
 			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
+				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
 				Check: acceptance.ComposeTestCheckFunc(
 					check.That(data.ResourceName).ExistsInAzure(r),
 					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
@@ -379,6 +386,18 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 			data.ImportStep(),
 			{
 				Config: r.enablePrivateLinkServiceNetworkPolicies(data, true),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
+					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
 				Check: acceptance.ComposeTestCheckFunc(
 					check.That(data.ResourceName).ExistsInAzure(r),
 					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
@@ -434,7 +453,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -446,7 +465,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("true"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -458,7 +477,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -584,7 +603,7 @@ func TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues(t *te
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -192,7 +192,7 @@ func TestAccSubnet_enablePrivateEndpointNetworkPolicies(t *testing.T) {
 			data.ImportStep(),
 		})
 	} else {
-		t.Skip("skipping due to deprecation of the 'enforce_private_link_endpoint_network_policies' and 'enforce_private_link_service_network_policies' and 'private_endpoint_network_policies_enabled' fields in 4.0")
+		t.Skip("skipping due to deprecation of the 'private_endpoint_network_policies_enabled' fields in 4.0")
 	}
 }
 

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -162,27 +162,61 @@ func TestAccSubnet_delegation(t *testing.T) {
 	})
 }
 
+// TODO 4.0: Remove test
 func TestAccSubnet_enablePrivateEndpointNetworkPolicies(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+		r := SubnetResource{}
+
+		data.ResourceTest(t, r, []acceptance.TestStep{
+			{
+				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.enablePrivateEndpointNetworkPolicies(data, false),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+		})
+	} else {
+		t.Skip("skipping due to deprecation of the 'enforce_private_link_endpoint_network_policies' and 'enforce_private_link_service_network_policies' and 'private_endpoint_network_policies_enabled' fields in 4.0")
+	}
+}
+
+func TestAccSubnet_privateEndpointNetworkPolicies(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.enablePrivateEndpointNetworkPolicies(data, true),
+			Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.enablePrivateEndpointNetworkPolicies(data, false),
+			Config: r.privateEndpointNetworkPolicies(data, "Disabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.enablePrivateEndpointNetworkPolicies(data, true),
+			Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -303,6 +337,19 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
+					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -314,6 +361,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -325,6 +373,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("true"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -336,6 +385,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
 				),
 			},
 			data.ImportStep(),
@@ -353,6 +403,18 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 
 		data.ResourceTest(t, r, []acceptance.TestStep{
 			{
+				Config: r.privateEndpointNetworkPolicies(data, "Disabled"),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("true"),
+					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
+					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
+				),
+			},
+			data.ImportStep(),
+			{
 				Config: r.enablePrivateEndpointNetworkPolicies(data, false),
 				Check: acceptance.ComposeTestCheckFunc(
 					check.That(data.ResourceName).ExistsInAzure(r),
@@ -360,6 +422,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
@@ -371,6 +434,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
@@ -382,6 +446,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("true"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
@@ -393,6 +458,7 @@ func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
@@ -499,7 +565,7 @@ func TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues(t *te
 				Config: r.privateLinkEndpointNetworkPoliciesDefaults(data),
 				Check: acceptance.ComposeTestCheckFunc(
 					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
 				),
 			},
@@ -518,6 +584,7 @@ func TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues(t *te
 					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
 					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
 					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
+					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
 				),
 			},
 			data.ImportStep(),
@@ -761,6 +828,7 @@ resource "azurerm_subnet" "test" {
 `, r.template(data))
 }
 
+// TODO 4.0: Remove test
 func (r SubnetResource) enablePrivateEndpointNetworkPolicies(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
@@ -772,6 +840,21 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.2.0/24"]
 
   private_endpoint_network_policies_enabled = %t
+}
+`, r.template(data), enabled)
+}
+
+func (r SubnetResource) privateEndpointNetworkPolicies(data acceptance.TestData, enabled string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  private_endpoint_network_policies = "%s"
 }
 `, r.template(data), enabled)
 }

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -37,7 +37,7 @@ output "subnet_id" {
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
 * `service_endpoints` - A list of Service Endpoints within this subnet.
-* `private_endpoint_network_policies_enabled` - Enable or Disable network policies for the private endpoint on the subnet.
+* `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.
 * `private_link_service_network_policies_enabled` - Enable or Disable network policies for the private link service on the subnet.
 
 ## Timeouts

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -65,9 +65,9 @@ The following arguments are supported:
 
 * `delegation` - (Optional) One or more `delegation` blocks as defined below.
 
-* `private_endpoint_network_policies_enabled` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Setting this to `true` will **Enable** the policy and setting this to `false` will **Disable** the policy. Defaults to `true`.
+* `private_endpoint_network_policies` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Possible values are `Disabled`, `Enabled`, `NetworkSecurityGroupEnabled` and `RouteTableEnabled`. Defaults to `Disabled`.
 
--> **NOTE:** Network policies, like network security groups (NSG), are not supported for Private Link Endpoints or Private Link Services. In order to deploy a Private Link Endpoint on a given subnet, you must set the `private_endpoint_network_policies_enabled` attribute to `false`. This setting is only applicable for the Private Link Endpoint, for all other resources in the subnet access is controlled based via the Network Security Group which can be configured using the `azurerm_subnet_network_security_group_association` resource.
+-> **NOTE:** Network policies, like network security groups (NSG), are not supported for Private Link Endpoints or Private Link Services. In order to deploy a Private Link Endpoint on a given subnet, you must set the `private_endpoint_network_policies` attribute to `Disabled`. This setting is only applicable for the Private Link Endpoint, for all other resources in the subnet access is controlled based via the Network Security Group which can be configured using the `azurerm_subnet_network_security_group_association` resource.
 
 * `private_link_service_network_policies_enabled` - (Optional) Enable or Disable network policies for the private link service on the subnet. Setting this to `true` will **Enable** the policy and setting this to `false` will **Disable** the policy. Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
Currently, azurerm_subnet has supported the ["privateEndpointNetworkPolicies"](https://github.com/Azure/azure-rest-api-specs/blob/99686ad45c380cf8fbcf7811db9c984a0e9d6639/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/virtualNetwork.json#L1602) property and it is marked as bool type in TF. But it's not expected since this property is expanded with new values and now it supports these values "Enabled"/"Disabled"/"NetworkSecurityGroupEnabled"/"RouteTableEnabled" in Swagger. So we have to convert it from bool to string to support more values in TF. This feature request is from Service team.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/432261f4-882c-4ccd-b7f5-9a4daeafd72b)

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 




If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_subnet` - convert the `privateEndpointNetworkPolicies` property from bool to string to support more values


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
