### PR TITLE
`appservice`: conditionally rewriting the value for `virtual_network_subnet_id`

### DIFF
--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -645,7 +645,12 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 					}
 
 					if subnetId := pointer.From(props.VirtualNetworkSubnetId); subnetId != "" {
-						state.VirtualNetworkSubnetID = subnetId
+						// some users have provisioned these without a prefixed `/` - as such we need to normalize these
+						parsed, err := commonids.ParseSubnetIDInsensitively(subnetId)
+						if err != nil {
+							return err
+						}
+						state.VirtualNetworkSubnetID = parsed.ID()
 					}
 				}
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -667,7 +667,12 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 					}
 
 					if subnetId := pointer.From(props.VirtualNetworkSubnetId); subnetId != "" {
-						state.VirtualNetworkSubnetID = subnetId
+						// some users have provisioned these without a prefixed `/` - as such we need to normalize these
+						parsed, err := commonids.ParseSubnetIDInsensitively(subnetId)
+						if err != nil {
+							return err
+						}
+						state.VirtualNetworkSubnetID = parsed.ID()
 					}
 
 					state.PublishingFTPBasicAuthEnabled = basicAuthFTP


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/25832 by ensuring that the Subnet ID is recased meaning that it'll be in the correct format.

From our side since we're validating the user input for this field, it's hard for us to write a test-case for this one since it'd be caught by the validation - but this is caused by user input for this field (provisioned through an ARM Template etc) providing this value without the prefix '/', which the API should be requiring (but isn't).
