### PR TITLE
azurerm_logic_app_trigger_custom - adding exported attribute callback_url

### DIFF
--- a/internal/services/logic/logic_app_trigger_custom_resource.go
+++ b/internal/services/logic/logic_app_trigger_custom_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -107,12 +108,7 @@ func resourceLogicAppTriggerCustomRead(d *pluginsdk.ResourceData, meta interface
 
 	d.Set("name", id.TriggerName)
 	d.Set("logic_app_id", app.Id)
-
-	if url != nil {
-		d.Set("callback_url", url)
-	} else {
-		d.Set("callback_url", "")
-	}
+	d.Set("callback_url", pointer.From(url))
 
 	// Azure returns an additional field called evaluatedRecurrence in the trigger body which
 	// is a copy of the recurrence specified in the body property and breaks the diff suppress logic

--- a/internal/services/logic/logic_app_trigger_custom_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_custom_resource_test.go
@@ -155,7 +155,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {

--- a/internal/services/logic/logic_app_trigger_custom_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_custom_resource_test.go
@@ -37,22 +37,6 @@ func TestAccLogicAppTriggerCustom_callbackUrl(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callback_url").IsEmpty(),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccLogicAppTriggerCustom_callbackUrl2(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_logic_app_trigger_custom", "test")
-	r := LogicAppTriggerCustomResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
 			Config: r.nonEmptyCallback(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/internal/services/logic/logic_app_trigger_http_request_resource.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource.go
@@ -141,7 +141,7 @@ func resourceLogicAppTriggerHttpRequestRead(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
-	t, app, url, err := retrieveLogicAppHttpTrigger(d, meta, *id)
+	t, app, url, err := retrieveLogicAppTrigger(d, meta, *id)
 	if err != nil {
 		return err
 	}

--- a/internal/services/logic/logic_app_trigger_http_request_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource_test.go
@@ -243,7 +243,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {

--- a/internal/services/logic/logic_app_trigger_http_request_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource_test.go
@@ -91,7 +91,7 @@ func TestAccLogicAppTriggerHttpRequest_callbackUrl(t *testing.T) {
 			Config: r.method(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callback_url").Exists(),
+				check.That(data.ResourceName).Key("callback_url").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -243,6 +243,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {

--- a/internal/services/logic/logic_app_trigger_recurrence_resource.go
+++ b/internal/services/logic/logic_app_trigger_recurrence_resource.go
@@ -169,9 +169,7 @@ func resourceLogicAppTriggerRecurrenceRead(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroupName, id.WorkflowName)
-
-	t, app, err := retrieveLogicAppTrigger(d, meta, workflowId, id.TriggerName)
+	t, app, _, err := retrieveLogicAppTrigger(d, meta, *id)
 	if err != nil {
 		return err
 	}

--- a/internal/services/logic/logic_app_trigger_recurrence_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_recurrence_resource_test.go
@@ -270,6 +270,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -296,6 +297,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -323,6 +325,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -351,6 +354,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -391,6 +395,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -423,6 +428,7 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {

--- a/internal/services/logic/logic_app_trigger_recurrence_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_recurrence_resource_test.go
@@ -270,7 +270,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -297,7 +296,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -325,7 +323,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -354,7 +351,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -395,7 +391,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {
@@ -428,7 +423,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-  tags 	   = { Contact = "jimbo" }
 }
 
 resource "azurerm_logic_app_workflow" "test" {

--- a/internal/services/logic/logic_apps.go
+++ b/internal/services/logic/logic_apps.go
@@ -241,11 +241,7 @@ func IsCallbackType(tType string) bool {
 	valid := validation.StringInSlice(cTypes, false)
 	_, errors := valid(tType, "callback_url")
 
-	if len(errors) == 0 {
-		return true
-	}
-
-	return false
+	return len(errors) == 0
 }
 
 func retreiveLogicAppTriggerCallbackUrl(d *pluginsdk.ResourceData, meta interface{}, id workflowtriggers.TriggerId) (*string, error) {

--- a/internal/services/logic/logic_apps.go
+++ b/internal/services/logic/logic_apps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -201,22 +202,50 @@ func retrieveLogicAppAction(d *pluginsdk.ResourceData, meta interface{}, id work
 	return retrieveLogicAppComponent(d, meta, "Action", "actions", id, name)
 }
 
-func retrieveLogicAppHttpTrigger(d *pluginsdk.ResourceData, meta interface{}, id workflowtriggers.TriggerId) (*map[string]interface{}, *workflows.Workflow, *string, error) {
+func retrieveLogicAppTrigger(d *pluginsdk.ResourceData, meta interface{}, id workflowtriggers.TriggerId) (*map[string]interface{}, *workflows.Workflow, *string, error) {
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroupName, id.WorkflowName)
 
-	t, app, err := retrieveLogicAppTrigger(d, meta, workflowId, id.TriggerName)
+	t, app, err := retrieveLogicAppComponent(d, meta, "Trigger", "triggers", workflowId, id.TriggerName)
+
 	if err != nil || t == nil {
 		return nil, nil, nil, err
 	}
-	url, err := retreiveLogicAppTriggerCallbackUrl(d, meta, id)
-	if err != nil {
-		return nil, nil, nil, err
+
+	trigger := *t
+	tType := trigger["type"]
+	if tType == nil {
+		return nil, nil, nil, fmt.Errorf("[ERROR] `type` was nil for %s", id.ID())
 	}
-	return t, app, url, err
+
+	log.Printf("[DEBUG] trigger type is %s", tType.(string))
+
+	if IsCallbackType(tType.(string)) {
+		url, err := retreiveLogicAppTriggerCallbackUrl(d, meta, id)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if url == nil {
+			return nil, nil, nil, fmt.Errorf("[ERROR] `callback_url` was nil for %s", id.ID())
+		}
+
+		return t, app, url, err
+	}
+
+	return t, app, nil, err
 }
 
-func retrieveLogicAppTrigger(d *pluginsdk.ResourceData, meta interface{}, id workflows.WorkflowId, name string) (*map[string]interface{}, *workflows.Workflow, error) {
-	return retrieveLogicAppComponent(d, meta, "Trigger", "triggers", id, name)
+func IsCallbackType(tType string) bool {
+	cTypes := []string{"ApiConnectionWebhook", "HTTPWebhook", "Request"}
+
+	valid := validation.StringInSlice(cTypes, false)
+	_, errors := valid(tType, "callback_url")
+
+	if len(errors) == 0 {
+		return true
+	}
+
+	return false
 }
 
 func retreiveLogicAppTriggerCallbackUrl(d *pluginsdk.ResourceData, meta interface{}, id workflowtriggers.TriggerId) (*string, error) {

--- a/website/docs/r/logic_app_trigger_custom.html.markdown
+++ b/website/docs/r/logic_app_trigger_custom.html.markdown
@@ -63,7 +63,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `callback_url` - The URL of the Trigger within the Logic App Workflow. For use with certain resources like [monitor_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) and [security_center_automation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_automation).
 
--> **NOTE:** callback_url is populated for [Triggers with a type of](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-actions-triggers#trigger-types-list) HTTPWebhook, Request, or ApiConnectionWebhook. For all other Trigger types, callback_url will be empty and should not be referenced.
+-> **NOTE:** `callback_url` is populated for [Triggers with a type of](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-actions-triggers#trigger-types-list) HTTPWebhook, Request, or ApiConnectionWebhook. For all other Trigger types, `callback_url` will be empty and should not be referenced.
 
 ## Timeouts
 

--- a/website/docs/r/logic_app_trigger_custom.html.markdown
+++ b/website/docs/r/logic_app_trigger_custom.html.markdown
@@ -61,6 +61,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Trigger within the Logic App Workflow.
 
+* `callback_url` - The URL of the Trigger within the Logic App Workflow. For use with certain resources like [monitor_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) and [security_center_automation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_automation).
+
+-> **NOTE:** callback_url is populated for [Triggers with a type of](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-actions-triggers#trigger-types-list) HTTPWebhook, Request, or ApiConnectionWebhook. For all other Trigger types, callback_url will be empty and should not be referenced.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/logic_app_trigger_http_request.html.markdown
+++ b/website/docs/r/logic_app_trigger_http_request.html.markdown
@@ -68,7 +68,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the HTTP Request Trigger within the Logic App Workflow.
 
-* `callback_url` - The URL for the workflow trigger
+* `callback_url` - The URL of the Trigger within the Logic App Workflow. For use with certain resources like [monitor_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) and [security_center_automation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_automation).
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

adds callback_url for azurerm_logic_app_trigger_custom. check occurs in logic_apps.retrieveLogicAppTrigger to get url if trigger is of relevant type. fixes #25623

## PR Checklist

- [ x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ x ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ x ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ x ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

=== CONT  TestAccLogicAppTriggerRecurrence_second
    testcase.go:113: TestCase error running init: exit status 1
        
        Error: Failed to install provider
        
        Error while installing hashicorp/tls v4.0.4: releases.hashicorp.com: Get
        "https://releases.hashicorp.com/terraform-provider-tls/4.0.4/terraform-provider-tls_4.0.4_darwin_arm64.zip":
        write tcp
        [fe80::fae4:3bff:fecb:82c5%utun5]:57517->[2600:9000:254a:f600:5:e2b6:b380:93a1]:443:
        write: socket is not connected
        
--- FAIL: TestAccLogicAppTriggerRecurrence_second (11.32s)
--- PASS: TestAccLogicAppTriggerRecurrence_day (71.30s)
--- PASS: TestAccLogicAppTriggerRecurrence_startTime (73.47s)
--- PASS: TestAccLogicAppTriggerRecurrence_minute (75.58s)
--- PASS: TestAccLogicAppTriggerRecurrence_hour (77.93s)
--- PASS: TestAccLogicAppTriggerRecurrence_requiresImport (80.49s)
--- PASS: TestAccLogicAppTriggerRecurrence_month (82.63s)
--- PASS: TestAccLogicAppTriggerRecurrence_week (84.76s)
--- PASS: TestAccLogicAppTriggerRecurrence_startTimeWithTimeZone (88.42s)
--- PASS: TestAccLogicAppTriggerRecurrence_update (103.60s)
--- PASS: TestAccLogicAppTriggerRecurrence_schedule (111.46s)
--- PASS: TestAccLogicAppTriggerRecurrence_timeZone (151.50s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 153.197s
FAIL

=== RUN   TestAccLogicAppTriggerCustom_callbackUrlider-azurerm> .\test.ps1
=== PAUSE TestAccLogicAppTriggerCustom_callbackUrl
=== RUN   TestAccLogicAppTriggerCustom_callbackUrl2
=== PAUSE TestAccLogicAppTriggerCustom_callbackUrl2
=== CONT  TestAccLogicAppTriggerCustom_callbackUrl
=== CONT  TestAccLogicAppTriggerCustom_callbackUrl2
--- PASS: TestAccLogicAppTriggerCustom_callbackUrl (58.77s)
--- PASS: TestAccLogicAppTriggerCustom_callbackUrl2 (61.96s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 63.689s
=== RUN   TestAccLogicAppTriggerHttpRequest_callbackUrlazurerm> .\test.ps1
=== PAUSE TestAccLogicAppTriggerHttpRequest_callbackUrl
=== CONT  TestAccLogicAppTriggerHttpRequest_callbackUrl
--- PASS: TestAccLogicAppTriggerHttpRequest_callbackUrl (54.58s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 56.306s

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_trigger_custom ` - support for the `callback_url` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ x ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
