### PR TITLE
`azurerm_data_factory_trigger_custom_event`: Allow subject_begins_with and subject_ends_with to both not be set

### DIFF
--- a/internal/services/datafactory/data_factory_trigger_custom_event_resource.go
+++ b/internal/services/datafactory/data_factory_trigger_custom_event_resource.go
@@ -124,13 +124,13 @@ func resourceDataFactoryTriggerCustomEvent() *pluginsdk.Resource {
 			"subject_begins_with": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"subject_ends_with": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}

--- a/internal/services/datafactory/data_factory_trigger_custom_event_resource.go
+++ b/internal/services/datafactory/data_factory_trigger_custom_event_resource.go
@@ -124,15 +124,13 @@ func resourceDataFactoryTriggerCustomEvent() *pluginsdk.Resource {
 			"subject_begins_with": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				AtLeastOneOf: []string{"subject_begins_with", "subject_ends_with"},
+				ValidateFunc: validation.StringIsNotEmpty
 			},
 
 			"subject_ends_with": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				AtLeastOneOf: []string{"subject_begins_with", "subject_ends_with"},
+				ValidateFunc: validation.StringIsNotEmpty
 			},
 		},
 	}

--- a/website/docs/r/data_factory_trigger_custom_event.html.markdown
+++ b/website/docs/r/data_factory_trigger_custom_event.html.markdown
@@ -86,8 +86,6 @@ The following arguments are supported:
 
 * `subject_ends_with` - (Optional) The pattern that event subject ends with for trigger to fire.
 
-~> **Note:** At least one of `subject_begins_with` and `subject_ends_with` must be set.
-
 ---
 
 A `pipeline` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Remove the mandatory field check on one of `subject_begins_with` / `subject_ends_with` for resource `azurerm_data_factory_trigger_custom_event`, as neither are required in the Azure REST API or Portal UI.

This PR resolves #25929 where there is more detail.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_trigger_custom_event` - remove mandatory field check on one of either `subject_begins_with` or `subject_ends_with` [GH-25929]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25929


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
