### PR TITLE
`container_app_job`: support secrets from Key Vault

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -270,6 +270,72 @@ func TestAccContainerAppJob_completeUpdate(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppJob_withKeyVaultSecret(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withKeyVaultSecret(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withKeyVaultSecret(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withKeyVaultSecretVersionless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_withKeyVaultSecretIdentityUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withKeyVaultSecretUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withKeyVaultSecretSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withKeyVaultSecretSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r ContainerAppJobResource) eventTrigger(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
@@ -473,6 +539,567 @@ resource "azurerm_container_app_job" "test" {
   }
 }
 `, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecret(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+    secret_permissions = [
+      "Set",
+      "Get",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+    secret_permissions = [
+      "Get",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret"
+        secret_name = "key-vault-secret"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = azurerm_key_vault_secret.test.id
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecretVersionless(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+    secret_permissions = [
+      "Set",
+      "Get",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+    secret_permissions = [
+      "Get",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret"
+        secret_name = "key-vault-secret"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = azurerm_key_vault_secret.test.versionless_id
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecretUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.self_key_vault_admin
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "self_key_vault_admin" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Set",
+    "Get",
+    "Delete",
+    "Purge",
+    "Recover"
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "mi_key_vault_secrets" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_container_app_job.test.identity[0].principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "user_mi_key_vault_secrets" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret"
+        secret_name = "key-vault-secret"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = azurerm_key_vault_secret.test.id
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.user_mi_key_vault_secrets
+  ]
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecretSystemAndUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.self_key_vault_admin
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "self_key_vault_admin" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Set",
+    "Get",
+    "Delete",
+    "Purge",
+    "Recover"
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "mi_key_vault_secrets" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_container_app_job.test.identity[0].principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "user_mi_key_vault_secrets" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret"
+        secret_name = "key-vault-secret"
+      }
+      env {
+        name        = "key-vault-secret-system"
+        secret_name = "key-vault-secret-system"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = azurerm_key_vault_secret.test.id
+  }
+
+  secret {
+    name                = "key-vault-secret-system"
+    identity            = "System"
+    key_vault_secret_id = azurerm_key_vault_secret.test.id
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.user_mi_key_vault_secrets
+  ]
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecretSystemIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.self_key_vault_admin
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "self_key_vault_admin" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Set",
+    "Get",
+    "Delete",
+    "Purge",
+    "Recover"
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "mi_key_vault_secrets" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_container_app_job.test.identity[0].principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret-system"
+        secret_name = "key-vault-secret-system"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret-system"
+    identity            = "System"
+    key_vault_secret_id = azurerm_key_vault_secret.test.id
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
 }
 
 func (r ContainerAppJobResource) withUserAssignedIdentity(data acceptance.TestData) string {

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -114,8 +114,10 @@ func ExpandContainerAppJobSecrets(input []Secret) *[]jobs.Secret {
 
 	for _, v := range input {
 		result = append(result, jobs.Secret{
-			Name:  pointer.To(v.Name),
-			Value: pointer.To(v.Value),
+			Identity:    pointer.To(v.Identity),
+			KeyVaultUrl: pointer.To(v.KeyVaultSecretId),
+			Name:        pointer.To(v.Name),
+			Value:       pointer.To(v.Value),
 		})
 	}
 
@@ -1004,10 +1006,15 @@ func FlattenContainerAppJobSecrets(input *jobs.JobSecretsCollection) []Secret {
 	result := make([]Secret, 0)
 
 	for _, v := range input.Value {
-		result = append(result, Secret{
-			Name:  pointer.From(v.Name),
-			Value: pointer.From(v.Value),
-		})
+		secret := Secret{
+			Identity:         pointer.From(v.Identity),
+			KeyVaultSecretId: pointer.From(v.KeyVaultUrl),
+			Name:             pointer.From(v.Name),
+		}
+		if v.KeyVaultUrl == nil {
+			secret.Value = pointer.From(v.Value)
+		}
+		result = append(result, secret)
 	}
 
 	return result

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
 
 A `secret` block supports the following:
 
+* `name` - (Required) The secret name.
+
 * `identity` - (Optional) The identity to use for accessing the Key Vault secret reference. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
 
 !> **Note:** `identity` must be used together with `key_vault_secret_id`
@@ -92,8 +94,6 @@ A `secret` block supports the following:
 * `key_vault_secret_id` - (Optional) The ID of a Key Vault secret. This can be a versioned or version-less ID.
 
 !> **Note:** When using `key_vault_secret_id`, `ignore_changes` should be used to ignore any changes to `value`.
-
-* `name` - (Required) The secret name.
 
 * `value` - (Optional) The value for this secret.
 

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -314,9 +314,19 @@ A `volume` block supports the following:
 
 A `secret` block supports the following:
 
-* `name` - (required) Name of the secret.
+* `identity` - (Optional) The identity to use for accessing the Key Vault secret reference. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
 
-* `value` - (required) Value of the secret.
+!> **Note:** `identity` must be used together with `key_vault_secret_id`
+
+* `key_vault_secret_id` - (Optional) The ID of a Key Vault secret. This can be a versioned or version-less ID.
+
+!> **Note:** When using `key_vault_secret_id`, `ignore_changes` should be used to ignore any changes to `value`.
+
+* `name` - (Required) The secret name.
+
+* `value` - (Optional) The value for this secret.
+
+!> **Note:** `value` will be ignored if `key_vault_secret_id` and `identity` are provided.
 
 ---
 

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -314,6 +314,8 @@ A `volume` block supports the following:
 
 A `secret` block supports the following:
 
+* `name` - (Required) The secret name.
+
 * `identity` - (Optional) The identity to use for accessing the Key Vault secret reference. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
 
 !> **Note:** `identity` must be used together with `key_vault_secret_id`
@@ -321,8 +323,6 @@ A `secret` block supports the following:
 * `key_vault_secret_id` - (Optional) The ID of a Key Vault secret. This can be a versioned or version-less ID.
 
 !> **Note:** When using `key_vault_secret_id`, `ignore_changes` should be used to ignore any changes to `value`.
-
-* `name` - (Required) The secret name.
 
 * `value` - (Optional) The value for this secret.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for referencing Key Vault secrets from Container App Jobs and lifts the restriction on removing secrets.
This code is ported from the Container Apps resource.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<details><summary>Testing evidence</summary>
<pre>
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppJob_withKeyVault -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppJob_withKeyVaultSecret
=== PAUSE TestAccContainerAppJob_withKeyVaultSecret
=== RUN   TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate
=== PAUSE TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate
=== RUN   TestAccContainerAppJob_withKeyVaultSecretIdentityUpdate
=== PAUSE TestAccContainerAppJob_withKeyVaultSecretIdentityUpdate
=== CONT  TestAccContainerAppJob_withKeyVaultSecret
=== CONT  TestAccContainerAppJob_withKeyVaultSecretIdentityUpdate
=== CONT  TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate
--- PASS: TestAccContainerAppJob_withKeyVaultSecret (894.40s)
--- PASS: TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate (974.74s)
--- PASS: TestAccContainerAppJob_withKeyVaultSecretIdentityUpdate (1019.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1022.386s
</pre>
</details>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `container_app_job` - support secrets from Key Vault [GH-0000]
* `container_app_job` - allow removing secrets [GH-0000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25934
Fixes #25994 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
