### PR TITLE
`azurerm_data_protection_backup_policy_blob_storage` - support azure blob vaulted backup

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -7,14 +7,18 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2023-05-01/backuppolicies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	helperValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -22,7 +26,7 @@ import (
 )
 
 func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
-	return &schema.Resource{
+	resource := &schema.Resource{
 		Create: resourceDataProtectionBackupPolicyBlobStorageCreate,
 		Read:   resourceDataProtectionBackupPolicyBlobStorageRead,
 		Delete: resourceDataProtectionBackupPolicyBlobStorageDelete,
@@ -56,14 +60,199 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 				ValidateFunc: backuppolicies.ValidateBackupVaultID,
 			},
 
-			"retention_duration": {
-				Type:         schema.TypeString,
-				Required:     true,
+			"backup_repeating_time_intervals": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"time_zone": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: helperValidate.ISO8601Duration,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"retention_rule": {
+				Type:         pluginsdk.TypeList,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"vault_default_retention_duration"},
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"criteria": {
+							Type:     pluginsdk.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"absolute_criteria": {
+										Type:     pluginsdk.TypeString,
+										Optional: true,
+										ForceNew: true,
+										ValidateFunc: validation.StringInSlice(
+											backuppolicies.PossibleValuesForAbsoluteMarker(), false),
+									},
+
+									"days_of_month": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeInt,
+											ValidateFunc: validation.Any(
+												validation.IntBetween(0, 28),
+											),
+										},
+									},
+
+									"days_of_week": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.IsDayOfTheWeek(false),
+										},
+									},
+
+									"months_of_year": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.IsMonth(false),
+										},
+									},
+
+									"scheduled_backup_times": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.IsRFC3339Time,
+										},
+									},
+
+									"weeks_of_month": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.StringInSlice(backuppolicies.PossibleValuesForWeekNumber(), false),
+										},
+									},
+								},
+							},
+						},
+
+						"life_cycle": {
+							Type:     pluginsdk.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"data_store_type": {
+										Type:     pluginsdk.TypeString,
+										Required: true,
+										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											// confirmed with the service team that currently only `VaultStore` is supported.
+											// However, since `ArchiveStore` may be supported in the future, it is open to user specification.
+											string(backuppolicies.DataStoreTypesVaultStore),
+										}, false),
+									},
+
+									"duration": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: helperValidate.ISO8601Duration,
+									},
+								},
+							},
+						},
+
+						"priority": {
+							Type:     pluginsdk.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["operational_default_retention_duration"] = &pluginsdk.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Computed: true,
+			AtLeastOneOf: []string{
+				"retention_duration", "operational_default_retention_duration", "vault_default_retention_duration"},
+			ValidateFunc: helperValidate.ISO8601Duration,
+		}
+
+		resource.Schema["retention_duration"] = &pluginsdk.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Computed:     true,
+			AtLeastOneOf: []string{"retention_duration", "operational_default_retention_duration", "vault_default_retention_duration"},
+			ValidateFunc: helperValidate.ISO8601Duration,
+			Deprecated:   "This property has been renamed to `operational_default_retention_duration` and will be removed in v4.0 of the AzureRM provider",
+		}
+
+		resource.Schema["vault_default_retention_duration"] = &pluginsdk.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			AtLeastOneOf: []string{"retention_duration", "operational_default_retention_duration", "vault_default_retention_duration"},
+			RequiredWith: []string{"backup_repeating_time_intervals"},
+			ValidateFunc: helperValidate.ISO8601Duration,
+		}
+	} else {
+		resource.Schema["operational_default_retention_duration"] = &pluginsdk.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			AtLeastOneOf: []string{"operational_default_retention_duration", "vault_default_retention_duration"},
+			ValidateFunc: helperValidate.ISO8601Duration,
+		}
+
+		resource.Schema["vault_default_retention_duration"] = &pluginsdk.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			AtLeastOneOf: []string{"operational_default_retention_duration", "vault_default_retention_duration"},
+			RequiredWith: []string{"backup_repeating_time_intervals"},
+			ValidateFunc: helperValidate.ISO8601Duration,
+		}
+	}
+
+	return resource
 }
 
 func resourceDataProtectionBackupPolicyBlobStorageCreate(d *schema.ResourceData, meta interface{}) error {
@@ -86,26 +275,40 @@ func resourceDataProtectionBackupPolicyBlobStorageCreate(d *schema.ResourceData,
 		return tf.ImportAsExistsError("azurerm_data_protection_backup_policy_blob_storage", id.ID())
 	}
 
+	policyRules := make([]backuppolicies.BasePolicyRule, 0)
+	// expand the default operational retention rule when the operational default duration is specified
+	operationalDefaultDuration := ""
+	if !features.FourPointOhBeta() {
+		if v, ok := d.GetOk("retention_duration"); ok {
+			operationalDefaultDuration = v.(string)
+		} else if v, ok := d.GetOk("operational_default_retention_duration"); ok {
+			operationalDefaultDuration = v.(string)
+		}
+	} else {
+		operationalDefaultDuration = d.Get("operational_default_retention_duration").(string)
+	}
+	if operationalDefaultDuration != "" {
+		policyRules = append(policyRules, expandBackupPolicyBlobStorageDefaultRetentionRuleArray(operationalDefaultDuration, backuppolicies.DataStoreTypesOperationalStore))
+	}
+
+	// expand the default vault retention rule when the vault default duration is specified
+	if v, ok := d.GetOk("vault_default_retention_duration"); ok {
+		taggingCriteria, err := expandBackupPolicyBlobStorageTaggingCriteriaArray(d.Get("retention_rule").([]interface{}))
+		if err != nil {
+			return err
+		}
+		policyRules = append(policyRules, expandBackupPolicyBlobStorageAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), d.Get("time_zone").(string), taggingCriteria)...)
+		policyRules = append(policyRules, expandBackupPolicyBlobStorageDefaultRetentionRuleArray(v.(string), backuppolicies.DataStoreTypesVaultStore))
+	}
+
+	// expand the vault retention rule when the vault retention rules are specified, the operational backup cannot specify retention rules.
+	if _, ok := d.GetOk("retention_rule"); ok {
+		policyRules = append(policyRules, expandBackupPolicyBlobStorageAzureRetentionRuleArray(d.Get("retention_rule").([]interface{}))...)
+	}
+
 	parameters := backuppolicies.BaseBackupPolicyResource{
 		Properties: &backuppolicies.BackupPolicy{
-			PolicyRules: []backuppolicies.BasePolicyRule{
-				backuppolicies.AzureRetentionRule{
-					Name:      "Default",
-					IsDefault: utils.Bool(true),
-					Lifecycles: []backuppolicies.SourceLifeCycle{
-						{
-							DeleteAfter: backuppolicies.AbsoluteDeleteOption{
-								Duration: d.Get("retention_duration").(string),
-							},
-							SourceDataStore: backuppolicies.DataStoreInfoBase{
-								DataStoreType: "OperationalStore",
-								ObjectType:    "DataStoreInfoBase",
-							},
-							TargetDataStoreCopySettings: &[]backuppolicies.TargetCopySetting{},
-						},
-					},
-				},
-			},
+			PolicyRules:     policyRules,
 			DatasourceTypes: []string{"Microsoft.Storage/storageAccounts/blobServices"},
 		},
 	}
@@ -143,8 +346,21 @@ func resourceDataProtectionBackupPolicyBlobStorageRead(d *schema.ResourceData, m
 	if resp.Model != nil {
 		if resp.Model.Properties != nil {
 			if props, ok := resp.Model.Properties.(backuppolicies.BackupPolicy); ok {
-				if err := d.Set("retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules)); err != nil {
-					return fmt.Errorf("setting `default_retention_duration`: %+v", err)
+				if err := d.Set("backup_repeating_time_intervals", flattenBackupPolicyBlobStorageVaultBackupRuleArray(&props.PolicyRules)); err != nil {
+					return fmt.Errorf("setting `backup_repeating_time_intervals`: %+v", err)
+				}
+				if err := d.Set("operational_default_retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesOperationalStore)); err != nil {
+					return fmt.Errorf("setting `operational_default_retention_duration`: %+v", err)
+				}
+				if err := d.Set("retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesOperationalStore)); err != nil {
+					return fmt.Errorf("setting `retention_duration`: %+v", err)
+				}
+				d.Set("time_zone", flattenBackupPolicyBlobStorageVaultBackupTimeZone(&props.PolicyRules))
+				if err := d.Set("vault_default_retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesVaultStore)); err != nil {
+					return fmt.Errorf("setting `vault_default_retention_duration`: %+v", err)
+				}
+				if err := d.Set("retention_rule", flattenBackupPolicyBlobStorageRetentionRuleArray(&props.PolicyRules)); err != nil {
+					return fmt.Errorf("setting `retention_rule`: %+v", err)
 				}
 			}
 		}
@@ -172,7 +388,184 @@ func resourceDataProtectionBackupPolicyBlobStorageDelete(d *schema.ResourceData,
 	return nil
 }
 
-func flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(input []backuppolicies.BasePolicyRule) interface{} {
+func expandBackupPolicyBlobStorageTaggingCriteriaArray(input []interface{}) (*[]backuppolicies.TaggingCriteria, error) {
+	results := []backuppolicies.TaggingCriteria{
+		{
+			Criteria:        nil,
+			IsDefault:       true,
+			TaggingPriority: 99,
+			TagInfo: backuppolicies.RetentionTag{
+				Id:      utils.String("Default_"),
+				TagName: "Default",
+			},
+		},
+	}
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		result := backuppolicies.TaggingCriteria{
+			IsDefault:       false,
+			TaggingPriority: int64(v["priority"].(int)),
+			TagInfo: backuppolicies.RetentionTag{
+				Id:      pointer.To(v["name"].(string) + "_"),
+				TagName: v["name"].(string),
+			},
+		}
+
+		criteria, err := expandBackupPolicyBlobStorageCriteriaArray(v["criteria"].([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		result.Criteria = criteria
+		results = append(results, result)
+	}
+	return &results, nil
+}
+
+func expandBackupPolicyBlobStorageCriteriaArray(input []interface{}) (*[]backuppolicies.BackupCriteria, error) {
+	if len(input) == 0 || input[0] == nil {
+		return nil, fmt.Errorf("criteria is a required field, cannot leave blank")
+	}
+	results := make([]backuppolicies.BackupCriteria, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		var absoluteCriteria []backuppolicies.AbsoluteMarker
+		if absoluteCriteriaRaw := v["absolute_criteria"].(string); len(absoluteCriteriaRaw) > 0 {
+			absoluteCriteria = []backuppolicies.AbsoluteMarker{backuppolicies.AbsoluteMarker(absoluteCriteriaRaw)}
+		}
+
+		var daysOfMonth []backuppolicies.Day
+		if v["days_of_month"].(*pluginsdk.Set).Len() > 0 {
+			daysOfMonth = make([]backuppolicies.Day, 0)
+			for _, value := range v["days_of_month"].(*pluginsdk.Set).List() {
+				isLast := false
+				if value == 0 {
+					isLast = true
+				}
+				daysOfMonth = append(daysOfMonth, backuppolicies.Day{
+					Date: pointer.To(int64(value.(int))), IsLast: pointer.To(isLast),
+				})
+			}
+		}
+
+		var daysOfWeek []backuppolicies.DayOfWeek
+		if v["days_of_week"].(*pluginsdk.Set).Len() > 0 {
+			daysOfWeek = make([]backuppolicies.DayOfWeek, 0)
+			for _, value := range v["days_of_week"].(*pluginsdk.Set).List() {
+				daysOfWeek = append(daysOfWeek, backuppolicies.DayOfWeek(value.(string)))
+			}
+		}
+
+		var monthsOfYear []backuppolicies.Month
+		if v["months_of_year"].(*pluginsdk.Set).Len() > 0 {
+			monthsOfYear = make([]backuppolicies.Month, 0)
+			for _, value := range v["months_of_year"].(*pluginsdk.Set).List() {
+				monthsOfYear = append(monthsOfYear, backuppolicies.Month(value.(string)))
+			}
+		}
+
+		var scheduleTimes *[]string
+		if v["scheduled_backup_times"].(*pluginsdk.Set).Len() > 0 {
+			scheduleTimes = utils.ExpandStringSlice(v["scheduled_backup_times"].(*pluginsdk.Set).List())
+		}
+
+		var weeksOfMonth []backuppolicies.WeekNumber
+		if v["weeks_of_month"].(*pluginsdk.Set).Len() > 0 {
+			weeksOfMonth = make([]backuppolicies.WeekNumber, 0)
+			for _, value := range v["weeks_of_month"].(*pluginsdk.Set).List() {
+				weeksOfMonth = append(weeksOfMonth, backuppolicies.WeekNumber(value.(string)))
+			}
+		}
+
+		results = append(results, backuppolicies.ScheduleBasedBackupCriteria{
+			AbsoluteCriteria: &absoluteCriteria,
+			DaysOfMonth:      &daysOfMonth,
+			DaysOfTheWeek:    &daysOfWeek,
+			MonthsOfYear:     &monthsOfYear,
+			ScheduleTimes:    scheduleTimes,
+			WeeksOfTheMonth:  &weeksOfMonth,
+		})
+	}
+	return &results, nil
+}
+
+func expandBackupPolicyBlobStorageAzureBackupRuleArray(input []interface{}, timeZone string, taggingCriteria *[]backuppolicies.TaggingCriteria) []backuppolicies.BasePolicyRule {
+	results := make([]backuppolicies.BasePolicyRule, 0)
+	results = append(results, backuppolicies.AzureBackupRule{
+		Name: "BackupIntervals",
+		DataStore: backuppolicies.DataStoreInfoBase{
+			DataStoreType: backuppolicies.DataStoreTypesVaultStore,
+			ObjectType:    "DataStoreInfoBase",
+		},
+		BackupParameters: &backuppolicies.AzureBackupParams{
+			BackupType: "Discrete",
+		},
+		Trigger: backuppolicies.ScheduleBasedTriggerContext{
+			Schedule: backuppolicies.BackupSchedule{
+				RepeatingTimeIntervals: *utils.ExpandStringSlice(input),
+				TimeZone:               pointer.To(timeZone),
+			},
+			TaggingCriteria: *taggingCriteria,
+		},
+	})
+
+	return results
+}
+
+func expandBackupPolicyBlobStorageDefaultRetentionRuleArray(input interface{}, dataStoreType backuppolicies.DataStoreTypes) backuppolicies.BasePolicyRule {
+	return backuppolicies.AzureRetentionRule{
+		Name:      "Default",
+		IsDefault: pointer.To(true),
+		Lifecycles: []backuppolicies.SourceLifeCycle{
+			{
+				DeleteAfter: backuppolicies.AbsoluteDeleteOption{
+					Duration: input.(string),
+				},
+				SourceDataStore: backuppolicies.DataStoreInfoBase{
+					DataStoreType: dataStoreType,
+					ObjectType:    "DataStoreInfoBase",
+				},
+				TargetDataStoreCopySettings: &[]backuppolicies.TargetCopySetting{},
+			},
+		},
+	}
+}
+
+func expandBackupPolicyBlobStorageAzureRetentionRuleArray(input []interface{}) []backuppolicies.BasePolicyRule {
+	results := make([]backuppolicies.BasePolicyRule, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, backuppolicies.AzureRetentionRule{
+			Name:       v["name"].(string),
+			IsDefault:  pointer.To(false),
+			Lifecycles: expandBackupPolicyBlobStorageLifeCycle(v["life_cycle"].([]interface{})),
+		})
+	}
+	return results
+}
+
+func expandBackupPolicyBlobStorageLifeCycle(input []interface{}) []backuppolicies.SourceLifeCycle {
+	results := make([]backuppolicies.SourceLifeCycle, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		sourceLifeCycle := backuppolicies.SourceLifeCycle{
+			DeleteAfter: backuppolicies.AbsoluteDeleteOption{
+				Duration: v["duration"].(string),
+			},
+			SourceDataStore: backuppolicies.DataStoreInfoBase{
+				DataStoreType: backuppolicies.DataStoreTypes(v["data_store_type"].(string)),
+				ObjectType:    "DataStoreInfoBase",
+			},
+			TargetDataStoreCopySettings: &[]backuppolicies.TargetCopySetting{},
+		}
+		results = append(results, sourceLifeCycle)
+	}
+
+	return results
+}
+
+func flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(input []backuppolicies.BasePolicyRule, dsType backuppolicies.DataStoreTypes) interface{} {
 	if input == nil {
 		return nil
 	}
@@ -181,10 +574,173 @@ func flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(input []backuppo
 		if retentionRule, ok := item.(backuppolicies.AzureRetentionRule); ok && retentionRule.IsDefault != nil && *retentionRule.IsDefault {
 			if retentionRule.Lifecycles != nil && len(retentionRule.Lifecycles) > 0 {
 				if deleteOption, ok := (retentionRule.Lifecycles)[0].DeleteAfter.(backuppolicies.AbsoluteDeleteOption); ok {
-					return deleteOption.Duration
+					if (retentionRule.Lifecycles)[0].SourceDataStore.DataStoreType == dsType {
+						return deleteOption.Duration
+					}
 				}
 			}
 		}
 	}
 	return nil
+}
+
+func flattenBackupPolicyBlobStorageVaultBackupRuleArray(input *[]backuppolicies.BasePolicyRule) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+	for _, item := range *input {
+		if backupRule, ok := item.(backuppolicies.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if scheduleBasedTrigger, ok := backupRule.Trigger.(backuppolicies.ScheduleBasedTriggerContext); ok {
+					return utils.FlattenStringSlice(&scheduleBasedTrigger.Schedule.RepeatingTimeIntervals)
+				}
+			}
+		}
+	}
+	return make([]interface{}, 0)
+}
+
+func flattenBackupPolicyBlobStorageVaultBackupTimeZone(input *[]backuppolicies.BasePolicyRule) string {
+	if input == nil {
+		return ""
+	}
+	for _, item := range *input {
+		if backupRule, ok := item.(backuppolicies.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if scheduleBasedTrigger, ok := backupRule.Trigger.(backuppolicies.ScheduleBasedTriggerContext); ok {
+					return pointer.From(scheduleBasedTrigger.Schedule.TimeZone)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func flattenBackupPolicyBlobStorageRetentionRuleArray(input *[]backuppolicies.BasePolicyRule) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	var taggingCriterias []backuppolicies.TaggingCriteria
+	for _, item := range *input {
+		if backupRule, ok := item.(backuppolicies.AzureBackupRule); ok {
+			if trigger, ok := backupRule.Trigger.(backuppolicies.ScheduleBasedTriggerContext); ok {
+				if trigger.TaggingCriteria != nil {
+					taggingCriterias = trigger.TaggingCriteria
+				}
+			}
+		}
+	}
+
+	for _, item := range *input {
+		if retentionRule, ok := item.(backuppolicies.AzureRetentionRule); ok && (retentionRule.IsDefault == nil || !*retentionRule.IsDefault) {
+			name := retentionRule.Name
+			var taggingPriority int64
+			var taggingCriteria []interface{}
+			for _, criteria := range taggingCriterias {
+				if strings.EqualFold(criteria.TagInfo.TagName, name) {
+					taggingPriority = criteria.TaggingPriority
+					taggingCriteria = flattenBackupPolicyBlobStorageBackupCriteriaArray(criteria.Criteria)
+					break
+				}
+			}
+
+			var lifeCycle []interface{}
+			if v := retentionRule.Lifecycles; len(v) > 0 {
+				lifeCycle = flattenBackupPolicyBlobStorageBackupLifeCycleArray(v, backuppolicies.DataStoreTypesVaultStore)
+			}
+			results = append(results, map[string]interface{}{
+				"name":       name,
+				"priority":   taggingPriority,
+				"criteria":   taggingCriteria,
+				"life_cycle": lifeCycle,
+			})
+		}
+	}
+	return results
+}
+
+func flattenBackupPolicyBlobStorageBackupLifeCycleArray(input []backuppolicies.SourceLifeCycle, dsType backuppolicies.DataStoreTypes) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range input {
+		var duration string
+		dataStoreType := item.SourceDataStore.DataStoreType
+		if deleteOption, ok := item.DeleteAfter.(backuppolicies.AbsoluteDeleteOption); ok {
+			if dataStoreType == dsType {
+				duration = deleteOption.Duration
+			} else {
+				continue
+			}
+		}
+
+		results = append(results, map[string]interface{}{
+			"duration":        duration,
+			"data_store_type": string(dataStoreType),
+		})
+	}
+	return results
+}
+
+func flattenBackupPolicyBlobStorageBackupCriteriaArray(input *[]backuppolicies.BackupCriteria) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		if criteria, ok := item.(backuppolicies.ScheduleBasedBackupCriteria); ok {
+			var absoluteCriteria string
+			if criteria.AbsoluteCriteria != nil && len(*criteria.AbsoluteCriteria) > 0 {
+				absoluteCriteria = string((*criteria.AbsoluteCriteria)[0])
+			}
+			var daysOfWeek []string
+			if criteria.DaysOfTheWeek != nil {
+				daysOfWeek = make([]string, 0)
+				for _, item := range *criteria.DaysOfTheWeek {
+					daysOfWeek = append(daysOfWeek, (string)(item))
+				}
+			}
+			var daysOfMonth []int
+			if criteria.DaysOfMonth != nil {
+				daysOfMonth = make([]int, 0)
+				for _, item := range *criteria.DaysOfMonth {
+					daysOfMonth = append(daysOfMonth, (int)(pointer.From(item.Date)))
+				}
+			}
+			var monthsOfYear []string
+			if criteria.MonthsOfYear != nil {
+				monthsOfYear = make([]string, 0)
+				for _, item := range *criteria.MonthsOfYear {
+					monthsOfYear = append(monthsOfYear, (string)(item))
+				}
+			}
+			var weeksOfMonth []string
+			if criteria.WeeksOfTheMonth != nil {
+				weeksOfMonth = make([]string, 0)
+				for _, item := range *criteria.WeeksOfTheMonth {
+					weeksOfMonth = append(weeksOfMonth, (string)(item))
+				}
+			}
+			var scheduleTimes []string
+			if criteria.ScheduleTimes != nil {
+				scheduleTimes = make([]string, 0)
+				scheduleTimes = append(scheduleTimes, *criteria.ScheduleTimes...)
+			}
+
+			results = append(results, map[string]interface{}{
+				"absolute_criteria":      absoluteCriteria,
+				"days_of_week":           daysOfWeek,
+				"days_of_month":          daysOfMonth,
+				"months_of_year":         monthsOfYear,
+				"weeks_of_month":         weeksOfMonth,
+				"scheduled_backup_times": scheduleTimes,
+			})
+		}
+	}
+	return results
 }

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -352,8 +352,10 @@ func resourceDataProtectionBackupPolicyBlobStorageRead(d *schema.ResourceData, m
 				if err := d.Set("operational_default_retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesOperationalStore)); err != nil {
 					return fmt.Errorf("setting `operational_default_retention_duration`: %+v", err)
 				}
-				if err := d.Set("retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesOperationalStore)); err != nil {
-					return fmt.Errorf("setting `retention_duration`: %+v", err)
+				if !features.FourPointOhBeta() {
+					if err := d.Set("retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesOperationalStore)); err != nil {
+						return fmt.Errorf("setting `retention_duration`: %+v", err)
+					}
 				}
 				d.Set("time_zone", flattenBackupPolicyBlobStorageVaultBackupTimeZone(&props.PolicyRules))
 				if err := d.Set("vault_default_retention_duration", flattenBackupPolicyBlobStorageDefaultRetentionRuleDuration(props.PolicyRules, backuppolicies.DataStoreTypesVaultStore)); err != nil {

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -99,7 +100,8 @@ resource "azurerm_data_protection_backup_vault" "test" {
 
 func (r DataProtectionBackupPolicyBlobStorageResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
@@ -108,10 +110,60 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
   retention_duration = "P30D"
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
+  name                                   = "acctest-dbp-%d"
+  vault_id                               = azurerm_data_protection_backup_vault.test.id
+  operational_default_retention_duration = "P30D"
+}
+`, template, data.RandomInteger)
 }
 
 func (r DataProtectionBackupPolicyBlobStorageResource) vaultBackup(data acceptance.TestData) string {
 	template := r.template(data)
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
+  name                             = "acctest-dbp-%d"
+  vault_id                         = azurerm_data_protection_backup_vault.test.id
+  retention_duration               = "P30D"
+  vault_default_retention_duration = "P7D"
+  backup_repeating_time_intervals  = ["R/2024-05-08T11:30:00+00:00/P1W"]
+
+  retention_rule {
+    name     = "Monthly"
+    priority = 15
+    life_cycle {
+      duration        = "P6M"
+      data_store_type = "VaultStore"
+    }
+    criteria {
+      days_of_month = [1, 2, 0]
+    }
+  }
+
+  retention_rule {
+    name     = "Daily"
+    priority = 25
+    life_cycle {
+      duration        = "P7D"
+      data_store_type = "VaultStore"
+    }
+    criteria {
+      days_of_week           = ["Thursday"]
+      months_of_year         = ["November"]
+      weeks_of_month         = ["First"]
+      scheduled_backup_times = ["2024-05-08T02:30:00Z"]
+    }
+  }
+}
+`, template, data.RandomInteger)
+	}
 	return fmt.Sprintf(`
 %s
 
@@ -154,13 +206,24 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
 
 func (r DataProtectionBackupPolicyBlobStorageResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "import" {
   name               = azurerm_data_protection_backup_policy_blob_storage.test.name
   vault_id           = azurerm_data_protection_backup_policy_blob_storage.test.vault_id
   retention_duration = "P30D"
+}
+`, config)
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "import" {
+  name                                   = azurerm_data_protection_backup_policy_blob_storage.test.name
+  vault_id                               = azurerm_data_protection_backup_policy_blob_storage.test.vault_id
+  operational_default_retention_duration = "P30D"
 }
 `, config)
 }

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
@@ -33,6 +33,20 @@ func TestAccDataProtectionBackupPolicyBlobStorage_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataProtectionBackupPolicyBlobStorage_vaultbackup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_blob_storage", "test")
+	r := DataProtectionBackupPolicyBlobStorageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vaultBackup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataProtectionBackupPolicyBlobStorage_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_blob_storage", "test")
 	r := DataProtectionBackupPolicyBlobStorageResource{}
@@ -92,6 +106,48 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
   name               = "acctest-dbp-%d"
   vault_id           = azurerm_data_protection_backup_vault.test.id
   retention_duration = "P30D"
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupPolicyBlobStorageResource) vaultBackup(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
+  name                                   = "acctest-dbp-%d"
+  vault_id                               = azurerm_data_protection_backup_vault.test.id
+  operational_default_retention_duration = "P30D"
+  vault_default_retention_duration       = "P7D"
+  backup_repeating_time_intervals        = ["R/2024-05-08T11:30:00+00:00/P1W"]
+
+  retention_rule {
+    name     = "Monthly"
+    priority = 15
+    life_cycle {
+      duration        = "P6M"
+      data_store_type = "VaultStore"
+    }
+    criteria {
+      days_of_month = [1, 2, 0]
+    }
+  }
+
+  retention_rule {
+    name     = "Daily"
+    priority = 25
+    life_cycle {
+      duration        = "P7D"
+      data_store_type = "VaultStore"
+    }
+    criteria {
+      days_of_week           = ["Thursday"]
+      months_of_year         = ["November"]
+      weeks_of_month         = ["First"]
+      scheduled_backup_times = ["2024-05-08T02:30:00Z"]
+    }
+  }
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
@@ -40,8 +40,60 @@ The following arguments are supported:
 * `name` - (Required) The name which should be used for this Backup Policy Blob Storage. Changing this forces a new Backup Policy Blob Storage to be created.
 
 * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Policy Blob Storage should exist. Changing this forces a new Backup Policy Blob Storage to be created.
-  
-* `retention_duration` - (Required) Duration of deletion after given timespan. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `backup_repeating_time_intervals` - (Optional) Specifies a list of repeating time interval. It should follow `ISO 8601` repeating time interval. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `operational_default_retention_duration` - (Optional) The duration of operational default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `retention_duration` - (Optional) Duration of deletion after given timespan. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+-> **Note:** -> `retention_duration` is deprecated in version 3.0 and will be removed in version 4.0 of the AzureRM Provider. Please use the `operational_default_retention_duration` instead.
+
+* `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
+
+-> **Note:** Setting `retention_rule` also requires setting `vault_default_retention_duration`.
+
+* `time_zone` - (Optional) Specifies the Time Zone which should be used by the backup schedule. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `vault_default_retention_duration` - (Optional) The duration of vault default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+-> **Note:** Setting `vault_default_retention_duration` also requires setting `backup_repeating_time_intervals`. At least one of `operational_default_retention_duration`, `retention_duration` or `vault_default_retention_duration` must be specified.
+
+---
+
+A `retention_rule` block supports the following:
+
+* `name` - (Required) The name which should be used for this retention rule. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `duration` - (Required) Duration after which the backup is deleted. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `criteria` - (Required) A `criteria` block as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `life_cycle` - (Required) A `life_cycle` block as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `priority` - (Required) Specifies the priority of the rule. The priority number must be unique for each rule. The lower the priority number, the higher the priority of the rule. Changing this forces a new Backup Policy Blob Storage to be created.
+
+---
+
+A `criteria` block supports the following:
+
+* `absolute_criteria` - (Optional) Possible values are `AllBackup`, `FirstOfDay`, `FirstOfWeek`, `FirstOfMonth` and `FirstOfYear`. These values mean the first successful backup of the day/week/month/year. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `days_of_month` - (Optional) Must be between `0` and `28`. `0` for last day within the month. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `days_of_week` - (Optional) Possible values are `Monday`, `Tuesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `months_of_year` - (Optional) Possible values are `January`, `February`, `March`, `April`, `May`, `June`, `July`, `August`, `September`, `October`, `November` and `December`. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `scheduled_backup_times` - (Optional) Specifies a list of backup times for backup in the `RFC3339` format. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `weeks_of_month` - (Optional) Possible values are `First`, `Second`, `Third`, `Fourth` and `Last`. Changing this forces a new Backup Policy Blob Storage to be created.
+
+A `life_cycle` block supports the following:
+
+* `data_store_type` - (Required) The type of data store. The only possible value is `VaultStore`. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `duration` - (Required) The retention duration up to which the backups are to be retained in the data stores. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Currently, Terraform only supports operational backup for Azure Blob backup (operational backup only supports setting the default retention rule). The service team requested to support vault backup for Azure blob backup, which in addition to the default retention rule, also supports user-specified retention rules.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
PASS: TestAccDataProtectionBackupPolicyBlobStorage_vaultbackup (328.49s)
PASS: TestAccDataProtectionBackupPolicyBlobStorage_basic (302.56s)
PASS: TestAccDataProtectionBackupPolicyBlobStorage_requiresImport (292.32s)


```

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


