### PR TITLE
dependencies: updating to `v0.68.0` of `github.com/hashicorp/go-azure-helpers`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.4.0
-	github.com/hashicorp/go-azure-helpers v0.67.0
+	github.com/hashicorp/go-azure-helpers v0.68.0
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240506.1094936
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240506.1094936
 	github.com/hashicorp/go-hclog v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.67.0 h1:0RY6mY3W3Ym2I+jExLtyLx96fh6p5n9vidqisAKGUSE=
-github.com/hashicorp/go-azure-helpers v0.67.0/go.mod h1:S4Bu66vyJvHA0trqHQB0YVGsISuF7HMH9tyEsMVlx8A=
+github.com/hashicorp/go-azure-helpers v0.68.0 h1:BszlR7WQ0e8IK4mbkxtxI0qPlopyopr5jfyykfIQq+o=
+github.com/hashicorp/go-azure-helpers v0.68.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240506.1094936 h1:7Y8i1HYjupSg1yYDosrrfc1fLCxdYUEzrBIedKwJeFs=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240506.1094936/go.mod h1:p1P+kBwN54NLKGg35s5O7sBoFP3Zk60nBTA5PsOqFus=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240506.1094936 h1:a7vuK6yajMRRpONXqOYOl0dE4TRIjzV8Rw5SFlUlYgw=

--- a/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -320,7 +321,7 @@ func (s SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Read() s
 			if result.Model != nil && result.Model.Value != nil {
 				for _, value := range *result.Model.Value {
 					apmId, err := appplatform.ParseApmIDInsensitively(value)
-					if err == nil && apmId.ID() == id.ID() {
+					if err == nil && resourceids.Match(apmId, id) {
 						globallyEnabled = true
 						break
 					}

--- a/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -268,7 +269,7 @@ func (s SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 			if result.Model != nil && result.Model.Value != nil {
 				for _, value := range *result.Model.Value {
 					apmId, err := appplatform.ParseApmIDInsensitively(value)
-					if err == nil && apmId.ID() == id.ID() {
+					if err == nil && resourceids.Match(apmId, id) {
 						globallyEnabled = true
 						break
 					}

--- a/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -286,7 +287,7 @@ func (s SpringCloudDynatraceApplicationPerformanceMonitoringResource) Read() sdk
 			if result.Model != nil && result.Model.Value != nil {
 				for _, value := range *result.Model.Value {
 					apmId, err := appplatform.ParseApmIDInsensitively(value)
-					if err == nil && apmId.ID() == id.ID() {
+					if err == nil && resourceids.Match(apmId, id) {
 						globallyEnabled = true
 						break
 					}

--- a/internal/services/springcloud/spring_cloud_elastic_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_elastic_application_performance_monitoring_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -251,7 +252,7 @@ func (s SpringCloudElasticApplicationPerformanceMonitoringResource) Read() sdk.R
 			if result.Model != nil && result.Model.Value != nil {
 				for _, value := range *result.Model.Value {
 					apmId, err := appplatform.ParseApmIDInsensitively(value)
-					if err == nil && apmId.ID() == id.ID() {
+					if err == nil && resourceids.Match(apmId, id) {
 						globallyEnabled = true
 						break
 					}

--- a/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -322,7 +323,7 @@ func (s SpringCloudNewRelicApplicationPerformanceMonitoringResource) Read() sdk.
 			if result.Model != nil && result.Model.Value != nil {
 				for _, value := range *result.Model.Value {
 					apmId, err := appplatform.ParseApmIDInsensitively(value)
-					if err == nil && apmId.ID() == id.ID() {
+					if err == nil && resourceids.Match(apmId, id) {
 						globallyEnabled = true
 						break
 					}

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/ids.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonids/ids.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package commonids
 
 import (

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/features/user_specified_segments.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/features/user_specified_segments.go
@@ -1,0 +1,15 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package features
+
+// TreatUserSpecifiedSegmentsAsCaseInsensitive is a feature-toggle which specifies whether User Specified
+// Resource ID Segments should be compared case-insensitively as required.
+//
+// @tombuildsstuff: whilst this IS EXPOSED in the public interface - this is NOT READY FOR USE and should
+// not be exposed to users (i.e. as a feature-toggle) until this work is completed - as this'll become a source of knock-on problems
+// rather than being useful.
+//
+// There are a number of dependencies to enabling this, including completing the standardiation on the
+// `ResourceId` interface and the `ResourceIDReference` schema types - and surrounding updates.
+var TreatUserSpecifiedSegmentsAsCaseInsensitive = false

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/recaser/recase.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/recaser/recase.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package recaser
 
 import (

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/recaser/registration.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/recaser/registration.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package recaser
 
 import (

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/match.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/match.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourceids
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/features"
+)
+
+// Match compares two instances of the same ResourceId and determines whether they are a match
+//
+// Whilst it might seem fine to compare the result of the `.ID()` function, that doesn't account
+// for Resource ID Segments which need to be compared as case-insensitive.
+//
+// As such whilst this function is NOT exposing that functionality right now, it will when the
+// centralised feature-flag for this is rolled out.
+func Match(first, second ResourceId) bool {
+	// since we're comparing interface types, ensure the two underlying types are the same
+	if reflect.TypeOf(first) != reflect.TypeOf(second) {
+		return false
+	}
+
+	parser := NewParserFromResourceIdType(first)
+	firstParsed, err := parser.Parse(first.ID(), true)
+	if err != nil {
+		return false
+	}
+	secondParsed, err := parser.Parse(second.ID(), true)
+	if err != nil {
+		return false
+	}
+	firstVal := firstParsed.Parsed
+	secondVal := secondParsed.Parsed
+	if len(firstVal) != len(secondVal) {
+		return false
+	}
+	for key, val := range firstVal {
+		otherVal, ok := secondVal[key]
+		if !ok {
+			return false
+		}
+
+		segment := parser.namedSegment(key)
+		if segment == nil {
+			return false
+		}
+
+		if features.TreatUserSpecifiedSegmentsAsCaseInsensitive && segment.Type == UserSpecifiedSegmentType {
+			if !strings.EqualFold(val, otherVal) {
+				return false
+			}
+		} else if val != otherVal {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/parse.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/parse.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 type Parser struct {
@@ -203,6 +205,17 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		}
 	}
 	return &parseResult, nil
+}
+
+// namedSegment returns the named Segment for a ResourceId, if it exists
+func (p Parser) namedSegment(name string) *Segment {
+	for _, item := range p.segments {
+		if item.Name == name {
+			return pointer.To(item)
+		}
+	}
+
+	return nil
 }
 
 func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.67.0
+# github.com/hashicorp/go-azure-helpers v0.68.0
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-helpers/eventhub
 github.com/hashicorp/go-azure-helpers/lang/dates
@@ -141,6 +141,7 @@ github.com/hashicorp/go-azure-helpers/polling
 github.com/hashicorp/go-azure-helpers/resourcemanager/commonids
 github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema
 github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones
+github.com/hashicorp/go-azure-helpers/resourcemanager/features
 github.com/hashicorp/go-azure-helpers/resourcemanager/identity
 github.com/hashicorp/go-azure-helpers/resourcemanager/location
 github.com/hashicorp/go-azure-helpers/resourcemanager/recaser


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR updates to `v0.68.0` of `github.com/hashicorp/go-azure-helpers` and adopts the new `resourceids.Match` method available from https://github.com/hashicorp/go-azure-helpers/pull/234

## Change Log

* dependencies: updating to `v0.68.0` of `github.com/hashicorp/go-azure-helpers`

