### PR TITLE
`azurerm_web_pubsub_custom_certificate` - added time delay to avoid 409 error 

### DIFF
--- a/internal/services/signalr/web_pubsub_custom_certificate_resource.go
+++ b/internal/services/signalr/web_pubsub_custom_certificate_resource.go
@@ -124,6 +124,8 @@ func (r CustomCertWebPubsubResource) Create() sdk.ResourceFunc {
 
 			}
 
+			time.Sleep(30 * time.Second)
+
 			if err := client.CustomCertificatesCreateOrUpdateThenPoll(ctx, id, customCertObj); err != nil {
 				return fmt.Errorf("creating web pubsub custom certificate: %s: %+v", id, err)
 			}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

I am getting an error when deploy web pubsub with azurerm_web_pubsub_custom_certificate. It will fail with the error below. If I re-run after failure, it succeeds. I add a time delay to the function and it seems to have resolved my issue when I compiled the provider and ran my tests. I apologize if the approach is wrong as I am not a developer at heart. 

``` CustomCertificatesCreateOrUpdate: unexpected status 409 (409 Conflict) with error: Conflict: The resource is not in succeeded state ````

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_web_pubsub_custom_certificate` - add time delay when deploying this resource as it fails right away. The error is "`CustomCertificatesCreateOrUpdate: unexpected status 409 (409 Conflict) with error: Conflict: The resource is not in succeeded state`", re-running from the fail then succeeds without making any changes. 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25828


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
