### PR TITLE
`loadtest` - fix missing build loadtest client issue

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -491,6 +491,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	if client.LoadBalancers, err = loadbalancers.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for LoadBalancers: %+v", err)
 	}
+	if client.LoadTestService, err = loadtestservice.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for LoadTestService: %+v", err)
+	}
 	if client.Logic, err = logic.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Logic: %+v", err)
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

All test cases for LoadTestService RP are failing in [TC ](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_LOADTESTSERVICE/145916?hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true)due to missing build client issue, submit this PR to fix this issue.

Test results in [TC](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_LOADTESTSERVICE/145961?buildTab=tests):
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/5fba88b9-2bd1-4660-8994-79da46617dab)

