### PR TITLE
`network` - split `CreateUpdate` method of several resources

### DIFF
--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -30,9 +31,9 @@ import (
 
 func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkWatcherFlowLogCreateUpdate,
+		Create: resourceNetworkWatcherFlowLogCreate,
 		Read:   resourceNetworkWatcherFlowLogRead,
-		Update: resourceNetworkWatcherFlowLogCreateUpdate,
+		Update: resourceNetworkWatcherFlowLogUpdate,
 		Delete: resourceNetworkWatcherFlowLogDelete,
 
 		SchemaVersion: 1,
@@ -183,10 +184,10 @@ func azureRMSuppressFlowLogRetentionPolicyDaysDiff(_, old, _ string, d *pluginsd
 	return old != "" && !d.Get("enabled").(bool)
 }
 
-func resourceNetworkWatcherFlowLogCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.FlowLogs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := flowlogs.NewFlowLogID(subscriptionId, d.Get("resource_group_name").(string), d.Get("network_watcher_name").(string), d.Get("name").(string))
@@ -195,22 +196,20 @@ func resourceNetworkWatcherFlowLogCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	if d.IsNewResource() {
-		// For newly created resources, the "name" is required, it is set as Optional and Computed is merely for the existing ones for the sake of backward compatibility.
-		if id.NetworkWatcherName == "" {
-			return fmt.Errorf("`name` is required for Network Watcher Flow Log")
-		}
+	// For newly created resources, the "name" is required, it is set as Optional and Computed is merely for the existing ones for the sake of backward compatibility.
+	if id.NetworkWatcherName == "" {
+		return fmt.Errorf("`name` is required for Network Watcher Flow Log")
+	}
 
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("failed checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_watcher_flow_log", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_watcher_flow_log", id.ID())
 	}
 
 	locks.ByID(nsgId.ID())
@@ -235,29 +234,93 @@ func resourceNetworkWatcherFlowLogCreateUpdate(d *pluginsdk.ResourceData, meta i
 		Properties: &flowlogs.FlowLogPropertiesFormat{
 			TargetResourceId: nsgId.ID(),
 			StorageId:        d.Get("storage_account_id").(string),
-			Enabled:          utils.Bool(d.Get("enabled").(bool)),
-			RetentionPolicy:  expandAzureRmNetworkWatcherFlowLogRetentionPolicy(d.Get("retention_policy").([]interface{})),
+			Enabled:          pointer.To(d.Get("enabled").(bool)),
+			RetentionPolicy:  expandNetworkWatcherFlowLogRetentionPolicy(d.Get("retention_policy").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if _, ok := d.GetOk("traffic_analytics"); ok {
-		parameters.Properties.FlowAnalyticsConfiguration = expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d)
+		parameters.Properties.FlowAnalyticsConfiguration = expandNetworkWatcherFlowLogTrafficAnalytics(d)
 	}
 
 	if version, ok := d.GetOk("version"); ok {
 		format := &flowlogs.FlowLogFormatParameters{
-			Version: utils.Int64(int64(version.(int))),
+			Version: pointer.To(int64(version.(int))),
 		}
 
 		parameters.Properties.Format = format
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("creating %q: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
+
+	return resourceNetworkWatcherFlowLogRead(d, meta)
+}
+
+func resourceNetworkWatcherFlowLogUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.FlowLogs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := flowlogs.ParseFlowLogID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	nsgId, err := parse.NetworkSecurityGroupID(d.Get("network_security_group_id").(string))
+	if err != nil {
+		return err
+	}
+	locks.ByID(nsgId.ID())
+	defer locks.UnlockByID(nsgId.ID())
+
+	if d.HasChange("storage_account_id") {
+		payload.Properties.StorageId = d.Get("storage_account_id").(string)
+	}
+
+	if d.HasChange("enabled") {
+		payload.Properties.Enabled = pointer.To(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("retention_policy") {
+		payload.Properties.RetentionPolicy = expandNetworkWatcherFlowLogRetentionPolicy(d.Get("retention_policy").([]interface{}))
+	}
+
+	if d.HasChange("traffic_analytics") {
+		payload.Properties.FlowAnalyticsConfiguration = expandNetworkWatcherFlowLogTrafficAnalytics(d)
+	}
+
+	if d.HasChange("version") {
+		if version, ok := d.GetOk("version"); ok && version != 0 {
+			payload.Properties.Format = &flowlogs.FlowLogFormatParameters{
+				Version: pointer.To(int64(d.Get("version").(int))),
+			}
+		} else {
+			payload.Properties.Format = &flowlogs.FlowLogFormatParameters{}
+		}
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
 
 	return resourceNetworkWatcherFlowLogRead(d, meta)
 }
@@ -292,7 +355,7 @@ func resourceNetworkWatcherFlowLogRead(d *pluginsdk.ResourceData, meta interface
 		d.Set("location", location.NormalizeNilable(model.Location))
 
 		if props := model.Properties; props != nil {
-			if err := d.Set("traffic_analytics", flattenAzureRmNetworkWatcherFlowLogTrafficAnalytics(props.FlowAnalyticsConfiguration)); err != nil {
+			if err := d.Set("traffic_analytics", flattenNetworkWatcherFlowLogTrafficAnalytics(props.FlowAnalyticsConfiguration)); err != nil {
 				return fmt.Errorf("setting `traffic_analytics`: %+v", err)
 			}
 
@@ -317,7 +380,7 @@ func resourceNetworkWatcherFlowLogRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("network_security_group_id", networkSecurityGroupId)
 
-			if err := d.Set("retention_policy", flattenAzureRmNetworkWatcherFlowLogRetentionPolicy(props.RetentionPolicy)); err != nil {
+			if err := d.Set("retention_policy", flattenNetworkWatcherFlowLogRetentionPolicy(props.RetentionPolicy)); err != nil {
 				return fmt.Errorf("setting `retention_policy`: %+v", err)
 			}
 		}
@@ -361,7 +424,7 @@ func resourceNetworkWatcherFlowLogDelete(d *pluginsdk.ResourceData, meta interfa
 	return nil
 }
 
-func expandAzureRmNetworkWatcherFlowLogRetentionPolicy(input []interface{}) *flowlogs.RetentionPolicyParameters {
+func expandNetworkWatcherFlowLogRetentionPolicy(input []interface{}) *flowlogs.RetentionPolicyParameters {
 	if len(input) < 1 || input[0] == nil {
 		return nil
 	}
@@ -371,12 +434,12 @@ func expandAzureRmNetworkWatcherFlowLogRetentionPolicy(input []interface{}) *flo
 	days := v["days"].(int)
 
 	return &flowlogs.RetentionPolicyParameters{
-		Enabled: utils.Bool(enabled),
-		Days:    utils.Int64(int64(days)),
+		Enabled: pointer.To(enabled),
+		Days:    pointer.To(int64(days)),
 	}
 }
 
-func flattenAzureRmNetworkWatcherFlowLogRetentionPolicy(input *flowlogs.RetentionPolicyParameters) []interface{} {
+func flattenNetworkWatcherFlowLogRetentionPolicy(input *flowlogs.RetentionPolicyParameters) []interface{} {
 	output := make([]interface{}, 0)
 
 	if input != nil {
@@ -397,7 +460,7 @@ func flattenAzureRmNetworkWatcherFlowLogRetentionPolicy(input *flowlogs.Retentio
 	return output
 }
 
-func flattenAzureRmNetworkWatcherFlowLogTrafficAnalytics(input *flowlogs.TrafficAnalyticsProperties) []interface{} {
+func flattenNetworkWatcherFlowLogTrafficAnalytics(input *flowlogs.TrafficAnalyticsProperties) []interface{} {
 	output := make([]interface{}, 0)
 	if input != nil {
 		if cfg := input.NetworkWatcherFlowAnalyticsConfiguration; cfg != nil {
@@ -435,7 +498,7 @@ func flattenAzureRmNetworkWatcherFlowLogTrafficAnalytics(input *flowlogs.Traffic
 	return output
 }
 
-func expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d *pluginsdk.ResourceData) *flowlogs.TrafficAnalyticsProperties {
+func expandNetworkWatcherFlowLogTrafficAnalytics(d *pluginsdk.ResourceData) *flowlogs.TrafficAnalyticsProperties {
 	vs := d.Get("traffic_analytics").([]interface{})
 
 	v := vs[0].(map[string]interface{})
@@ -447,11 +510,11 @@ func expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d *pluginsdk.ResourceDat
 
 	return &flowlogs.TrafficAnalyticsProperties{
 		NetworkWatcherFlowAnalyticsConfiguration: &flowlogs.TrafficAnalyticsConfigurationProperties{
-			Enabled:                  utils.Bool(enabled),
+			Enabled:                  pointer.To(enabled),
 			WorkspaceId:              utils.String(workspaceID),
 			WorkspaceRegion:          utils.String(workspaceRegion),
 			WorkspaceResourceId:      utils.String(workspaceResourceID),
-			TrafficAnalyticsInterval: utils.Int64(int64(interval)),
+			TrafficAnalyticsInterval: pointer.To(int64(interval)),
 		},
 	}
 }

--- a/internal/services/network/network_watcher_flow_log_resource_test.go
+++ b/internal/services/network/network_watcher_flow_log_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/flowlogs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkWatcherFlowLogResource struct{}
@@ -242,10 +242,10 @@ func (t NetworkWatcherFlowLogResource) Exists(ctx context.Context, clients *clie
 
 	resp, err := clients.Network.FlowLogs.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Network Watcher Flow Log (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkWatcherFlowLogResource) prerequisites(data acceptance.TestData) string {

--- a/internal/services/network/network_watcher_resource.go
+++ b/internal/services/network/network_watcher_resource.go
@@ -21,9 +21,9 @@ import (
 
 func resourceNetworkWatcher() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkWatcherCreateUpdate,
+		Create: resourceNetworkWatcherCreate,
 		Read:   resourceNetworkWatcherRead,
-		Update: resourceNetworkWatcherCreateUpdate,
+		Update: resourceNetworkWatcherUpdate,
 		Delete: resourceNetworkWatcherDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := networkwatchers.ParseNetworkWatcherID(id)
@@ -53,24 +53,23 @@ func resourceNetworkWatcher() *pluginsdk.Resource {
 	}
 }
 
-func resourceNetworkWatcherCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkWatcherCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.NetworkWatchers
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := networkwatchers.NewNetworkWatcherID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
 
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_watcher", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_watcher", id.ID())
 	}
 
 	watcher := networkwatchers.NetworkWatcher{
@@ -79,10 +78,42 @@ func resourceNetworkWatcherCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, watcher); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
+
+	return resourceNetworkWatcherRead(d, meta)
+}
+
+func resourceNetworkWatcherUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.NetworkWatchers
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := networkwatchers.ParseNetworkWatcherID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
 
 	return resourceNetworkWatcherRead(d, meta)
 }

--- a/internal/services/network/route_resource.go
+++ b/internal/services/network/route_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/routes"
@@ -17,14 +18,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRoute() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceRouteCreateUpdate,
+		Create: resourceRouteCreate,
 		Read:   resourceRouteRead,
-		Update: resourceRouteCreateUpdate,
+		Update: resourceRouteUpdate,
 		Delete: resourceRouteDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -83,34 +83,33 @@ func resourceRoute() *pluginsdk.Resource {
 	}
 }
 
-func resourceRouteCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceRouteCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Routes
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	addressPrefix := d.Get("address_prefix").(string)
 	nextHopType := d.Get("next_hop_type").(string)
 
 	id := routes.NewRouteID(subscriptionId, d.Get("resource_group_name").(string), d.Get("route_table_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_route", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_route", id.ID())
 	}
 
 	locks.ByName(id.RouteTableName, routeTableResourceName)
 	defer locks.UnlockByName(id.RouteTableName, routeTableResourceName)
 
 	route := routes.Route{
-		Name: utils.String(id.RouteName),
+		Name: pointer.To(id.RouteName),
 		Properties: &routes.RoutePropertiesFormat{
 			AddressPrefix: &addressPrefix,
 			NextHopType:   routes.RouteNextHopType(nextHopType),
@@ -118,14 +117,60 @@ func resourceRouteCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("next_hop_in_ip_address"); ok {
-		route.Properties.NextHopIPAddress = utils.String(v.(string))
+		route.Properties.NextHopIPAddress = pointer.To(v.(string))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, route); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
+	return resourceRouteRead(d, meta)
+}
+
+func resourceRouteUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.Routes
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := routes.ParseRouteID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	locks.ByName(id.RouteTableName, routeTableResourceName)
+	defer locks.UnlockByName(id.RouteTableName, routeTableResourceName)
+
+	if d.HasChange("address_prefix") {
+		payload.Properties.AddressPrefix = pointer.To(d.Get("address_prefix").(string))
+	}
+
+	if d.HasChange("next_hop_type") {
+		payload.Properties.NextHopType = routes.RouteNextHopType(d.Get("next_hop_type").(string))
+	}
+
+	if d.HasChange("next_hop_in_ip_address") {
+		payload.Properties.NextHopIPAddress = pointer.To(d.Get("next_hop_in_ip_address").(string))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
 	return resourceRouteRead(d, meta)
 }
 

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -5,15 +5,14 @@ package network
 
 import (
 	"fmt"
-	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/routetables"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -27,9 +26,9 @@ var routeTableResourceName = "azurerm_route_table"
 
 func resourceRouteTable() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceRouteTableCreateUpdate,
+		Create: resourceRouteTableCreate,
 		Read:   resourceRouteTableRead,
-		Update: resourceRouteTableCreateUpdate,
+		Update: resourceRouteTableUpdate,
 		Delete: resourceRouteTableDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -115,46 +114,83 @@ func resourceRouteTable() *pluginsdk.Resource {
 	}
 }
 
-func resourceRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceRouteTableCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.RouteTables
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Route Table creation.")
-
 	id := routetables.NewRouteTableID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	t := d.Get("tags").(map[string]interface{})
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id, routetables.DefaultGetOperationOptions())
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id, routetables.DefaultGetOperationOptions())
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_route_table", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_route_table", id.ID())
 	}
 
 	routeSet := routetables.RouteTable{
 		Name:     &id.RouteTableName,
-		Location: &location,
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &routetables.RouteTablePropertiesFormat{
 			Routes:                     expandRouteTableRoutes(d),
-			DisableBgpRoutePropagation: utils.Bool(d.Get("disable_bgp_route_propagation").(bool)),
+			DisableBgpRoutePropagation: pointer.To(d.Get("disable_bgp_route_propagation").(bool)),
 		},
-		Tags: tags.Expand(t),
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, routeSet); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
+
+	return resourceRouteTableRead(d, meta)
+}
+
+func resourceRouteTableUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.RouteTables
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := routetables.ParseRouteTableID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id, routetables.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("route") {
+		payload.Properties.Routes = expandRouteTableRoutes(d)
+	}
+
+	if d.HasChange("disable_bgp_route_propagation") {
+		payload.Properties.DisableBgpRoutePropagation = pointer.To(d.Get("disable_bgp_route_propagation").(bool))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
 
 	return resourceRouteTableRead(d, meta)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Splits CreateUpdate method for
- `azurerm_network_watcher_flow_log`
- `azurerm_network_watcher`
- `azurerm_route`
- `azurerm_route_table`

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/0af59d94-88d5-4beb-b654-0bd490fd34a0)

Test failure on main as well

