### PR TITLE
azurerm_subnet - Fix service_endpoint_policy_ids bug

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -148,7 +148,7 @@ func resourceSubnet() *pluginsdk.Resource {
 			"service_endpoint_policy_ids": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
-				MinItems: 1,
+				MinItems: 0,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validate.SubnetServiceEndpointStoragePolicyID,

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -148,7 +148,6 @@ func resourceSubnet() *pluginsdk.Resource {
 			"service_endpoint_policy_ids": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
-				MinItems: 0,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validate.SubnetServiceEndpointStoragePolicyID,


### PR DESCRIPTION
change the service_endpoint_policy_ids minIteams so it wont fail if you add null or empty list

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Fix the following error:

│ Attribute service_endpoint_policy_ids requires 1 item minimum, but config has only 0 declared

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_subnet` - Fix service_endpoint_policy_ids MinIteam value


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
