### PR TITLE
azurerm_log_analytics_saved_search - fix function_parameters not created in correct order

### DIFF
--- a/internal/services/loganalytics/log_analytics_saved_search_resource.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource.go
@@ -86,7 +86,7 @@ func resourceLogAnalyticsSavedSearch() *pluginsdk.Resource {
 			},
 
 			"function_parameters": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &pluginsdk.Schema{
@@ -138,7 +138,7 @@ func resourceLogAnalyticsSavedSearchCreate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("function_parameters"); ok {
-		attrs := v.(*pluginsdk.Set).List()
+		attrs := v.([]interface{})
 		result := make([]string, 0)
 		for _, item := range attrs {
 			if item != nil {

--- a/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
@@ -167,7 +167,7 @@ resource "azurerm_log_analytics_saved_search" "test" {
   query        = "Heartbeat | summarize Count() by Computer | take a"
 
   function_alias      = "heartbeat_func"
-  function_parameters = ["a:int=1"]
+  function_parameters = ["a:int=1", "b:int=2", "c:int=3"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This resource does not respect the sequence of the function parameters, this makes it unusable particularly for ASIM Log Parsers. The function parameters will be referenced in the queries, with the same sequence as defined in the function. For more context have a look at the issue connected. 

I have validated that the order is now maintained by using the provider locally.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_saved_search` - respects the order of the function_parameters property

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #12539 

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
