### PR TITLE
kubernetes_cluster_node_pool: Fix race condition with virtual network status when creating node pool

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -700,8 +700,12 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	if subnetID != nil {
 		// Wait for vnet to come back to Succeeded before releasing any locks
-		timeout, _ := ctx.Deadline()
+		timeout, ok := ctx.Deadline()
+		if !ok {
+			return fmt.Errorf("internal-error: context had no deadline")
+		}
 
+		// TODO: refactor this into a `custompoller` within the `network` package
 		stateConf := &pluginsdk.StateChangeConf{
 			Pending:    []string{string(subnets.ProvisioningStateUpdating)},
 			Target:     []string{string(subnets.ProvisioningStateSucceeded)},

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -22,14 +22,17 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/managedclusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-06-02-preview/snapshots"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
 	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -423,16 +426,34 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 	return s
 }
+
 func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	containersClient := meta.(*clients.Client).Containers
 	clustersClient := containersClient.KubernetesClustersClient
 	poolsClient := containersClient.AgentPoolsClient
+	subnetClient := meta.(*clients.Client).Network.Client.Subnets
+	vnetClient := meta.(*clients.Client).Network.VnetClient
+
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	clusterId, err := commonids.ParseKubernetesClusterID(d.Get("kubernetes_cluster_id").(string))
 	if err != nil {
 		return err
+	}
+
+	var subnetID *commonids.SubnetId
+	if subnetIDValue, ok := d.GetOk("vnet_subnet_id"); ok {
+		subnetID, err = commonids.ParseSubnetID(subnetIDValue.(string))
+		if err != nil {
+			return err
+		}
+
+		locks.ByName(subnetID.VirtualNetworkName, network.VirtualNetworkResourceName)
+		defer locks.UnlockByName(subnetID.VirtualNetworkName, network.VirtualNetworkResourceName)
+
+		locks.ByName(subnetID.SubnetName, network.SubnetResourceName)
+		defer locks.UnlockByName(subnetID.SubnetName, network.SubnetResourceName)
 	}
 
 	id := agentpools.NewAgentPoolID(clusterId.SubscriptionId, clusterId.ResourceGroupName, clusterId.ManagedClusterName, d.Get("name").(string))
@@ -602,8 +623,8 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.PodSubnetID = utils.String(podSubnetID)
 	}
 
-	if vnetSubnetID := d.Get("vnet_subnet_id").(string); vnetSubnetID != "" {
-		profile.VnetSubnetID = utils.String(vnetSubnetID)
+	if subnetID != nil {
+		profile.VnetSubnetID = utils.String(subnetID.ID())
 	}
 
 	if hostGroupID := d.Get("host_group_id").(string); hostGroupID != "" {
@@ -675,6 +696,34 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	err = poolsClient.CreateOrUpdateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	if subnetID != nil {
+		// Wait for vnet to come back to Succeeded before releasing any locks
+		timeout, _ := ctx.Deadline()
+
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+			Target:     []string{string(subnets.ProvisioningStateSucceeded)},
+			Refresh:    network.SubnetProvisioningStateRefreshFunc(ctx, subnetClient, *subnetID),
+			MinTimeout: 1 * time.Minute,
+			Timeout:    time.Until(timeout),
+		}
+		if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for provisioning state of subnet for AKS Node Pool creation %s: %+v", *subnetID, err)
+		}
+
+		vnetId := commonids.NewVirtualNetworkID(subnetID.SubscriptionId, subnetID.ResourceGroupName, subnetID.VirtualNetworkName)
+		vnetStateConf := &pluginsdk.StateChangeConf{
+			Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+			Target:     []string{string(subnets.ProvisioningStateSucceeded)},
+			Refresh:    network.VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
+			MinTimeout: 1 * time.Minute,
+			Timeout:    time.Until(timeout),
+		}
+		if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for provisioning state of virtual network for AKS Node Pool creation %s: %+v", vnetId, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2979,7 +2979,7 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  count                = 20
+  count                = 8
   name                 = "acctestsubnet%d${count.index}"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
@@ -3008,8 +3008,8 @@ resource "azurerm_kubernetes_cluster" "test" {
     name           = "default"
     node_count     = 1
     vm_size        = "Standard_DS2_v2"
-    vnet_subnet_id = azurerm_subnet.test["19"].id
-    pod_subnet_id  = azurerm_subnet.test["18"].id
+    vnet_subnet_id = azurerm_subnet.test["6"].id
+    pod_subnet_id  = azurerm_subnet.test["7"].id
     upgrade_settings {
       max_surge = "10%%"
     }
@@ -3030,8 +3030,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "test1" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_L8s_v3"
   node_count            = 1
-  vnet_subnet_id        = azurerm_subnet.test[1].id
-  pod_subnet_id         = azurerm_subnet.test[2].id
+  vnet_subnet_id        = azurerm_subnet.test[0].id
+  pod_subnet_id         = azurerm_subnet.test[1].id
   zones                 = ["1"]
 }
 
@@ -3040,8 +3040,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "test2" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_L8s_v3"
   node_count            = 1
-  vnet_subnet_id        = azurerm_subnet.test[3].id
-  pod_subnet_id         = azurerm_subnet.test[4].id
+  vnet_subnet_id        = azurerm_subnet.test[2].id
+  pod_subnet_id         = azurerm_subnet.test[3].id
   zones                 = ["1"]
 }
 
@@ -3050,8 +3050,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "test3" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_L8s_v3"
   node_count            = 1
-  vnet_subnet_id        = azurerm_subnet.test[5].id
-  pod_subnet_id         = azurerm_subnet.test[6].id
+  vnet_subnet_id        = azurerm_subnet.test[4].id
+  pod_subnet_id         = azurerm_subnet.test[5].id
   zones                 = ["1"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-azurerm/issues/13105. We are able to consistently trigger it in our testing. 

```
❯  make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition (1395.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	1398.094s
```

### Error 
```console
    Error: creating Agent Pool (Subscription: "312d56f6-697b-4377-9a9a-83257ce33066"
        Resource Group Name: "acctestRG-aks-240506121623880995"
        Managed Cluster Name: "acctestaks240506121623880995"
        Agent Pool Name: "internal3"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:

        Status: "SetVNetOwnershipFailed"
        Code: ""
        Message: "Set virtual network ownership failed. Subscription: 312d56f6-697b-4377-9a9a-83257ce33066; resource group: acctestRG-aks-240506121623880995; virtual network name: acctestvirtnet240506121623880995. autorest/azure: Service returned an error. Status=400 Code=\"VirtualNetworkNotInSucceededState\" Message=\"Virtual network /subscriptions/312d56f6-697b-4377-9a9a-83257ce33066/resourceGroups/acctestRG-aks-240506121623880995/providers/Microsoft.Network/virtualNetworks/acctestvirtnet240506121623880995 is in Updating state. It needs to be in Succeeded state in order to set resource ownership.\" Details=[]\nVirtual network /subscriptions/312d56f6-697b-4377-9a9a-83257ce33066/resourceGroups/acctestRG-aks-240506121623880995/providers/Microsoft.Network/virtualNetworks/acctestvirtnet240506121623880995 is in Updating state. It needs to be in Succeeded state in order to set resource ownership."
        Activity Id: ""

        ---

        API Response:

        ----[start]----
        {
          "name": "da6f9f40-6f18-4380-b252-d516cd3659f0",
          "status": "Failed",
          "startTime": "2024-05-06T16:21:01.6132767Z",
          "endTime": "2024-05-06T16:21:09.0898922Z",
          "error": {
           "code": "SetVNetOwnershipFailed",
           "message": "Set virtual network ownership failed. Subscription: 312d56f6-697b-4377-9a9a-83257ce33066; resource group: acctestRG-aks-240506121623880995; virtual network name: acctestvirtnet240506121623880995. autorest/azure: Service returned an error. Status=400 Code=\"VirtualNetworkNotInSucceededState\" Message=\"Virtual network /subscriptions/312d56f6-697b-4377-9a9a-83257ce33066/resourceGroups/acctestRG-aks-240506121623880995/providers/Microsoft.Network/virtualNetworks/acctestvirtnet240506121623880995 is in Updating state. It needs to be in Succeeded state in order to set resource ownership.\" Details=[]",
           "details": [
            {
             "code": "",
             "message": "Virtual network /subscriptions/312d56f6-697b-4377-9a9a-83257ce33066/resourceGroups/acctestRG-aks-240506121623880995/providers/Microsoft.Network/virtualNetworks/acctestvirtnet240506121623880995 is in Updating state. It needs to be in Succeeded state in order to set resource ownership."
            }
           ]
          }
         }
        -----[end]-----


          with azurerm_kubernetes_cluster_node_pool.test3,
          on terraform_plugin_test.tf line 97, in resource "azurerm_kubernetes_cluster_node_pool" "test3":
          97: resource "azurerm_kubernetes_cluster_node_pool" "test3" {
```

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.



## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster_node_pool` - Fix race condition between virtual network status and node pool creation. The virtual network must be in Succeeded state for an AKS node pool to be correctly created. 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix


## Related Issue(s)
https://github.com/hashicorp/terraform-provider-azurerm/issues/13105


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
