### PR TITLE
`tools`: fix document linter panic if document not eixsts

### DIFF
--- a/internal/tools/document-lint/check/check_iface.go
+++ b/internal/tools/document-lint/check/check_iface.go
@@ -62,3 +62,29 @@ func newCheckBase(line int, key string, mdField *model.Field) checkBase {
 		mdField: mdField,
 	}
 }
+
+// for some special diff, we need to show message instead of diff
+type diffWithMessage struct {
+	checkBase
+	msg  string
+	skip bool
+}
+
+func (i diffWithMessage) Fix(line string) (string, error) {
+	return line, nil
+}
+
+func (i diffWithMessage) String() string {
+	return i.msg
+}
+func (i diffWithMessage) ShouldSkip() bool {
+	return i.skip
+}
+
+func newDiffWithMessage(msg string, skip bool) Checker {
+	return diffWithMessage{
+		checkBase: newCheckBase(0, msg, nil),
+		msg:       msg,
+		skip:      skip,
+	}
+}

--- a/internal/tools/document-lint/check/check_resource.go
+++ b/internal/tools/document-lint/check/check_resource.go
@@ -75,6 +75,10 @@ func NewResourceDiff(tf *schema.Resource) *ResourceDiff {
 
 func (r *ResourceDiff) DiffAll() {
 	if r.md == nil {
+		if r.MDFile == "" {
+			r.Diff = append(r.Diff, newDiffWithMessage(fmt.Sprintf("%s has no document", r.tf.ResourceType), r.tf.IsDeprecated()))
+			return
+		}
 		mark := md.MustNewMarkFromFile(r.MDFile)
 		r.md = mark.BuildResourceDoc()
 	}

--- a/internal/tools/document-lint/check/document_fixer.go
+++ b/internal/tools/document-lint/check/document_fixer.go
@@ -96,6 +96,10 @@ func (f *Fixer) TryFix() (err error) {
 	if len(f.Diff) == 0 {
 		return
 	}
+	if d, ok := f.Diff[0].(diffWithMessage); ok {
+		log.Printf("%s: %s", f.ResourceType, d.msg)
+		return
+	}
 	content, err := os.ReadFile(f.MDFile)
 	if err != nil {
 		log.Printf("open %s: %v", f.MDFile, err)

--- a/internal/tools/document-lint/schema/resource_schema.go
+++ b/internal/tools/document-lint/schema/resource_schema.go
@@ -105,3 +105,13 @@ func (r *Resource) HasPathFor(path []string) bool {
 	}
 	return true
 }
+
+func (r *Resource) IsDeprecated() bool {
+	if r.Schema != nil {
+		return r.Schema.DeprecationMessage != ""
+	} else if _, ok := r.SDKResource.(sdk.ResourceWithDeprecationReplacedBy); ok {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
…in document<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to fix a panic issue when the document is removed for these deprecated resources. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `tools` - fix document linter panic if document not exists for resource

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
