### PR TITLE
`azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` - Support `hibernation_enabled`

### DIFF
--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -37,6 +37,13 @@ func virtualMachineAdditionalCapabilitiesSchema() *pluginsdk.Schema {
 					Optional: true,
 					Default:  false,
 				},
+
+				"hibernation_enabled": {
+					Type:     pluginsdk.TypeBool,
+					ForceNew: true,
+					Optional: true,
+					Default:  false,
+				},
 			},
 		},
 	}
@@ -49,6 +56,8 @@ func expandVirtualMachineAdditionalCapabilities(input []interface{}) *virtualmac
 		raw := input[0].(map[string]interface{})
 
 		capabilities.UltraSSDEnabled = pointer.To(raw["ultra_ssd_enabled"].(bool))
+
+		capabilities.HibernationEnabled = pointer.To(raw["hibernation_enabled"].(bool))
 	}
 
 	return &capabilities
@@ -65,9 +74,15 @@ func flattenVirtualMachineAdditionalCapabilities(input *virtualmachines.Addition
 		ultraSsdEnabled = *input.UltraSSDEnabled
 	}
 
+	hibernationEnabled := false
+	if input.HibernationEnabled != nil {
+		hibernationEnabled = *input.HibernationEnabled
+	}
+
 	return []interface{}{
 		map[string]interface{}{
-			"ultra_ssd_enabled": ultraSsdEnabled,
+			"ultra_ssd_enabled":   ultraSsdEnabled,
+			"hibernation_enabled": hibernationEnabled,
 		},
 	}
 }

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -844,6 +844,21 @@ func TestAccWindowsVirtualMachine_otherTimeZone(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_otherHibernation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherHibernation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_otherUltraSsdDefault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -3028,6 +3043,42 @@ resource "azurerm_windows_virtual_machine" "test" {
     offer     = "WindowsServer"
     sku       = "2016-Datacenter"
     version   = "latest"
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherHibernation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D16as_v5"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  zone = 1
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 128
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  additional_capabilities {
+    hibernation_enabled = true
   }
 }
 `, r.template(data))

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -230,6 +230,8 @@ A `additional_capabilities` block supports the following:
 
 * `ultra_ssd_enabled` - (Optional) Should the capacity to enable Data Disks of the `UltraSSD_LRS` storage account type be supported on this Virtual Machine? Defaults to `false`.
 
+* `hibernation_enabled` - (Optional) Whether to enable the hibernation capability or not. Changing this forces a new Linux Virtual Machine to be created.
+
 ---
 
 A `admin_ssh_key` block supports the following:

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -229,6 +229,8 @@ A `additional_capabilities` block supports the following:
 
 * `ultra_ssd_enabled` - (Optional) Should the capacity to enable Data Disks of the `UltraSSD_LRS` storage account type be supported on this Virtual Machine? Defaults to `false`.
 
+* `hibernation_enabled` - (Optional) Whether to enable the hibernation capability or not. Changing this forces a new Windows Virtual Machine to be created.
+
 ---
 
 A `additional_unattend_content` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

=== RUN   TestAccLinuxVirtualMachine_otherHibernation
=== PAUSE TestAccLinuxVirtualMachine_otherHibernation
=== RUN   TestAccWindowsVirtualMachine_otherHibernation
=== PAUSE TestAccWindowsVirtualMachine_otherHibernation
=== CONT  TestAccLinuxVirtualMachine_otherHibernation
=== CONT  TestAccWindowsVirtualMachine_otherHibernation
--- PASS: TestAccLinuxVirtualMachine_otherHibernation (341.40s)
--- PASS: TestAccWindowsVirtualMachine_otherHibernation (424.59s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       464.251s

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` - Support `hibernation_enabled` [GH-24780]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
close https://github.com/hashicorp/terraform-provider-azurerm/issues/24780


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
