### PR TITLE
`network` - update resources and data sources to use `hashicorp/go-azure-sdk`

### DIFF
--- a/internal/services/network/edge_zone.go
+++ b/internal/services/network/edge_zone.go
@@ -45,3 +45,22 @@ func flattenEdgeZoneModel(input *edgezones.Model) string {
 	}
 	return edgezones.Normalize(input.Name)
 }
+
+// These will be renamed to expandEdgeZone when all calls to the former expandEdgeZone have been removed
+func expandEdgeZoneNew(input string) *edgezones.Model {
+	normalized := edgezones.Normalize(input)
+	if normalized == "" {
+		return nil
+	}
+
+	return &edgezones.Model{
+		Name: normalized,
+	}
+}
+
+func flattenEdgeZoneNew(input *edgezones.Model) string {
+	if input == nil || input.Name == "" {
+		return ""
+	}
+	return edgezones.Normalize(input.Name)
+}

--- a/internal/services/network/network_security_group_data_source.go
+++ b/internal/services/network/network_security_group_data_source.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networksecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceNetworkSecurityGroup() *pluginsdk.Resource {
@@ -135,43 +135,44 @@ func dataSourceNetworkSecurityGroup() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.SchemaDataSource(),
+			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
 
 func dataSourceNetworkSecurityGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SecurityGroupClient
+	client := meta.(*clients.Client).Network.NetworkSecurityGroups
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewNetworkSecurityGroupID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := networksecuritygroups.NewNetworkSecurityGroupID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, id, networksecuritygroups.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("making Read request on %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("reading request on %s: %+v", id, err)
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 	d.SetId(id.ID())
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.NetworkSecurityGroupName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
-
-	if props := resp.SecurityGroupPropertiesFormat; props != nil {
-		flattenedRules := flattenNetworkSecurityRules(props.SecurityRules)
-		if err := d.Set("security_rule", flattenedRules); err != nil {
-			return fmt.Errorf("setting `security_rule`: %+v", err)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if props := model.Properties; props != nil {
+			flattenedRules := flattenNetworkSecurityRules(props.SecurityRules)
+			if err := d.Set("security_rule", flattenedRules); err != nil {
+				return fmt.Errorf("setting `security_rule`: %+v", err)
+			}
 		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }

--- a/internal/services/network/network_security_group_resource_test.go
+++ b/internal/services/network/network_security_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networksecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkSecurityGroupResource struct{}
@@ -214,35 +214,30 @@ func TestAccNetworkSecurityGroup_deleteRule(t *testing.T) {
 }
 
 func (t NetworkSecurityGroupResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.NetworkSecurityGroupID(state.ID)
+	id, err := networksecuritygroups.ParseNetworkSecurityGroupID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.SecurityGroupClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := clients.Network.Client.NetworkSecurityGroups.Get(ctx, *id, networksecuritygroups.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading Network Security Group (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkSecurityGroupResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.NetworkSecurityGroupID(state.ID)
+	id, err := networksecuritygroups.ParseNetworkSecurityGroupID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	future, err := client.Network.SecurityGroupClient.Delete(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
-		return nil, fmt.Errorf("deleting Network Security Group %q: %+v", id, err)
+	if err := client.Network.Client.NetworkSecurityGroups.DeleteThenPoll(ctx, *id); err != nil {
+		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Network.SecurityGroupClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for Deletion of Network Security Group: %+v", err)
-	}
-
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetworkSecurityGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -7,16 +7,18 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipaddresses"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourcePublicIP() *pluginsdk.Resource {
@@ -104,70 +106,67 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 }
 
 func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPsClient
+	client := meta.(*clients.Client).Network.PublicIPAddresses
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewPublicIpAddressID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := commonids.NewPublicIPAddressID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, id, publicipaddresses.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("making Read request on %s: %s", id, err)
+		return fmt.Errorf("retrieving %s: %s", id, err)
 	}
 
 	d.SetId(id.ID())
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.FlattenUntyped(resp.Zones))
-
-	if resp.PublicIPAddressPropertiesFormat == nil {
-		return fmt.Errorf("retreving %s: `properties` was nil", id)
-	}
-
-	skuName := ""
-	if sku := resp.Sku; sku != nil {
-		skuName = string(sku.Name)
-	}
-	d.Set("sku", skuName)
-
-	props := *resp.PublicIPAddressPropertiesFormat
-
-	domainNameLabel := ""
-	fqdn := ""
-	reverseFqdn := ""
-	if dnsSettings := props.DNSSettings; dnsSettings != nil {
-		if dnsSettings.DomainNameLabel != nil {
-			domainNameLabel = *dnsSettings.DomainNameLabel
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
+		skuName := ""
+		if sku := model.Sku; sku != nil {
+			skuName = string(pointer.From(sku.Name))
 		}
-		if dnsSettings.Fqdn != nil {
-			fqdn = *dnsSettings.Fqdn
+		d.Set("sku", skuName)
+
+		if props := model.Properties; props != nil {
+			domainNameLabel := ""
+			fqdn := ""
+			reverseFqdn := ""
+			if dnsSettings := props.DnsSettings; dnsSettings != nil {
+				if dnsSettings.DomainNameLabel != nil {
+					domainNameLabel = *dnsSettings.DomainNameLabel
+				}
+				if dnsSettings.Fqdn != nil {
+					fqdn = *dnsSettings.Fqdn
+				}
+				if dnsSettings.ReverseFqdn != nil {
+					reverseFqdn = *dnsSettings.ReverseFqdn
+				}
+			}
+
+			if ddosSetting := props.DdosSettings; ddosSetting != nil {
+				d.Set("ddos_protection_mode", string(pointer.From(ddosSetting.ProtectionMode)))
+				if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
+					d.Set("ddos_protection_plan_id", subResource.Id)
+				}
+			}
+
+			d.Set("domain_name_label", domainNameLabel)
+			d.Set("fqdn", fqdn)
+			d.Set("reverse_fqdn", reverseFqdn)
+
+			d.Set("allocation_method", string(pointer.From(props.PublicIPAllocationMethod)))
+			d.Set("ip_address", props.IPAddress)
+			d.Set("ip_version", string(pointer.From(props.PublicIPAddressVersion)))
+			d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
+
+			d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
 		}
-		if dnsSettings.ReverseFqdn != nil {
-			reverseFqdn = *dnsSettings.ReverseFqdn
-		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	if ddosSetting := props.DdosSettings; ddosSetting != nil {
-		d.Set("ddos_protection_mode", string(ddosSetting.ProtectionMode))
-		if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
-			d.Set("ddos_protection_plan_id", subResource.ID)
-		}
-	}
-
-	d.Set("domain_name_label", domainNameLabel)
-	d.Set("fqdn", fqdn)
-	d.Set("reverse_fqdn", reverseFqdn)
-
-	d.Set("allocation_method", string(props.PublicIPAllocationMethod))
-	d.Set("ip_address", props.IPAddress)
-	d.Set("ip_version", string(props.PublicIPAddressVersion))
-	d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
-
-	d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }

--- a/internal/services/network/public_ip_prefix_data_source.go
+++ b/internal/services/network/public_ip_prefix_data_source.go
@@ -7,15 +7,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipprefixes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourcePublicIpPrefix() *pluginsdk.Resource {
@@ -59,15 +60,15 @@ func dataSourcePublicIpPrefix() *pluginsdk.Resource {
 }
 
 func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPPrefixesClient
+	client := meta.(*clients.Client).Network.PublicIPPrefixes
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewPublicIpPrefixID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	id := publicipprefixes.NewPublicIPPrefixID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	resp, err := client.Get(ctx, id, publicipprefixes.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -75,15 +76,18 @@ func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	d.SetId(id.ID())
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.FlattenUntyped(resp.Zones))
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
-	if sku := resp.Sku; sku != nil {
-		d.Set("sku", string(sku.Name))
+		if sku := model.Sku; sku != nil {
+			d.Set("sku", string(pointer.From(sku.Name)))
+		}
+		if props := model.Properties; props != nil {
+			d.Set("prefix_length", props.PrefixLength)
+			d.Set("ip_prefix", props.IPPrefix)
+		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-	if props := resp.PublicIPPrefixPropertiesFormat; props != nil {
-		d.Set("prefix_length", props.PrefixLength)
-		d.Set("ip_prefix", props.IPPrefix)
-	}
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -9,23 +9,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/ddosprotectionplans"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipaddresses"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourcePublicIp() *pluginsdk.Resource {
@@ -36,7 +36,7 @@ func resourcePublicIp() *pluginsdk.Resource {
 		Delete: resourcePublicIpDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.PublicIpAddressID(id)
+			_, err := commonids.ParsePublicIPAddressID(id)
 			return err
 		}),
 
@@ -63,8 +63,8 @@ func resourcePublicIp() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.IPAllocationMethodStatic),
-					string(network.IPAllocationMethodDynamic),
+					string(publicipaddresses.IPAllocationMethodStatic),
+					string(publicipaddresses.IPAllocationMethodDynamic),
 				}, false),
 			},
 
@@ -73,11 +73,11 @@ func resourcePublicIp() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.DdosSettingsProtectionModeDisabled),
-					string(network.DdosSettingsProtectionModeEnabled),
-					string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
+					string(publicipaddresses.DdosSettingsProtectionModeDisabled),
+					string(publicipaddresses.DdosSettingsProtectionModeEnabled),
+					string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited),
 				}, false),
-				Default: string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
+				Default: string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited),
 			},
 
 			"ddos_protection_plan_id": {
@@ -91,11 +91,11 @@ func resourcePublicIp() *pluginsdk.Resource {
 			"ip_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(network.IPVersionIPv4),
+				Default:  string(publicipaddresses.IPVersionIPvFour),
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.IPVersionIPv4),
-					string(network.IPVersionIPv6),
+					string(publicipaddresses.IPVersionIPvFour),
+					string(publicipaddresses.IPVersionIPvSix),
 				}, false),
 			},
 
@@ -106,24 +106,24 @@ func resourcePublicIp() *pluginsdk.Resource {
 				Default: func() interface{} {
 					// https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/
 					if !features.FourPointOhBeta() {
-						return string(network.PublicIPAddressSkuNameBasic)
+						return string(publicipaddresses.PublicIPAddressSkuNameBasic)
 					}
-					return string(network.PublicIPAddressSkuNameStandard)
+					return string(publicipaddresses.PublicIPAddressSkuNameStandard)
 				}(),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.PublicIPAddressSkuNameBasic),
-					string(network.PublicIPAddressSkuNameStandard),
+					string(publicipaddresses.PublicIPAddressSkuNameBasic),
+					string(publicipaddresses.PublicIPAddressSkuNameStandard),
 				}, false),
 			},
 
 			"sku_tier": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(network.PublicIPAddressSkuTierRegional),
+				Default:  string(publicipaddresses.PublicIPAddressSkuTierRegional),
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.PublicIPAddressSkuTierGlobal),
-					string(network.PublicIPAddressSkuTierRegional),
+					string(publicipaddresses.PublicIPAddressSkuTierGlobal),
+					string(publicipaddresses.PublicIPAddressSkuTierRegional),
 				}, false),
 			},
 
@@ -173,40 +173,34 @@ func resourcePublicIp() *pluginsdk.Resource {
 
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 		},
 	}
 }
 
 func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPsClient
+	client := meta.(*clients.Client).Network.PublicIPAddresses
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Public IP creation.")
 
-	id := parse.NewPublicIpAddressID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := commonids.NewPublicIPAddressID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+		existing, err := client.Get(ctx, id, publicipaddresses.DefaultGetOperationOptions())
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_public_ip", id.ID())
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
 	sku := d.Get("sku").(string)
-	skuTier := d.Get("sku_tier").(string)
-	t := d.Get("tags").(map[string]interface{})
-
-	idleTimeout := d.Get("idle_timeout_in_minutes").(int)
-	ipVersion := network.IPVersion(d.Get("ip_version").(string))
 	ipAllocationMethod := d.Get("allocation_method").(string)
 
 	if strings.EqualFold(sku, "standard") {
@@ -217,31 +211,32 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	ddosProtectionMode := d.Get("ddos_protection_mode").(string)
 
-	publicIp := network.PublicIPAddress{
-		Name:             utils.String(id.Name),
-		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
-		Location:         &location,
-		Sku: &network.PublicIPAddressSku{
-			Name: network.PublicIPAddressSkuName(sku),
-			Tier: network.PublicIPAddressSkuTier(skuTier),
+	publicIp := publicipaddresses.PublicIPAddress{
+		Name:             pointer.To(id.PublicIPAddressesName),
+		ExtendedLocation: expandEdgeZoneNew(d.Get("edge_zone").(string)),
+		Location:         pointer.To(location.Normalize(d.Get("location").(string))),
+		Sku: &publicipaddresses.PublicIPAddressSku{
+			Name: pointer.To(publicipaddresses.PublicIPAddressSkuName(sku)),
+			Tier: pointer.To(publicipaddresses.PublicIPAddressSkuTier(d.Get("sku_tier").(string))),
 		},
-		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: network.IPAllocationMethod(ipAllocationMethod),
-			PublicIPAddressVersion:   ipVersion,
-			IdleTimeoutInMinutes:     utils.Int32(int32(idleTimeout)),
-			DdosSettings: &network.DdosSettings{
-				ProtectionMode: network.DdosSettingsProtectionMode(ddosProtectionMode),
+		Properties: &publicipaddresses.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: pointer.To(publicipaddresses.IPAllocationMethod(ipAllocationMethod)),
+			PublicIPAddressVersion:   pointer.To(publicipaddresses.IPVersion(d.Get("ip_version").(string))),
+			IdleTimeoutInMinutes:     pointer.To(int64(d.Get("idle_timeout_in_minutes").(int))),
+			DdosSettings: &publicipaddresses.DdosSettings{
+				ProtectionMode: pointer.To(publicipaddresses.DdosSettingsProtectionMode(ddosProtectionMode)),
 			},
 		},
-		Tags: tags.Expand(t),
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
+
 	ddosProtectionPlanId, planOk := d.GetOk("ddos_protection_plan_id")
 	if planOk {
 		if !strings.EqualFold(ddosProtectionMode, "enabled") {
 			return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
 		}
-		publicIp.PublicIPAddressPropertiesFormat.DdosSettings.DdosProtectionPlan = &network.SubResource{
-			ID: utils.String(ddosProtectionPlanId.(string)),
+		publicIp.Properties.DdosSettings.DdosProtectionPlan = &publicipaddresses.SubResource{
+			Id: pointer.To(ddosProtectionPlanId.(string)),
 		}
 	}
 
@@ -253,50 +248,45 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	publicIpPrefixId, publicIpPrefixIdOk := d.GetOk("public_ip_prefix_id")
 
 	if publicIpPrefixIdOk {
-		publicIpPrefix := network.SubResource{}
-		publicIpPrefix.ID = utils.String(publicIpPrefixId.(string))
-		publicIp.PublicIPAddressPropertiesFormat.PublicIPPrefix = &publicIpPrefix
+		publicIpPrefix := publicipaddresses.SubResource{}
+		publicIpPrefix.Id = pointer.To(publicIpPrefixId.(string))
+		publicIp.Properties.PublicIPPrefix = &publicIpPrefix
 	}
 
 	dnl, dnlOk := d.GetOk("domain_name_label")
 	rfqdn, rfqdnOk := d.GetOk("reverse_fqdn")
 
 	if dnlOk || rfqdnOk {
-		dnsSettings := network.PublicIPAddressDNSSettings{}
+		dnsSettings := publicipaddresses.PublicIPAddressDnsSettings{}
 
 		if rfqdnOk {
-			dnsSettings.ReverseFqdn = utils.String(rfqdn.(string))
+			dnsSettings.ReverseFqdn = pointer.To(rfqdn.(string))
 		}
 
 		if dnlOk {
-			dnsSettings.DomainNameLabel = utils.String(dnl.(string))
+			dnsSettings.DomainNameLabel = pointer.To(dnl.(string))
 		}
 
-		publicIp.PublicIPAddressPropertiesFormat.DNSSettings = &dnsSettings
+		publicIp.Properties.DnsSettings = &dnsSettings
 	}
 
 	if v, ok := d.GetOk("ip_tags"); ok {
 		ipTags := v.(map[string]interface{})
-		newIpTags := []network.IPTag{}
+		newIpTags := []publicipaddresses.IPTag{}
 
 		for key, val := range ipTags {
-			ipTag := network.IPTag{
-				IPTagType: utils.String(key),
-				Tag:       utils.String(val.(string)),
+			ipTag := publicipaddresses.IPTag{
+				IPTagType: pointer.To(key),
+				Tag:       pointer.To(val.(string)),
 			}
 			newIpTags = append(newIpTags, ipTag)
 		}
 
-		publicIp.PublicIPAddressPropertiesFormat.IPTags = &newIpTags
+		publicIp.Properties.IPTags = &newIpTags
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, publicIp)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, publicIp); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -304,18 +294,18 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourcePublicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPsClient
+	client := meta.(*clients.Client).Network.PublicIPAddresses
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.PublicIpAddressID(d.Id())
+	id, err := commonids.ParsePublicIPAddressID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, *id, publicipaddresses.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
@@ -323,72 +313,69 @@ func resourcePublicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
-	d.Set("zones", zones.FlattenUntyped(resp.Zones))
+	d.Set("name", id.PublicIPAddressesName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if sku := resp.Sku; sku != nil {
-		d.Set("sku", string(sku.Name))
-		d.Set("sku_tier", string(sku.Tier))
-	}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("edge_zone", flattenEdgeZoneNew(model.ExtendedLocation))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
-	if props := resp.PublicIPAddressPropertiesFormat; props != nil {
-		d.Set("allocation_method", string(props.PublicIPAllocationMethod))
-		d.Set("ip_version", string(props.PublicIPAddressVersion))
-
-		if publicIpPrefix := props.PublicIPPrefix; publicIpPrefix != nil {
-			d.Set("public_ip_prefix_id", publicIpPrefix.ID)
+		if sku := model.Sku; sku != nil {
+			d.Set("sku", string(pointer.From(sku.Name)))
+			d.Set("sku_tier", string(pointer.From(sku.Tier)))
 		}
+		if props := model.Properties; props != nil {
+			d.Set("allocation_method", string(pointer.From(props.PublicIPAllocationMethod)))
+			d.Set("ip_version", string(pointer.From(props.PublicIPAddressVersion)))
 
-		if settings := props.DNSSettings; settings != nil {
-			d.Set("fqdn", settings.Fqdn)
-			d.Set("reverse_fqdn", settings.ReverseFqdn)
-			d.Set("domain_name_label", settings.DomainNameLabel)
-		}
-
-		ddosProtectionMode := string(network.DdosSettingsProtectionModeVirtualNetworkInherited)
-		if ddosSetting := props.DdosSettings; ddosSetting != nil {
-			ddosProtectionMode = string(ddosSetting.ProtectionMode)
-			if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
-				d.Set("ddos_protection_plan_id", subResource.ID)
+			if publicIpPrefix := props.PublicIPPrefix; publicIpPrefix != nil {
+				d.Set("public_ip_prefix_id", publicIpPrefix.Id)
 			}
+
+			if settings := props.DnsSettings; settings != nil {
+				d.Set("fqdn", settings.Fqdn)
+				d.Set("reverse_fqdn", settings.ReverseFqdn)
+				d.Set("domain_name_label", settings.DomainNameLabel)
+			}
+
+			ddosProtectionMode := string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited)
+			if ddosSetting := props.DdosSettings; ddosSetting != nil {
+				ddosProtectionMode = string(pointer.From(ddosSetting.ProtectionMode))
+				if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
+					d.Set("ddos_protection_plan_id", subResource.Id)
+				}
+			}
+			d.Set("ddos_protection_mode", ddosProtectionMode)
+
+			d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
+
+			d.Set("ip_address", props.IPAddress)
+			d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
 		}
-		d.Set("ddos_protection_mode", ddosProtectionMode)
-
-		d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
-
-		d.Set("ip_address", props.IPAddress)
-		d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourcePublicIpDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPsClient
+	client := meta.(*clients.Client).Network.PublicIPAddresses
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.PublicIpAddressID(d.Id())
+	id, err := commonids.ParsePublicIPAddressID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 	}
 
 	return nil
 }
 
-func flattenPublicIpPropsIpTags(input *[]network.IPTag) map[string]interface{} {
+func flattenPublicIpPropsIpTags(input *[]publicipaddresses.IPTag) map[string]interface{} {
 	out := make(map[string]interface{})
 
 	if input != nil {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -6,15 +6,15 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipaddresses"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipaddresses"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -6,8 +6,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -348,24 +346,6 @@ func TestAccPublicIpDynamic_basic(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccPublicIpStatic_importIdError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
-	r := PublicIPResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.static_basic(data),
-		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateId:     fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/publicIPAdresses/acctestpublicip-%d", os.Getenv("ARM_SUBSCRIPTION_ID"), data.RandomInteger, data.RandomInteger),
-			ExpectError:       regexp.MustCompile("ID was missing the `publicIPAddresses` element"),
-		},
 	})
 }
 

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -6,16 +6,16 @@ package network
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/publicipaddresses"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func dataSourcePublicIPs() *pluginsdk.Resource {
@@ -52,8 +52,8 @@ func dataSourcePublicIPSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(network.IPAllocationMethodDynamic),
-				string(network.IPAllocationMethodStatic),
+				string(publicipaddresses.IPAllocationMethodDynamic),
+				string(publicipaddresses.IPAllocationMethodStatic),
 			}, false),
 		},
 
@@ -89,50 +89,55 @@ func dataSourcePublicIPSchema() map[string]*pluginsdk.Schema {
 }
 
 func dataSourcePublicIPsRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.PublicIPsClient
+	client := meta.(*clients.Client).Network.PublicIPAddresses
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
+	resourceGroupId := commonids.NewResourceGroupID(subscriptionId, d.Get("resource_group_name").(string))
 
-	log.Printf("[DEBUG] Reading Public IP's in Resource Group %q", resourceGroup)
-	resp, err := client.List(ctx, resourceGroup)
+	resp, err := client.List(ctx, resourceGroupId)
 	if err != nil {
-		return fmt.Errorf("listing Public IP Addresses in the Resource Group %q: %v", resourceGroup, err)
+		return fmt.Errorf("listing Public IP Addresses in %s: %v", resourceGroupId, err)
 	}
 
 	prefix := d.Get("name_prefix").(string)
 	attachmentStatus, attachmentStatusOk := d.GetOk("attachment_status")
 	allocationType := d.Get("allocation_type").(string)
 
-	filteredIPAddresses := make([]network.PublicIPAddress, 0)
-	for _, element := range resp.Values() {
-		nicIsAttached := element.IPConfiguration != nil || element.NatGateway != nil
+	filteredIPAddresses := make([]publicipaddresses.PublicIPAddress, 0)
 
-		if prefix != "" {
-			if !strings.HasPrefix(*element.Name, prefix) {
-				continue
+	if model := resp.Model; model != nil {
+		for _, address := range *model {
+			if props := address.Properties; props != nil {
+				nicIsAttached := props.IPConfiguration != nil || props.NatGateway != nil
+
+				if prefix != "" {
+					if !strings.HasPrefix(*address.Name, prefix) {
+						continue
+					}
+				}
+
+				if attachmentStatusOk && attachmentStatus.(string) == "Attached" && !nicIsAttached {
+					continue
+				}
+				if attachmentStatusOk && attachmentStatus.(string) == "Unattached" && nicIsAttached {
+					continue
+				}
+
+				if allocationType != "" {
+					allocation := publicipaddresses.IPAllocationMethod(allocationType)
+					if props.PublicIPAllocationMethod != nil && *props.PublicIPAllocationMethod != allocation {
+						continue
+					}
+				}
 			}
-		}
 
-		if attachmentStatusOk && attachmentStatus.(string) == "Attached" && !nicIsAttached {
-			continue
+			filteredIPAddresses = append(filteredIPAddresses, address)
 		}
-		if attachmentStatusOk && attachmentStatus.(string) == "Unattached" && nicIsAttached {
-			continue
-		}
-
-		if allocationType != "" {
-			allocation := network.IPAllocationMethod(allocationType)
-			if element.PublicIPAllocationMethod != allocation {
-				continue
-			}
-		}
-
-		filteredIPAddresses = append(filteredIPAddresses, element)
 	}
 
-	id := fmt.Sprintf("networkPublicIPs/resourceGroup/%s/namePrefix=%s;attachmentStatus=%s;allocationType=%s", resourceGroup, prefix, attachmentStatus, allocationType)
+	id := fmt.Sprintf("networkPublicIPs/resourceGroup/%s/namePrefix=%s;attachmentStatus=%s;allocationType=%s", resourceGroupId.ResourceGroupName, prefix, attachmentStatus, allocationType)
 	d.SetId(base64.StdEncoding.EncodeToString([]byte(id)))
 
 	results := flattenDataSourcePublicIPs(filteredIPAddresses)
@@ -143,7 +148,7 @@ func dataSourcePublicIPsRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func flattenDataSourcePublicIPs(input []network.PublicIPAddress) []interface{} {
+func flattenDataSourcePublicIPs(input []publicipaddresses.PublicIPAddress) []interface{} {
 	results := make([]interface{}, 0)
 
 	for _, element := range input {
@@ -154,10 +159,10 @@ func flattenDataSourcePublicIPs(input []network.PublicIPAddress) []interface{} {
 	return results
 }
 
-func flattenDataSourcePublicIP(input network.PublicIPAddress) map[string]string {
+func flattenDataSourcePublicIP(input publicipaddresses.PublicIPAddress) map[string]string {
 	id := ""
-	if input.ID != nil {
-		id = *input.ID
+	if input.Id != nil {
+		id = *input.Id
 	}
 
 	name := ""
@@ -168,8 +173,8 @@ func flattenDataSourcePublicIP(input network.PublicIPAddress) map[string]string 
 	domainNameLabel := ""
 	fqdn := ""
 	ipAddress := ""
-	if props := input.PublicIPAddressPropertiesFormat; props != nil {
-		if dns := props.DNSSettings; dns != nil {
+	if props := input.Properties; props != nil {
+		if dns := props.DnsSettings; dns != nil {
 			if dns.Fqdn != nil {
 				fqdn = *dns.Fqdn
 			}

--- a/internal/services/network/virtual_wan_data_source.go
+++ b/internal/services/network/virtual_wan_data_source.go
@@ -7,16 +7,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func dataSourceVirtualWan() *pluginsdk.Resource {
@@ -67,64 +67,65 @@ func dataSourceVirtualWan() *pluginsdk.Resource {
 
 			"location": commonschema.LocationComputed(),
 
-			"tags": tags.SchemaDataSource(),
+			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
 
 func dataSourceVirtualWanRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualWanClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewVirtualWanID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualwans.NewVirtualWANID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.VirtualWansGet(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("reading %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.VirtualWanName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
-
-	if props := resp.VirtualWanProperties; props != nil {
-		d.Set("allow_branch_to_branch_traffic", props.AllowBranchToBranchTraffic)
-		d.Set("disable_vpn_encryption", props.DisableVpnEncryption)
-		if err := d.Set("office365_local_breakout_category", props.Office365LocalBreakoutCategory); err != nil {
-			return fmt.Errorf("setting `office365_local_breakout_category`: %v", err)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if props := model.Properties; props != nil {
+			d.Set("allow_branch_to_branch_traffic", pointer.From(props.AllowBranchToBranchTraffic))
+			d.Set("disable_vpn_encryption", pointer.From(props.DisableVpnEncryption))
+			if err := d.Set("office365_local_breakout_category", pointer.From(props.Office365LocalBreakoutCategory)); err != nil {
+				return fmt.Errorf("setting `office365_local_breakout_category`: %v", err)
+			}
+			d.Set("office365_local_breakout_category", pointer.From(props.Office365LocalBreakoutCategory))
+			if err := d.Set("sku", props.Type); err != nil {
+				return fmt.Errorf("setting `sku`: %v", err)
+			}
+			d.Set("sku", props.Type)
+			if err := d.Set("virtual_hub_ids", flattenVirtualWanProperties(props.VirtualHubs)); err != nil {
+				return fmt.Errorf("setting `virtual_hubs`: %v", err)
+			}
+			if err := d.Set("vpn_site_ids", flattenVirtualWanProperties(props.VpnSites)); err != nil {
+				return fmt.Errorf("setting `vpn_sites`: %v", err)
+			}
 		}
-		d.Set("office365_local_breakout_category", props.Office365LocalBreakoutCategory)
-		if err := d.Set("sku", props.Type); err != nil {
-			return fmt.Errorf("setting `sku`: %v", err)
-		}
-		d.Set("sku", props.Type)
-		if err := d.Set("virtual_hub_ids", flattenVirtualWanProperties(props.VirtualHubs)); err != nil {
-			return fmt.Errorf("setting `virtual_hubs`: %v", err)
-		}
-		if err := d.Set("vpn_site_ids", flattenVirtualWanProperties(props.VpnSites)); err != nil {
-			return fmt.Errorf("setting `vpn_sites`: %v", err)
-		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
-func flattenVirtualWanProperties(input *[]network.SubResource) []interface{} {
+func flattenVirtualWanProperties(input *[]virtualwans.SubResource) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
 	output := make([]interface{}, 0)
 	for _, v := range *input {
-		if v.ID != nil {
-			output = append(output, *v.ID)
+		if v.Id != nil {
+			output = append(output, *v.Id)
 		}
 	}
 	return output

--- a/internal/services/network/virtual_wan_resource_test.go
+++ b/internal/services/network/virtual_wan_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualWanResource struct{}
@@ -67,17 +67,17 @@ func TestAccAzureRMVirtualWan_complete(t *testing.T) {
 }
 
 func (t VirtualWanResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualWanID(state.ID)
+	id, err := virtualwans.ParseVirtualWANID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.VirtualWanClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Network.VirtualWANs.VirtualWansGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual WAN (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualWanResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/vpn_gateway_nat_rule_resource.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/vpngateways"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -37,7 +36,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := vpngateways.ParseVpnGatewayID(id)
+			_, err := virtualwans.ParseNatRuleID(id)
 			return err
 		}),
 

--- a/internal/services/network/vpn_gateway_nat_rule_resource.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource.go
@@ -8,17 +8,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/vpngateways"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVPNGatewayNatRule() *pluginsdk.Resource {
@@ -36,7 +37,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.VpnGatewayNatRuleID(id)
+			_, err := vpngateways.ParseVpnGatewayID(id)
 			return err
 		}),
 
@@ -47,9 +48,6 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
-
-			// TODO: we should be able to remove this in 4.0 since it can be inferred from `vpn_gateway_id`?
-			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"vpn_gateway_id": {
 				Type:         pluginsdk.TypeString,
@@ -131,10 +129,10 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(network.VpnNatRuleModeEgressSnat),
+				Default:  string(virtualwans.VpnNatRuleModeEgressSnat),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.VpnNatRuleModeEgressSnat),
-					string(network.VpnNatRuleModeIngressSnat),
+					string(virtualwans.VpnNatRuleModeEgressSnat),
+					string(virtualwans.VpnNatRuleModeIngressSnat),
 				}, false),
 			},
 
@@ -142,10 +140,10 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(network.VpnNatRuleTypeStatic),
+				Default:  string(virtualwans.VpnNatRuleTypeStatic),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.VpnNatRuleTypeStatic),
-					string(network.VpnNatRuleTypeDynamic),
+					string(virtualwans.VpnNatRuleTypeStatic),
+					string(virtualwans.VpnNatRuleTypeDynamic),
 				}, false),
 			},
 		},
@@ -191,6 +189,13 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 				ValidateFunc: validation.IsCIDR,
 			},
 		}
+		resource.Schema["resource_group_name"] = &pluginsdk.Schema{
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: resourcegroups.ValidateName,
+			Deprecated:   "The property `resource_group_name` has been superseded by `vpn_gateway_id` and will be removed in v4.0 of the AzureRM provider",
+		}
 	}
 
 	return resource
@@ -198,7 +203,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 
 func resourceVPNGatewayNatRuleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).Network.NatRuleClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -207,74 +212,70 @@ func resourceVPNGatewayNatRuleCreate(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	id := parse.NewVpnGatewayNatRuleID(subscriptionId, d.Get("resource_group_name").(string), vpnGatewayId.VpnGatewayName, d.Get("name").(string))
+	id := virtualwans.NewNatRuleID(subscriptionId, vpnGatewayId.ResourceGroupName, vpnGatewayId.VpnGatewayName, d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName)
+	existing, err := client.NatRulesGet(ctx, id)
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for existing %s: %+v", id, err)
 		}
 	}
-	if !utils.ResponseWasNotFound(existing.Response) {
+	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_vpn_gateway_nat_rule", id.ID())
 	}
 
-	props := network.VpnGatewayNatRule{
-		Name: utils.String(d.Get("name").(string)),
-		VpnGatewayNatRuleProperties: &network.VpnGatewayNatRuleProperties{
-			Mode: network.VpnNatRuleMode(d.Get("mode").(string)),
-			Type: network.VpnNatRuleType(d.Get("type").(string)),
+	props := virtualwans.VpnGatewayNatRule{
+		Name: pointer.To(d.Get("name").(string)),
+		Properties: &virtualwans.VpnGatewayNatRuleProperties{
+			Mode: pointer.To(virtualwans.VpnNatRuleMode(d.Get("mode").(string))),
+			Type: pointer.To(virtualwans.VpnNatRuleType(d.Get("type").(string))),
 		},
 	}
 
 	if !features.FourPointOhBeta() {
 		if v, ok := d.GetOk("external_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
+			props.Properties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("internal_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
+			props.Properties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
 		}
 	}
 
 	if v, ok := d.GetOk("external_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
+		props.Properties.ExternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("internal_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
+		props.Properties.InternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("ip_configuration_id"); ok {
-		props.VpnGatewayNatRuleProperties.IPConfigurationID = utils.String(v.(string))
+		props.Properties.IPConfigurationId = pointer.To(v.(string))
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName, props)
-	if err != nil {
+	if err := client.NatRulesCreateOrUpdateThenPoll(ctx, id, props); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of the %s: %+v", id, err)
-	}
-
 	d.SetId(id.ID())
+
 	return resourceVPNGatewayNatRuleRead(d, meta)
 }
 
 func resourceVPNGatewayNatRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.NatRuleClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VpnGatewayNatRuleID(d.Id())
+	id, err := virtualwans.ParseNatRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName)
+	resp, err := client.NatRulesGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] %s was not found - removing from state", id)
 			d.SetId("")
 			return nil
@@ -283,32 +284,37 @@ func resourceVPNGatewayNatRuleRead(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	d.Set("name", id.NatRuleName)
-	d.Set("resource_group_name", id.ResourceGroup)
 
-	gatewayId := virtualwans.NewVpnGatewayID(id.SubscriptionId, id.ResourceGroup, id.VpnGatewayName)
+	if !features.FourPointOhBeta() {
+		d.Set("resource_group_name", id.ResourceGroupName)
+	}
+
+	gatewayId := virtualwans.NewVpnGatewayID(id.SubscriptionId, id.ResourceGroupName, id.VpnGatewayName)
 	d.Set("vpn_gateway_id", gatewayId.ID())
 
-	if props := resp.VpnGatewayNatRuleProperties; props != nil {
-		d.Set("ip_configuration_id", props.IPConfigurationID)
-		d.Set("mode", props.Mode)
-		d.Set("type", props.Type)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("ip_configuration_id", props.IPConfigurationId)
+			d.Set("mode", pointer.From(props.Mode))
+			d.Set("type", pointer.From(props.Type))
 
-		if !features.FourPointOhBeta() {
-			if err := d.Set("external_address_space_mappings", flattenVpnGatewayNatRuleAddressSpaceMappings(props.ExternalMappings)); err != nil {
-				return fmt.Errorf("setting `external_address_space_mappings`: %+v", err)
+			if !features.FourPointOhBeta() {
+				if err := d.Set("external_address_space_mappings", flattenVpnGatewayNatRuleAddressSpaceMappings(props.ExternalMappings)); err != nil {
+					return fmt.Errorf("setting `external_address_space_mappings`: %+v", err)
+				}
+
+				if err := d.Set("internal_address_space_mappings", flattenVpnGatewayNatRuleAddressSpaceMappings(props.InternalMappings)); err != nil {
+					return fmt.Errorf("setting `internal_address_space_mappings`: %+v", err)
+				}
 			}
 
-			if err := d.Set("internal_address_space_mappings", flattenVpnGatewayNatRuleAddressSpaceMappings(props.InternalMappings)); err != nil {
-				return fmt.Errorf("setting `internal_address_space_mappings`: %+v", err)
+			if err := d.Set("external_mapping", flattenVpnGatewayNatRuleMappings(props.ExternalMappings)); err != nil {
+				return fmt.Errorf("setting `external_mapping`: %+v", err)
 			}
-		}
 
-		if err := d.Set("external_mapping", flattenVpnGatewayNatRuleMappings(props.ExternalMappings)); err != nil {
-			return fmt.Errorf("setting `external_mapping`: %+v", err)
-		}
-
-		if err := d.Set("internal_mapping", flattenVpnGatewayNatRuleMappings(props.InternalMappings)); err != nil {
-			return fmt.Errorf("setting `internal_mapping`: %+v", err)
+			if err := d.Set("internal_mapping", flattenVpnGatewayNatRuleMappings(props.InternalMappings)); err != nil {
+				return fmt.Errorf("setting `internal_mapping`: %+v", err)
+			}
 		}
 	}
 
@@ -316,114 +322,108 @@ func resourceVPNGatewayNatRuleRead(d *pluginsdk.ResourceData, meta interface{}) 
 }
 
 func resourceVPNGatewayNatRuleUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).Network.NatRuleClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	vpnGatewayId, err := virtualwans.ParseVpnGatewayID(d.Get("vpn_gateway_id").(string))
+	id, err := virtualwans.ParseNatRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	id := parse.NewVpnGatewayNatRuleID(subscriptionId, d.Get("resource_group_name").(string), vpnGatewayId.VpnGatewayName, d.Get("name").(string))
-
-	existing, err := client.Get(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName)
+	existing, err := client.NatRulesGet(ctx, *id)
 	if err != nil {
-		return err
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	props := network.VpnGatewayNatRule{
-		Name: utils.String(d.Get("name").(string)),
-		VpnGatewayNatRuleProperties: &network.VpnGatewayNatRuleProperties{
-			Mode:             network.VpnNatRuleMode(d.Get("mode").(string)),
-			Type:             network.VpnNatRuleType(d.Get("type").(string)),
-			ExternalMappings: existing.VpnGatewayNatRuleProperties.ExternalMappings,
-			InternalMappings: existing.VpnGatewayNatRuleProperties.InternalMappings,
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	props := virtualwans.VpnGatewayNatRule{
+		Name: pointer.To(d.Get("name").(string)),
+		Properties: &virtualwans.VpnGatewayNatRuleProperties{
+			Mode:             pointer.To(virtualwans.VpnNatRuleMode(d.Get("mode").(string))),
+			Type:             pointer.To(virtualwans.VpnNatRuleType(d.Get("type").(string))),
+			ExternalMappings: existing.Model.Properties.ExternalMappings,
+			InternalMappings: existing.Model.Properties.InternalMappings,
 		},
 	}
 
 	// d.GetOk always returns true and the value that is set in the previous apply when the property has the attribute `Computed: true`. Hence, at this time d.GetOk cannot identify whether user sets the property in tf config so that it has to identify it via splitting create and update method and using d.HasChange
 	if !features.FourPointOhBeta() {
 		if ok := d.HasChange("external_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("external_address_space_mappings").([]interface{}))
+			props.Properties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("external_address_space_mappings").([]interface{}))
 		}
 
 		if ok := d.HasChange("internal_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("internal_address_space_mappings").([]interface{}))
+			props.Properties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("internal_address_space_mappings").([]interface{}))
 		}
 	}
 
 	if ok := d.HasChange("external_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(d.Get("external_mapping").([]interface{}))
+		props.Properties.ExternalMappings = expandVpnGatewayNatRuleMappings(d.Get("external_mapping").([]interface{}))
 	}
 
 	if ok := d.HasChange("internal_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(d.Get("internal_mapping").([]interface{}))
+		props.Properties.InternalMappings = expandVpnGatewayNatRuleMappings(d.Get("internal_mapping").([]interface{}))
 	}
 
 	if v, ok := d.GetOk("ip_configuration_id"); ok {
-		props.VpnGatewayNatRuleProperties.IPConfigurationID = utils.String(v.(string))
+		props.Properties.IPConfigurationId = pointer.To(v.(string))
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName, props)
-	if err != nil {
+	if err := client.NatRulesCreateOrUpdateThenPoll(ctx, *id, props); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of the %s: %+v", id, err)
 	}
 
 	return resourceVPNGatewayNatRuleRead(d, meta)
 }
 
 func resourceVPNGatewayNatRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.NatRuleClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VpnGatewayNatRuleID(d.Id())
+	id, err := virtualwans.ParseNatRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName)
-	if err != nil {
+	if err := client.NatRulesDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of the %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func expandVpnGatewayNatRuleAddressSpaceMappings(input []interface{}) *[]network.VpnNatRuleMapping {
-	results := make([]network.VpnNatRuleMapping, 0)
+func expandVpnGatewayNatRuleAddressSpaceMappings(input []interface{}) *[]virtualwans.VpnNatRuleMapping {
+	results := make([]virtualwans.VpnNatRuleMapping, 0)
 
 	for _, v := range input {
-		results = append(results, network.VpnNatRuleMapping{
-			AddressSpace: utils.String(v.(string)),
+		results = append(results, virtualwans.VpnNatRuleMapping{
+			AddressSpace: pointer.To(v.(string)),
 		})
 	}
 
 	return &results
 }
 
-func expandVpnGatewayNatRuleMappings(input []interface{}) *[]network.VpnNatRuleMapping {
-	results := make([]network.VpnNatRuleMapping, 0)
+func expandVpnGatewayNatRuleMappings(input []interface{}) *[]virtualwans.VpnNatRuleMapping {
+	results := make([]virtualwans.VpnNatRuleMapping, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		result := network.VpnNatRuleMapping{
-			AddressSpace: utils.String(v["address_space"].(string)),
+		result := virtualwans.VpnNatRuleMapping{
+			AddressSpace: pointer.To(v["address_space"].(string)),
 		}
 
 		if portRange := v["port_range"].(string); portRange != "" {
-			result.PortRange = utils.String(portRange)
+			result.PortRange = pointer.To(portRange)
 		}
 
 		results = append(results, result)
@@ -432,7 +432,7 @@ func expandVpnGatewayNatRuleMappings(input []interface{}) *[]network.VpnNatRuleM
 	return &results
 }
 
-func flattenVpnGatewayNatRuleMappings(input *[]network.VpnNatRuleMapping) []interface{} {
+func flattenVpnGatewayNatRuleMappings(input *[]virtualwans.VpnNatRuleMapping) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results
@@ -458,7 +458,7 @@ func flattenVpnGatewayNatRuleMappings(input *[]network.VpnNatRuleMapping) []inte
 	return results
 }
 
-func flattenVpnGatewayNatRuleAddressSpaceMappings(input *[]network.VpnNatRuleMapping) []interface{} {
+func flattenVpnGatewayNatRuleAddressSpaceMappings(input *[]virtualwans.VpnNatRuleMapping) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results

--- a/internal/services/network/vpn_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VPNGatewayNatRuleResource struct{}
@@ -109,17 +109,17 @@ func TestAccVpnGatewayNatRule_externalMappingAndInternalMapping(t *testing.T) {
 }
 
 func (r VPNGatewayNatRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VpnGatewayNatRuleID(state.ID)
+	id, err := virtualwans.ParseNatRuleID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.NatRuleClient.Get(ctx, id.ResourceGroup, id.VpnGatewayName, id.NatRuleName)
+	resp, err := clients.Network.VirtualWANs.NatRulesGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VPNGatewayNatRuleResource) basic(data acceptance.TestData) string {

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -76,7 +76,7 @@ function runGraduallyDeprecatedFunctions {
     fi
 
     # exceptions to avoid false positives and legacy resources should have their original behaviour preserved
-    exceptions=("run-gradually-deprecated" "/legacy/" "network/ip_group_cidr_resource.go")
+    exceptions=("run-gradually-deprecated" "/legacy/" "network/ip_group_cidr_resource.go" "network/network_security_group_resource.go")
     toSkip=false
     for e in "${exceptions[@]}"; do
       isThisException=$(echo "$f" | grep "$e")

--- a/website/docs/r/vpn_gateway_nat_rule.html.markdown
+++ b/website/docs/r/vpn_gateway_nat_rule.html.markdown
@@ -40,8 +40,8 @@ resource "azurerm_vpn_gateway" "example" {
 }
 
 resource "azurerm_vpn_gateway_nat_rule" "example" {
-  name                = "example-vpngatewaynatrule"
-  vpn_gateway_id      = azurerm_vpn_gateway.example.id
+  name           = "example-vpngatewaynatrule"
+  vpn_gateway_id = azurerm_vpn_gateway.example.id
 
   external_mapping {
     address_space = "192.168.21.0/26"

--- a/website/docs/r/vpn_gateway_nat_rule.html.markdown
+++ b/website/docs/r/vpn_gateway_nat_rule.html.markdown
@@ -41,7 +41,6 @@ resource "azurerm_vpn_gateway" "example" {
 
 resource "azurerm_vpn_gateway_nat_rule" "example" {
   name                = "example-vpngatewaynatrule"
-  resource_group_name = azurerm_resource_group.example.name
   vpn_gateway_id      = azurerm_vpn_gateway.example.id
 
   external_mapping {
@@ -60,8 +59,6 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this VPN Gateway NAT Rule. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which this VPN Gateway NAT Rule should be created. Changing this forces a new resource to be created.
-
 * `vpn_gateway_id` - (Required) The ID of the VPN Gateway that this VPN Gateway NAT Rule belongs to. Changing this forces a new resource to be created.
 
 * `external_mapping` - (Optional) One or more `external_mapping` blocks as documented below.
@@ -74,13 +71,9 @@ The following arguments are supported:
 
 * `type` - (Optional) The type of the VPN Gateway NAT Rule. Possible values are `Dynamic` and `Static`. Defaults to `Static`. Changing this forces a new resource to be created.
 
-* `external_address_space_mappings` - (Optional) (Deprecated) A list of CIDR Ranges which are used for external mapping of the VPN Gateway NAT Rule.
+* `external_mapping` - (Optional) One of more `external_mapping` blocks as defined below.
 
-~> **NOTE:** `external_address_space_mappings` is deprecated and will be removed in favour of the property `external_mapping` in version 4.0 of the AzureRM Provider.
-
-* `internal_address_space_mappings` - (Optional) (Deprecated) A list of CIDR Ranges which are used for internal mapping of the VPN Gateway NAT Rule.
-
-~> **NOTE:** `internal_address_space_mappings` is deprecated and will be removed in favour of the property `internal_mapping` in version 4.0 of the AzureRM Provider.
+* `internal_mapping` - (Optional) One of more `internal_mapping` blocks as defined below.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Following resources were updated to use `hashicorp/go-azure-sdk`:

- `azurerm_network_security_group`
- `azurerm_public_ip`
- `azurerm_public_ip_prefix`
- `azurerm_virtual_wan`
- `azurerm_vpn_gateway_nat_rule`

Following data sources were update to use `hashicorp/go-azure-sdk`:

- `azurerm_network_security_group`
- `azurerm_public_ip`
- `azurerm_public_ips`
- `azurerm_public_ip_prefix`
- `azurerm_virtual_wan`

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/1dc08034-a295-4eed-832e-dbb67c4c4ab3)


