### PR TITLE
`network` - update several association resources to use `hashicorp/go-azure-sdk`

### DIFF
--- a/internal/services/network/nat_gateway_public_ip_association_resource.go
+++ b/internal/services/network/nat_gateway_public_ip_association_resource.go
@@ -61,17 +61,15 @@ func resourceNATGatewayPublicIpAssociationCreate(d *pluginsdk.ResourceData, meta
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for NAT Gateway <-> Public IP Association creation.")
 	publicIpAddressId, err := commonids.ParsePublicIPAddressID(d.Get("public_ip_address_id").(string))
 	if err != nil {
 		return err
 	}
+
 	natGatewayId, err := natgateways.ParseNatGatewayID(d.Get("nat_gateway_id").(string))
 	if err != nil {
 		return err
 	}
-
-	id := commonids.NewCompositeResourceID(natGatewayId, publicIpAddressId)
 
 	locks.ByName(natGatewayId.NatGatewayName, natGatewayResourceName)
 	defer locks.UnlockByName(natGatewayId.NatGatewayName, natGatewayResourceName)
@@ -90,6 +88,8 @@ func resourceNATGatewayPublicIpAssociationCreate(d *pluginsdk.ResourceData, meta
 	if natGateway.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", natGatewayId)
 	}
+
+	id := commonids.NewCompositeResourceID(natGatewayId, publicIpAddressId)
 
 	publicIpAddresses := make([]natgateways.SubResource, 0)
 	if natGateway.Model.Properties.PublicIPAddresses != nil {
@@ -159,6 +159,7 @@ func resourceNATGatewayPublicIpAssociationRead(d *pluginsdk.ResourceData, meta i
 					break
 				}
 			}
+
 			if publicIPAddressId == "" {
 				log.Printf("[DEBUG] Association between %s and %s was not found - removing from state", id.First, id.Second)
 				d.SetId("")

--- a/internal/services/network/nat_gateway_public_ip_association_resource.go
+++ b/internal/services/network/nat_gateway_public_ip_association_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -43,14 +42,14 @@ func resourceNATGatewayPublicIpAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NatGatewayID,
+				ValidateFunc: natgateways.ValidateNatGatewayID,
 			},
 
 			"public_ip_address_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.PublicIpAddressID,
+				ValidateFunc: commonids.ValidatePublicIPAddressID,
 			},
 		},
 	}

--- a/internal/services/network/nat_gateway_public_ip_association_resource_test.go
+++ b/internal/services/network/nat_gateway_public_ip_association_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -123,7 +124,9 @@ func (NatGatewayPublicAssociationResource) Destroy(ctx context.Context, client *
 		return nil, err
 	}
 
-	resp, err := client.Network.Client.NatGateways.Get(ctx, *id.First, natgateways.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	resp, err := client.Network.Client.NatGateways.Get(ctx2, *id.First, natgateways.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
@@ -145,7 +148,7 @@ func (NatGatewayPublicAssociationResource) Destroy(ctx context.Context, client *
 	}
 	resp.Model.Properties.PublicIPAddresses = &updatedAddresses
 
-	if err := client.Network.Client.NatGateways.CreateOrUpdateThenPoll(ctx, *id.First, *resp.Model); err != nil {
+	if err := client.Network.Client.NatGateways.CreateOrUpdateThenPoll(ctx2, *id.First, *resp.Model); err != nil {
 		return nil, fmt.Errorf("removing Association between %s and %s: %+v", id.First, id.Second, err)
 	}
 

--- a/internal/services/network/nat_gateway_public_ip_association_resource_test.go
+++ b/internal/services/network/nat_gateway_public_ip_association_resource_test.go
@@ -96,7 +96,25 @@ func (t NatGatewayPublicAssociationResource) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	return pointer.To(resp.Model != nil), nil
+	found := false
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.PublicIPAddresses != nil {
+				for _, pip := range *props.PublicIPAddresses {
+					if pip.Id == nil {
+						continue
+					}
+
+					if strings.EqualFold(*pip.Id, id.Second.ID()) {
+						found = true
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return pointer.To(found), nil
 }
 
 func (NatGatewayPublicAssociationResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/internal/services/network/nat_gateway_public_ip_prefix_association_resource.go
+++ b/internal/services/network/nat_gateway_public_ip_prefix_association_resource.go
@@ -62,19 +62,15 @@ func resourceNATGatewayPublicIpPrefixAssociationCreate(d *pluginsdk.ResourceData
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for NAT Gateway <-> Public IP Prefix Association creation.")
-
-	natGatewayId, err := natgateways.ParseNatGatewayID(d.Get("nat_gateway_id").(string))
-	if err != nil {
-		return err
-	}
-
 	publicIpPrefixId, err := publicipprefixes.ParsePublicIPPrefixID(d.Get("public_ip_prefix_id").(string))
 	if err != nil {
 		return err
 	}
 
-	id := commonids.NewCompositeResourceID(natGatewayId, publicIpPrefixId)
+	natGatewayId, err := natgateways.ParseNatGatewayID(d.Get("nat_gateway_id").(string))
+	if err != nil {
+		return err
+	}
 
 	locks.ByName(natGatewayId.NatGatewayName, natGatewayResourceName)
 	defer locks.UnlockByName(natGatewayId.NatGatewayName, natGatewayResourceName)
@@ -93,6 +89,8 @@ func resourceNATGatewayPublicIpPrefixAssociationCreate(d *pluginsdk.ResourceData
 	if natGateway.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", natGatewayId)
 	}
+
+	id := commonids.NewCompositeResourceID(natGatewayId, publicIpPrefixId)
 
 	publicIpPrefixes := make([]natgateways.SubResource, 0)
 	if natGateway.Model.Properties.PublicIPPrefixes != nil {
@@ -162,6 +160,7 @@ func resourceNATGatewayPublicIpPrefixAssociationRead(d *pluginsdk.ResourceData, 
 					break
 				}
 			}
+
 			if publicIPPrefixId == "" {
 				log.Printf("[DEBUG] Association between %s and %s was not found - removing from state", id.First, id.Second)
 				d.SetId("")
@@ -196,6 +195,7 @@ func resourceNATGatewayPublicIpPrefixAssociationDelete(d *pluginsdk.ResourceData
 		}
 		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
+
 	if natGateway.Model == nil {
 		return fmt.Errorf("retrieving %s: `model` was nil", id.First)
 	}

--- a/internal/services/network/nat_gateway_public_ip_prefix_association_resource.go
+++ b/internal/services/network/nat_gateway_public_ip_prefix_association_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -44,14 +43,14 @@ func resourceNATGatewayPublicIpPrefixAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NatGatewayID,
+				ValidateFunc: natgateways.ValidateNatGatewayID,
 			},
 
 			"public_ip_prefix_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.PublicIpPrefixID,
+				ValidateFunc: publicipprefixes.ValidatePublicIPPrefixID,
 			},
 		},
 	}

--- a/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
+++ b/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
@@ -129,7 +129,7 @@ func (NatGatewayPublicIpPrefixAssociationResource) Destroy(ctx context.Context, 
 	resp.Model.Properties.PublicIPPrefixes = &updatedPrefixes
 
 	if err := client.Network.Client.NatGateways.CreateOrUpdateThenPoll(ctx, *id.First, *resp.Model); err != nil {
-		return nil, fmt.Errorf("deleting %s from %s: %+v", id.Second, id.First, err)
+		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return pointer.To(true), nil

--- a/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
+++ b/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -124,7 +125,9 @@ func (NatGatewayPublicIpPrefixAssociationResource) Destroy(ctx context.Context, 
 		return nil, err
 	}
 
-	resp, err := client.Network.Client.NatGateways.Get(ctx, *id.First, natgateways.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	resp, err := client.Network.Client.NatGateways.Get(ctx2, *id.First, natgateways.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
@@ -146,7 +149,7 @@ func (NatGatewayPublicIpPrefixAssociationResource) Destroy(ctx context.Context, 
 	}
 	resp.Model.Properties.PublicIPPrefixes = &updatedPrefixes
 
-	if err := client.Network.Client.NatGateways.CreateOrUpdateThenPoll(ctx, *id.First, *resp.Model); err != nil {
+	if err := client.Network.Client.NatGateways.CreateOrUpdateThenPoll(ctx2, *id.First, *resp.Model); err != nil {
 		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
+++ b/internal/services/network/nat_gateway_public_ip_prefix_association_resource_test.go
@@ -97,7 +97,25 @@ func (t NatGatewayPublicIpPrefixAssociationResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	return pointer.To(resp.Model != nil), nil
+	found := false
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.PublicIPPrefixes != nil {
+				for _, pip := range *props.PublicIPPrefixes {
+					if pip.Id == nil {
+						continue
+					}
+
+					if strings.EqualFold(*pip.Id, id.Second.ID()) {
+						found = true
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return pointer.To(found), nil
 }
 
 func (NatGatewayPublicIpPrefixAssociationResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -6,7 +6,6 @@ package network
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -29,15 +28,8 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation() *
 		Read:   resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead,
 		Delete: resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			splitId := strings.Split(id, "|")
-			if _, err := parse.NetworkInterfaceIpConfigurationID(splitId[0]); err != nil {
-				return err
-			}
-
-			if _, err := parse.BackendAddressPoolID(splitId[1]); err != nil {
-				return err
-			}
-			return nil
+			_, err := commonids.ParseCompositeResourceID(id, &commonids.NetworkInterfaceIPConfigurationId{}, &parse.ApplicationGatewayBackendAddressPoolId{})
+			return err
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -126,7 +118,6 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationCrea
 	id := commonids.NewCompositeResourceID(&ipConfigId, backendAddressPoolId)
 
 	// first double-check it doesn't exist
-	//resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
 	if ipConfigProps.ApplicationGatewayBackendAddressPools != nil {
 		for _, existingPool := range *ipConfigProps.ApplicationGatewayBackendAddressPools {
 			if poolId := existingPool.Id; poolId != nil {

--- a/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -205,7 +205,7 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead
 
 	d.Set("backend_address_pool_id", id.Second.ID())
 	d.Set("ip_configuration_name", id.First.IpConfigurationName)
-	d.Set("network_interface_id", id.ID())
+	d.Set("network_interface_id", networkInterfaceId.ID())
 
 	return nil
 }

--- a/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -43,7 +43,7 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation() *
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkInterfaceID,
+				ValidateFunc: commonids.ValidateNetworkInterfaceID,
 			},
 
 			"ip_configuration_name": {
@@ -94,7 +94,7 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationCrea
 		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
 	}
 	if resp.Model.Properties.IPConfigurations == nil {
-		return fmt.Errorf("retrieving %s: `properties.IPConfigurations` was nil", networkInterfaceId)
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 	props := resp.Model.Properties
 
@@ -103,14 +103,14 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationCrea
 		return fmt.Errorf("IP Configuration %q was not found on %s", ipConfigurationName, *networkInterfaceId)
 	}
 	if config.Properties == nil {
-		return fmt.Errorf("`IPConfiguration.properties` was nil for %s", *networkInterfaceId)
+		return fmt.Errorf("`retrieving %s: ipConfiguration.properties` was nil", *networkInterfaceId)
 	}
 	ipConfigProps := config.Properties
 
 	pools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
 
 	ipConfigId := commonids.NewNetworkInterfaceIPConfigurationID(networkInterfaceId.SubscriptionId, networkInterfaceId.ResourceGroupName, networkInterfaceId.NetworkInterfaceName, ipConfigurationName)
-	backendAddressPoolId, err := parse.ParseApplicationGatewayBackendAddressPoolID(d.Get("backend_address_pool_id").(string))
+	backendAddressPoolId, err := parse.ApplicationGatewayBackendAddressPoolID(d.Get("backend_address_pool_id").(string))
 	if err != nil {
 		return err
 	}
@@ -200,12 +200,13 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead
 				d.SetId("")
 				return nil
 			}
-
-			d.Set("backend_address_pool_id", id.Second.ID())
-			d.Set("ip_configuration_name", id.First.IpConfigurationName)
-			d.Set("network_interface_id", id.ID())
 		}
 	}
+
+	d.Set("backend_address_pool_id", id.Second.ID())
+	d.Set("ip_configuration_name", id.First.IpConfigurationName)
+	d.Set("network_interface_id", id.ID())
+
 	return nil
 }
 

--- a/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -17,8 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation() *pluginsdk.Resource {
@@ -70,63 +72,66 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation() *
 }
 
 func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Interface <-> Application Gateway Backend Address Pool Association creation.")
-
-	networkInterfaceId := d.Get("network_interface_id").(string)
 	ipConfigurationName := d.Get("ip_configuration_name").(string)
-	backendAddressPoolId := d.Get("backend_address_pool_id").(string)
 
-	id, err := parse.NetworkInterfaceID(networkInterfaceId)
+	networkInterfaceId, err := commonids.ParseNetworkInterfaceID(d.Get("network_interface_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
+	locks.ByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, *networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("%s was not found!", *id)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", *networkInterfaceId)
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", *networkInterfaceId, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *id)
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if resp.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if resp.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.IPConfigurations` was nil", networkInterfaceId)
+	}
+	props := resp.Model.Properties
+
+	config := FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, ipConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q was not found on %s", ipConfigurationName, *networkInterfaceId)
+	}
+	if config.Properties == nil {
+		return fmt.Errorf("`IPConfiguration.properties` was nil for %s", *networkInterfaceId)
+	}
+	ipConfigProps := config.Properties
+
+	pools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
+
+	ipConfigId := commonids.NewNetworkInterfaceIPConfigurationID(networkInterfaceId.SubscriptionId, networkInterfaceId.ResourceGroupName, networkInterfaceId.NetworkInterfaceName, ipConfigurationName)
+	backendAddressPoolId, err := parse.ParseApplicationGatewayBackendAddressPoolID(d.Get("backend_address_pool_id").(string))
+	if err != nil {
+		return err
 	}
 
-	ipConfigs := props.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for %s", *id)
-	}
-
-	c := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on %s", ipConfigurationName, *id)
-	}
-
-	config := *c
-	p := config.InterfaceIPConfigurationPropertiesFormat
-	if p == nil {
-		return fmt.Errorf("Error: `IPConfiguration.properties` was nil for %s", *id)
-	}
-
-	pools := make([]network.ApplicationGatewayBackendAddressPool, 0)
+	id := commonids.NewCompositeResourceID(&ipConfigId, backendAddressPoolId)
 
 	// first double-check it doesn't exist
-	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
-	if p.ApplicationGatewayBackendAddressPools != nil {
-		for _, existingPool := range *p.ApplicationGatewayBackendAddressPools {
-			if id := existingPool.ID; id != nil {
-				if *id == backendAddressPoolId {
-					return tf.ImportAsExistsError("azurerm_network_interface_application_gateway_backend_address_pool_association", resourceId)
+	//resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
+	if ipConfigProps.ApplicationGatewayBackendAddressPools != nil {
+		for _, existingPool := range *ipConfigProps.ApplicationGatewayBackendAddressPools {
+			if poolId := existingPool.Id; poolId != nil {
+				if *poolId == backendAddressPoolId.ID() {
+					return tf.ImportAsExistsError("azurerm_network_interface_application_gateway_backend_address_pool_association", id.ID())
 				}
 
 				pools = append(pools, existingPool)
@@ -134,175 +139,147 @@ func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationCrea
 		}
 	}
 
-	pool := network.ApplicationGatewayBackendAddressPool{
-		ID: utils.String(backendAddressPoolId),
+	pool := networkinterfaces.ApplicationGatewayBackendAddressPool{
+		Id: pointer.To(backendAddressPoolId.ID()),
 	}
 	pools = append(pools, pool)
-	p.ApplicationGatewayBackendAddressPools = &pools
+	ipConfigProps.ApplicationGatewayBackendAddressPools = &pools
 
-	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, props.IPConfigurations)
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, read)
-	if err != nil {
-		return fmt.Errorf("updating Application Gateway Backend Address Pool Association for %s: %+v", *id, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *networkInterfaceId, *resp.Model); err != nil {
+		return fmt.Errorf("updating Application Gateway Backend Address Pool Association for %s: %+v", *networkInterfaceId, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for completion of Application Gateway Backend Address Pool Association for %s: %+v", *id, err)
-	}
-
-	d.SetId(resourceId)
+	d.SetId(id.ID())
 
 	return resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead(d, meta)
 }
 
 func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &parse.ApplicationGatewayBackendAddressPoolId{})
 	if err != nil {
 		return err
 	}
 
-	backendAddressPoolId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	resp, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			log.Printf("%s was not found - removing from state!", *nicID)
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("%s was not found - removing from state!", networkInterfaceId)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
-	}
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+			if config == nil {
+				log.Printf("%s was not found - removing from state!", id.First.ID())
+				d.SetId("")
+				return nil
+			}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for %s", *nicID)
-	}
+			found := false
+			if ipConfigProps := config.Properties; ipConfigProps != nil {
+				if backendPools := ipConfigProps.ApplicationGatewayBackendAddressPools; backendPools != nil {
+					for _, pool := range *backendPools {
+						if pool.Id == nil {
+							continue
+						}
 
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		log.Printf("%s was not found - removing from state!", *nicID)
-		d.SetId("")
-		return nil
-	}
-	config := *c
-
-	found := false
-	if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
-		if backendPools := props.ApplicationGatewayBackendAddressPools; backendPools != nil {
-			for _, pool := range *backendPools {
-				if pool.ID == nil {
-					continue
-				}
-
-				if *pool.ID == backendAddressPoolId {
-					found = true
-					break
+						if *pool.Id == id.Second.ID() {
+							found = true
+							break
+						}
+					}
 				}
 			}
+
+			if !found {
+				log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.First, id.Second)
+				d.SetId("")
+				return nil
+			}
+
+			d.Set("backend_address_pool_id", id.Second.ID())
+			d.Set("ip_configuration_name", id.First.IpConfigurationName)
+			d.Set("network_interface_id", id.ID())
 		}
 	}
-
-	if !found {
-		log.Printf("[DEBUG] Association between %s and Application Gateway Backend Pool %q was not found - removing from state!", *nicID, backendAddressPoolId)
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("backend_address_pool_id", backendAddressPoolId)
-	d.Set("ip_configuration_name", nicID.IpConfigurationName)
-	d.Set("network_interface_id", read.ID)
-
 	return nil
 }
 
 func resourceNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &parse.ApplicationGatewayBackendAddressPoolId{})
 	if err != nil {
 		return err
 	}
 
-	backendAddressPoolId := splitId[1]
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
-	locks.ByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	resp, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("%s was not found!", *nicID)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", networkInterfaceId)
 		}
 
-		return fmt.Errorf("retrieving %s : %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s : %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if resp.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+	if resp.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.IPConfigurations` was nil", id)
 	}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for %s", *nicID)
+	config := FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q was not found on %s", id.First.IpConfigurationName, id)
 	}
-
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	if config.Properties == nil {
+		return fmt.Errorf("`IPConfiguration.properties` was nil for %s", id)
 	}
-	config := *c
+	props := resp.Model.Properties
 
-	props := config.InterfaceIPConfigurationPropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: Properties for IPConfiguration %q was nil for Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
+	ipConfigProps := config.Properties
 
-	backendAddressPools := make([]network.ApplicationGatewayBackendAddressPool, 0)
-	if backendPools := props.ApplicationGatewayBackendAddressPools; backendPools != nil {
+	backendAddressPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
+	if backendPools := ipConfigProps.ApplicationGatewayBackendAddressPools; backendPools != nil {
 		for _, pool := range *backendPools {
-			if pool.ID == nil {
+			if pool.Id == nil {
 				continue
 			}
 
-			if *pool.ID != backendAddressPoolId {
+			if *pool.Id != id.Second.ID() {
 				backendAddressPools = append(backendAddressPools, pool)
 			}
 		}
 	}
-	props.ApplicationGatewayBackendAddressPools = &backendAddressPools
-	nicProps.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, nicProps.IPConfigurations)
+	ipConfigProps.ApplicationGatewayBackendAddressPools = &backendAddressPools
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, read)
-	if err != nil {
-		return fmt.Errorf("removing Application Gateway Backend Address Pool Association for %s: %+v", *nicID, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Application Gateway Backend Address Pool Association for %s: %+v", *nicID, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *resp.Model); err != nil {
+		return fmt.Errorf("removing %s Association for %s: %+v", id.Second, id.First, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_application_gateway_association_resource_test.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -148,7 +149,9 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) d
 
 	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	resp, err := client.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	resp, err := client.Network.Client.NetworkInterfaces.Get(ctx2, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -168,7 +171,7 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) d
 	}
 	config.Properties.ApplicationGatewayBackendAddressPools = &updatedPools
 
-	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *resp.Model); err != nil {
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx2, networkInterfaceId, *resp.Model); err != nil {
 		return fmt.Errorf("removing Application Gateway Backend Address Pool Association for %s: %+v", networkInterfaceId, err)
 	}
 

--- a/internal/services/network/network_interface_application_gateway_association_resource_test.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	network2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -116,7 +116,7 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) E
 		return nil, fmt.Errorf("retrieving %s: `properties.IPConfigurations` was nil", id)
 	}
 
-	config := network2.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	config := network.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
 	if config == nil {
 		return nil, fmt.Errorf("IP configuration was nil for %s: %+v", id, err)
 	}
@@ -154,7 +154,7 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) d
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	config := network2.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, ipConfigurationName)
+	config := network.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, ipConfigurationName)
 	if config == nil {
 		return fmt.Errorf("IP Configuration %q wasn't found for %s", ipConfigurationName, id)
 	}

--- a/internal/services/network/network_interface_application_gateway_association_resource_test.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource_test.go
@@ -6,17 +6,17 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	network2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource struct{}
@@ -94,48 +94,42 @@ func TestAccNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_upda
 }
 
 func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	splitId := strings.Split(state.ID, "|")
-	if len(splitId) != 2 {
-		return nil, fmt.Errorf("expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", state.ID)
-	}
-
-	id, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &parse.ApplicationGatewayBackendAddressPoolId{})
 	if err != nil {
 		return nil, err
 	}
 
-	backendAddressPoolId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := clients.Network.InterfacesClient.Get(ctx, id.ResourceGroup, id.NetworkInterfaceName, "")
+	resp, err := clients.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading NetworkInterfaceApplicationGatewayBackendAddressPoolAssociation (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return nil, fmt.Errorf("`properties` was nil for (%s): %+v", id, err)
+	if resp.Model == nil {
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if resp.Model.Properties == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+	if resp.Model.Properties.IPConfigurations == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties.IPConfigurations` was nil", id)
 	}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return nil, fmt.Errorf("`properties.IPConfigurations` was nil for  (%s): %+v", id, err)
+	config := network2.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return nil, fmt.Errorf("IP configuration was nil for %s: %+v", id, err)
 	}
-
-	c := network2.FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, id.IpConfigurationName)
-	if c == nil {
-		return nil, fmt.Errorf("IP configuration was nil for (%s): %+v", id, err)
-	}
-	config := *c
 
 	found := false
-	if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
+	if props := config.Properties; props != nil {
 		if backendPools := props.ApplicationGatewayBackendAddressPools; backendPools != nil {
 			for _, pool := range *backendPools {
-				if pool.ID == nil {
+				if pool.Id == nil {
 					continue
 				}
 
-				if *pool.ID == backendAddressPoolId {
+				if *pool.Id == id.Second.ID() {
 					found = true
 					break
 				}
@@ -143,11 +137,11 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) E
 		}
 	}
 
-	return utils.Bool(found), nil
+	return pointer.To(found), nil
 }
 
 func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
+	id, err := commonids.ParseNetworkInterfaceID(state.Attributes["network_interface_id"])
 	if err != nil {
 		return err
 	}
@@ -155,34 +149,28 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) d
 	backendAddressPoolId := state.Attributes["backend_address_pool_id"]
 	ipConfigurationName := state.Attributes["ip_configuration_name"]
 
-	read, err := client.Network.InterfacesClient.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	resp, err := client.Network.Client.NetworkInterfaces.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v", nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	c := network2.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("IP Configuration %q wasn't found for %s", ipConfigurationName, nicID)
+	config := network2.FindNetworkInterfaceIPConfiguration(resp.Model.Properties.IPConfigurations, ipConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q wasn't found for %s", ipConfigurationName, id)
 	}
-	config := *c
 
-	updatedPools := make([]network.ApplicationGatewayBackendAddressPool, 0)
-	if config.InterfaceIPConfigurationPropertiesFormat.ApplicationGatewayBackendAddressPools != nil {
-		for _, pool := range *config.InterfaceIPConfigurationPropertiesFormat.ApplicationGatewayBackendAddressPools {
-			if *pool.ID != backendAddressPoolId {
+	updatedPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
+	if config.Properties.ApplicationGatewayBackendAddressPools != nil {
+		for _, pool := range *config.Properties.ApplicationGatewayBackendAddressPools {
+			if *pool.Id != backendAddressPoolId {
 				updatedPools = append(updatedPools, pool)
 			}
 		}
 	}
-	config.InterfaceIPConfigurationPropertiesFormat.ApplicationGatewayBackendAddressPools = &updatedPools
+	config.Properties.ApplicationGatewayBackendAddressPools = &updatedPools
 
-	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.Name, read)
-	if err != nil {
-		return fmt.Errorf("removing Application Gateway Backend Address Pool Association for %s: %+v", nicID, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Application Gateway Backend Address Pool Association for %s: %+v", nicID, err)
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, *id, *resp.Model); err != nil {
+		return fmt.Errorf("removing Application Gateway Backend Address Pool Association for %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -6,7 +6,6 @@ package network
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -29,14 +28,8 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *pluginsdk.Re
 		Read:   resourceNetworkInterfaceApplicationSecurityGroupAssociationRead,
 		Delete: resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			splitId := strings.Split(id, "|")
-			if _, err := commonids.ParseNetworkInterfaceID(splitId[0]); err != nil {
-				return err
-			}
-			if _, err := applicationsecuritygroups.ParseApplicationSecurityGroupID(splitId[1]); err != nil {
-				return err
-			}
-			return nil
+			_, err := commonids.ParseCompositeResourceID(id, &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
+			return err
 		}),
 
 		SchemaVersion: 1,
@@ -75,56 +68,58 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 
 	log.Printf("[INFO] preparing arguments for Network Interface <-> Application Security Group Association creation.")
 
-	networkInterfaceId := d.Get("network_interface_id").(string)
-	applicationSecurityGroupId := d.Get("application_security_group_id").(string)
-
-	id, err := commonids.ParseNetworkInterfaceID(networkInterfaceId)
+	applicationSecurityGroupId, err := applicationsecuritygroups.ParseApplicationSecurityGroupID(d.Get("application_security_group_id").(string))
+	if err != nil {
+		return err
+	}
+	networkInterfaceId, err := commonids.ParseNetworkInterfaceID(d.Get("network_interface_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
+	locks.ByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
+	read, err := client.Get(ctx, *networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(read.HttpResponse) {
-			log.Printf("[INFO] Network Interface %q does not exist - removing from state", d.Id())
+			log.Printf("[INFO] %s does not exist - removing from state", networkInterfaceId.ID())
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", *networkInterfaceId, err)
 	}
 
 	if read.Model == nil {
-		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
 	}
 
 	props := read.Model.Properties
 	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *id)
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
 	}
 	if props.IPConfigurations == nil {
-		return fmt.Errorf("Error: `properties.ipConfigurations` was nil for %s", *id)
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
 	info := parseFieldsFromNetworkInterface(*props)
-	resourceId := fmt.Sprintf("%s|%s", networkInterfaceId, applicationSecurityGroupId)
-	if utils.SliceContainsValue(info.applicationSecurityGroupIDs, applicationSecurityGroupId) {
-		return tf.ImportAsExistsError("azurerm_network_interface_application_security_group_association", resourceId)
+	id := commonids.NewCompositeResourceID(networkInterfaceId, applicationSecurityGroupId)
+
+	if utils.SliceContainsValue(info.applicationSecurityGroupIDs, applicationSecurityGroupId.ID()) {
+		return tf.ImportAsExistsError("azurerm_network_interface_application_security_group_association", id.ID())
 	}
 
-	info.applicationSecurityGroupIDs = append(info.applicationSecurityGroupIDs, applicationSecurityGroupId)
+	info.applicationSecurityGroupIDs = append(info.applicationSecurityGroupIDs, applicationSecurityGroupId.ID())
 
 	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, *read.Model)
+	err = client.CreateOrUpdateThenPoll(ctx, *networkInterfaceId, *read.Model)
 	if err != nil {
-		return fmt.Errorf("updating Application Security Group Association for %s: %+v", *id, err)
+		return fmt.Errorf("updating Application Security Group Association for %s: %+v", *networkInterfaceId, err)
 	}
 
-	d.SetId(resourceId)
+	d.SetId(id.ID())
 
 	return resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d, meta)
 }
@@ -134,51 +129,44 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d *pluginsd
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{applicationSecurityGroupId} but got %q", d.Id())
-	}
-
-	nicID, err := commonids.ParseNetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	applicationSecurityGroupId := splitId[1]
-
-	read, err := client.Get(ctx, *nicID, networkinterfaces.DefaultGetOperationOptions())
+	read, err := client.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(read.HttpResponse) {
-			log.Printf("[DEBUG] %s was not found - removing from state!", *nicID)
+			log.Printf("[DEBUG] %s was not found - removing from state!", id.First)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
 	if model := read.Model; model != nil {
 		nicProps := read.Model.Properties
 		if nicProps == nil {
-			return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
+			return fmt.Errorf("retrieving %s: `properties` was nil", id.First)
 		}
 
 		info := parseFieldsFromNetworkInterface(*nicProps)
 		exists := false
 		for _, groupId := range info.applicationSecurityGroupIDs {
-			if groupId == applicationSecurityGroupId {
+			if groupId == id.Second.ID() {
 				exists = true
 			}
 		}
 
 		if !exists {
-			log.Printf("[DEBUG] Association between %s and Application Security Group %q was not found - removing from state!", *nicID, applicationSecurityGroupId)
+			log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.First, id.Second)
 			d.SetId("")
 			return nil
 		}
 
-		d.Set("application_security_group_id", applicationSecurityGroupId)
-		d.Set("network_interface_id", model.Id)
+		d.Set("application_security_group_id", id.Second.ID())
+		d.Set("network_interface_id", id.First.ID())
 	}
 
 	return nil
@@ -189,57 +177,50 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *plugin
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{applicationSecurityGroupId} but got %q", d.Id())
-	}
-
-	nicID, err := commonids.ParseNetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	applicationSecurityGroupId := splitId[1]
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
-	locks.ByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
-
-	read, err := client.Get(ctx, *nicID, networkinterfaces.DefaultGetOperationOptions())
+	read, err := client.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(read.HttpResponse) {
-			return fmt.Errorf("%s was not found!", *nicID)
+			return fmt.Errorf("%s was not found", id.First)
 		}
 
-		return fmt.Errorf("retrieving  %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
 	if read.Model == nil {
-		return fmt.Errorf("retrieving %s: `model` was nil", *nicID)
+		return fmt.Errorf("retrieving %s: `model` was nil", id.First)
 	}
 
 	props := read.Model.Properties
 	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
+		return fmt.Errorf("retrieving %s: `properties` was nil for %s", id.First)
 	}
 
 	if props.IPConfigurations == nil {
-		return fmt.Errorf("Error: `properties.ipConfigurations` was nil for %s)", *nicID)
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil)", id.First)
 	}
 
 	info := parseFieldsFromNetworkInterface(*props)
 
 	applicationSecurityGroupIds := make([]string, 0)
 	for _, v := range info.applicationSecurityGroupIDs {
-		if v != applicationSecurityGroupId {
+		if v != id.Second.ID() {
 			applicationSecurityGroupIds = append(applicationSecurityGroupIds, v)
 		}
 	}
 	info.applicationSecurityGroupIDs = applicationSecurityGroupIds
 	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	err = client.CreateOrUpdateThenPoll(ctx, *nicID, *read.Model)
+	err = client.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model)
 	if err != nil {
-		return fmt.Errorf("removing Application Security Group for %s: %+v", *nicID, err)
+		return fmt.Errorf("removing Application Security Group for %s: %+v", id.First, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/migration"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -48,7 +47,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *pluginsdk.Re
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkInterfaceID,
+				ValidateFunc: commonids.ValidateNetworkInterfaceID,
 			},
 
 			"application_security_group_id": {
@@ -164,10 +163,10 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d *pluginsd
 			d.SetId("")
 			return nil
 		}
-
-		d.Set("application_security_group_id", id.Second.ID())
-		d.Set("network_interface_id", id.First.ID())
 	}
+
+	d.Set("application_security_group_id", id.Second.ID())
+	d.Set("network_interface_id", id.First.ID())
 
 	return nil
 }
@@ -200,7 +199,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *plugin
 
 	props := read.Model.Properties
 	if props == nil {
-		return fmt.Errorf("retrieving %s: `properties` was nil for %s", id.First)
+		return fmt.Errorf("retrieving %s: `properties` was nil", id.First)
 	}
 
 	if props.IPConfigurations == nil {

--- a/internal/services/network/network_interface_application_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource_test.go
@@ -6,16 +6,16 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/applicationsecuritygroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type NetworkInterfaceApplicationSecurityGroupAssociationResource struct{}
@@ -103,72 +103,80 @@ func TestAccNetworkInterfaceApplicationSecurityGroupAssociation_updateNIC(t *tes
 }
 
 func (t NetworkInterfaceApplicationSecurityGroupAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	splitId := strings.Split(state.ID, "|")
-	if len(splitId) != 2 {
-		return nil, fmt.Errorf("expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", state.ID)
-	}
-
-	id, err := parse.NetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
 	if err != nil {
 		return nil, err
 	}
-	applicationSecurityGroupId := splitId[1]
 
-	read, err := clients.Network.InterfacesClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	read, err := clients.Network.Client.NetworkInterfaces.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
+	}
+
+	if read.Model == nil {
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", id.First)
+	}
+	if read.Model.Properties == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties` was nil", id.First)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", id.First)
 	}
 
 	found := false
-	for _, config := range *read.InterfacePropertiesFormat.IPConfigurations {
-		if config.ApplicationSecurityGroups != nil {
-			for _, group := range *config.ApplicationSecurityGroups {
-				if *group.ID == applicationSecurityGroupId {
-					found = true
-					break
+	for _, config := range *read.Model.Properties.IPConfigurations {
+		if props := config.Properties; props != nil {
+			if props.ApplicationSecurityGroups != nil {
+				for _, group := range *props.ApplicationSecurityGroups {
+					if *group.Id == id.Second.ID() {
+						found = true
+						break
+					}
 				}
 			}
 		}
 	}
 
-	return utils.Bool(found), nil
+	return pointer.To(found), nil
 }
 
 func (NetworkInterfaceApplicationSecurityGroupAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	applicationSecurityGroupId := state.Attributes["application_security_group_id"]
-
-	read, err := client.Network.InterfacesClient.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
+	}
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id.First)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id.First)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", id.First)
 	}
 
-	configs := *read.InterfacePropertiesFormat.IPConfigurations
+	configs := *read.Model.Properties.IPConfigurations
 	for _, config := range configs {
-		if config.ApplicationSecurityGroups != nil {
-			groups := make([]network.ApplicationSecurityGroup, 0)
-			for _, group := range *config.ApplicationSecurityGroups {
-				if *group.ID != applicationSecurityGroupId {
+		if props := config.Properties; props != nil {
+			groups := make([]networkinterfaces.ApplicationSecurityGroup, 0)
+			for _, group := range *props.ApplicationSecurityGroups {
+				if *group.Id != id.Second.ID() {
 					groups = append(groups, group)
 				}
 			}
-			config.ApplicationSecurityGroups = &groups
+			props.ApplicationSecurityGroups = &groups
 		}
 	}
 
-	read.InterfacePropertiesFormat.IPConfigurations = &configs
+	read.Model.Properties.IPConfigurations = &configs
 
-	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.Name, read)
-	if err != nil {
-		return fmt.Errorf("removing Application Security Group Association for %s: %+v", *nicID, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Application Security Group Association for %s: %+v", *nicID, err)
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model); err != nil {
+		return fmt.Errorf("removing Application Security Group Association for %s: %+v", id.First, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_application_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -142,7 +143,9 @@ func (NetworkInterfaceApplicationSecurityGroupAssociationResource) destroy(ctx c
 		return err
 	}
 
-	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx2, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
@@ -171,7 +174,7 @@ func (NetworkInterfaceApplicationSecurityGroupAssociationResource) destroy(ctx c
 
 	read.Model.Properties.IPConfigurations = &configs
 
-	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model); err != nil {
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx2, *id.First, *read.Model); err != nil {
 		return fmt.Errorf("removing Application Security Group Association for %s: %+v", id.First, err)
 	}
 

--- a/internal/services/network/network_interface_application_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource_test.go
@@ -113,24 +113,20 @@ func (t NetworkInterfaceApplicationSecurityGroupAssociationResource) Exists(ctx 
 		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	if read.Model == nil {
-		return nil, fmt.Errorf("retrieving %s: `model` was nil", id.First)
-	}
-	if read.Model.Properties == nil {
-		return nil, fmt.Errorf("retrieving %s: `properties` was nil", id.First)
-	}
-	if read.Model.Properties.IPConfigurations == nil {
-		return nil, fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", id.First)
-	}
-
 	found := false
-	for _, config := range *read.Model.Properties.IPConfigurations {
-		if props := config.Properties; props != nil {
-			if props.ApplicationSecurityGroups != nil {
-				for _, group := range *props.ApplicationSecurityGroups {
-					if *group.Id == id.Second.ID() {
-						found = true
-						break
+	if model := read.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.IPConfigurations != nil {
+				for _, config := range *props.IPConfigurations {
+					if ipConfigProps := config.Properties; ipConfigProps != nil {
+						if ipConfigProps.ApplicationSecurityGroups != nil {
+							for _, group := range *ipConfigProps.ApplicationSecurityGroups {
+								if *group.Id == id.Second.ID() {
+									found = true
+									break
+								}
+							}
+						}
 					}
 				}
 			}

--- a/internal/services/network/network_interface_backend_address_pool_association_resource.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -44,7 +42,7 @@ func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkInterfaceID,
+				ValidateFunc: commonids.ValidateNetworkInterfaceID,
 			},
 
 			"ip_configuration_name": {
@@ -58,7 +56,7 @@ func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: loadBalancerValidate.LoadBalancerBackendAddressPoolID,
+				ValidateFunc: loadbalancers.ValidateBackendAddressPoolID,
 			},
 		},
 	}
@@ -104,7 +102,7 @@ func resourceNetworkInterfaceBackendAddressPoolAssociationCreate(d *pluginsdk.Re
 
 	config := FindNetworkInterfaceIPConfiguration(read.Model.Properties.IPConfigurations, ipConfigId.IpConfigurationName)
 	if config == nil {
-		return fmt.Errorf("retrieving %s: IP Configuration %q was not found", ipConfigId.IpConfigurationName, networkInterfaceId)
+		return fmt.Errorf("IP Configuration %q was not found on %s", ipConfigId.IpConfigurationName, networkInterfaceId)
 	}
 
 	ipConfigProps := config.Properties

--- a/internal/services/network/network_interface_backend_address_pool_association_resource.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource.go
@@ -6,21 +6,21 @@ package network
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/loadbalancers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	loadBalancerParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/parse"
 	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource {
@@ -29,14 +29,8 @@ func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource
 		Read:   resourceNetworkInterfaceBackendAddressPoolAssociationRead,
 		Delete: resourceNetworkInterfaceBackendAddressPoolAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			splitId := strings.Split(id, "|")
-			if _, err := parse.NetworkInterfaceIpConfigurationID(splitId[0]); err != nil {
-				return err
-			}
-			if _, err := loadBalancerParse.LoadBalancerBackendAddressPoolID(splitId[1]); err != nil {
-				return err
-			}
-			return nil
+			_, err := commonids.ParseCompositeResourceID(id, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
+			return err
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -71,63 +65,62 @@ func resourceNetworkInterfaceBackendAddressPoolAssociation() *pluginsdk.Resource
 }
 
 func resourceNetworkInterfaceBackendAddressPoolAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Interface <-> Load Balancer Backend Address Pool Association creation.")
-
-	networkInterfaceId := d.Get("network_interface_id").(string)
-	ipConfigurationName := d.Get("ip_configuration_name").(string)
-	backendAddressPoolId := d.Get("backend_address_pool_id").(string)
-
-	id, err := parse.NetworkInterfaceID(networkInterfaceId)
+	networkInterfaceId, err := commonids.ParseNetworkInterfaceID(d.Get("network_interface_id").(string))
 	if err != nil {
 		return err
 	}
-
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
-
-	read, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	backendAddressPoolId, err := loadbalancers.ParseBackendAddressPoolID(d.Get("backend_address_pool_id").(string))
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("%s was not found!", *id)
+		return err
+	}
+	ipConfigId := commonids.NewNetworkInterfaceIPConfigurationID(networkInterfaceId.SubscriptionId, networkInterfaceId.ResourceGroupName, networkInterfaceId.NetworkInterfaceName, d.Get("ip_configuration_name").(string))
+
+	locks.ByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+
+	read, err := client.Get(ctx, *networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf("%s was not found", networkInterfaceId)
 		}
-
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *id)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
-	ipConfigs := props.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for %s", *id)
+	props := read.Model.Properties
+
+	config := FindNetworkInterfaceIPConfiguration(read.Model.Properties.IPConfigurations, ipConfigId.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("retrieving %s: IP Configuration %q was not found", ipConfigId.IpConfigurationName, networkInterfaceId)
 	}
 
-	c := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on %s", ipConfigurationName, *id)
+	ipConfigProps := config.Properties
+	if ipConfigProps == nil {
+		return fmt.Errorf("retrieving %s: `ipConfiguration.properties` was nil", networkInterfaceId)
 	}
 
-	config := *c
-	p := config.InterfaceIPConfigurationPropertiesFormat
-	if p == nil {
-		return fmt.Errorf("Error: `IPConfiguration.properties` was nil for %s", *id)
-	}
-
-	pools := make([]network.BackendAddressPool, 0)
+	id := commonids.NewCompositeResourceID(&ipConfigId, backendAddressPoolId)
+	pools := make([]networkinterfaces.BackendAddressPool, 0)
 
 	// first double-check it doesn't exist
-	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
-	if p.LoadBalancerBackendAddressPools != nil {
-		for _, existingPool := range *p.LoadBalancerBackendAddressPools {
-			if id := existingPool.ID; id != nil {
-				if *id == backendAddressPoolId {
-					return tf.ImportAsExistsError("azurerm_network_interface_backend_address_pool_association", resourceId)
+	if ipConfigProps.LoadBalancerBackendAddressPools != nil {
+		for _, existingPool := range *ipConfigProps.LoadBalancerBackendAddressPools {
+			if poolId := existingPool.Id; poolId != nil {
+				if *poolId == backendAddressPoolId.ID() {
+					return tf.ImportAsExistsError("azurerm_network_interface_backend_address_pool_association", id.ID())
 				}
 
 				pools = append(pools, existingPool)
@@ -135,175 +128,146 @@ func resourceNetworkInterfaceBackendAddressPoolAssociationCreate(d *pluginsdk.Re
 		}
 	}
 
-	pool := network.BackendAddressPool{
-		ID: utils.String(backendAddressPoolId),
+	pool := networkinterfaces.BackendAddressPool{
+		Id: pointer.To(backendAddressPoolId.ID()),
 	}
 	pools = append(pools, pool)
-	p.LoadBalancerBackendAddressPools = &pools
+	ipConfigProps.LoadBalancerBackendAddressPools = &pools
 
-	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, props.IPConfigurations)
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, read)
-	if err != nil {
-		return fmt.Errorf("updating Backend Address Pool Association for %s: %+v", *id, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("updating Backend Address Pool Association for %s: %+v", id, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for completion of Backend Address Pool Association for %s: %+v", *id, err)
-	}
-
-	d.SetId(resourceId)
+	d.SetId(id.ID())
 
 	return resourceNetworkInterfaceBackendAddressPoolAssociationRead(d, meta)
 }
 
 func resourceNetworkInterfaceBackendAddressPoolAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
 	if err != nil {
 		return err
 	}
 
-	backendAddressPoolId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	read, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+		if response.WasNotFound(read.HttpResponse) {
+			log.Printf("%s was not found - removing from state!", networkInterfaceId)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
+	if model := read.Model; model != nil {
+		if props := model.Properties; props != nil {
+			config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+			if config == nil {
+				log.Printf("IP Configuration %q was not found in %s - removing from state!", id.First.IpConfigurationName, networkInterfaceId)
+				d.SetId("")
+				return nil
+			}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
+			found := false
+			if ipConfigProps := config.Properties; ipConfigProps != nil {
+				if backendPools := ipConfigProps.LoadBalancerBackendAddressPools; backendPools != nil {
+					for _, pool := range *backendPools {
+						if pool.Id == nil {
+							continue
+						}
 
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		log.Printf("IP Configuration %q was not found in Network Interface %q (Resource Group %q) - removing from state!", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
-		d.SetId("")
-		return nil
-	}
-	config := *c
-
-	found := false
-	if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
-		if backendPools := props.LoadBalancerBackendAddressPools; backendPools != nil {
-			for _, pool := range *backendPools {
-				if pool.ID == nil {
-					continue
+						if *pool.Id == id.Second.ID() {
+							found = true
+							break
+						}
+					}
 				}
-
-				if *pool.ID == backendAddressPoolId {
-					found = true
-					break
-				}
+			}
+			if !found {
+				log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.First, id.Second)
+				d.SetId("")
+				return nil
 			}
 		}
 	}
 
-	if !found {
-		log.Printf("[DEBUG] Association between Network Interface %q (Resource Group %q) and Load Balancer Backend Pool %q was not found - removing from state!", nicID.NetworkInterfaceName, nicID.ResourceGroup, backendAddressPoolId)
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("backend_address_pool_id", backendAddressPoolId)
-	d.Set("ip_configuration_name", nicID.IpConfigurationName)
-	d.Set("network_interface_id", read.ID)
+	d.Set("backend_address_pool_id", id.Second.ID())
+	d.Set("ip_configuration_name", id.First.IpConfigurationName)
+	d.Set("network_interface_id", networkInterfaceId.ID())
 
 	return nil
 }
 
 func resourceNetworkInterfaceBackendAddressPoolAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
 	if err != nil {
 		return err
 	}
 
-	backendAddressPoolId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	locks.ByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	read, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf("%s was not found", networkInterfaceId)
 		}
-
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	props := read.Model.Properties
+	config := FindNetworkInterfaceIPConfiguration(read.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q was not found on %s", id.First.IpConfigurationName, networkInterfaceId)
 	}
 
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
-	config := *c
-
-	props := config.InterfaceIPConfigurationPropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: Properties for IPConfiguration %q was nil for Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	ipConfigProps := config.Properties
+	if ipConfigProps == nil {
+		return fmt.Errorf("retrieving %s: `properties` for IPConfiguration %q was nil", id.First.IpConfigurationName, networkInterfaceId)
 	}
 
-	backendAddressPools := make([]network.BackendAddressPool, 0)
-	if backendPools := props.LoadBalancerBackendAddressPools; backendPools != nil {
+	backendAddressPools := make([]networkinterfaces.BackendAddressPool, 0)
+	if backendPools := ipConfigProps.LoadBalancerBackendAddressPools; backendPools != nil {
 		for _, pool := range *backendPools {
-			if pool.ID == nil {
+			if pool.Id == nil {
 				continue
 			}
 
-			if *pool.ID != backendAddressPoolId {
+			if *pool.Id != id.Second.ID() {
 				backendAddressPools = append(backendAddressPools, pool)
 			}
 		}
 	}
-	props.LoadBalancerBackendAddressPools = &backendAddressPools
-	nicProps.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, nicProps.IPConfigurations)
+	ipConfigProps.LoadBalancerBackendAddressPools = &backendAddressPools
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, read)
-	if err != nil {
-		return fmt.Errorf("removing Backend Address Pool Association for Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Backend Address Pool Association for NIC %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("removing Backend Address Pool Association for %s: %+v", networkInterfaceId, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -142,7 +143,9 @@ func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, c
 
 	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx2, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
@@ -162,7 +165,7 @@ func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, c
 	}
 	config.Properties.LoadBalancerBackendAddressPools = &updatedPools
 
-	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx2, networkInterfaceId, *read.Model); err != nil {
 		return fmt.Errorf("removing Backend Address Pool Association for %s: %+v", networkInterfaceId, err)
 	}
 

--- a/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
@@ -6,17 +6,17 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/loadbalancers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	network2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type NetworkInterfaceBackendAddressPoolResource struct{}
@@ -94,86 +94,76 @@ func TestAccNetworkInterfaceBackendAddressPoolAssociation_updateNIC(t *testing.T
 }
 
 func (t NetworkInterfaceBackendAddressPoolResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	splitId := strings.Split(state.ID, "|")
-	if len(splitId) != 2 {
-		return nil, fmt.Errorf("expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId} but got %q", state.ID)
-	}
-
-	id, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
 	if err != nil {
 		return nil, err
 	}
 
-	backendAddressPoolId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := clients.Network.InterfacesClient.Get(ctx, id.ResourceGroup, id.NetworkInterfaceName, "")
+	read, err := clients.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return nil, fmt.Errorf("`properties` was nil for %s: %+v", *id, err)
+	if read.Model == nil {
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
-	c := network2.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, id.IpConfigurationName)
-	if c == nil {
-		return nil, fmt.Errorf("IP Configuration %q wasn't found for %s", id.IpConfigurationName, *id)
+	config := network.FindNetworkInterfaceIPConfiguration(read.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return nil, fmt.Errorf("IP Configuration %q wasn't found for %s", id.First.IpConfigurationName, networkInterfaceId)
 	}
-	config := *c
 
 	found := false
-	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools != nil {
-		for _, pool := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools {
-			if *pool.ID == backendAddressPoolId {
+	if config.Properties.LoadBalancerBackendAddressPools != nil {
+		for _, pool := range *config.Properties.LoadBalancerBackendAddressPools {
+			if *pool.Id == id.Second.ID() {
 				found = true
 				break
 			}
 		}
 	}
 
-	return utils.Bool(found), nil
+	return pointer.To(found), nil
 }
 
 func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
 	if err != nil {
 		return err
 	}
 
-	nicName := nicID.Name
-	resourceGroup := nicID.ResourceGroup
-	backendAddressPoolId := state.Attributes["backend_address_pool_id"]
-	ipConfigurationName := state.Attributes["ip_configuration_name"]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Network.InterfacesClient.Get(ctx, resourceGroup, nicName, "")
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	c := network2.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+	config := network.FindNetworkInterfaceIPConfiguration(read.Model.Properties.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q wasn't found for %s", id.First.IpConfigurationName, networkInterfaceId)
 	}
-	config := *c
 
-	updatedPools := make([]network.BackendAddressPool, 0)
-	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools != nil {
-		for _, pool := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools {
-			if *pool.ID != backendAddressPoolId {
+	updatedPools := make([]networkinterfaces.BackendAddressPool, 0)
+	if config.Properties.LoadBalancerBackendAddressPools != nil {
+		for _, pool := range *config.Properties.LoadBalancerBackendAddressPools {
+			if *pool.Id != id.Second.ID() {
 				updatedPools = append(updatedPools, pool)
 			}
 		}
 	}
-	config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &updatedPools
+	config.Properties.LoadBalancerBackendAddressPools = &updatedPools
 
-	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, resourceGroup, nicName, read)
-	if err != nil {
-		return fmt.Errorf("removing Backend Address Pool Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Backend Address Pool Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("removing Backend Address Pool Association for %s: %+v", networkInterfaceId, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_helpers.go
+++ b/internal/services/network/network_interface_helpers.go
@@ -3,9 +3,11 @@
 
 package network
 
-import "github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
+)
 
-func FindNetworkInterfaceIPConfiguration(input *[]network.InterfaceIPConfiguration, name string) *network.InterfaceIPConfiguration {
+func FindNetworkInterfaceIPConfiguration(input *[]networkinterfaces.NetworkInterfaceIPConfiguration, name string) *networkinterfaces.NetworkInterfaceIPConfiguration {
 	if input == nil {
 		return nil
 	}
@@ -23,8 +25,8 @@ func FindNetworkInterfaceIPConfiguration(input *[]network.InterfaceIPConfigurati
 	return nil
 }
 
-func updateNetworkInterfaceIPConfiguration(config network.InterfaceIPConfiguration, configs *[]network.InterfaceIPConfiguration) *[]network.InterfaceIPConfiguration {
-	output := make([]network.InterfaceIPConfiguration, 0)
+func updateNetworkInterfaceIPConfiguration(config networkinterfaces.NetworkInterfaceIPConfiguration, configs *[]networkinterfaces.NetworkInterfaceIPConfiguration) *[]networkinterfaces.NetworkInterfaceIPConfiguration {
+	output := make([]networkinterfaces.NetworkInterfaceIPConfiguration, 0)
 	if configs == nil {
 		return &output
 	}

--- a/internal/services/network/network_interface_nat_rule_association_resource.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -44,7 +42,7 @@ func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkInterfaceID,
+				ValidateFunc: commonids.ValidateNetworkInterfaceID,
 			},
 
 			"ip_configuration_name": {
@@ -58,7 +56,7 @@ func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: loadBalancerValidate.LoadBalancerInboundNatRuleID,
+				ValidateFunc: loadbalancers.ValidateInboundNatRuleID,
 			},
 		},
 	}
@@ -107,7 +105,7 @@ func resourceNetworkInterfaceNatRuleAssociationCreate(d *pluginsdk.ResourceData,
 
 	config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigId.IpConfigurationName)
 	if config == nil {
-		return fmt.Errorf("retrieving %s: IP Configuration %q was not found", networkInterfaceId, ipConfigId.IpConfigurationName)
+		return fmt.Errorf("IP Configuration %q was not found for %s", ipConfigId.IpConfigurationName, networkInterfaceId)
 	}
 
 	ipConfigProps := config.Properties
@@ -205,12 +203,12 @@ func resourceNetworkInterfaceNatRuleAssociationRead(d *pluginsdk.ResourceData, m
 				d.SetId("")
 				return nil
 			}
-
-			d.Set("ip_configuration_name", id.First.IpConfigurationName)
-			d.Set("nat_rule_id", id.Second.ID())
-			d.Set("network_interface_id", networkInterfaceId.ID())
 		}
 	}
+
+	d.Set("ip_configuration_name", id.First.IpConfigurationName)
+	d.Set("nat_rule_id", id.Second.ID())
+	d.Set("network_interface_id", networkInterfaceId.ID())
 
 	return nil
 }
@@ -253,7 +251,7 @@ func resourceNetworkInterfaceNatRuleAssociationDelete(d *pluginsdk.ResourceData,
 
 	config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
 	if config == nil {
-		return fmt.Errorf("retrieving %s: IP Configuration %q was not found on", networkInterfaceId, id.First.IpConfigurationName)
+		return fmt.Errorf("IP Configuration %q was not found for %s", id.First.IpConfigurationName, networkInterfaceId)
 	}
 
 	ipConfigProps := config.Properties

--- a/internal/services/network/network_interface_nat_rule_association_resource.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource.go
@@ -6,21 +6,21 @@ package network
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/loadbalancers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	loadBalancerParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/parse"
 	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
@@ -29,14 +29,8 @@ func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
 		Read:   resourceNetworkInterfaceNatRuleAssociationRead,
 		Delete: resourceNetworkInterfaceNatRuleAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			splitId := strings.Split(id, "|")
-			if _, err := parse.NetworkInterfaceIpConfigurationID(splitId[0]); err != nil {
-				return err
-			}
-			if _, err := loadBalancerParse.LoadBalancerInboundNatRuleID(splitId[1]); err != nil {
-				return err
-			}
-			return nil
+			_, err := commonids.ParseCompositeResourceID(id, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
+			return err
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -71,63 +65,65 @@ func resourceNetworkInterfaceNatRuleAssociation() *pluginsdk.Resource {
 }
 
 func resourceNetworkInterfaceNatRuleAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Interface <-> Load Balancer NAT Rule Association creation.")
-
-	networkInterfaceId := d.Get("network_interface_id").(string)
-	ipConfigurationName := d.Get("ip_configuration_name").(string)
-	natRuleId := d.Get("nat_rule_id").(string)
-
-	id, err := parse.NetworkInterfaceID(networkInterfaceId)
+	networkInterfaceId, err := commonids.ParseNetworkInterfaceID(d.Get("network_interface_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
-
-	read, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	natRuleId, err := loadbalancers.ParseInboundNatRuleID(d.Get("nat_rule_id").(string))
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf(" %s was not found!", *id)
+		return err
+	}
+
+	ipConfigId := commonids.NewNetworkInterfaceIPConfigurationID(networkInterfaceId.SubscriptionId, networkInterfaceId.ResourceGroupName, networkInterfaceId.NetworkInterfaceName, d.Get("ip_configuration_name").(string))
+
+	locks.ByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(networkInterfaceId.NetworkInterfaceName, networkInterfaceResourceName)
+
+	read, err := client.Get(ctx, *networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf(" %s was not found!", networkInterfaceId)
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *id)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
-	ipConfigs := props.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for %s", *id)
+	props := read.Model.Properties
+
+	config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigId.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("retrieving %s: IP Configuration %q was not found", networkInterfaceId, ipConfigId.IpConfigurationName)
 	}
 
-	c := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on %s", ipConfigurationName, *id)
+	ipConfigProps := config.Properties
+	if ipConfigProps == nil {
+		return fmt.Errorf("retrieving %s: `ipConfiguration.properties` was nil", networkInterfaceId)
 	}
 
-	config := *c
-	p := config.InterfaceIPConfigurationPropertiesFormat
-	if p == nil {
-		return fmt.Errorf("Error: `IPConfiguration.properties` was nil for %s", *id)
-	}
-
-	rules := make([]network.InboundNatRule, 0)
+	id := commonids.NewCompositeResourceID(&ipConfigId, natRuleId)
+	rules := make([]networkinterfaces.InboundNatRule, 0)
 
 	// first double-check it doesn't exist
-	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, natRuleId)
-	if p.LoadBalancerInboundNatRules != nil {
-		for _, existingRule := range *p.LoadBalancerInboundNatRules {
-			if id := existingRule.ID; id != nil {
-				if *id == natRuleId {
-					return tf.ImportAsExistsError("azurerm_network_interface_nat_rule_association", resourceId)
+	if ipConfigProps.LoadBalancerInboundNatRules != nil {
+		for _, existingRule := range *ipConfigProps.LoadBalancerInboundNatRules {
+			if ruleId := existingRule.Id; ruleId != nil {
+				if *ruleId == natRuleId.ID() {
+					return tf.ImportAsExistsError("azurerm_network_interface_nat_rule_association", id.ID())
 				}
 
 				rules = append(rules, existingRule)
@@ -135,175 +131,153 @@ func resourceNetworkInterfaceNatRuleAssociationCreate(d *pluginsdk.ResourceData,
 		}
 	}
 
-	rule := network.InboundNatRule{
-		ID: utils.String(natRuleId),
+	rule := networkinterfaces.InboundNatRule{
+		Id: pointer.To(natRuleId.ID()),
 	}
 	rules = append(rules, rule)
-	p.LoadBalancerInboundNatRules = &rules
+	ipConfigProps.LoadBalancerInboundNatRules = &rules
 
-	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, props.IPConfigurations)
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, read)
-	if err != nil {
-		return fmt.Errorf("updating NAT Rule Association for %s: %+v", *id, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("updating NAT Rule Association for %s: %+v", networkInterfaceId, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for completion of NAT Rule Association for %s: %+v", *id, err)
-	}
-
-	d.SetId(resourceId)
+	d.SetId(id.ID())
 
 	return resourceNetworkInterfaceNatRuleAssociationRead(d, meta)
 }
 
 func resourceNetworkInterfaceNatRuleAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{natRuleId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
 	if err != nil {
 		return err
 	}
 
-	natRuleId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	read, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+		if response.WasNotFound(read.HttpResponse) {
+			log.Printf("%s was not found - removing from state!", networkInterfaceId)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
+	if model := read.Model; model != nil {
+		if props := model.Properties; props != nil {
+			ipConfigs := props.IPConfigurations
+			if ipConfigs == nil {
+				return fmt.Errorf("`properties.ipConfigurations` was nil for %s", networkInterfaceId)
+			}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
+			config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+			if config == nil {
+				log.Printf("IP Configuration %q was not found in %s - removing from state!", id.First.IpConfigurationName, networkInterfaceId)
+				d.SetId("")
+				return nil
+			}
 
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		log.Printf("IP Configuration %q was not found in Network Interface %q (Resource Group %q) - removing from state!", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
-		d.SetId("")
-		return nil
-	}
-	config := *c
+			found := false
+			if ipConfigProps := config.Properties; ipConfigProps != nil {
+				if rules := ipConfigProps.LoadBalancerInboundNatRules; rules != nil {
+					for _, rule := range *rules {
+						if rule.Id == nil {
+							continue
+						}
 
-	found := false
-	if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
-		if rules := props.LoadBalancerInboundNatRules; rules != nil {
-			for _, rule := range *rules {
-				if rule.ID == nil {
-					continue
-				}
-
-				if *rule.ID == natRuleId {
-					found = true
-					break
+						if *rule.Id == id.Second.ID() {
+							found = true
+							break
+						}
+					}
 				}
 			}
+			if !found {
+				log.Printf("[DEBUG] Association between %s and %s was not found - removing from state!", id.First, id.Second)
+				d.SetId("")
+				return nil
+			}
+
+			d.Set("ip_configuration_name", id.First.IpConfigurationName)
+			d.Set("nat_rule_id", id.Second.ID())
+			d.Set("network_interface_id", networkInterfaceId.ID())
 		}
 	}
-
-	if !found {
-		log.Printf("[DEBUG] Association between Network Interface %q (Resource Group %q) and Load Balancer NAT Rule %q was not found - removing from state!", nicID.NetworkInterfaceName, nicID.ResourceGroup, natRuleId)
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("ip_configuration_name", nicID.IpConfigurationName)
-	d.Set("nat_rule_id", natRuleId)
-	d.Set("network_interface_id", read.ID)
 
 	return nil
 }
 
 func resourceNetworkInterfaceNatRuleAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.Client.NetworkInterfaces
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{natRuleId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
 	if err != nil {
 		return err
 	}
 
-	natRuleId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	locks.ByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	read, err := client.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf("%s was not found", networkInterfaceId)
 		}
 
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
 	}
 
-	ipConfigs := nicProps.IPConfigurations
-	if ipConfigs == nil {
-		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	props := read.Model.Properties
+
+	config := FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("retrieving %s: IP Configuration %q was not found on", networkInterfaceId, id.First.IpConfigurationName)
 	}
 
-	c := FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		return fmt.Errorf("Error: IP Configuration %q was not found on Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
-	}
-	config := *c
-
-	props := config.InterfaceIPConfigurationPropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: Properties for IPConfiguration %q was nil for Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	ipConfigProps := config.Properties
+	if ipConfigProps == nil {
+		return fmt.Errorf("retrieving %s: `ipConfiguration.Properties` was nil", networkInterfaceId)
 	}
 
-	updatedRules := make([]network.InboundNatRule, 0)
-	if existingRules := props.LoadBalancerInboundNatRules; existingRules != nil {
+	updatedRules := make([]networkinterfaces.InboundNatRule, 0)
+	if existingRules := ipConfigProps.LoadBalancerInboundNatRules; existingRules != nil {
 		for _, rule := range *existingRules {
-			if rule.ID == nil {
+			if rule.Id == nil {
 				continue
 			}
 
-			if *rule.ID != natRuleId {
+			if *rule.Id != id.Second.ID() {
 				updatedRules = append(updatedRules, rule)
 			}
 		}
 	}
-	props.LoadBalancerInboundNatRules = &updatedRules
-	nicProps.IPConfigurations = updateNetworkInterfaceIPConfiguration(config, nicProps.IPConfigurations)
+	ipConfigProps.LoadBalancerInboundNatRules = &updatedRules
+	props.IPConfigurations = updateNetworkInterfaceIPConfiguration(*config, props.IPConfigurations)
 
-	future, err := client.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, read)
-	if err != nil {
-		return fmt.Errorf("removing NAT Rule Association for Network Interface %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for removal of NAT Rule Association for NIC %q (Resource Group %q): %+v", nicID.NetworkInterfaceName, nicID.ResourceGroup, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("removing NAT Rule Association for %s: %+v", networkInterfaceId, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_nat_rule_association_resource_test.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -144,7 +145,9 @@ func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, c
 
 	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx2, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
@@ -176,7 +179,7 @@ func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, c
 	}
 	config.Properties.LoadBalancerInboundNatRules = &updatedRules
 
-	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx2, networkInterfaceId, *read.Model); err != nil {
 		return fmt.Errorf("removing NAT Rule Association for %s: %+v", networkInterfaceId, err)
 	}
 

--- a/internal/services/network/network_interface_nat_rule_association_resource_test.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource_test.go
@@ -6,17 +6,17 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/loadbalancers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	network2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type NetworkInterfaceNATRuleAssociationResource struct{}
@@ -94,81 +94,90 @@ func TestAccNetworkInterfaceNATRuleAssociation_updateNIC(t *testing.T) {
 }
 
 func (t NetworkInterfaceNATRuleAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	splitId := strings.Split(state.ID, "|")
-	if len(splitId) != 2 {
-		return nil, fmt.Errorf("expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", state.ID)
-	}
-
-	nicID, err := parse.NetworkInterfaceIpConfigurationID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
 	if err != nil {
 		return nil, err
 	}
 
-	natRuleId := splitId[1]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := clients.Network.InterfacesClient.Get(ctx, nicID.ResourceGroup, nicID.NetworkInterfaceName, "")
+	read, err := clients.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	c := network2.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, nicID.IpConfigurationName)
-	if c == nil {
-		return nil, fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", nicID.IpConfigurationName, nicID.NetworkInterfaceName, nicID.ResourceGroup)
+	if read.Model == nil {
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
 	}
-	config := *c
+	if read.Model.Properties == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return nil, fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
+	}
+
+	props := read.Model.Properties
+
+	config := network.FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return nil, fmt.Errorf("IP Configuration %q wasn't found for %s", id.First.IpConfigurationName, networkInterfaceId)
+	}
 
 	found := false
-	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules != nil {
-		for _, rule := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules {
-			if *rule.ID == natRuleId {
+	if config.Properties.LoadBalancerInboundNatRules != nil {
+		for _, rule := range *config.Properties.LoadBalancerInboundNatRules {
+			if *rule.Id == id.Second.ID() {
 				found = true
 				break
 			}
 		}
 	}
 
-	return utils.Bool(found), nil
+	return pointer.To(found), nil
 }
 
 func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
 	if err != nil {
 		return err
 	}
 
-	nicName := nicID.Name
-	resourceGroup := nicID.ResourceGroup
-	ipConfigurationName := state.Attributes["ip_configuration_name"]
-	natRuleId := state.Attributes["nat_rule_id"]
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
 
-	read, err := client.Network.InterfacesClient.Get(ctx, resourceGroup, nicName, "")
+	read, err := client.Network.Client.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
 	}
 
-	c := network2.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
-	if c == nil {
-		return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", networkInterfaceId)
 	}
-	config := *c
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", networkInterfaceId)
+	}
+	if read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
+	}
 
-	updatedRules := make([]network.InboundNatRule, 0)
-	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules != nil {
-		for _, rule := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules {
-			if *rule.ID != natRuleId {
+	props := read.Model.Properties
+
+	config := network.FindNetworkInterfaceIPConfiguration(props.IPConfigurations, id.First.IpConfigurationName)
+	if config == nil {
+		return fmt.Errorf("IP Configuration %q wasn't found for %s", id.First.IpConfigurationName, networkInterfaceId)
+	}
+
+	updatedRules := make([]networkinterfaces.InboundNatRule, 0)
+	if config.Properties.LoadBalancerInboundNatRules != nil {
+		for _, rule := range *config.Properties.LoadBalancerInboundNatRules {
+			if *rule.Id != id.Second.ID() {
 				updatedRules = append(updatedRules, rule)
 			}
 		}
 	}
-	config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules = &updatedRules
+	config.Properties.LoadBalancerInboundNatRules = &updatedRules
 
-	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, resourceGroup, nicName, read)
-	if err != nil {
-		return fmt.Errorf("removing NAT Rule Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
-		return fmt.Errorf("waiting for removal of NAT Rule Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	if err := client.Network.Client.NetworkInterfaces.CreateOrUpdateThenPoll(ctx, networkInterfaceId, *read.Model); err != nil {
+		return fmt.Errorf("removing NAT Rule Association for %s: %+v", networkInterfaceId, err)
 	}
 
 	return nil

--- a/internal/services/network/parse/application_gateway_backend_address_pool.go
+++ b/internal/services/network/parse/application_gateway_backend_address_pool.go
@@ -1,0 +1,134 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = &ApplicationGatewayBackendAddressPoolId{}
+
+// ApplicationGatewayBackendAddressPoolId is a struct representing the Resource ID for a Compilation Job
+type ApplicationGatewayBackendAddressPoolId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	ApplicationGatewayName string
+	BackendAddressPoolName string
+}
+
+// NewApplicationGatewayBackendAddressPoolID returns a new ApplicationGatewayBackendAddressPoolId struct
+func NewApplicationGatewayBackendAddressPoolID(subscriptionId string, resourceGroupName string, applicationGatewayName string, backendAddressPoolName string) ApplicationGatewayBackendAddressPoolId {
+	return ApplicationGatewayBackendAddressPoolId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		ApplicationGatewayName: applicationGatewayName,
+		BackendAddressPoolName: backendAddressPoolName,
+	}
+}
+
+// ParseApplicationGatewayBackendAddressPoolID parses 'input' into a ApplicationGatewayBackendAddressPoolId
+func ParseApplicationGatewayBackendAddressPoolID(input string) (*ApplicationGatewayBackendAddressPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ApplicationGatewayBackendAddressPoolId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ApplicationGatewayBackendAddressPoolId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseApplicationGatewayBackendAddressPoolIDInsensitively parses 'input' case-insensitively into a ApplicationGatewayBackendAddressPoolId
+// note: this method should only be used for API response data and not user input
+func ParseApplicationGatewayBackendAddressPoolIDInsensitively(input string) (*ApplicationGatewayBackendAddressPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ApplicationGatewayBackendAddressPoolId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ApplicationGatewayBackendAddressPoolId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ApplicationGatewayBackendAddressPoolId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ApplicationGatewayName, ok = input.Parsed["applicationGatewayName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "applicationGatewayName", input)
+	}
+
+	if id.BackendAddressPoolName, ok = input.Parsed["backendAddressPoolName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "backendAddressPoolName", input)
+	}
+
+	return nil
+}
+
+// ValidateApplicationGatewayBackendAddressPoolID checks that 'input' can be parsed as a Compilation Job ID
+func ValidateApplicationGatewayBackendAddressPoolID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseApplicationGatewayBackendAddressPoolID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Compilation Job ID
+func (id ApplicationGatewayBackendAddressPoolId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/applicationGateways/%s/backendAddressPools/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ApplicationGatewayName, id.BackendAddressPoolName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud Services I P Configuration ID
+func (id ApplicationGatewayBackendAddressPoolId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticApplicationGateways", "applicationGateways", "applicationGateways"),
+		resourceids.UserSpecifiedSegment("applicationGatewayName", "applicationGatewaysValue"),
+		resourceids.StaticSegment("staticBackendAddressPools", "backendAddressPools", "backendAddressPools"),
+		resourceids.UserSpecifiedSegment("backendAddressPoolName", "backendAddressPoolNameValue"),
+	}
+}
+
+// String returns a human-readable description of this Backend Address Pool ID
+func (id ApplicationGatewayBackendAddressPoolId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Application Gateway Name: %q", id.ApplicationGatewayName),
+		fmt.Sprintf("Backend Address Pool: %q", id.BackendAddressPoolName),
+	}
+	return fmt.Sprintf("Application Gateway Backend Address Pool (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/network/parse/application_gateway_backend_address_pool.go
+++ b/internal/services/network/parse/application_gateway_backend_address_pool.go
@@ -30,8 +30,8 @@ func NewApplicationGatewayBackendAddressPoolID(subscriptionId string, resourceGr
 	}
 }
 
-// ParseApplicationGatewayBackendAddressPoolID parses 'input' into a ApplicationGatewayBackendAddressPoolId
-func ParseApplicationGatewayBackendAddressPoolID(input string) (*ApplicationGatewayBackendAddressPoolId, error) {
+// ApplicationGatewayBackendAddressPoolID parses 'input' into a ApplicationGatewayBackendAddressPoolId
+func ApplicationGatewayBackendAddressPoolID(input string) (*ApplicationGatewayBackendAddressPoolId, error) {
 	parser := resourceids.NewParserFromResourceIdType(&ApplicationGatewayBackendAddressPoolId{})
 	parsed, err := parser.Parse(input, false)
 	if err != nil {
@@ -93,7 +93,7 @@ func ValidateApplicationGatewayBackendAddressPoolID(input interface{}, key strin
 		return
 	}
 
-	if _, err := ParseApplicationGatewayBackendAddressPoolID(v); err != nil {
+	if _, err := ApplicationGatewayBackendAddressPoolID(v); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/internal/services/network/parse/application_gateway_backend_address_pool_test.go
+++ b/internal/services/network/parse/application_gateway_backend_address_pool_test.go
@@ -114,7 +114,7 @@ func TestParseApplicationGatewayBackendAddressPoolID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ParseApplicationGatewayBackendAddressPoolID(v.Input)
+		actual, err := ApplicationGatewayBackendAddressPoolID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/internal/services/network/parse/application_gateway_backend_address_pool_test.go
+++ b/internal/services/network/parse/application_gateway_backend_address_pool_test.go
@@ -1,0 +1,327 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = &ApplicationGatewayBackendAddressPoolId{}
+
+func TestNewApplicationGatewayBackendAddressPoolID(t *testing.T) {
+	id := NewApplicationGatewayBackendAddressPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "applicationGatewayValue", "backendAddressPoolNameValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.ApplicationGatewayName != "applicationGatewayValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ApplicationGatewayName'", id.ApplicationGatewayName, "applicationGatewayValue")
+	}
+
+	if id.BackendAddressPoolName != "backendAddressPoolNameValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'BackEndAddressPoolName'", id.BackendAddressPoolName, "backendAddressPoolNameValue")
+	}
+}
+
+func TestFormatApplicationGatewayBackendAddressPoolID(t *testing.T) {
+	actual := NewApplicationGatewayBackendAddressPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "applicationGatewayValue", "backendAddressPoolNameValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools/backendAddressPoolNameValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseApplicationGatewayBackendAddressPoolID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ApplicationGatewayBackendAddressPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools/backendAddressPoolValue",
+			Expected: &ApplicationGatewayBackendAddressPoolId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:      "example-resource-group",
+				ApplicationGatewayName: "applicationGatewayValue",
+				BackendAddressPoolName: "backendAddressPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools/backendAddressPoolValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseApplicationGatewayBackendAddressPoolID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ApplicationGatewayName != v.Expected.ApplicationGatewayName {
+			t.Fatalf("Expected %q but got %q for ApplicationGatewayName", v.Expected.ApplicationGatewayName, actual.ApplicationGatewayName)
+		}
+
+		if actual.BackendAddressPoolName != v.Expected.BackendAddressPoolName {
+			t.Fatalf("Expected %q but got %q for BackendAddressPoolName", v.Expected.BackendAddressPoolName, actual.BackendAddressPoolName)
+		}
+
+	}
+}
+
+func TestParseApplicationGatewayBackendAddressPoolIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ApplicationGatewayBackendAddressPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/aPpLiCaTiOnGaTeWaYs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/aPpLiCaTiOnGaTeWaYs/aPpLiCaTiOnGaTeWaYVaLuE",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/aPpLiCaTiOnGaTeWaYs/aPpLiCaTiOnGaTeWaYVaLuE/bAcKeNdAdDreSSPoOls",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools/backendAddressPoolValue",
+			Expected: &ApplicationGatewayBackendAddressPoolId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:      "example-resource-group",
+				ApplicationGatewayName: "applicationGatewayValue",
+				BackendAddressPoolName: "backendAddressPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/applicationGateways/applicationGatewayValue/backendAddressPools/backendAddressPoolValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/aPpLiCaTiOnGaTeWaYs/aPpLiCaTiOnGaTeWaYVaLuE/bAcKeNdAdDreSSPoOls/bAcKeNdAdDreSSPoOlvAlUe",
+			Expected: &ApplicationGatewayBackendAddressPoolId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:      "eXaMpLe-rEsOuRcE-GrOuP",
+				ApplicationGatewayName: "aPpLiCaTiOnGaTeWaYVaLuE",
+				BackendAddressPoolName: "bAcKeNdAdDreSSPoOlvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/aPpLiCaTiOnGaTeWaYs/aPpLiCaTiOnGaTeWaYVaLuE/bAcKeNdAdDreSSPoOls/bAcKeNdAdDreSSPoOlvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseApplicationGatewayBackendAddressPoolIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ApplicationGatewayName != v.Expected.ApplicationGatewayName {
+			t.Fatalf("Expected %q but got %q for ApplicationGatewayName", v.Expected.ApplicationGatewayName, actual.ApplicationGatewayName)
+		}
+
+		if actual.BackendAddressPoolName != v.Expected.BackendAddressPoolName {
+			t.Fatalf("Expected %q but got %q for BackendAddressPoolName", v.Expected.BackendAddressPoolName, actual.BackendAddressPoolName)
+		}
+
+	}
+}
+
+func TestSegmentsForApplicationGatewayBackendAddressPoolId(t *testing.T) {
+	segments := ApplicationGatewayBackendAddressPoolId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ApplicationGatewayBackendAddressPoolId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates the following resources to use `hashicorp/go-azure-sdk` as well as use the `commonids.CompositeResourceId` functions:

- `azurerm_network_interface_nat_rule_association` 
- `azurerm_network_interface_backend_address_pool_association` 
- `azurerm_network_interface_application_security_group_association` 
- `azurerm_nat_gateway_public_ip_prefix_association` 
- `azurerm_nat_gateway_public_ip_association` 
- `azurerm_nat_gateway_application_gateway_association` 

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/7ff4f764-612e-4dc7-b446-0afcca4e37d4)
