### PR TITLE
`azurerm_container_app_custom_domain` - fix parsing the certificate ID error

### DIFF
--- a/internal/services/containerapps/container_app_custom_domain_resource.go
+++ b/internal/services/containerapps/container_app_custom_domain_resource.go
@@ -28,10 +28,11 @@ type ContainerAppCustomDomainResource struct{}
 var _ sdk.Resource = ContainerAppCustomDomainResource{}
 
 type ContainerAppCustomDomainResourceModel struct {
-	Name           string `tfschema:"name"`
-	ContainerAppId string `tfschema:"container_app_id"`
-	CertificateId  string `tfschema:"container_app_environment_certificate_id"`
-	BindingType    string `tfschema:"certificate_binding_type"`
+	Name                 string `tfschema:"name"`
+	ContainerAppId       string `tfschema:"container_app_id"`
+	CertificateId        string `tfschema:"container_app_environment_certificate_id"`
+	BindingType          string `tfschema:"certificate_binding_type"`
+	ManagedCertificateId string `tfschema:"container_app_environment_managed_certificate_id"`
 }
 
 func (a ContainerAppCustomDomainResource) Arguments() map[string]*pluginsdk.Schema {
@@ -70,7 +71,12 @@ func (a ContainerAppCustomDomainResource) Arguments() map[string]*pluginsdk.Sche
 }
 
 func (a ContainerAppCustomDomainResource) Attributes() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{}
+	return map[string]*pluginsdk.Schema{
+		"container_app_environment_managed_certificate_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
 }
 
 func (a ContainerAppCustomDomainResource) ModelObject() interface{} {
@@ -215,18 +221,16 @@ func (a ContainerAppCustomDomainResource) Read() sdk.ResourceFunc {
 							// its format is "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s/managedCertificates/%s",
 							// another format is "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s/certificates/%s",
 							// both cases are handled here to avoid parsing error.
-							certificateId := ""
 							certId, err1 := managedenvironments.ParseCertificateIDInsensitively(pointer.From(v.CertificateId))
 							if err1 != nil {
 								managedCertId, err2 := managedenvironments.ParseManagedCertificateID(pointer.From(v.CertificateId))
 								if err2 != nil {
 									return err1
 								}
-								certificateId = managedCertId.ID()
+								state.ManagedCertificateId = managedCertId.ID()
 							} else {
-								certificateId = certId.ID()
+								state.CertificateId = certId.ID()
 							}
-							state.CertificateId = certificateId
 						}
 
 						state.BindingType = string(pointer.From(v.BindingType))

--- a/website/docs/r/container_app_custom_domain.html.markdown
+++ b/website/docs/r/container_app_custom_domain.html.markdown
@@ -125,6 +125,12 @@ The following arguments are supported:
 
 !> **NOTE:** If using an Azure Managed Certificate `container_app_environment_certificate_id` and `certificate_binding_type` should be added to `ignore_changes` to prevent resource recreation due to these values being modified asynchronously outside of Terraform.
 
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `container_app_environment_managed_certificate_id` - The ID of the Container App Environment Managed Certificate to use.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- The Certificate Id returned from API has two possible values. When using an Azure created Managed Certificate, its format is "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s/managedCertificates/%s", another format is "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s/certificates/%s",
 we should handle both cases to avoid parsing error to fix #25788 .

- Fix following 'run bash ./scripts/fun-gradually-deprecated.sh' error.

   ![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/029d5380-da09-4ca5-8313-dfd03dfb5a5e)


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 




## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.



<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25788

