### PR TITLE
Data Source: `azurerm_system_center_virtual_machine_manager_inventory_items` - normalize the resource ID

### DIFF
--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
@@ -147,8 +147,6 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachine) {
-				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -159,8 +157,6 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineTemplateInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachineTemplate) {
-				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -171,8 +167,6 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualNetworkInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualNetwork) {
-				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
@@ -127,7 +127,7 @@ func (l SystemCenterVirtualMachineManagerInventoryItemsDataSource) Read() sdk.Re
 func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType string) (*[]InventoryItem, error) {
 	results := make([]InventoryItem, 0)
 	if input == nil {
-		return pointer.To(results), nil
+		return &results, nil
 	}
 
 	for _, item := range *input {
@@ -136,7 +136,7 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 
 			if v, ok := props.(inventoryitems.CloudInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeCloud) {
 				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -148,7 +148,7 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachine) {
 				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -160,7 +160,7 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineTemplateInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachineTemplate) {
 				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -172,7 +172,7 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualNetworkInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualNetwork) {
 				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
-				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by the API starts with uppercase. So all instances of setting the inventory item ID must use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
 				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
 				if err != nil {
 					return nil, err
@@ -186,5 +186,5 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 		}
 	}
 
-	return pointer.To(results), nil
+	return &results, nil
 }

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
@@ -107,7 +107,10 @@ func (l SystemCenterVirtualMachineManagerInventoryItemsDataSource) Read() sdk.Re
 			}
 
 			if model := resp.Model; model != nil {
-				inventoryItems := flattenInventoryItems(model, state.InventoryType)
+				inventoryItems, err := flattenInventoryItems(model, state.InventoryType)
+				if err != nil {
+					return err
+				}
 				if len(inventoryItems) == 0 {
 					return fmt.Errorf("no inventory items were found for %s", scvmmServerId)
 				}
@@ -121,10 +124,10 @@ func (l SystemCenterVirtualMachineManagerInventoryItemsDataSource) Read() sdk.Re
 	}
 }
 
-func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType string) []InventoryItem {
+func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType string) ([]InventoryItem, error) {
 	results := make([]InventoryItem, 0)
 	if input == nil {
-		return results
+		return results, nil
 	}
 
 	for _, item := range *input {
@@ -132,22 +135,50 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 			inventoryItem := InventoryItem{}
 
 			if v, ok := props.(inventoryitems.CloudInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeCloud) {
-				inventoryItem.id = pointer.From(item.Id)
+				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
+				if err != nil {
+					return nil, err
+				}
+				inventoryItem.id = scvmmServerInventoryItemId.ID()
+
 				inventoryItem.name = pointer.From(v.InventoryItemName)
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachine) {
-				inventoryItem.id = pointer.From(item.Id)
+				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
+				if err != nil {
+					return nil, err
+				}
+				inventoryItem.id = scvmmServerInventoryItemId.ID()
+
 				inventoryItem.name = pointer.From(v.InventoryItemName)
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualMachineTemplateInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualMachineTemplate) {
-				inventoryItem.id = pointer.From(item.Id)
+				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
+				if err != nil {
+					return nil, err
+				}
+				inventoryItem.id = scvmmServerInventoryItemId.ID()
+
 				inventoryItem.name = pointer.From(v.InventoryItemName)
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
 			} else if v, ok := props.(inventoryitems.VirtualNetworkInventoryItem); ok && inventoryType == string(inventoryitems.InventoryTypeVirtualNetwork) {
-				inventoryItem.id = pointer.From(item.Id)
+				// Service API indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785
+				// But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID
+				scvmmServerInventoryItemId, err := inventoryitems.ParseInventoryItemIDInsensitively(pointer.From(item.Id))
+				if err != nil {
+					return nil, err
+				}
+				inventoryItem.id = scvmmServerInventoryItemId.ID()
+
 				inventoryItem.name = pointer.From(v.InventoryItemName)
 				inventoryItem.Uuid = pointer.From(v.Uuid)
 				results = append(results, inventoryItem)
@@ -155,5 +186,5 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 		}
 	}
 
-	return results
+	return results, nil
 }

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_inventory_items_data_source.go
@@ -111,10 +111,10 @@ func (l SystemCenterVirtualMachineManagerInventoryItemsDataSource) Read() sdk.Re
 				if err != nil {
 					return err
 				}
-				if len(inventoryItems) == 0 {
+				if len(pointer.From(inventoryItems)) == 0 {
 					return fmt.Errorf("no inventory items were found for %s", scvmmServerId)
 				}
-				state.InventoryItems = inventoryItems
+				state.InventoryItems = pointer.From(inventoryItems)
 			}
 
 			metadata.ResourceData.SetId(scvmmServerId.ID())
@@ -124,10 +124,10 @@ func (l SystemCenterVirtualMachineManagerInventoryItemsDataSource) Read() sdk.Re
 	}
 }
 
-func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType string) ([]InventoryItem, error) {
+func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType string) (*[]InventoryItem, error) {
 	results := make([]InventoryItem, 0)
 	if input == nil {
-		return results, nil
+		return pointer.To(results), nil
 	}
 
 	for _, item := range *input {
@@ -186,5 +186,5 @@ func flattenInventoryItems(input *[]inventoryitems.InventoryItem, inventoryType 
 		}
 	}
 
-	return results, nil
+	return pointer.To(results), nil
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
Swagger indicates that the static segment `inventoryItems` in the resource ID of the Inventory Item should start with lowercase. See more details from https://github.com/Azure/azure-rest-api-specs/blob/92c409d93f895a30d51603b2fda78a49b3a2cd60/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L1785. But the static segment `InventoryItems` in the resource ID of the Inventory Item returned by API starts with uppercase. So it has to use ParseInventoryItemIDInsensitively() in Read() to normalize the resource ID.

--- PASS: TestAccDataSourceSystemCenterVirtualMachineManagerInventoryItems_basic (314.73s)

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_system_center_virtual_machine_manager_inventory_items` - normalize the resource ID for this data source


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
