### PR TITLE
`azurerm_linux_function_app_slot` - fixed panic when planning from a version older than 3.88.0

### DIFF
--- a/internal/services/appservice/migration/linux_function_app_slot.go
+++ b/internal/services/appservice/migration/linux_function_app_slot.go
@@ -1575,9 +1575,8 @@ func (l LinuxFunctionAppSlotV0toV1) Schema() map[string]*pluginsdk.Schema {
 
 func (l LinuxFunctionAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-		oldId := rawState["service_plan_id"].(string)
-		// service_plan_id can be empty if it is not in a different Service Plan to the "parent" app
-		if oldId == "" {
+		oldId, ok := rawState["service_plan_id"].(string)
+		if !ok || oldId == "" {
 			return rawState, nil
 		}
 		parsedId, err := commonids.ParseAppServicePlanIDInsensitively(oldId)

--- a/internal/services/appservice/migration/linux_function_app_slot.go
+++ b/internal/services/appservice/migration/linux_function_app_slot.go
@@ -1576,6 +1576,7 @@ func (l LinuxFunctionAppSlotV0toV1) Schema() map[string]*pluginsdk.Schema {
 func (l LinuxFunctionAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId, ok := rawState["service_plan_id"].(string)
+		// service_plan_id can be empty if it is not in a different Service Plan to the "parent" app
 		if !ok || oldId == "" {
 			return rawState, nil
 		}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
When planning changes on a linux function app slot that has been previously created with an older version of the provider, the plugin panics during the migration of the model.
This prevents from changes in the whole terraform workspace, so may be blocking for the many users in the same situation.

```
Stack trace from the terraform-provider-azurerm_v3.101.0_x5 plugin:

panic: interface conversion: interface {} is nil, not string

goroutine 57 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/migration.(*LinuxFunctionAppSlotV0toV1).UpgradeFunc.LinuxFunctionAppSlotV0toV1.UpgradeFunc.func1({0x0?, 0x0?}, 0x0?, {0x0?, 0x0?})
...
panic: interface conversion: interface {} is nil, not string
```

The error is caused by unsafe get of the `service_plan_id` key from the rawState map during state migration from v0 to v1.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [X] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The test has been taken creating the resource with the 3.87.0 version of the provider and planned again with 3.101.0 version. No plan edits returned.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_function_app_slot` - fixed error when resource is firstly deployed with provider version <= 3.88.0 and then upgraded


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
