### PR TITLE
`azurerm_log_analytics_cluster` - support `UserAssigned` and `SystemAssigned, UserAssigned` identity

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -52,7 +52,7 @@ func (l LogAnalyticsClusterResource) Arguments() map[string]*schema.Schema {
 
 		"location": commonschema.Location(),
 
-		"identity": commonschema.SystemAssignedIdentityRequiredForceNew(),
+		"identity": commonschema.SystemOrUserAssignedIdentityRequiredForceNew(),
 
 		"size_gb": {
 			Type:     pluginsdk.TypeInt,

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -57,9 +57,13 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Log Analytics Cluster. The only possible value is `SystemAssigned`. Changing this forces a new resource to be created.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Log Analytics Cluster. Possible values are `SystemAssigned` and  `UserAssigned`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned` and the Log Analytics Cluster has been created. More details are available below.
+
+* `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Windows Web App Slot.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
 ## Attributes Reference
 
@@ -79,7 +83,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
-* `type` - (Required) The identity type of this Managed Service Identity.
+* `type` - The identity type of this Managed Service Identity.
 
 -> You can access the Principal ID via `azurerm_log_analytics_cluster.example.identity[0].principal_id` and the Tenant ID via `azurerm_log_analytics_cluster.example.identity[0].tenant_id`
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Adding fully support of `identity` to this resource.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

only provided results of the following 2 test cases, since there is a limit on the creation and deletion of clusters, only 1 schema changed,  the `_basic` one  covers `SystemAssigned` case and the `_userAssignedIdentity` one covers `UserAssigned` case.

```
❯❯ tftest loganalytics TestAccLogAnalyticsCluster_basic
=== RUN   TestAccLogAnalyticsCluster_basic
=== PAUSE TestAccLogAnalyticsCluster_basic
=== CONT  TestAccLogAnalyticsCluster_basic
--- PASS: TestAccLogAnalyticsCluster_basic (1972.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  1974.462s
```
```
❯❯ tftest loganalytics TestAccLogAnalyticsCluster_userAssignedIdentity
=== RUN   TestAccLogAnalyticsCluster_userAssignedIdentity
=== PAUSE TestAccLogAnalyticsCluster_userAssignedIdentity
=== CONT  TestAccLogAnalyticsCluster_userAssignedIdentity
--- PASS: TestAccLogAnalyticsCluster_userAssignedIdentity (2187.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  2189.291s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_cluster` - support `UserAssigned` and `SystemAssigned, UserAssigned` identity [GH-25940]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #20889

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
