### PR TITLE
`4.0` - remove `ConfigModeAttr` from `kusto` and `logic`

### DIFF
--- a/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -272,7 +272,7 @@ resource "azurerm_key_vault_access_policy" "cluster" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_user_assigned_identity.test.principal_id
 
-  key_permissions = ["Get", "UnwrapKey", "WrapKey"]
+  key_permissions = ["Get", "UnwrapKey", "WrapKey", "GetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_access_policy" "client" {

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -33,7 +33,7 @@ import (
 )
 
 func resourceKustoCluster() *pluginsdk.Resource {
-	s := &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceKustoClusterCreate,
 		Read:   resourceKustoClusterRead,
 		Update: resourceKustoClusterUpdate,
@@ -112,10 +112,8 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			},
 
 			"trusted_external_tenants": {
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				Computed:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Type:     pluginsdk.TypeList,
+				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
@@ -243,7 +241,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 	}
 
 	if features.FourPointOhBeta() {
-		s.Schema["language_extensions"] = &pluginsdk.Schema{
+		resource.Schema["language_extensions"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Elem: &pluginsdk.Resource{
@@ -261,8 +259,18 @@ func resourceKustoCluster() *pluginsdk.Resource {
 				},
 			},
 		}
+		resource.Schema["trusted_external_tenants"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
+			},
+		}
 	} else {
-		s.Schema["language_extensions"] = &pluginsdk.Schema{
+		resource.Schema["language_extensions"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeSet,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
@@ -272,7 +280,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 		}
 	}
 
-	return s
+	return resource
 }
 
 func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -957,7 +957,7 @@ resource "azurerm_kusto_cluster" "test" {
 
   optimized_auto_scale {
     minimum_instances = 2
-    maximum_instances = 2
+    maximum_instances = 3
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -380,7 +381,7 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.trustedExternalTenants(data, "[]"),
+			Config: r.unsetTrustedExternalTenants(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -515,6 +516,61 @@ resource "azurerm_kusto_cluster" "test" {
   trusted_external_tenants = %s
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantConfig)
+}
+
+func (KustoClusterResource) unsetTrustedExternalTenants(data acceptance.TestData) string {
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  trusted_external_tenants = []
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (KustoClusterResource) doubleEncryption(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -919,11 +919,119 @@ func schemaLogicAppCorsSettings() *pluginsdk.Schema {
 }
 
 func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
+	if !features.FourPointOhBeta() {
+		return &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"ip_address": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"service_tag": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"virtual_network_subnet_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"priority": {
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						Default:      65000,
+						ValidateFunc: validation.IntBetween(1, 2147483647),
+					},
+
+					"action": {
+						Type:     pluginsdk.TypeString,
+						Default:  "Allow",
+						Optional: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"Allow",
+							"Deny",
+						}, false),
+					},
+
+					// lintignore:XS003
+					"headers": {
+						Type:       pluginsdk.TypeList,
+						Optional:   true,
+						Computed:   true,
+						MaxItems:   1,
+						ConfigMode: pluginsdk.SchemaConfigModeAttr,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								// lintignore:S018
+								"x_forwarded_host": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									MaxItems: 8,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								// lintignore:S018
+								"x_forwarded_for": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									MaxItems: 8,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.IsCIDR,
+									},
+								},
+
+								// lintignore:S018
+								"x_azure_fdid": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									MaxItems: 8,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.IsUUID,
+									},
+								},
+
+								// lintignore:S018
+								"x_fd_health_probe": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{
+											"1",
+										}, false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
 	return &pluginsdk.Schema{
-		Type:       pluginsdk.TypeList,
-		Optional:   true,
-		Computed:   true,
-		ConfigMode: pluginsdk.SchemaConfigModeAttr,
+		Type:     pluginsdk.TypeList,
+		Optional: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"ip_address": {
@@ -970,11 +1078,9 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 
 				// lintignore:XS003
 				"headers": {
-					Type:       pluginsdk.TypeList,
-					Optional:   true,
-					Computed:   true,
-					MaxItems:   1,
-					ConfigMode: pluginsdk.SchemaConfigModeAttr,
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					MaxItems: 1,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							// lintignore:S018

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1818,9 +1818,7 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
-    ip_restriction {
-      scm_ip_address = []
-    }
+    scm_ip_restriction = []
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -575,6 +575,38 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// This configuration includes a single explicit ip_restriction
+			Config: r.oneIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
+			),
+		},
+		{
+			// This configuration has no site_config blocks at all.
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
+			),
+		},
+		{
+			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
+			Config: r.ipRestrictionRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
+			),
+		},
+	})
+}
+
 func TestAccLogicAppStandard_manyIpRestrictions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
@@ -627,6 +659,13 @@ func TestAccLogicAppStandard_scmOneIpRestriction(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.scmIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unsetScmIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1645,7 +1684,8 @@ resource "azurerm_logic_app_standard" "test" {
 }
 
 func (r LogicAppStandardResource) ipRestrictionRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -1663,6 +1703,25 @@ resource "azurerm_logic_app_standard" "test" {
   site_config {
     ip_restriction = []
   }
+}
+`, r.template(data), data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {}
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -1733,10 +1792,55 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
-    ip_restriction {
+    scm_ip_restriction {
       ip_address = "10.10.10.10/32"
     }
   }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogicAppStandardResource) unsetScmIpRestriction(data acceptance.TestData) string {
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    ip_restriction {
+      scm_ip_address = []
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {}
 }
 `, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removes `ConfigModeAttr` from `azurerm_kusto_cluster`
- Removes `ConfigModeAttr` from `azurerm_logic_standard_app`
- Updates tests for `azurerm_logic_standard_app` that add and remove `ip_restriction` and `scm_ip_restriction`

## Testing 

<img width="406" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/be57f26b-4344-4f34-9cbc-0d65d089a087">

<img width="406" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/ba0e0d2b-c525-4914-9ff0-56683fea2ec4">

