### PR TITLE
`network` - update virtual hub resources to use `hashicorp/go-azure-sdk`

### DIFF
--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -440,3 +440,32 @@ func flattenExpressRouteConnectionPropagatedRouteTable(input *network.Propagated
 		},
 	}
 }
+
+func expandIDsToSubResources(input []interface{}) *[]network.SubResource {
+	ids := make([]network.SubResource, 0)
+
+	for _, v := range input {
+		ids = append(ids, network.SubResource{
+			ID: pointer.To(v.(string)),
+		})
+	}
+
+	return &ids
+}
+
+func flattenSubResourcesToIDs(input *[]network.SubResource) []interface{} {
+	ids := make([]interface{}, 0)
+	if input == nil {
+		return ids
+	}
+
+	for _, v := range *input {
+		if v.ID == nil {
+			continue
+		}
+
+		ids = append(ids, *v.ID)
+	}
+
+	return ids
+}

--- a/internal/services/network/network_interface_security_group_association_resource.go
+++ b/internal/services/network/network_interface_security_group_association_resource.go
@@ -6,19 +6,18 @@ package network
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networksecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/azuresdkhacks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
@@ -27,17 +26,8 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 		Read:   resourceNetworkInterfaceSecurityGroupAssociationRead,
 		Delete: resourceNetworkInterfaceSecurityGroupAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			splitId := strings.Split(id, "|")
-			if len(splitId) != 2 {
-				return fmt.Errorf("expect ID to be the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", id)
-			}
-			if _, err := parse.NetworkInterfaceID(splitId[0]); err != nil {
-				return err
-			}
-			if _, err := parse.NetworkSecurityGroupID(splitId[1]); err != nil {
-				return err
-			}
-			return nil
+			_, err := commonids.ParseCompositeResourceID(id, &commonids.NetworkInterfaceId{}, &networksecuritygroups.NetworkSecurityGroupId{})
+			return err
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -51,169 +41,144 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkInterfaceID,
+				ValidateFunc: commonids.ValidateNetworkInterfaceID,
 			},
 
 			"network_security_group_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkSecurityGroupID,
+				ValidateFunc: networksecuritygroups.ValidateNetworkSecurityGroupID,
 			},
 		},
 	}
 }
 
 func resourceNetworkInterfaceSecurityGroupAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfaces
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Interface <-> Network Security Group Association creation.")
-
-	networkInterfaceId := d.Get("network_interface_id").(string)
-	networkSecurityGroupId := d.Get("network_security_group_id").(string)
-
-	nicId, err := parse.NetworkInterfaceID(networkInterfaceId)
+	nicId, err := commonids.ParseNetworkInterfaceID(d.Get("network_interface_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(nicId.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicId.Name, networkInterfaceResourceName)
+	locks.ByName(nicId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(nicId.NetworkInterfaceName, networkInterfaceResourceName)
 
-	nsgId, err := parse.NetworkSecurityGroupID(networkSecurityGroupId)
+	nsgId, err := networksecuritygroups.ParseNetworkSecurityGroupID(d.Get("network_security_group_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(nsgId.Name, networkSecurityGroupResourceName)
-	defer locks.UnlockByName(nsgId.Name, networkSecurityGroupResourceName)
+	locks.ByName(nsgId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(nsgId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
 
-	read, err := client.Get(ctx, nicId.ResourceGroup, nicId.Name, "")
+	read, err := client.Get(ctx, *nicId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("%s was not found!", *nicId)
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf("%s was not found", *nicId)
 		}
-
 		return fmt.Errorf("retrieving %s: %+v", *nicId, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicId)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", nicId)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", nicId)
 	}
 
-	// first double-check it doesn't exist
-	resourceId := fmt.Sprintf("%s|%s", networkInterfaceId, networkSecurityGroupId)
-	if props.NetworkSecurityGroup != nil {
-		return tf.ImportAsExistsError("azurerm_network_interface_security_group_association", resourceId)
+	id := commonids.NewCompositeResourceID(nicId, nsgId)
+
+	if read.Model.Properties.NetworkSecurityGroup != nil {
+		return tf.ImportAsExistsError("azurerm_network_interface_security_group_association", id.ID())
 	}
 
-	props.NetworkSecurityGroup = &network.SecurityGroup{
-		ID: utils.String(networkSecurityGroupId),
+	read.Model.Properties.NetworkSecurityGroup = &networkinterfaces.NetworkSecurityGroup{
+		Id: pointer.To(nsgId.ID()),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, nicId.ResourceGroup, nicId.Name, read)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, *nicId, *read.Model); err != nil {
 		return fmt.Errorf("updating Security Group Association for %s: %+v", *nicId, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for completion of Security Group Association for %s: %+v", *nicId, err)
-	}
-
-	d.SetId(resourceId)
+	d.SetId(id.ID())
 
 	return resourceNetworkInterfaceSecurityGroupAssociationRead(d, meta)
 }
 
 func resourceNetworkInterfaceSecurityGroupAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfaces
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceId{}, &networksecuritygroups.NetworkSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := client.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			log.Printf("%s was not found - removing from state!", *nicID)
+		if response.WasNotFound(read.HttpResponse) {
+			log.Printf("%s was not found - removing from state!", id.First)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
+	if model := read.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.NetworkSecurityGroup == nil || props.NetworkSecurityGroup.Id == nil {
+				log.Printf("%s doesn't have a Security Group attached - removing from state!", id.First)
+				d.SetId("")
+				return nil
+			}
+		}
 	}
 
-	if props.NetworkSecurityGroup == nil || props.NetworkSecurityGroup.ID == nil {
-		log.Printf("%s doesn't have a Security Group attached - removing from state!", *nicID)
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("network_interface_id", read.ID)
-
-	// nil-checked above
-	d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)
+	d.Set("network_interface_id", id.First.ID())
+	d.Set("network_security_group_id", id.Second.ID())
 
 	return nil
 }
 
 func resourceNetworkInterfaceSecurityGroupAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfaces
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	splitId := strings.Split(d.Id(), "|")
-	if len(splitId) != 2 {
-		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/{networkSecurityGroup} but got %q", d.Id())
-	}
-
-	nicID, err := parse.NetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(d.Id(), &commonids.NetworkInterfaceId{}, &networksecuritygroups.NetworkSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(nicID.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.Name, networkInterfaceResourceName)
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := client.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf(" %s was not found!", *nicID)
+		if response.WasNotFound(read.HttpResponse) {
+			return fmt.Errorf(" %s was not found!", id.First)
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	props := read.InterfacePropertiesFormat
-	if props == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id.First)
+	}
+	if read.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id.First)
 	}
 
-	props.NetworkSecurityGroup = nil
-	read.InterfacePropertiesFormat = props
+	read.Model.Properties.NetworkSecurityGroup = nil
 
-	future, err := azuresdkhacks.UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx, client, nicID.ResourceGroup, nicID.Name, read)
-	if err != nil {
-		return fmt.Errorf("updating %s: %+v", *nicID, err)
-	}
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s: %+v", *nicID, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model); err != nil {
+		return fmt.Errorf("updating %s: %+v", id.First, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_security_group_association_resource_test.go
@@ -6,16 +6,17 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkinterfaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networksecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/azuresdkhacks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkInterfaceNetworkSecurityGroupAssociationResource struct{}
@@ -93,54 +94,46 @@ func TestAccNetworkInterfaceSecurityGroupAssociation_updateNIC(t *testing.T) {
 }
 
 func (t NetworkInterfaceNetworkSecurityGroupAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	splitId := strings.Split(state.ID, "|")
-	if len(splitId) != 2 {
-		return nil, fmt.Errorf("expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", state.ID)
-	}
-
-	nicID, err := parse.NetworkInterfaceID(splitId[0])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &networksecuritygroups.NetworkSecurityGroupId{})
 	if err != nil {
 		return nil, err
 	}
 
-	read, err := clients.Network.InterfacesClient.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := clients.Network.NetworkInterfaces.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %+v", *nicID, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
 	found := false
-	if read.InterfacePropertiesFormat != nil {
-		if read.InterfacePropertiesFormat.NetworkSecurityGroup != nil && read.InterfacePropertiesFormat.NetworkSecurityGroup.ID != nil {
-			found = *read.InterfacePropertiesFormat.NetworkSecurityGroup.ID == state.Attributes["network_security_group_id"]
+	if model := read.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
+				found = *props.NetworkSecurityGroup.Id == state.Attributes["network_security_group_id"]
+			}
 		}
 	}
 
-	return utils.Bool(found), nil
+	return pointer.To(found), nil
 }
 
 func (NetworkInterfaceNetworkSecurityGroupAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
-	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &networksecuritygroups.NetworkSecurityGroupId{})
 	if err != nil {
 		return err
 	}
 
-	resourceGroup := nicID.ResourceGroup
-	nicName := nicID.Name
-
-	read, err := client.Network.InterfacesClient.Get(ctx, resourceGroup, nicName, "")
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	read, err := client.Network.NetworkInterfaces.Get(ctx2, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		return fmt.Errorf("retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
 	}
 
-	read.InterfacePropertiesFormat.NetworkSecurityGroup = nil
+	read.Model.Properties.NetworkSecurityGroup = nil
 
-	future, err := azuresdkhacks.UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx, client.Network.InterfacesClient, resourceGroup, nicName, read)
-	if err != nil {
-		return fmt.Errorf("removing Network Security Group Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-	}
+	if err := client.Network.NetworkInterfaces.CreateOrUpdateThenPoll(ctx2, *id.First, *read.Model); err != nil {
+		return fmt.Errorf("removing Network Security Group Association for %s: %+v", id.First, err)
 
-	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Network Security Group Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
 	}
 
 	return nil

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -8,18 +8,16 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networksecuritygroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
@@ -51,7 +49,7 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NetworkSecurityGroupID,
+				ValidateFunc: networksecuritygroups.ValidateNetworkSecurityGroupID,
 			},
 		},
 	}
@@ -63,37 +61,32 @@ func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceDa
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Subnet <-> Network Security Group Association creation.")
-
-	subnetId := d.Get("subnet_id").(string)
-	networkSecurityGroupId := d.Get("network_security_group_id").(string)
-
-	parsedSubnetId, err := commonids.ParseSubnetID(subnetId)
+	subnetId, err := commonids.ParseSubnetID(d.Get("subnet_id").(string))
 	if err != nil {
 		return err
 	}
 
-	parsedNetworkSecurityGroupId, err := parse.NetworkSecurityGroupID(networkSecurityGroupId)
+	networkSecurityGroupId, err := networksecuritygroups.ParseNetworkSecurityGroupID(d.Get("network_security_group_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(parsedNetworkSecurityGroupId.Name, networkSecurityGroupResourceName)
-	defer locks.UnlockByName(parsedNetworkSecurityGroupId.Name, networkSecurityGroupResourceName)
+	locks.ByName(networkSecurityGroupId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(networkSecurityGroupId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
 
-	locks.ByName(parsedSubnetId.VirtualNetworkName, VirtualNetworkResourceName)
-	defer locks.UnlockByName(parsedSubnetId.VirtualNetworkName, VirtualNetworkResourceName)
+	locks.ByName(subnetId.VirtualNetworkName, VirtualNetworkResourceName)
+	defer locks.UnlockByName(subnetId.VirtualNetworkName, VirtualNetworkResourceName)
 
-	locks.ByName(parsedSubnetId.SubnetName, SubnetResourceName)
-	defer locks.UnlockByName(parsedSubnetId.SubnetName, SubnetResourceName)
+	locks.ByName(subnetId.SubnetName, SubnetResourceName)
+	defer locks.UnlockByName(subnetId.SubnetName, SubnetResourceName)
 
-	subnet, err := client.Get(ctx, *parsedSubnetId, subnets.DefaultGetOperationOptions())
+	subnet, err := client.Get(ctx, *subnetId, subnets.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(subnet.HttpResponse) {
-			return fmt.Errorf("%s was not found", *parsedSubnetId)
+			return fmt.Errorf("%s was not found", *subnetId)
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *parsedSubnetId, err)
+		return fmt.Errorf("retrieving %s: %+v", *subnetId, err)
 	}
 
 	if model := subnet.Model; model != nil {
@@ -106,41 +99,41 @@ func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceDa
 			}
 
 			props.NetworkSecurityGroup = &subnets.NetworkSecurityGroup{
-				Id: utils.String(networkSecurityGroupId),
+				Id: pointer.To(networkSecurityGroupId.ID()),
 			}
 		}
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, *parsedSubnetId, *subnet.Model); err != nil {
-		return fmt.Errorf("updating Network Security Group Association for %s: %+v", *parsedSubnetId, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *subnetId, *subnet.Model); err != nil {
+		return fmt.Errorf("updating Network Security Group Association for %s: %+v", *subnetId, err)
 	}
 
 	timeout, _ := ctx.Deadline()
 
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *parsedSubnetId),
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
+		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *subnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for provisioning state of subnet for Network Security Group Association for %s: %+v", *parsedSubnetId, err)
+		return fmt.Errorf("waiting for provisioning state of subnet for Network Security Group Association for %s: %+v", *subnetId, err)
 	}
 
-	vnetId := commonids.NewVirtualNetworkID(parsedSubnetId.SubscriptionId, parsedSubnetId.ResourceGroupName, parsedSubnetId.VirtualNetworkName)
+	vnetId := commonids.NewVirtualNetworkID(subnetId.SubscriptionId, subnetId.ResourceGroupName, subnetId.VirtualNetworkName)
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
 	if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for provisioning state of virtual network for Network Security Group Association for %s: %+v", *parsedSubnetId, err)
+		return fmt.Errorf("waiting for provisioning state of virtual network for Network Security Group Association for %s: %+v", *subnetId, err)
 	}
 
-	d.SetId(parsedSubnetId.ID())
+	d.SetId(subnetId.ID())
 
 	return resourceSubnetNetworkSecurityGroupAssociationRead(d, meta)
 }
@@ -225,13 +218,13 @@ func resourceSubnetNetworkSecurityGroupAssociationDelete(d *pluginsdk.ResourceDa
 	}
 
 	// once we have the network security group id to lock on, lock on that
-	parsedNetworkSecurityGroupId, err := parse.NetworkSecurityGroupID(*props.NetworkSecurityGroup.Id)
+	networkSecurityGroupId, err := networksecuritygroups.ParseNetworkSecurityGroupID(*props.NetworkSecurityGroup.Id)
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(parsedNetworkSecurityGroupId.Name, networkSecurityGroupResourceName)
-	defer locks.UnlockByName(parsedNetworkSecurityGroupId.Name, networkSecurityGroupResourceName)
+	locks.ByName(networkSecurityGroupId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(networkSecurityGroupId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
 
 	locks.ByName(id.VirtualNetworkName, VirtualNetworkResourceName)
 	defer locks.UnlockByName(id.VirtualNetworkName, VirtualNetworkResourceName)

--- a/internal/services/network/virtual_hub_bgp_connection_resource.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource.go
@@ -8,16 +8,16 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
@@ -35,7 +35,7 @@ func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.BgpConnectionID(id)
+			_, err := commonids.ParseVirtualHubBGPConnectionID(id)
 			return err
 		}),
 
@@ -51,7 +51,7 @@ func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.VirtualHubID,
+				ValidateFunc: virtualwans.ValidateVirtualHubID,
 			},
 
 			"peer_asn": {
@@ -71,61 +71,56 @@ func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
 			"virtual_network_connection_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validate.HubVirtualNetworkConnectionID,
+				ValidateFunc: virtualwans.ValidateHubVirtualNetworkConnectionID,
 			},
 		},
 	}
 }
 
 func resourceVirtualHubBgpConnectionCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubBgpConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(virtHubId.Name, virtualHubResourceName)
-	defer locks.UnlockByName(virtHubId.Name, virtualHubResourceName)
+	locks.ByName(virtHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtHubId.VirtualHubName, virtualHubResourceName)
 
-	id := parse.NewBgpConnectionID(virtHubId.SubscriptionId, virtHubId.ResourceGroup, virtHubId.Name, d.Get("name").(string))
+	id := commonids.NewVirtualHubBGPConnectionID(virtHubId.SubscriptionId, virtHubId.ResourceGroupName, virtHubId.VirtualHubName, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+		existing, err := client.VirtualHubBgpConnectionGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_hub_bgp_connection", id.ID())
 		}
 	}
 
-	parameters := network.BgpConnection{
-		Name: utils.String(d.Get("name").(string)),
-		BgpConnectionProperties: &network.BgpConnectionProperties{
-			PeerAsn: utils.Int64(int64(d.Get("peer_asn").(int))),
-			PeerIP:  utils.String(d.Get("peer_ip").(string)),
+	parameters := virtualwans.BgpConnection{
+		Name: pointer.To(d.Get("name").(string)),
+		Properties: &virtualwans.BgpConnectionProperties{
+			PeerAsn: pointer.To(int64(d.Get("peer_asn").(int))),
+			PeerIP:  pointer.To(d.Get("peer_ip").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("virtual_network_connection_id"); ok {
-		parameters.BgpConnectionProperties.HubVirtualNetworkConnection = &network.SubResource{
-			ID: utils.String(v.(string)),
+		parameters.Properties.HubVirtualNetworkConnection = &virtualwans.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.Name, parameters)
-	if err != nil {
+	if err := client.VirtualHubBgpConnectionCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on creating/updating future for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -134,49 +129,52 @@ func resourceVirtualHubBgpConnectionCreate(d *pluginsdk.ResourceData, meta inter
 }
 
 func resourceVirtualHubBgpConnectionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubBgpConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(virtHubId.Name, virtualHubResourceName)
-	defer locks.UnlockByName(virtHubId.Name, virtualHubResourceName)
+	locks.ByName(virtHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtHubId.VirtualHubName, virtualHubResourceName)
 
-	id, err := parse.BgpConnectionID(d.Id())
+	id, err := commonids.ParseVirtualHubBGPConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	existing, err := client.VirtualHubBgpConnectionGet(ctx, *id)
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
 	}
 
 	if d.HasChange("virtual_network_connection_id") {
 		if v, ok := d.GetOk("virtual_network_connection_id"); ok {
-			existing.BgpConnectionProperties.HubVirtualNetworkConnection = &network.SubResource{
-				ID: utils.String(v.(string)),
+			existing.Model.Properties.HubVirtualNetworkConnection = &virtualwans.SubResource{
+				Id: pointer.To(v.(string)),
 			}
 		} else {
-			existing.BgpConnectionProperties.HubVirtualNetworkConnection = &network.SubResource{
-				ID: nil,
+			existing.Model.Properties.HubVirtualNetworkConnection = &virtualwans.SubResource{
+				Id: nil,
 			}
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.Name, existing)
-	if err != nil {
+	if err := client.VirtualHubBgpConnectionCreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on updating future for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -185,34 +183,35 @@ func resourceVirtualHubBgpConnectionUpdate(d *pluginsdk.ResourceData, meta inter
 }
 
 func resourceVirtualHubBgpConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubBgpConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.BgpConnectionID(d.Id())
+	id, err := commonids.ParseVirtualHubBGPConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := client.VirtualHubBgpConnectionGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] network %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-
-		return fmt.Errorf("retrieving Virtual Hub Bgp Connection %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("name", id.ConnectionName)
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.HubName).ID())
 
-	if props := resp.BgpConnectionProperties; props != nil {
-		d.Set("peer_asn", props.PeerAsn)
-		d.Set("peer_ip", props.PeerIP)
-		if v := props.HubVirtualNetworkConnection; v != nil {
-			d.Set("virtual_network_connection_id", v.ID)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("peer_asn", props.PeerAsn)
+			d.Set("peer_ip", props.PeerIP)
+			if v := props.HubVirtualNetworkConnection; v != nil {
+				d.Set("virtual_network_connection_id", v.Id)
+			}
 		}
 	}
 
@@ -220,25 +219,20 @@ func resourceVirtualHubBgpConnectionRead(d *pluginsdk.ResourceData, meta interfa
 }
 
 func resourceVirtualHubBgpConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubBgpConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.BgpConnectionID(d.Id())
+	id, err := commonids.ParseVirtualHubBGPConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.VirtualHubName, virtualHubResourceName)
-	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
+	locks.ByName(id.HubName, virtualHubResourceName)
+	defer locks.UnlockByName(id.HubName, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
-	if err != nil {
-		return fmt.Errorf("deleting Virtual Hub Bgp Connection %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on deleting future for Virtual Hub Bgp Connection %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
+	if err := client.VirtualHubBgpConnectionDeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/virtual_hub_bgp_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubBGPConnectionResource struct{}
@@ -75,17 +75,17 @@ func TestAccVirtualHubBgpConnection_requiresImport(t *testing.T) {
 }
 
 func (t VirtualHubBGPConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.BgpConnectionID(state.ID)
+	id, err := commonids.ParseVirtualHubBGPConnectionID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.VirtualHubBgpConnectionClient.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := clients.Network.VirtualWANs.VirtualHubBgpConnectionGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub BGP Connectionn (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualHubBGPConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_hub_connection_data_source.go
+++ b/internal/services/network/virtual_hub_connection_data_source.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceVirtualHubConnection() *pluginsdk.Resource {
@@ -137,16 +137,16 @@ func dataSourceVirtualHubConnection() *pluginsdk.Resource {
 }
 
 func dataSourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubVirtualNetworkConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewHubVirtualNetworkConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_hub_name").(string), d.Get("name").(string))
+	id := virtualwans.NewHubVirtualNetworkConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_hub_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := client.HubVirtualNetworkConnectionsGet(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 
@@ -155,21 +155,23 @@ func dataSourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interfac
 
 	d.SetId(id.ID())
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.HubVirtualNetworkConnectionName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("virtual_hub_name", id.VirtualHubName)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if props := resp.HubVirtualNetworkConnectionProperties; props != nil {
-		d.Set("internet_security_enabled", props.EnableInternetSecurity)
-		remoteVirtualNetworkId := ""
-		if props.RemoteVirtualNetwork != nil && props.RemoteVirtualNetwork.ID != nil {
-			remoteVirtualNetworkId = *props.RemoteVirtualNetwork.ID
-		}
-		d.Set("remote_virtual_network_id", remoteVirtualNetworkId)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("internet_security_enabled", props.EnableInternetSecurity)
+			remoteVirtualNetworkId := ""
+			if props.RemoteVirtualNetwork != nil && props.RemoteVirtualNetwork.Id != nil {
+				remoteVirtualNetworkId = *props.RemoteVirtualNetwork.Id
+			}
+			d.Set("remote_virtual_network_id", remoteVirtualNetworkId)
 
-		if err := d.Set("routing", flattenVirtualHubConnectionRouting(props.RoutingConfiguration)); err != nil {
-			return fmt.Errorf("setting `routing`: %+v", err)
+			if err := d.Set("routing", flattenVirtualHubConnectionRouting(props.RoutingConfiguration)); err != nil {
+				return fmt.Errorf("setting `routing`: %+v", err)
+			}
 		}
 	}
 

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -214,7 +214,7 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	}
 
 	connection := virtualwans.HubVirtualNetworkConnection{
-		Name: pointer.To(id.VirtualHubName),
+		Name: pointer.To(id.HubVirtualNetworkConnectionName),
 		Properties: &virtualwans.HubVirtualNetworkConnectionProperties{
 			RemoteVirtualNetwork: &virtualwans.SubResource{
 				Id: pointer.To(remoteVirtualNetworkId.ID()),
@@ -269,7 +269,7 @@ func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", id.VirtualHubName)
+	d.Set("name", id.HubVirtualNetworkConnectionName)
 	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
 	if model := resp.Model; model != nil {
@@ -439,7 +439,7 @@ func flattenVirtualHubConnectionRouting(input *virtualwans.RoutingConfiguration)
 
 	staticVnetLocalRouteOverrideCriteria := ""
 	if input.VnetRoutes != nil && input.VnetRoutes.StaticRoutesConfig != nil && input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria != nil {
-		staticVnetLocalRouteOverrideCriteria = string(pointer.From(input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria))
+		staticVnetLocalRouteOverrideCriteria = string(*input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria)
 	}
 
 	return []interface{}{

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -9,17 +9,18 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubConnection() *pluginsdk.Resource {
@@ -37,143 +38,139 @@ func resourceVirtualHubConnection() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.HubVirtualNetworkConnectionID(id)
+			_, err := virtualwans.ParseHubVirtualNetworkConnectionID(id)
 			return err
 		}),
 
-		Schema: resourceVirtualHubConnectionSchema(),
-	}
-}
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.VirtualHubConnectionName,
+			},
 
-func resourceVirtualHubConnectionSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validate.VirtualHubConnectionName,
-		},
+			"virtual_hub_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: virtualwans.ValidateVirtualHubID,
+			},
 
-		"virtual_hub_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validate.VirtualHubID,
-		},
+			"remote_virtual_network_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: commonids.ValidateVirtualNetworkID,
+			},
 
-		"remote_virtual_network_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: commonids.ValidateVirtualNetworkID,
-		},
+			"internet_security_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 
-		"internet_security_enabled": {
-			Type:     pluginsdk.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
+			"routing": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"associated_route_table_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validate.HubRouteTableID,
+							AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
+						},
 
-		"routing": {
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			Computed: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"associated_route_table_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ValidateFunc: validate.HubRouteTableID,
-						AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
-					},
+						"inbound_route_map_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.RouteMapID,
+						},
 
-					"inbound_route_map_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validate.RouteMapID,
-					},
+						"outbound_route_map_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.RouteMapID,
+						},
 
-					"outbound_route_map_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validate.RouteMapID,
-					},
+						"propagated_route_table": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"labels": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Computed: true,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.StringIsNotEmpty,
+										},
+										AtLeastOneOf: []string{"routing.0.propagated_route_table.0.labels", "routing.0.propagated_route_table.0.route_table_ids"},
+									},
 
-					"propagated_route_table": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
-						Computed: true,
-						MaxItems: 1,
-						Elem: &pluginsdk.Resource{
-							Schema: map[string]*pluginsdk.Schema{
-								"labels": {
-									Type:     pluginsdk.TypeSet,
-									Optional: true,
-									Computed: true,
-									Elem: &pluginsdk.Schema{
+									"route_table_ids": {
+										Type:     pluginsdk.TypeList,
+										Optional: true,
+										Computed: true,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validate.HubRouteTableID,
+										},
+										AtLeastOneOf: []string{"routing.0.propagated_route_table.0.labels", "routing.0.propagated_route_table.0.route_table_ids"},
+									},
+								},
+							},
+							AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
+						},
+
+						"static_vnet_local_route_override_criteria": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  string(virtualwans.VnetLocalRouteOverrideCriteriaContains),
+							ValidateFunc: validation.StringInSlice([]string{
+								string(virtualwans.VnetLocalRouteOverrideCriteriaContains),
+								string(virtualwans.VnetLocalRouteOverrideCriteriaEqual),
+							}, false),
+						},
+
+						//lintignore:XS003
+						"static_vnet_route": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"name": {
 										Type:         pluginsdk.TypeString,
+										Optional:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
-									AtLeastOneOf: []string{"routing.0.propagated_route_table.0.labels", "routing.0.propagated_route_table.0.route_table_ids"},
-								},
 
-								"route_table_ids": {
-									Type:     pluginsdk.TypeList,
-									Optional: true,
-									Computed: true,
-									Elem: &pluginsdk.Schema{
-										Type:         pluginsdk.TypeString,
-										ValidateFunc: validate.HubRouteTableID,
+									"address_prefixes": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.IsCIDR,
+										},
 									},
-									AtLeastOneOf: []string{"routing.0.propagated_route_table.0.labels", "routing.0.propagated_route_table.0.route_table_ids"},
-								},
-							},
-						},
-						AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
-					},
 
-					"static_vnet_local_route_override_criteria": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						Default:  string(network.VnetLocalRouteOverrideCriteriaContains),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(network.VnetLocalRouteOverrideCriteriaContains),
-							string(network.VnetLocalRouteOverrideCriteriaEqual),
-						}, false),
-					},
-
-					//lintignore:XS003
-					"static_vnet_route": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
-						Elem: &pluginsdk.Resource{
-							Schema: map[string]*pluginsdk.Schema{
-								"name": {
-									Type:         pluginsdk.TypeString,
-									Optional:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
-								},
-
-								"address_prefixes": {
-									Type:     pluginsdk.TypeSet,
-									Optional: true,
-									Elem: &pluginsdk.Schema{
+									"next_hop_ip_address": {
 										Type:         pluginsdk.TypeString,
-										ValidateFunc: validation.IsCIDR,
+										Optional:     true,
+										ValidateFunc: validation.IsIPv4Address,
 									},
 								},
-
-								"next_hop_ip_address": {
-									Type:         pluginsdk.TypeString,
-									Optional:     true,
-									ValidateFunc: validation.IsIPv4Address,
-								},
 							},
+							AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
 						},
-						AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
 					},
 				},
 			},
@@ -182,19 +179,19 @@ func resourceVirtualHubConnectionSchema() map[string]*pluginsdk.Schema {
 }
 
 func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubVirtualNetworkConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtualHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtualHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	id := parse.NewHubVirtualNetworkConnectionID(virtualHubId.SubscriptionId, virtualHubId.ResourceGroup, virtualHubId.Name, d.Get("name").(string))
+	id := virtualwans.NewHubVirtualNetworkConnectionID(virtualHubId.SubscriptionId, virtualHubId.ResourceGroupName, virtualHubId.VirtualHubName, d.Get("name").(string))
 
-	locks.ByName(virtualHubId.Name, virtualHubResourceName)
-	defer locks.UnlockByName(virtualHubId.Name, virtualHubResourceName)
+	locks.ByName(virtualHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtualHubId.VirtualHubName, virtualHubResourceName)
 
 	remoteVirtualNetworkId, err := commonids.ParseVirtualNetworkID(d.Get("remote_virtual_network_id").(string))
 	if err != nil {
@@ -205,45 +202,40 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	defer locks.UnlockByName(remoteVirtualNetworkId.VirtualNetworkName, VirtualNetworkResourceName)
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+		existing, err := client.HubVirtualNetworkConnectionsGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of %s: %+v", id, err)
 			}
 		}
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_hub_connection", id.ID())
 		}
 	}
 
-	connection := network.HubVirtualNetworkConnection{
-		Name: utils.String(id.Name),
-		HubVirtualNetworkConnectionProperties: &network.HubVirtualNetworkConnectionProperties{
-			RemoteVirtualNetwork: &network.SubResource{
-				ID: utils.String(remoteVirtualNetworkId.ID()),
+	connection := virtualwans.HubVirtualNetworkConnection{
+		Name: pointer.To(id.VirtualHubName),
+		Properties: &virtualwans.HubVirtualNetworkConnectionProperties{
+			RemoteVirtualNetwork: &virtualwans.SubResource{
+				Id: pointer.To(remoteVirtualNetworkId.ID()),
 			},
-			EnableInternetSecurity: utils.Bool(d.Get("internet_security_enabled").(bool)),
+			EnableInternetSecurity: pointer.To(d.Get("internet_security_enabled").(bool)),
 		},
 	}
 
 	if v, ok := d.GetOk("routing"); ok {
-		connection.HubVirtualNetworkConnectionProperties.RoutingConfiguration = expandVirtualHubConnectionRouting(v.([]interface{}))
+		connection.Properties.RoutingConfiguration = expandVirtualHubConnectionRouting(v.([]interface{}))
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.Name, connection)
-	if err != nil {
+	if err := client.HubVirtualNetworkConnectionsCreateOrUpdateThenPoll(ctx, id, connection); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	timeout, _ := ctx.Deadline()
 
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(network.ProvisioningStateUpdating)},
-		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Pending:    []string{string(virtualwans.ProvisioningStateUpdating)},
+		Target:     []string{string(virtualwans.ProvisioningStateSucceeded)},
 		Refresh:    virtualHubConnectionProvisioningStateRefreshFunc(ctx, client, id),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -258,38 +250,40 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 }
 
 func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubVirtualNetworkConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.HubVirtualNetworkConnectionID(d.Id())
+	id, err := virtualwans.ParseHubVirtualNetworkConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := client.HubVirtualNetworkConnectionsGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] %s does not exist - removing from state", *id)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("reading %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("name", id.VirtualHubName)
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if props := resp.HubVirtualNetworkConnectionProperties; props != nil {
-		d.Set("internet_security_enabled", props.EnableInternetSecurity)
-		remoteVirtualNetworkId := ""
-		if props.RemoteVirtualNetwork != nil && props.RemoteVirtualNetwork.ID != nil {
-			remoteVirtualNetworkId = *props.RemoteVirtualNetwork.ID
-		}
-		d.Set("remote_virtual_network_id", remoteVirtualNetworkId)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("internet_security_enabled", props.EnableInternetSecurity)
+			remoteVirtualNetworkId := ""
+			if props.RemoteVirtualNetwork != nil && props.RemoteVirtualNetwork.Id != nil {
+				remoteVirtualNetworkId = *props.RemoteVirtualNetwork.Id
+			}
+			d.Set("remote_virtual_network_id", remoteVirtualNetworkId)
 
-		if err := d.Set("routing", flattenVirtualHubConnectionRouting(props.RoutingConfiguration)); err != nil {
-			return fmt.Errorf("setting `routing`: %+v", err)
+			if err := d.Set("routing", flattenVirtualHubConnectionRouting(props.RoutingConfiguration)); err != nil {
+				return fmt.Errorf("setting `routing`: %+v", err)
+			}
 		}
 	}
 
@@ -297,11 +291,11 @@ func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{
 }
 
 func resourceVirtualHubConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubVirtualNetworkConnectionClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.HubVirtualNetworkConnectionID(d.Id())
+	id, err := virtualwans.ParseHubVirtualNetworkConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -309,49 +303,44 @@ func resourceVirtualHubConnectionDelete(d *pluginsdk.ResourceData, meta interfac
 	locks.ByName(id.VirtualHubName, virtualHubResourceName)
 	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
-	if err != nil {
+	if err := client.HubVirtualNetworkConnectionsDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 	}
 
 	return nil
 }
 
-func expandVirtualHubConnectionRouting(input []interface{}) *network.RoutingConfiguration {
+func expandVirtualHubConnectionRouting(input []interface{}) *virtualwans.RoutingConfiguration {
 	if len(input) == 0 {
-		return &network.RoutingConfiguration{}
+		return &virtualwans.RoutingConfiguration{}
 	}
 
 	v := input[0].(map[string]interface{})
 
-	result := &network.RoutingConfiguration{
-		VnetRoutes: &network.VnetRoute{
+	result := &virtualwans.RoutingConfiguration{
+		VnetRoutes: &virtualwans.VnetRoute{
 			StaticRoutes: expandVirtualHubConnectionVnetStaticRoute(v["static_vnet_route"].([]interface{})),
-			StaticRoutesConfig: &network.StaticRoutesConfig{
-				VnetLocalRouteOverrideCriteria: network.VnetLocalRouteOverrideCriteria(v["static_vnet_local_route_override_criteria"].(string)),
+			StaticRoutesConfig: &virtualwans.StaticRoutesConfig{
+				VnetLocalRouteOverrideCriteria: pointer.To(virtualwans.VnetLocalRouteOverrideCriteria(v["static_vnet_local_route_override_criteria"].(string))),
 			},
 		},
 	}
 
 	if associatedRouteTableId := v["associated_route_table_id"].(string); associatedRouteTableId != "" {
-		result.AssociatedRouteTable = &network.SubResource{
-			ID: utils.String(associatedRouteTableId),
+		result.AssociatedRouteTable = &virtualwans.SubResource{
+			Id: pointer.To(associatedRouteTableId),
 		}
 	}
 
 	if inboundRouteMapId := v["inbound_route_map_id"].(string); inboundRouteMapId != "" {
-		result.InboundRouteMap = &network.SubResource{
-			ID: utils.String(inboundRouteMapId),
+		result.InboundRouteMap = &virtualwans.SubResource{
+			Id: pointer.To(inboundRouteMapId),
 		}
 	}
 
 	if outboundRouteMapId := v["outbound_route_map_id"].(string); outboundRouteMapId != "" {
-		result.OutboundRouteMap = &network.SubResource{
-			ID: utils.String(outboundRouteMapId),
+		result.OutboundRouteMap = &virtualwans.SubResource{
+			Id: pointer.To(outboundRouteMapId),
 		}
 	}
 
@@ -362,32 +351,32 @@ func expandVirtualHubConnectionRouting(input []interface{}) *network.RoutingConf
 	return result
 }
 
-func expandVirtualHubConnectionPropagatedRouteTable(input []interface{}) *network.PropagatedRouteTable {
+func expandVirtualHubConnectionPropagatedRouteTable(input []interface{}) *virtualwans.PropagatedRouteTable {
 	if len(input) == 0 {
-		return &network.PropagatedRouteTable{}
+		return &virtualwans.PropagatedRouteTable{}
 	}
 
 	v := input[0].(map[string]interface{})
 
-	result := network.PropagatedRouteTable{}
+	result := virtualwans.PropagatedRouteTable{}
 
 	if labels := v["labels"].(*pluginsdk.Set).List(); len(labels) != 0 {
 		result.Labels = utils.ExpandStringSlice(labels)
 	}
 
 	if routeTableIds := v["route_table_ids"].([]interface{}); len(routeTableIds) != 0 {
-		result.Ids = expandIDsToSubResources(routeTableIds)
+		result.Ids = expandIDsToVirtualWANSubResources(routeTableIds)
 	}
 
 	return &result
 }
 
-func expandVirtualHubConnectionVnetStaticRoute(input []interface{}) *[]network.StaticRoute {
+func expandVirtualHubConnectionVnetStaticRoute(input []interface{}) *[]virtualwans.StaticRoute {
 	if len(input) == 0 {
 		return nil
 	}
 
-	results := make([]network.StaticRoute, 0)
+	results := make([]virtualwans.StaticRoute, 0)
 
 	for _, item := range input {
 		if item == nil {
@@ -396,10 +385,10 @@ func expandVirtualHubConnectionVnetStaticRoute(input []interface{}) *[]network.S
 
 		v := item.(map[string]interface{})
 
-		result := network.StaticRoute{}
+		result := virtualwans.StaticRoute{}
 
 		if name := v["name"].(string); name != "" {
-			result.Name = utils.String(name)
+			result.Name = pointer.To(name)
 		}
 
 		if addressPrefixes := v["address_prefixes"].(*pluginsdk.Set).List(); len(addressPrefixes) != 0 {
@@ -407,7 +396,7 @@ func expandVirtualHubConnectionVnetStaticRoute(input []interface{}) *[]network.S
 		}
 
 		if nextHopIPAddress := v["next_hop_ip_address"].(string); nextHopIPAddress != "" {
-			result.NextHopIPAddress = utils.String(nextHopIPAddress)
+			result.NextHopIPAddress = pointer.To(nextHopIPAddress)
 		}
 
 		results = append(results, result)
@@ -416,41 +405,41 @@ func expandVirtualHubConnectionVnetStaticRoute(input []interface{}) *[]network.S
 	return &results
 }
 
-func expandIDsToSubResources(input []interface{}) *[]network.SubResource {
-	ids := make([]network.SubResource, 0)
+func expandIDsToVirtualWANSubResources(input []interface{}) *[]virtualwans.SubResource {
+	ids := make([]virtualwans.SubResource, 0)
 
 	for _, v := range input {
-		ids = append(ids, network.SubResource{
-			ID: utils.String(v.(string)),
+		ids = append(ids, virtualwans.SubResource{
+			Id: pointer.To(v.(string)),
 		})
 	}
 
 	return &ids
 }
 
-func flattenVirtualHubConnectionRouting(input *network.RoutingConfiguration) []interface{} {
+func flattenVirtualHubConnectionRouting(input *virtualwans.RoutingConfiguration) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
 
 	associatedRouteTableId := ""
-	if input.AssociatedRouteTable != nil && input.AssociatedRouteTable.ID != nil {
-		associatedRouteTableId = *input.AssociatedRouteTable.ID
+	if input.AssociatedRouteTable != nil && input.AssociatedRouteTable.Id != nil {
+		associatedRouteTableId = *input.AssociatedRouteTable.Id
 	}
 
 	inboundRouteMapId := ""
-	if input.InboundRouteMap != nil && input.InboundRouteMap.ID != nil {
-		inboundRouteMapId = *input.InboundRouteMap.ID
+	if input.InboundRouteMap != nil && input.InboundRouteMap.Id != nil {
+		inboundRouteMapId = *input.InboundRouteMap.Id
 	}
 
 	outboundRouteMapId := ""
-	if input.OutboundRouteMap != nil && input.OutboundRouteMap.ID != nil {
-		outboundRouteMapId = *input.OutboundRouteMap.ID
+	if input.OutboundRouteMap != nil && input.OutboundRouteMap.Id != nil {
+		outboundRouteMapId = *input.OutboundRouteMap.Id
 	}
 
 	staticVnetLocalRouteOverrideCriteria := ""
-	if input.VnetRoutes != nil && input.VnetRoutes.StaticRoutesConfig != nil && input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria != "" {
-		staticVnetLocalRouteOverrideCriteria = string(input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria)
+	if input.VnetRoutes != nil && input.VnetRoutes.StaticRoutesConfig != nil && input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria != nil {
+		staticVnetLocalRouteOverrideCriteria = string(pointer.From(input.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria))
 	}
 
 	return []interface{}{
@@ -465,7 +454,7 @@ func flattenVirtualHubConnectionRouting(input *network.RoutingConfiguration) []i
 	}
 }
 
-func flattenVirtualHubConnectionPropagatedRouteTable(input *network.PropagatedRouteTable) []interface{} {
+func flattenVirtualHubConnectionPropagatedRouteTable(input *virtualwans.PropagatedRouteTable) []interface{} {
 	if input == nil {
 		return make([]interface{}, 0)
 	}
@@ -477,7 +466,7 @@ func flattenVirtualHubConnectionPropagatedRouteTable(input *network.PropagatedRo
 
 	routeTableIds := make([]interface{}, 0)
 	if input.Ids != nil {
-		routeTableIds = flattenSubResourcesToIDs(input.Ids)
+		routeTableIds = flattenVirtualWANSubResourcesToIDs(input.Ids)
 	}
 
 	return []interface{}{
@@ -488,7 +477,7 @@ func flattenVirtualHubConnectionPropagatedRouteTable(input *network.PropagatedRo
 	}
 }
 
-func flattenVirtualHubConnectionVnetStaticRoute(input *network.VnetRoute) []interface{} {
+func flattenVirtualHubConnectionVnetStaticRoute(input *virtualwans.VnetRoute) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil || input.StaticRoutes == nil {
 		return results
@@ -522,30 +511,39 @@ func flattenVirtualHubConnectionVnetStaticRoute(input *network.VnetRoute) []inte
 	return results
 }
 
-func flattenSubResourcesToIDs(input *[]network.SubResource) []interface{} {
+func flattenVirtualWANSubResourcesToIDs(input *[]virtualwans.SubResource) []interface{} {
 	ids := make([]interface{}, 0)
 	if input == nil {
 		return ids
 	}
 
 	for _, v := range *input {
-		if v.ID == nil {
+		if v.Id == nil {
 			continue
 		}
 
-		ids = append(ids, *v.ID)
+		ids = append(ids, *v.Id)
 	}
 
 	return ids
 }
 
-func virtualHubConnectionProvisioningStateRefreshFunc(ctx context.Context, client *network.HubVirtualNetworkConnectionsClient, id parse.HubVirtualNetworkConnectionId) pluginsdk.StateRefreshFunc {
+func virtualHubConnectionProvisioningStateRefreshFunc(ctx context.Context, client *virtualwans.VirtualWANsClient, id virtualwans.HubVirtualNetworkConnectionId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+		res, err := client.HubVirtualNetworkConnectionsGet(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("polling for %s: %+v", id, err)
 		}
 
-		return res, string(res.ProvisioningState), nil
+		if res.Model == nil {
+			return res, "", fmt.Errorf("retrieving %s: `model` was nil", id)
+		}
+		if res.Model.Properties == nil {
+			return res, "", fmt.Errorf("retrieving %s: `properties` was nil", id)
+		}
+		if res.Model.Properties.ProvisioningState == nil {
+			return res, "", fmt.Errorf("retrieving %s: `properties.provisioningState` was nil", id)
+		}
+		return res, string(*res.Model.Properties.ProvisioningState), nil
 	}
 }

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubConnectionResource struct{}
@@ -130,9 +131,13 @@ func TestAccVirtualHubConnection_recreateWithSameConnectionName(t *testing.T) {
 
 	vhubData := data
 	vhubData.ResourceName = "azurerm_virtual_hub.test"
-	resourceGroupName := fmt.Sprintf("acctestRG-vhub-%d", data.RandomInteger)
-	vhubName := fmt.Sprintf("acctest-VHUB-%d", data.RandomInteger)
-	vhubConnectionName := fmt.Sprintf("acctestbasicvhubconn-%d", data.RandomInteger)
+
+	id := virtualwans.NewHubVirtualNetworkConnectionID(
+		data.Subscriptions.Primary,
+		fmt.Sprintf("acctestRG-vhub-%d", data.RandomInteger),
+		fmt.Sprintf("acctest-VHUB-%d", data.RandomInteger),
+		fmt.Sprintf("acctestbasicvhubconn-%d", data.RandomInteger),
+	)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -145,7 +150,7 @@ func TestAccVirtualHubConnection_recreateWithSameConnectionName(t *testing.T) {
 		{
 			Config: r.template(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				vhubData.CheckWithClient(checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName)),
+				vhubData.CheckWithClient(checkVirtualHubConnectionDoesNotExist(id)),
 			),
 		},
 		{
@@ -274,29 +279,28 @@ func TestAccVirtualHubConnection_routeMapAndStaticVnetLocalRouteOverrideCriteria
 }
 
 func (t VirtualHubConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.HubVirtualNetworkConnectionID(state.ID)
+	id, err := virtualwans.ParseHubVirtualNetworkConnectionID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.HubVirtualNetworkConnectionClient.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := clients.Network.VirtualWANs.HubVirtualNetworkConnectionsGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub Network Connection (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
-func checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName string) acceptance.ClientCheckFunc {
+func checkVirtualHubConnectionDoesNotExist(id virtualwans.HubVirtualNetworkConnectionId) acceptance.ClientCheckFunc {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-		if resp, err := clients.Network.HubVirtualNetworkConnectionClient.Get(ctx, resourceGroupName, vhubName, vhubConnectionName); err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
+		if resp, err := clients.Network.VirtualWANs.HubVirtualNetworkConnectionsGet(ctx, id); err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
 				return nil
 			}
-			return fmt.Errorf("Bad: Get on network.HubVirtualNetworkConnectionClient: %+v", err)
+			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
-
-		return fmt.Errorf("Bad: Virtual Hub Connection %q (Resource Group %q) still exists", vhubConnectionName, resourceGroupName)
+		return fmt.Errorf("%s still exists", id)
 	}
 }
 

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -294,7 +295,9 @@ func (t VirtualHubConnectionResource) Exists(ctx context.Context, clients *clien
 
 func checkVirtualHubConnectionDoesNotExist(id virtualwans.HubVirtualNetworkConnectionId) acceptance.ClientCheckFunc {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-		if resp, err := clients.Network.VirtualWANs.HubVirtualNetworkConnectionsGet(ctx, id); err != nil {
+		ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		if resp, err := clients.Network.VirtualWANs.HubVirtualNetworkConnectionsGet(ctx2, id); err != nil {
 			if response.WasNotFound(resp.HttpResponse) {
 				return nil
 			}

--- a/internal/services/network/virtual_hub_data_source.go
+++ b/internal/services/network/virtual_hub_data_source.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceVirtualHub() *pluginsdk.Resource {
@@ -60,7 +60,7 @@ func dataSourceVirtualHub() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.SchemaDataSource(),
+			"tags": commonschema.TagsDataSource(),
 
 			"default_route_table_id": {
 				Type:     pluginsdk.TypeString,
@@ -71,57 +71,54 @@ func dataSourceVirtualHub() *pluginsdk.Resource {
 }
 
 func dataSourceVirtualHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewVirtualHubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualwans.NewVirtualHubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.VirtualHubsGet(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("reading %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.VirtualHubName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	d.Set("location", location.NormalizeNilable(resp.Location))
-
-	if props := resp.VirtualHubProperties; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
-
-		var virtualWanId *string
-		if props.VirtualWan != nil {
-			virtualWanId = props.VirtualWan.ID
-		}
-		d.Set("virtual_wan_id", virtualWanId)
-
-		var virtualRouterAsn *int64
-		if props.VirtualRouterAsn != nil {
-			virtualRouterAsn = props.VirtualRouterAsn
-		}
-		d.Set("virtual_router_asn", virtualRouterAsn)
-
-		var virtualRouterIps *[]string
-		if props.VirtualRouterIps != nil {
-			virtualRouterIps = props.VirtualRouterIps
-		}
-		d.Set("virtual_router_ips", virtualRouterIps)
-	}
-
-	virtualHub, err := parse.VirtualHubID(*resp.ID)
-	if err != nil {
-		return err
-	}
-
-	defaultRouteTable := parse.NewHubRouteTableID(virtualHub.SubscriptionId, virtualHub.ResourceGroup, virtualHub.Name, "defaultRouteTable")
+	defaultRouteTable := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName, "defaultRouteTable")
 	d.Set("default_route_table_id", defaultRouteTable.ID())
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+
+		if props := model.Properties; props != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+
+			var virtualWanId *string
+			if props.VirtualWAN != nil {
+				virtualWanId = props.VirtualWAN.Id
+			}
+			d.Set("virtual_wan_id", virtualWanId)
+
+			var virtualRouterAsn *int64
+			if props.VirtualRouterAsn != nil {
+				virtualRouterAsn = props.VirtualRouterAsn
+			}
+			d.Set("virtual_router_asn", virtualRouterAsn)
+
+			var virtualRouterIps *[]string
+			if props.VirtualRouterIPs != nil {
+				virtualRouterIps = props.VirtualRouterIPs
+			}
+			d.Set("virtual_router_ips", virtualRouterIps)
+		}
+		return tags.FlattenAndSet(d, model.Tags)
+	}
+	return nil
 }

--- a/internal/services/network/virtual_hub_ip_resource.go
+++ b/internal/services/network/virtual_hub_ip_resource.go
@@ -8,17 +8,16 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubIP() *pluginsdk.Resource {
@@ -36,7 +35,7 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.VirtualHubIpConfigurationID(id)
+			_, err := commonids.ParseVirtualHubIPConfigurationID(id)
 			return err
 		}),
 
@@ -52,7 +51,7 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: networkValidate.VirtualHubID,
+				ValidateFunc: virtualwans.ValidateVirtualHubID,
 			},
 
 			"subnet_id": {
@@ -71,10 +70,10 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 			"private_ip_allocation_method": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  network.IPAllocationMethodDynamic,
+				Default:  virtualwans.IPAllocationMethodDynamic,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.IPAllocationMethodDynamic),
-					string(network.IPAllocationMethodStatic),
+					string(virtualwans.IPAllocationMethodDynamic),
+					string(virtualwans.IPAllocationMethodStatic),
 				}, false),
 			},
 
@@ -83,74 +82,64 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: networkValidate.PublicIpAddressID,
+				ValidateFunc: commonids.ValidatePublicIPAddressID,
 			},
 		},
 	}
 }
 
 func resourceVirtualHubIPCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubIPClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtualHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(virtHubId.Name, virtualHubResourceName)
-	defer locks.UnlockByName(virtHubId.Name, virtualHubResourceName)
+	locks.ByName(virtualHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtualHubId.VirtualHubName, virtualHubResourceName)
 
-	id := parse.NewVirtualHubIpConfigurationID(virtHubId.SubscriptionId, virtHubId.ResourceGroup, virtHubId.Name, d.Get("name").(string))
+	id := commonids.NewVirtualHubIPConfigurationID(virtualHubId.SubscriptionId, virtualHubId.ResourceGroupName, virtualHubId.VirtualHubName, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.IpConfigurationName)
+		existing, err := client.VirtualHubIPConfigurationGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of %s: %+v", id, err)
 			}
 		}
-
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_hub_ip", id.ID())
-		}
-
-		if d.Get("public_ip_address_id").(string) == "" {
-			return fmt.Errorf("`public_ip_address_id` is required for new resources, created after September 1st 2021")
 		}
 	}
 
-	parameters := network.HubIPConfiguration{
-		Name: utils.String(id.IpConfigurationName),
-		HubIPConfigurationPropertiesFormat: &network.HubIPConfigurationPropertiesFormat{
-			Subnet: &network.Subnet{
-				ID: utils.String(d.Get("subnet_id").(string)),
+	parameters := virtualwans.HubIPConfiguration{
+		Name: pointer.To(id.IpConfigName),
+		Properties: &virtualwans.HubIPConfigurationPropertiesFormat{
+			Subnet: &virtualwans.Subnet{
+				Id: pointer.To(d.Get("subnet_id").(string)),
 			},
 		},
 	}
 
 	if v, ok := d.GetOk("private_ip_address"); ok {
-		parameters.HubIPConfigurationPropertiesFormat.PrivateIPAddress = utils.String(v.(string))
+		parameters.Properties.PrivateIPAddress = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("private_ip_allocation_method"); ok {
-		parameters.HubIPConfigurationPropertiesFormat.PrivateIPAllocationMethod = network.IPAllocationMethod(v.(string))
+		parameters.Properties.PrivateIPAllocationMethod = pointer.To(virtualwans.IPAllocationMethod(v.(string)))
 	}
 
 	if v, ok := d.GetOk("public_ip_address_id"); ok {
-		parameters.HubIPConfigurationPropertiesFormat.PublicIPAddress = &network.PublicIPAddress{
-			ID: utils.String(v.(string)),
+		parameters.Properties.PublicIPAddress = &virtualwans.PublicIPAddress{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.IpConfigurationName, parameters)
-	if err != nil {
+	if err := client.VirtualHubIPConfigurationCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on creating/updating future for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -159,39 +148,40 @@ func resourceVirtualHubIPCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 }
 
 func resourceVirtualHubIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubIPClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualHubIpConfigurationID(d.Id())
+	id, err := commonids.ParseVirtualHubIPConfigurationID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.IpConfigurationName)
+	resp, err := client.VirtualHubIPConfigurationGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] Virtual Hub IP %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-
-		return fmt.Errorf("retrieving Virtual Hub IP %q (Resource Group %q / Virtual Hub %q): %+v", id.IpConfigurationName, id.ResourceGroup, id.VirtualHubName, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.IpConfigurationName)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("name", id.IpConfigName)
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if props := resp.HubIPConfigurationPropertiesFormat; props != nil {
-		d.Set("private_ip_address", props.PrivateIPAddress)
-		d.Set("private_ip_allocation_method", props.PrivateIPAllocationMethod)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("private_ip_address", props.PrivateIPAddress)
+			d.Set("private_ip_allocation_method", string(pointer.From(props.PrivateIPAllocationMethod)))
 
-		if v := props.PublicIPAddress; v != nil {
-			d.Set("public_ip_address_id", v.ID)
-		}
+			if v := props.PublicIPAddress; v != nil {
+				d.Set("public_ip_address_id", v.Id)
+			}
 
-		if v := props.Subnet; v != nil {
-			d.Set("subnet_id", v.ID)
+			if v := props.Subnet; v != nil {
+				d.Set("subnet_id", v.Id)
+			}
 		}
 	}
 
@@ -199,11 +189,11 @@ func resourceVirtualHubIPRead(d *pluginsdk.ResourceData, meta interface{}) error
 }
 
 func resourceVirtualHubIPDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubIPClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualHubIpConfigurationID(d.Id())
+	id, err := commonids.ParseVirtualHubIPConfigurationID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -211,13 +201,8 @@ func resourceVirtualHubIPDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	locks.ByName(id.VirtualHubName, virtualHubResourceName)
 	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualHubName, id.IpConfigurationName)
-	if err != nil {
-		return fmt.Errorf("deleting Virtual Hub IP %q (Resource Group %q / virtualHubName %q): %+v", id.IpConfigurationName, id.ResourceGroup, id.VirtualHubName, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on deleting future for Virtual Hub IP %q (Resource Group %q / virtualHubName %q): %+v", id.IpConfigurationName, id.ResourceGroup, id.VirtualHubName, err)
+	if err := client.VirtualHubIPConfigurationDeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/virtual_hub_ip_resource_test.go
+++ b/internal/services/network/virtual_hub_ip_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubIPResource struct{}
@@ -89,17 +89,17 @@ func TestAccVirtualHubIP_update(t *testing.T) {
 }
 
 func (t VirtualHubIPResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualHubIpConfigurationID(state.ID)
+	id, err := commonids.ParseVirtualHubIPConfigurationID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.VirtualHubIPClient.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.IpConfigurationName)
+	resp, err := clients.Network.VirtualWANs.VirtualHubIPConfigurationGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub IP (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualHubIPResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -9,21 +9,22 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 const virtualHubResourceName = "azurerm_virtual_hub"
@@ -117,16 +118,16 @@ func resourceVirtualHub() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 
 			"hub_routing_preference": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(network.HubRoutingPreferenceExpressRoute),
+				Default:  string(virtualwans.HubRoutingPreferenceExpressRoute),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.HubRoutingPreferenceExpressRoute),
-					string(network.HubRoutingPreferenceVpnGateway),
-					string(network.HubRoutingPreferenceASPath),
+					string(virtualwans.HubRoutingPreferenceExpressRoute),
+					string(virtualwans.HubRoutingPreferenceVpnGateway),
+					string(virtualwans.HubRoutingPreferenceASPath),
 				}, false),
 			},
 
@@ -146,7 +147,7 @@ func resourceVirtualHub() *pluginsdk.Resource {
 }
 
 func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -155,68 +156,57 @@ func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("deadline is not properly set for Virtual Hub")
 	}
 
-	id := parse.NewVirtualHubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := virtualwans.NewVirtualHubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	locks.ByName(id.Name, virtualHubResourceName)
-	defer locks.UnlockByName(id.Name, virtualHubResourceName)
+	locks.ByName(id.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+		existing, err := client.VirtualHubsGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for present of existing %s: %+v", id, err)
 			}
 		}
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_hub", id.ID())
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	route := d.Get("route").(*pluginsdk.Set).List()
-	t := d.Get("tags").(map[string]interface{})
-
-	hubRoutingPreference := d.Get("hub_routing_preference").(string)
-
-	parameters := network.VirtualHub{
-		Location: utils.String(location),
-		VirtualHubProperties: &network.VirtualHubProperties{
-			RouteTable:           expandVirtualHubRoute(route),
-			HubRoutingPreference: network.HubRoutingPreference(hubRoutingPreference),
+	parameters := virtualwans.VirtualHub{
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Properties: &virtualwans.VirtualHubProperties{
+			RouteTable:           expandVirtualHubRoute(d.Get("route").(*pluginsdk.Set).List()),
+			HubRoutingPreference: pointer.To(virtualwans.HubRoutingPreference(d.Get("hub_routing_preference").(string))),
 		},
-		Tags: tags.Expand(t),
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("address_prefix"); ok {
-		parameters.VirtualHubProperties.AddressPrefix = utils.String(v.(string))
+		parameters.Properties.AddressPrefix = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("sku"); ok {
-		parameters.VirtualHubProperties.Sku = utils.String(v.(string))
+		parameters.Properties.Sku = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("virtual_wan_id"); ok {
-		parameters.VirtualHubProperties.VirtualWan = &network.SubResource{
-			ID: utils.String(v.(string)),
+		parameters.Properties.VirtualWAN = &virtualwans.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("virtual_router_auto_scale_min_capacity"); ok {
-		parameters.VirtualHubProperties.VirtualRouterAutoScaleConfiguration = &network.VirtualRouterAutoScaleConfiguration{
-			MinCapacity: utils.Int32(int32(v.(int))),
+		parameters.Properties.VirtualRouterAutoScaleConfiguration = &virtualwans.VirtualRouterAutoScaleConfiguration{
+			MinCapacity: pointer.To(int64(v.(int))),
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, parameters)
-	if err != nil {
+	if err := client.VirtualHubsCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
-	}
-
-	// Hub returns provisioned while the routing state is still "provisining". This might cause issues with following hubvnet connection operations.
+	// Hub returns provisioned while the routing state is still "provisioning". This might cause issues with following hubvnet connection operations.
 	// https://github.com/Azure/azure-rest-api-specs/issues/10391
 	// As a workaround, we will poll the routing state and ensure it is "Provisioned".
 
@@ -225,12 +215,12 @@ func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:                   []string{"Provisioning"},
 		Target:                    []string{"Provisioned", "Failed", "None"},
-		Refresh:                   virtualHubCreateRefreshFunc(ctx, client, id.ResourceGroup, id.Name),
+		Refresh:                   virtualHubCreateRefreshFunc(ctx, client, id),
 		PollInterval:              15 * time.Second,
 		ContinuousTargetOccurence: 3,
 		Timeout:                   time.Until(timeout),
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
+	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for %s provisioning route: %+v", id, err)
 	}
@@ -241,100 +231,95 @@ func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 }
 
 func resourceVirtualHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualHubID(d.Id())
+	id, err := virtualwans.ParseVirtualHubID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.VirtualHubsGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Virtual Hub %q does not exist - removing from state", d.Id())
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] %s does not exist - removing from state", id)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("reading %s: %+v", *id, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
-	if props := resp.VirtualHubProperties; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
-		d.Set("sku", props.Sku)
+	d.Set("name", id.VirtualHubName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-		if err := d.Set("route", flattenVirtualHubRoute(props.RouteTable)); err != nil {
-			return fmt.Errorf("setting `route`: %+v", err)
-		}
-
-		d.Set("hub_routing_preference", props.HubRoutingPreference)
-
-		var virtualWanId *string
-		if props.VirtualWan != nil {
-			virtualWanId = props.VirtualWan.ID
-		}
-		d.Set("virtual_wan_id", virtualWanId)
-
-		var virtualRouterAsn *int64
-		if props.VirtualRouterAsn != nil {
-			virtualRouterAsn = props.VirtualRouterAsn
-		}
-		d.Set("virtual_router_asn", virtualRouterAsn)
-
-		var virtualRouterIps *[]string
-		if props.VirtualRouterIps != nil {
-			virtualRouterIps = props.VirtualRouterIps
-		}
-		d.Set("virtual_router_ips", virtualRouterIps)
-
-		d.Set("virtual_router_auto_scale_min_capacity", props.VirtualRouterAutoScaleConfiguration.MinCapacity)
-	}
-
-	defaultRouteTable := parse.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.Name, "defaultRouteTable")
+	defaultRouteTable := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName, "defaultRouteTable")
 	d.Set("default_route_table_id", defaultRouteTable.ID())
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if props := model.Properties; props != nil {
+
+			d.Set("address_prefix", props.AddressPrefix)
+			d.Set("sku", props.Sku)
+
+			if err := d.Set("route", flattenVirtualHubRoute(props.RouteTable)); err != nil {
+				return fmt.Errorf("setting `route`: %+v", err)
+			}
+
+			d.Set("hub_routing_preference", string(pointer.From(props.HubRoutingPreference)))
+
+			var virtualWanId *string
+			if props.VirtualWAN != nil {
+				virtualWanId = props.VirtualWAN.Id
+			}
+			d.Set("virtual_wan_id", virtualWanId)
+
+			var virtualRouterAsn *int64
+			if props.VirtualRouterAsn != nil {
+				virtualRouterAsn = props.VirtualRouterAsn
+			}
+			d.Set("virtual_router_asn", virtualRouterAsn)
+
+			var virtualRouterIps *[]string
+			if props.VirtualRouterIPs != nil {
+				virtualRouterIps = props.VirtualRouterIPs
+			}
+			d.Set("virtual_router_ips", virtualRouterIps)
+
+			d.Set("virtual_router_auto_scale_min_capacity", props.VirtualRouterAutoScaleConfiguration.MinCapacity)
+		}
+		return tags.FlattenAndSet(d, model.Tags)
+	}
+	return nil
 }
 
 func resourceVirtualHubDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualHubClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualHubID(d.Id())
+	id, err := virtualwans.ParseVirtualHubID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, virtualHubResourceName)
-	defer locks.UnlockByName(id.Name, virtualHubResourceName)
+	locks.ByName(id.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
+	if err := client.VirtualHubsDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("waiting for deleting %s: %+v", *id, err)
-		}
 	}
 
 	return nil
 }
 
-func expandVirtualHubRoute(input []interface{}) *network.VirtualHubRouteTable {
+func expandVirtualHubRoute(input []interface{}) *virtualwans.VirtualHubRouteTable {
 	if len(input) == 0 {
 		return nil
 	}
 
-	results := make([]network.VirtualHubRoute, 0)
+	results := make([]virtualwans.VirtualHubRoute, 0)
 	for _, item := range input {
 		if item == nil {
 			continue
@@ -344,20 +329,20 @@ func expandVirtualHubRoute(input []interface{}) *network.VirtualHubRouteTable {
 		addressPrefixes := v["address_prefixes"].([]interface{})
 		nextHopIpAddress := v["next_hop_ip_address"].(string)
 
-		results = append(results, network.VirtualHubRoute{
+		results = append(results, virtualwans.VirtualHubRoute{
 			AddressPrefixes:  utils.ExpandStringSlice(addressPrefixes),
-			NextHopIPAddress: utils.String(nextHopIpAddress),
+			NextHopIPAddress: pointer.To(nextHopIpAddress),
 		})
 	}
 
-	result := network.VirtualHubRouteTable{
+	result := virtualwans.VirtualHubRouteTable{
 		Routes: &results,
 	}
 
 	return &result
 }
 
-func flattenVirtualHubRoute(input *network.VirtualHubRouteTable) []interface{} {
+func flattenVirtualHubRoute(input *virtualwans.VirtualHubRouteTable) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil || input.Routes == nil {
 		return results
@@ -380,24 +365,26 @@ func flattenVirtualHubRoute(input *network.VirtualHubRouteTable) []interface{} {
 	return results
 }
 
-func virtualHubCreateRefreshFunc(ctx context.Context, client *network.VirtualHubsClient, resourceGroup, name string) pluginsdk.StateRefreshFunc {
+func virtualHubCreateRefreshFunc(ctx context.Context, client *virtualwans.VirtualWANsClient, id virtualwans.VirtualHubId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, resourceGroup, name)
+		res, err := client.VirtualHubsGet(ctx, id)
 		if err != nil {
-			if utils.ResponseWasNotFound(res.Response) {
-				return nil, "", fmt.Errorf("Virtual Hub %q (Resource Group %q) doesn't exist", resourceGroup, name)
+			if response.WasNotFound(res.HttpResponse) {
+				return nil, "", fmt.Errorf("%s doesn't exist", id)
 			}
+			return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+		if res.Model == nil {
+			return nil, "", fmt.Errorf("retrieving %s: `model` was nil", id)
+		}
+		if res.Model.Properties == nil {
+			return nil, "", fmt.Errorf("retrieving %s: `properties` was nil", id)
+		}
 
-			return nil, "", fmt.Errorf("retrieving Virtual Hub %q (Resource Group %q): %+v", resourceGroup, name, err)
+		state := res.Model.Properties.RoutingState
+		if state != nil && *state == "Failed" {
+			return nil, "", fmt.Errorf("failed to provision routing on %s", id)
 		}
-		if res.VirtualHubProperties == nil {
-			return nil, "", fmt.Errorf("unexpected nil properties of Virtual Hub %q (Resource Group %q)", resourceGroup, name)
-		}
-
-		state := res.VirtualHubProperties.RoutingState
-		if state == "Failed" {
-			return nil, "", fmt.Errorf("failed to provision routing on Virtual Hub %q (Resource Group %q)", resourceGroup, name)
-		}
-		return res, string(res.VirtualHubProperties.RoutingState), nil
+		return res, string(*res.Model.Properties.RoutingState), nil
 	}
 }

--- a/internal/services/network/virtual_hub_resource_test.go
+++ b/internal/services/network/virtual_hub_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubResource struct{}
@@ -124,17 +124,17 @@ func TestAccVirtualHub_auto_scale_min_capacity(t *testing.T) {
 }
 
 func (t VirtualHubResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualHubID(state.ID)
+	id, err := virtualwans.ParseVirtualHubID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.VirtualHubClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Network.VirtualWANs.VirtualHubsGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualHubResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/virtual_hub_route_table_data_source.go
+++ b/internal/services/network/virtual_hub_route_table_data_source.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -92,16 +93,16 @@ func dataSourceVirtualHubRouteTable() *pluginsdk.Resource {
 }
 
 func dataSourceVirtualHubRouteTableRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewHubRouteTableID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_hub_name").(string), d.Get("name").(string))
+	id := virtualwans.NewHubRouteTableID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_hub_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := client.HubRouteTablesGet(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 
@@ -110,17 +111,20 @@ func dataSourceVirtualHubRouteTableRead(d *pluginsdk.ResourceData, meta interfac
 
 	d.SetId(id.ID())
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.HubRouteTableName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("virtual_hub_name", id.VirtualHubName)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if props := resp.HubRouteTableProperties; props != nil {
-		d.Set("labels", utils.FlattenStringSlice(props.Labels))
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("labels", utils.FlattenStringSlice(props.Labels))
 
-		if err := d.Set("route", flattenVirtualHubRouteTableHubRoutes(props.Routes)); err != nil {
-			return fmt.Errorf("setting `route`: %+v", err)
+			if err := d.Set("route", flattenVirtualHubRouteTableHubRoutes(props.Routes)); err != nil {
+				return fmt.Errorf("setting `route`: %+v", err)
+			}
 		}
 	}
+
 	return nil
 }

--- a/internal/services/network/virtual_hub_route_table_resource.go
+++ b/internal/services/network/virtual_hub_route_table_resource.go
@@ -8,17 +8,18 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubRouteTable() *pluginsdk.Resource {
@@ -36,7 +37,7 @@ func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.HubRouteTableID(id)
+			_, err := virtualwans.ParseHubRouteTableID(id)
 			return err
 		}),
 
@@ -52,7 +53,7 @@ func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: networkValidate.VirtualHubID,
+				ValidateFunc: virtualwans.ValidateVirtualHubID,
 			},
 
 			"labels": {
@@ -116,48 +117,43 @@ func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 }
 
 func resourceVirtualHubRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	virtHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(virtHubId.Name, virtualHubResourceName)
-	defer locks.UnlockByName(virtHubId.Name, virtualHubResourceName)
+	locks.ByName(virtHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtHubId.VirtualHubName, virtualHubResourceName)
 
-	id := parse.NewHubRouteTableID(virtHubId.SubscriptionId, virtHubId.ResourceGroup, virtHubId.Name, d.Get("name").(string))
+	id := virtualwans.NewHubRouteTableID(virtHubId.SubscriptionId, virtHubId.ResourceGroupName, virtHubId.VirtualHubName, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+		existing, err := client.HubRouteTablesGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of %s: %+v", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_virtual_hub_route_table", id.ID())
 		}
 	}
 
-	parameters := network.HubRouteTable{
-		Name: utils.String(d.Get("name").(string)),
-		HubRouteTableProperties: &network.HubRouteTableProperties{
+	parameters := virtualwans.HubRouteTable{
+		Name: pointer.To(d.Get("name").(string)),
+		Properties: &virtualwans.HubRouteTableProperties{
 			Labels: utils.ExpandStringSlice(d.Get("labels").(*pluginsdk.Set).List()),
 			Routes: expandVirtualHubRouteTableHubRoutes(d.Get("route").(*pluginsdk.Set).List()),
 		},
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.Name, parameters)
-	if err != nil {
+	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on creating/updating future for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -166,45 +162,47 @@ func resourceVirtualHubRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta in
 }
 
 func resourceVirtualHubRouteTableRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.HubRouteTableID(d.Id())
+	id, err := virtualwans.ParseHubRouteTableID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := client.HubRouteTablesGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Virtual Hub Route Table %q does not exist - removing from state", d.Id())
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] %s does not exist - removing from state", id)
 			d.SetId("")
 			return nil
 		}
-
-		return fmt.Errorf("retrieving HubRouteTable %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("virtual_hub_id", parse.NewVirtualHubID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName).ID())
+	d.Set("name", id.HubRouteTableName)
+	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if props := resp.HubRouteTableProperties; props != nil {
-		d.Set("labels", utils.FlattenStringSlice(props.Labels))
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("labels", utils.FlattenStringSlice(props.Labels))
 
-		if err := d.Set("route", flattenVirtualHubRouteTableHubRoutes(props.Routes)); err != nil {
-			return fmt.Errorf("setting `route`: %+v", err)
+			if err := d.Set("route", flattenVirtualHubRouteTableHubRoutes(props.Routes)); err != nil {
+				return fmt.Errorf("setting `route`: %+v", err)
+			}
 		}
 	}
+
 	return nil
 }
 
 func resourceVirtualHubRouteTableDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.HubRouteTableID(d.Id())
+	id, err := virtualwans.ParseHubRouteTableID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -212,30 +210,25 @@ func resourceVirtualHubRouteTableDelete(d *pluginsdk.ResourceData, meta interfac
 	locks.ByName(id.VirtualHubName, virtualHubResourceName)
 	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
-	if err != nil {
-		return fmt.Errorf("deleting HubRouteTable %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on deleting future for HubRouteTable %q (Resource Group %q / Virtual Hub %q): %+v", id.Name, id.ResourceGroup, id.VirtualHubName, err)
+	if err := client.HubRouteTablesDeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func expandVirtualHubRouteTableHubRoutes(input []interface{}) *[]network.HubRoute {
-	results := make([]network.HubRoute, 0)
+func expandVirtualHubRouteTableHubRoutes(input []interface{}) *[]virtualwans.HubRoute {
+	results := make([]virtualwans.HubRoute, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		result := network.HubRoute{
-			Name:            utils.String(v["name"].(string)),
-			DestinationType: utils.String(v["destinations_type"].(string)),
-			Destinations:    utils.ExpandStringSlice(v["destinations"].(*pluginsdk.Set).List()),
-			NextHopType:     utils.String(v["next_hop_type"].(string)),
-			NextHop:         utils.String(v["next_hop"].(string)),
+		result := virtualwans.HubRoute{
+			Name:            v["name"].(string),
+			DestinationType: v["destinations_type"].(string),
+			Destinations:    pointer.From(utils.ExpandStringSlice(v["destinations"].(*pluginsdk.Set).List())),
+			NextHopType:     v["next_hop_type"].(string),
+			NextHop:         v["next_hop"].(string),
 		}
 
 		results = append(results, result)
@@ -244,39 +237,19 @@ func expandVirtualHubRouteTableHubRoutes(input []interface{}) *[]network.HubRout
 	return &results
 }
 
-func flattenVirtualHubRouteTableHubRoutes(input *[]network.HubRoute) []interface{} {
+func flattenVirtualHubRouteTableHubRoutes(input *[]virtualwans.HubRoute) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results
 	}
 
 	for _, item := range *input {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
-
-		var destinationType string
-		if item.DestinationType != nil {
-			destinationType = *item.DestinationType
-		}
-
-		var nextHop string
-		if item.NextHop != nil {
-			nextHop = *item.NextHop
-		}
-
-		var nextHopType string
-		if item.NextHopType != nil {
-			nextHopType = *item.NextHopType
-		}
-
 		v := map[string]interface{}{
-			"name":              name,
-			"destinations":      utils.FlattenStringSlice(item.Destinations),
-			"destinations_type": destinationType,
-			"next_hop":          nextHop,
-			"next_hop_type":     nextHopType,
+			"name":              item.Name,
+			"destinations":      utils.FlattenStringSlice(&item.Destinations),
+			"destinations_type": item.DestinationType,
+			"next_hop":          item.NextHop,
+			"next_hop_type":     item.NextHopType,
 		}
 
 		results = append(results, v)

--- a/internal/services/network/virtual_hub_route_table_resource_test.go
+++ b/internal/services/network/virtual_hub_route_table_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubRouteTableResource struct{}
@@ -89,17 +89,17 @@ func TestAccVirtualHubRouteTable_update(t *testing.T) {
 }
 
 func (t VirtualHubRouteTableResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.HubRouteTableID(state.ID)
+	id, err := virtualwans.ParseHubRouteTableID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.HubRouteTableClient.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+	resp, err := clients.Network.VirtualWANs.HubRouteTablesGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub Route Table (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualHubRouteTableResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_hub_route_table_route_resource.go
+++ b/internal/services/network/virtual_hub_route_table_route_resource.go
@@ -149,7 +149,7 @@ func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, me
 		routes = append(routes, result)
 
 	} else {
-		routes := *props.Routes
+		routes = *props.Routes
 		for i := range routes {
 			if routes[i].Name == name {
 				routes[i].DestinationType = d.Get("destinations_type").(string)

--- a/internal/services/network/virtual_hub_route_table_route_resource.go
+++ b/internal/services/network/virtual_hub_route_table_route_resource.go
@@ -8,6 +8,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -18,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubRouteTableRoute() *pluginsdk.Resource {
@@ -93,11 +95,11 @@ func resourceVirtualHubRouteTableRoute() *pluginsdk.Resource {
 }
 
 func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	routeTableId, err := parse.HubRouteTableID(d.Get("route_table_id").(string))
+	routeTableId, err := virtualwans.ParseHubRouteTableID(d.Get("route_table_id").(string))
 	if err != nil {
 		return err
 	}
@@ -105,56 +107,64 @@ func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, me
 	locks.ByName(routeTableId.VirtualHubName, virtualHubResourceName)
 	defer locks.UnlockByName(routeTableId.VirtualHubName, virtualHubResourceName)
 
-	routeTable, err := client.Get(ctx, routeTableId.ResourceGroup, routeTableId.VirtualHubName, routeTableId.Name)
+	routeTable, err := client.HubRouteTablesGet(ctx, *routeTableId)
 	if err != nil {
-		if !utils.ResponseWasNotFound(routeTable.Response) {
+		if !response.WasNotFound(routeTable.HttpResponse) {
 			return fmt.Errorf("checking for existing %s: %+v", routeTableId, err)
 		}
-
 		return fmt.Errorf("retrieving %s: %+v", routeTableId, err)
 	}
 
-	name := d.Get("name").(string)
-	id := parse.NewHubRouteTableRouteID(routeTableId.SubscriptionId, routeTableId.ResourceGroup, routeTableId.VirtualHubName, routeTableId.Name, name)
+	if routeTable.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", routeTableId)
+	}
+	if routeTable.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", routeTableId)
+	}
 
+	props := routeTable.Model.Properties
+
+	name := d.Get("name").(string)
+	id := parse.NewHubRouteTableRouteID(routeTableId.SubscriptionId, routeTableId.ResourceGroupName, routeTableId.VirtualHubName, routeTableId.HubRouteTableName, name)
+
+	routes := make([]virtualwans.HubRoute, 0)
 	if d.IsNewResource() {
-		for _, r := range *routeTable.Routes {
-			if *r.Name == name {
-				return tf.ImportAsExistsError("azurerm_virtual_hub_route_table_route", id.ID())
+		if hubRoutes := props.Routes; hubRoutes != nil {
+			for _, r := range *hubRoutes {
+				if r.Name == name {
+					return tf.ImportAsExistsError("azurerm_virtual_hub_route_table_route", id.ID())
+				}
 			}
+			routes = *props.Routes
 		}
 
-		routes := *routeTable.Routes
-		result := network.HubRoute{
-			Name:            utils.String(d.Get("name").(string)),
-			DestinationType: utils.String(d.Get("destinations_type").(string)),
-			Destinations:    utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List()),
-			NextHopType:     utils.String(d.Get("next_hop_type").(string)),
-			NextHop:         utils.String(d.Get("next_hop").(string)),
+		result := virtualwans.HubRoute{
+			Name:            d.Get("name").(string),
+			DestinationType: d.Get("destinations_type").(string),
+			Destinations:    pointer.From(utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List())),
+			NextHopType:     d.Get("next_hop_type").(string),
+			NextHop:         d.Get("next_hop").(string),
 		}
 
 		routes = append(routes, result)
-		routeTable.Routes = &routes
+
 	} else {
-		routes := *routeTable.Routes
+		routes := *props.Routes
 		for i := range routes {
-			if *routes[i].Name == name {
-				routes[i].DestinationType = utils.String(d.Get("destinations_type").(string))
-				routes[i].Destinations = utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List())
-				routes[i].NextHopType = utils.String(d.Get("next_hop_type").(string))
-				routes[i].NextHop = utils.String(d.Get("next_hop").(string))
+			if routes[i].Name == name {
+				routes[i].DestinationType = d.Get("destinations_type").(string)
+				routes[i].Destinations = pointer.From(utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List()))
+				routes[i].NextHopType = d.Get("next_hop_type").(string)
+				routes[i].NextHop = d.Get("next_hop").(string)
 				break
 			}
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, routeTableId.ResourceGroup, routeTableId.VirtualHubName, routeTableId.Name, routeTable)
-	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
+	routeTable.Model.Properties.Routes = pointer.To(routes)
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting to create/update %s: %+v", id, err)
+	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, *routeTableId, *routeTable.Model); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -163,102 +173,108 @@ func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, me
 }
 
 func resourceVirtualHubRouteTableRouteRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	route, err := parse.HubRouteTableRouteID(d.Id())
+	id, err := parse.HubRouteTableRouteID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, route.ResourceGroup, route.VirtualHubName, route.HubRouteTableName)
+	routeTableId := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName, id.HubRouteTableName)
+
+	resp, err := client.HubRouteTablesGet(ctx, routeTableId)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Virtual Hub Route Table %q does not exist - removing route %s from state", route.HubRouteTableName, route.RouteName)
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] %s does not exist - removing from state", routeTableId.ID())
 			d.SetId("")
 			return nil
 		}
-
-		return fmt.Errorf("retrieving %s: %+v", route, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if props := resp.HubRouteTableProperties; props != nil {
-		found := false
-		for _, r := range *props.Routes {
-			if *r.Name == route.RouteName {
-				found = true
+	d.Set("name", id.RouteName)
 
-				d.Set("destinations_type", r.DestinationType)
-				d.Set("destinations", utils.FlattenStringSlice(r.Destinations))
-				d.Set("next_hop_type", r.NextHopType)
-				d.Set("next_hop", r.NextHop)
+	routeTableID := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName, id.HubRouteTableName)
+	d.Set("route_table_id", routeTableID.ID())
 
-				break
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			found := false
+			for _, r := range *props.Routes {
+				if r.Name == id.RouteName {
+					found = true
+					d.Set("destinations_type", r.DestinationType)
+					d.Set("destinations", r.Destinations)
+					d.Set("next_hop_type", r.NextHopType)
+					d.Set("next_hop", r.NextHop)
+					break
+				}
+			}
+
+			if !found {
+				// could not find existing id by name
+				d.SetId("")
+				return nil
 			}
 		}
-
-		if !found {
-			// could not find existing route by name
-			d.SetId("")
-			return nil
-		}
 	}
-
-	d.Set("name", route.RouteName)
-	routeTableID := parse.NewHubRouteTableID(route.SubscriptionId, route.ResourceGroup, route.VirtualHubName, route.HubRouteTableName)
-	d.Set("route_table_id", routeTableID.ID())
 
 	return nil
 }
 
 func resourceVirtualHubRouteTableRouteDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.HubRouteTableClient
+	client := meta.(*clients.Client).Network.VirtualWANs
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	route, err := parse.HubRouteTableRouteID(d.Id())
+	id, err := parse.HubRouteTableRouteID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(route.VirtualHubName, virtualHubResourceName)
-	defer locks.UnlockByName(route.VirtualHubName, virtualHubResourceName)
+	routeTableId := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName, id.HubRouteTableName)
+
+	locks.ByName(id.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
 	// get latest list of routes
-	routeTable, err := client.Get(ctx, route.ResourceGroup, route.VirtualHubName, route.HubRouteTableName)
+	routeTable, err := client.HubRouteTablesGet(ctx, routeTableId)
 	if err != nil {
-		if !utils.ResponseWasNotFound(routeTable.Response) {
-			// route table does not exist, therefore route does not exist
+		if !response.WasNotFound(routeTable.HttpResponse) {
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", route, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if props := routeTable.HubRouteTableProperties; props != nil {
-		if props.Routes != nil {
-			routes := *props.Routes
+	if routeTable.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", routeTableId)
+	}
+	if routeTable.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", routeTableId)
+	}
 
-			newRoutes := make([]network.HubRoute, 0)
+	props := routeTable.Model.Properties
 
-			for _, r := range routes {
-				if *r.Name != route.RouteName {
-					newRoutes = append(newRoutes, r)
-				}
+	if props.Routes != nil {
+		routes := *props.Routes
+
+		newRoutes := make([]virtualwans.HubRoute, 0)
+		for _, r := range routes {
+			if r.Name != id.RouteName {
+				newRoutes = append(newRoutes, r)
 			}
-
-			props.Routes = &newRoutes
 		}
+		props.Routes = &newRoutes
+
 	}
 
-	future, err := client.CreateOrUpdate(ctx, route.ResourceGroup, route.VirtualHubName, route.HubRouteTableName, routeTable)
-	if err != nil {
-		return fmt.Errorf("removing %s: %+v", route, err)
-	}
+	routeTable.Model.Properties = props
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting to remove %s: %+v", route, err)
+	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, routeTableId, *routeTable.Model); err != nil {
+		return fmt.Errorf("removing %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/virtual_hub_route_table_route_resource_test.go
+++ b/internal/services/network/virtual_hub_route_table_route_resource_test.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubRouteTableRouteResource struct{}
@@ -96,27 +97,32 @@ func TestAccVirtualHubRouteTableRoute_update(t *testing.T) {
 }
 
 func (t VirtualHubRouteTableRouteResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	route, err := parse.HubRouteTableRouteID(state.ID)
+	id, err := parse.HubRouteTableRouteID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.HubRouteTableClient.Get(ctx, route.ResourceGroup, route.VirtualHubName, route.HubRouteTableName)
+	routeTableId := virtualwans.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.VirtualHubName, id.HubRouteTableName)
+
+	resp, err := clients.Network.VirtualWANs.HubRouteTablesGet(ctx, routeTableId)
 	if err != nil {
-		return nil, fmt.Errorf("reading Virtual Hub Route Table (%s): %+v", route, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if props := resp.HubRouteTableProperties; props != nil {
-		if routes := props.Routes; routes != nil {
-			for _, r := range *routes {
-				if *r.Name == route.RouteName {
-					return utils.Bool(true), nil
+	found := false
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if routes := props.Routes; routes != nil {
+				for _, r := range *routes {
+					if r.Name == id.RouteName {
+						found = true
+					}
 				}
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(found), nil
 }
 
 func (VirtualHubRouteTableRouteResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_hub_security_partner_provider_resource.go
+++ b/internal/services/network/virtual_hub_security_partner_provider_resource.go
@@ -8,18 +8,18 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/securitypartnerproviders"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
-	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceVirtualHubSecurityPartnerProvider() *pluginsdk.Resource {
@@ -37,7 +37,7 @@ func resourceVirtualHubSecurityPartnerProvider() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.SecurityPartnerProviderID(id)
+			_, err := securitypartnerproviders.ParseSecurityPartnerProviderID(id)
 			return err
 		}),
 
@@ -57,9 +57,9 @@ func resourceVirtualHubSecurityPartnerProvider() *pluginsdk.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.SecurityProviderNameZScaler),
-					string(network.SecurityProviderNameIBoss),
-					string(network.SecurityProviderNameCheckpoint),
+					string(securitypartnerproviders.SecurityProviderNameZScaler),
+					string(securitypartnerproviders.SecurityProviderNameIBoss),
+					string(securitypartnerproviders.SecurityProviderNameCheckpoint),
 				}, false),
 			},
 
@@ -67,54 +67,49 @@ func resourceVirtualHubSecurityPartnerProvider() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: networkValidate.VirtualHubID,
+				ValidateFunc: virtualwans.ValidateVirtualHubID,
 			},
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 		},
 	}
 }
 
 func resourceVirtualHubSecurityPartnerProviderCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SecurityPartnerProviderClient
+	client := meta.(*clients.Client).Network.SecurityPartnerProviders
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewSecurityPartnerProviderID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := securitypartnerproviders.NewSecurityPartnerProviderID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	existing, err := client.Get(ctx, id)
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for present of existing %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(existing.Response) {
+	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_virtual_hub_security_partner_provider", id.ID())
 	}
 
-	parameters := network.SecurityPartnerProvider{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
-		SecurityPartnerProviderPropertiesFormat: &network.SecurityPartnerProviderPropertiesFormat{
-			SecurityProviderName: network.SecurityProviderName(d.Get("security_provider_name").(string)),
+	parameters := securitypartnerproviders.SecurityPartnerProvider{
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Properties: &securitypartnerproviders.SecurityPartnerProviderPropertiesFormat{
+			SecurityProviderName: pointer.To(securitypartnerproviders.SecurityProviderName(d.Get("security_provider_name").(string))),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("virtual_hub_id"); ok {
-		parameters.SecurityPartnerProviderPropertiesFormat.VirtualHub = &network.SubResource{
-			ID: utils.String(v.(string)),
+		parameters.Properties.VirtualHub = &securitypartnerproviders.SubResource{
+			Id: pointer.To(v.(string)),
 		}
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, parameters)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on creating future for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -123,80 +118,78 @@ func resourceVirtualHubSecurityPartnerProviderCreate(d *pluginsdk.ResourceData, 
 }
 
 func resourceVirtualHubSecurityPartnerProviderRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SecurityPartnerProviderClient
+	client := meta.(*clients.Client).Network.SecurityPartnerProviders
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SecurityPartnerProviderID(d.Id())
+	id, err := securitypartnerproviders.ParseSecurityPartnerProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] security partner provider %q does not exist - removing from state", d.Id())
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] %s does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("retrieving Security Partner Provider %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", location.NormalizeNilable(resp.Location))
+	d.Set("name", id.SecurityPartnerProviderName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if props := resp.SecurityPartnerProviderPropertiesFormat; props != nil {
-		d.Set("security_provider_name", props.SecurityProviderName)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
 
-		if props.VirtualHub != nil && props.VirtualHub.ID != nil {
-			d.Set("virtual_hub_id", props.VirtualHub.ID)
+		if props := model.Properties; props != nil {
+			d.Set("security_provider_name", string(pointer.From(props.SecurityProviderName)))
+
+			if props.VirtualHub != nil && props.VirtualHub.Id != nil {
+				d.Set("virtual_hub_id", props.VirtualHub.Id)
+			}
 		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceVirtualHubSecurityPartnerProviderUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SecurityPartnerProviderClient
+	client := meta.(*clients.Client).Network.SecurityPartnerProviders
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SecurityPartnerProviderID(d.Id())
+	id, err := securitypartnerproviders.ParseSecurityPartnerProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	parameters := network.TagsObject{}
+	parameters := securitypartnerproviders.TagsObject{}
 
 	if d.HasChange("tags") {
 		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	if _, err := client.UpdateTags(ctx, id.ResourceGroup, id.Name, parameters); err != nil {
-		return fmt.Errorf("updating Security Partner Provider %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	if _, err := client.UpdateTags(ctx, *id, parameters); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return resourceVirtualHubSecurityPartnerProviderRead(d, meta)
 }
 
 func resourceVirtualHubSecurityPartnerProviderDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.SecurityPartnerProviderClient
+	client := meta.(*clients.Client).Network.SecurityPartnerProviders
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SecurityPartnerProviderID(d.Id())
+	id, err := securitypartnerproviders.ParseSecurityPartnerProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
-		return fmt.Errorf("deleting Security Partner Provider %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on deleting future for Security Partner Provider %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/virtual_hub_security_partner_provider_resource_test.go
+++ b/internal/services/network/virtual_hub_security_partner_provider_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/securitypartnerproviders"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubSecurityPartnerProviderResource struct{}
@@ -82,17 +82,17 @@ func TestAccVirtualHubSecurityPartnerProvider_update(t *testing.T) {
 }
 
 func (t VirtualHubSecurityPartnerProviderResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.SecurityPartnerProviderID(state.ID)
+	id, err := securitypartnerproviders.ParseSecurityPartnerProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.SecurityPartnerProviderClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Network.SecurityPartnerProviders.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Security Partner Provider (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualHubSecurityPartnerProviderResource) template(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates the following resources to use `hashicorp/go-azure-sdk`:
- `azurerm_network_interface_security_group_association`
- `azurerm_virtual_hub_bgp_connection`
- `azurerm_virtual_hub_connection`
- `azurerm_virtual_hub_ip`
- `azurerm_virtual_hub`
- `azurerm_virtual_hub_route_table`
- `azurerm_virtual_hub_route_table_route`
- `azurerm_virtual_hub_security_partner_provider`

Updates the following data sources to use `hashicorp/go-azure-sdk`:
- `azurerm_virtual_hub_connection`
- `azurerm_virtual_hub`
- `azurerm_virtual_hub_route_table`

## Testing 

Tests are looking good, however as of last night some tests that didn't fail previously are failing with `InternalServerError`. These look to be transient.

