### PR TITLE
`azurerm_storage_account`: add retry when retrieving web static properties response 404 Not Found

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -54,6 +54,30 @@ func TestAccStorageAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_basicDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:  r.basic(data),
+			Destroy: true,
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccStorageAccount_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}


### PR DESCRIPTION
…create sa issue

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The `accountsClient.GetServiceProperties` call consistently returns a `404 Not Found` error when attempting to destroy and then create a storage account with the same name. This PR aims to include a retry call in order to prevent the unexpected occurrence of this error. If the resource is still not found after the retry, an error will be raised, ensuring that issue #20257 is not overlooked. This is a improvement of #19062 and serves as a fix for #24982.

```
        Error: retrieving static website properties for Storage Account (Subscription: "xxx"
        Resource Group Name: "acctestRG-storage-240429173322807028"
        Storage Account Name: "unlikely23exst2acct20lxz"): executing request: unexpected status 404 (404 The specified resource does not exist.) with ResourceNotFound: The specified resource does not exist.
        RequestId:48abb5e8-a01e-0053-0e18-9a123d000000
        Time:2024-04-29T09:37:30.3373663Z



          with azurerm_storage_account.test,
          on terraform_plugin_test.tf line 30, in resource "azurerm_storage_account" "test":
          30: resource "azurerm_storage_account" "test" {
```
 
> Just found that #23002 fixes the same issue but not updated for a while. I/m ok to close my PR if #23002 is going to be merged.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccStorageAccount_basicDestroy (353.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage    353.040s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - fix the error of `retrieving static website properties for Storage Account xxx: executing request: unexpected status 404 (404 The specified resource does not exist.) with ResourceNotFound` when recreate a storage account with the same name.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24982


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
