### PR TITLE
`azurerm_monitor_private_link_scoped_service` - normalize `linked_resource_id`

### DIFF
--- a/internal/services/monitor/monitor_private_link_scoped_service_resource.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource.go
@@ -134,7 +134,7 @@ func resourceMonitorPrivateLinkScopedServiceRead(d *pluginsdk.ResourceData, meta
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("linked_resource_id", props.LinkedResourceId)
+			d.Set("linked_resource_id", normalizeLinkedResourceId(props.LinkedResourceId))
 		}
 	}
 
@@ -157,4 +157,25 @@ func resourceMonitorPrivateLinkScopedServiceDelete(d *pluginsdk.ResourceData, me
 	}
 
 	return nil
+}
+
+func normalizeLinkedResourceId(input *string) *string {
+	if input == nil {
+		return input
+	}
+
+	if resourceId, err := components.ParseComponentIDInsensitively(*input); err == nil {
+		nomalizedId := resourceId.ID()
+		return &nomalizedId
+	}
+	if resourceId, err := workspaces.ParseWorkspaceIDInsensitively(*input); err == nil {
+		nomalizedId := resourceId.ID()
+		return &nomalizedId
+	}
+	if resourceId, err := datacollectionendpoints.ParseDataCollectionEndpointIDInsensitively(*input); err == nil {
+		nomalizedId := resourceId.ID()
+		return &nomalizedId
+	}
+
+	return input
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
normalize `linked_resource_id` 
fix `TestAccMonitorPrivateLinkScopedService_requiresImport` failed with 
```
------- Stdout: -------
=== RUN   TestAccMonitorPrivateLinkScopedService_requiresImport
=== PAUSE TestAccMonitorPrivateLinkScopedService_requiresImport
=== CONT  TestAccMonitorPrivateLinkScopedService_requiresImport
    testcase.go:113: Step 2/2, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1
        Error: parsing "/subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257": parsing segment "staticResourceGroups": parsing the Component ID: the segment at position 2 didn't match
        Expected a Component ID that matched:
        > /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Insights/components/componentValue
        However this value was provided:
        > /subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257
        The parsed Resource ID was missing a value for the segment at position 2
        (which should be the literal value "resourceGroups").
          with azurerm_monitor_private_link_scoped_service.import,
          on terraform_plugin_test.tf line 55, in resource "azurerm_monitor_private_link_scoped_service" "import":
          55:   linked_resource_id  = azurerm_monitor_private_link_scoped_service.test.linked_resource_id
        Error: parsing "/subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257": parsing segment "staticResourceGroups": parsing the Workspace ID: the segment at position 2 didn't match
        Expected a Workspace ID that matched:
        > /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.OperationalInsights/workspaces/workspaceValue
        However this value was provided:
        > /subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257
        The parsed Resource ID was missing a value for the segment at position 2
        (which should be the literal value "resourceGroups").
          with azurerm_monitor_private_link_scoped_service.import,
          on terraform_plugin_test.tf line 55, in resource "azurerm_monitor_private_link_scoped_service" "import":
          55:   linked_resource_id  = azurerm_monitor_private_link_scoped_service.test.linked_resource_id
        Error: parsing "/subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257": parsing segment "staticResourceGroups": parsing the DataCollectionEndpoint ID: the segment at position 2 didn't match
        Expected a DataCollectionEndpoint ID that matched:
        > /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Insights/dataCollectionEndpoints/dataCollectionEndpointValue
        However this value was provided:
        > /subscriptions/*******/resourcegroups/acctestrg-plss-240425002002027257/providers/microsoft.insights/components/acctest-appinsights-240425002002027257
        The parsed Resource ID was missing a value for the segment at position 2
        (which should be the literal value "resourceGroups").
          with azurerm_monitor_private_link_scoped_service.import,
          on terraform_plugin_test.tf line 55, in resource "azurerm_monitor_private_link_scoped_service" "import":
          55:   linked_resource_id  = azurerm_monitor_private_link_scoped_service.test.linked_resource_id
--- FAIL: TestAccMonitorPrivateLinkScopedService_requiresImport (237.87s)
FAIL
```
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_private_link_scoped_service` - normalize `linked_resource_id`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
