### PR TITLE
`webpubsub`: fixing a panic where `networkACL.PublicNetwork.Deny` was nil

### DIFF
--- a/internal/services/signalr/web_pubsub_network_acl_resource.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource.go
@@ -165,7 +165,7 @@ func resourceWebPubsubNetworkACLCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	if defaultAction == webpubsub.ACLActionAllow && networkACL.PublicNetwork.Allow != nil && len(*networkACL.PublicNetwork.Allow) != 0 {
 		return fmt.Errorf("when `default_action` is `Allow` for `public_network`, `allowed_request_types` cannot be specified")
-	} else if defaultAction == webpubsub.ACLActionDeny && len(*networkACL.PublicNetwork.Deny) != 0 {
+	} else if defaultAction == webpubsub.ACLActionDeny && networkACL.PublicNetwork.Deny != nil && len(*networkACL.PublicNetwork.Deny) != 0 {
 		return fmt.Errorf("when `default_action` is `Deny` for `public_network`, `denied_request_types` cannot be specified")
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes #25855

## Changelog

```
* `azurerm_web_pubsub_network_acl` - fixing a crash when `networkACL.PublicNetwork.Deny` was nil
```