### PR TITLE
`vmss` - rename `maximum_surge_instances` to `maximum_surge_instances_enabled`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -2795,7 +2795,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     max_unhealthy_upgraded_instance_percent = %d
     pause_time_between_batches              = "%s"
     prioritize_unhealthy_instances_enabled  = %t
-    maximum_surge_instances                 = %t
+    maximum_surge_instances_enabled         = %t
   }
 
   source_image_reference {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1738,7 +1738,7 @@ func VirtualMachineScaleSetRollingUpgradePolicySchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 				},
-				"maximum_surge_instances": {
+				"maximum_surge_instances_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 				},
@@ -1760,7 +1760,7 @@ func ExpandVirtualMachineScaleSetRollingUpgradePolicy(input []interface{}, isZon
 		MaxUnhealthyUpgradedInstancePercent: pointer.To(int64(raw["max_unhealthy_upgraded_instance_percent"].(int))),
 		PauseTimeBetweenBatches:             pointer.To(raw["pause_time_between_batches"].(string)),
 		PrioritizeUnhealthyInstances:        pointer.To(raw["prioritize_unhealthy_instances_enabled"].(bool)),
-		MaxSurge:                            pointer.To(raw["maximum_surge_instances"].(bool)),
+		MaxSurge:                            pointer.To(raw["maximum_surge_instances_enabled"].(bool)),
 	}
 
 	enableCrossZoneUpgrade := raw["cross_zone_upgrades_enabled"].(bool)
@@ -1771,10 +1771,10 @@ func ExpandVirtualMachineScaleSetRollingUpgradePolicy(input []interface{}, isZon
 		return nil, fmt.Errorf("`rolling_upgrade_policy.0.cross_zone_upgrades_enabled` can only be set to `true` when `zones` is specified")
 	}
 
-	maxSurge := raw["maximum_surge_instances"].(bool)
+	maxSurge := raw["maximum_surge_instances_enabled"].(bool)
 	if overProvision && maxSurge {
 		// MaxSurge can only be set when overprovision is set to false
-		return nil, fmt.Errorf("`rolling_upgrade_policy.0.maximum_surge_instances` can only be set to `true` when `overprovision` is disabled (set to `false`)")
+		return nil, fmt.Errorf("`rolling_upgrade_policy.0.maximum_surge_instances_enabled` can only be set to `true` when `overprovision` is disabled (set to `false`)")
 	}
 
 	return rollingUpgradePolicy, nil
@@ -1828,7 +1828,7 @@ func FlattenVirtualMachineScaleSetRollingUpgradePolicy(input *virtualmachinescal
 			"max_unhealthy_upgraded_instance_percent": maxUnhealthyUpgradedInstancePercent,
 			"pause_time_between_batches":              pauseTimeBetweenBatches,
 			"prioritize_unhealthy_instances_enabled":  prioritizeUnhealthyInstances,
-			"maximum_surge_instances":                 maxSurge,
+			"maximum_surge_instances_enabled":         maxSurge,
 		},
 	}
 }

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -540,9 +540,9 @@ A `rolling_upgrade_policy` block supports the following:
 
 * `prioritize_unhealthy_instances_enabled` - (Optional) Upgrade all unhealthy instances in a scale set before any healthy instances. Possible values are `true` or `false`.
 
-* `maximum_surge_instances` - (Optional) Create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines. Existing virtual machines will be deleted once the new virtual machines are created for each batch. Possible values are `true` or `false`.
+* `maximum_surge_instances_enabled` - (Optional) Create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines. Existing virtual machines will be deleted once the new virtual machines are created for each batch. Possible values are `true` or `false`.
 
--> **NOTE:** `overprovision` must be set to `false` when `maximum_surge_instances` is specified.
+-> **NOTE:** `overprovision` must be set to `false` when `maximum_surge_instances_enabled` is specified.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -529,9 +529,9 @@ A `rolling_upgrade_policy` block supports the following:
 
 * `prioritize_unhealthy_instances_enabled` - (Optional) Upgrade all unhealthy instances in a scale set before any healthy instances. Possible values are `true` or `false`.
 
-* `maximum_surge_instances` - (Optional) Create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines. Existing virtual machines will be deleted once the new virtual machines are created for each batch. Possible values are `true` or `false`.
+* `maximum_surge_instances_enabled` - (Optional) Create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines. Existing virtual machines will be deleted once the new virtual machines are created for each batch. Possible values are `true` or `false`.
 
--> **NOTE:** `overprovision` must be set to `false` when `maximum_surge_instances` is specified.
+-> **NOTE:** `overprovision` must be set to `false` when `maximum_surge_instances_enabled` is specified.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This property was introduced by #24914 and hasn't been released yet, but should probably be renamed to `maximum_surge_instances_enabled` since it's a boolean.

