### PR TITLE
`loadtest` - manually register client and resources

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -88,6 +88,7 @@ import (
 	labservice "github.com/hashicorp/terraform-provider-azurerm/internal/services/labservice/client"
 	lighthouse "github.com/hashicorp/terraform-provider-azurerm/internal/services/lighthouse/client"
 	loadbalancers "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/client"
+	loadtestservice "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice/client"
 	loganalytics "github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/client"
 	logic "github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/client"
 	logz "github.com/hashicorp/terraform-provider-azurerm/internal/services/logz/client"
@@ -224,6 +225,7 @@ type Client struct {
 	LabService                        *labservice.Client
 	Lighthouse                        *lighthouse.Client
 	LoadBalancers                     *loadbalancers.Client
+	LoadTestService                   *loadtestservice.AutoClient
 	LogAnalytics                      *loganalytics.Client
 	Logic                             *logic.Client
 	Logz                              *logz.Client

--- a/internal/clients/client_gen.go
+++ b/internal/clients/client_gen.go
@@ -9,7 +9,6 @@ import (
 	chaosstudio "github.com/hashicorp/terraform-provider-azurerm/internal/services/chaosstudio/client"
 	containers "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/client"
 	devcenter "github.com/hashicorp/terraform-provider-azurerm/internal/services/devcenter/client"
-	loadtestservice "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice/client"
 	managedidentity "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/client"
 )
 
@@ -17,7 +16,6 @@ type autoClient struct {
 	ChaosStudio      *chaosstudio.AutoClient
 	ContainerService *containers.AutoClient
 	DevCenter        *devcenter.AutoClient
-	LoadTestService  *loadtestservice.AutoClient
 	ManagedIdentity  *managedidentity.AutoClient
 }
 
@@ -33,10 +31,6 @@ func buildAutoClients(client *autoClient, o *common.ClientOptions) (err error) {
 
 	if client.DevCenter, err = devcenter.NewClient(o); err != nil {
 		return fmt.Errorf("building client for DevCenter: %+v", err)
-	}
-
-	if client.LoadTestService, err = loadtestservice.NewClient(o); err != nil {
-		return fmt.Errorf("building client for LoadTestService: %+v", err)
 	}
 
 	if client.ManagedIdentity, err = managedidentity.NewClient(o); err != nil {

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -70,6 +70,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/legacy"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/lighthouse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logz"
@@ -180,6 +181,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		kusto.Registration{},
 		labservice.Registration{},
 		loadbalancer.Registration{},
+		loadtestservice.Registration{},
 		loganalytics.Registration{},
 		machinelearning.Registration{},
 		managedhsm.Registration{},

--- a/internal/provider/services_gen.go
+++ b/internal/provider/services_gen.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/chaosstudio"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devcenter"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity"
 )
 
@@ -16,7 +15,6 @@ func autoRegisteredTypedServices() []sdk.TypedServiceRegistration {
 		chaosstudio.Registration{},
 		containers.Registration{},
 		devcenter.Registration{},
-		loadtestservice.Registration{},
 		managedidentity.Registration{},
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


Loadtest is no longer generated so the client and resources should be registered manually