### PR TITLE
`azurerm_route_map` - Make rule parameters optional when type is `Drop`

### DIFF
--- a/internal/services/network/route_map_resource_test.go
+++ b/internal/services/network/route_map_resource_test.go
@@ -199,6 +199,20 @@ resource "azurerm_route_map" "test" {
       route_prefix    = ["10.0.0.0/8"]
     }
   }
+
+  rule {
+    name                 = "rule2"
+    next_step_if_matched = "Terminate"
+
+    action {
+      type = "Drop"
+    }
+
+    match_criterion {
+      match_condition = "Contains"
+      route_prefix    = ["172.16.0.0/12"]
+    }
+  }
 }
 `, r.template(data), nameSuffix)
 }
@@ -212,7 +226,7 @@ resource "azurerm_route_map" "test" {
   virtual_hub_id = azurerm_virtual_hub.test.id
 
   rule {
-    name                 = "rule2"
+    name                 = "rule3"
     next_step_if_matched = "Terminate"
 
     action {

--- a/website/docs/r/route_map.html.markdown
+++ b/website/docs/r/route_map.html.markdown
@@ -82,7 +82,7 @@ A `rule` block supports the following:
 
 An `action` block supports the following:
 
-* `parameter` - (Required) A `parameter` block as defined below.
+* `parameter` - A `parameter` block as defined below. Required if `type` is anything other than `Drop`.
 
 * `type` - (Required) The type of the action to be taken. Possible values are `Add`, `Drop`, `Remove`, `Replace` and `Unknown`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Route Map rule do not support parameters when the action type is `Drop`. With the current provider, the parameter block must be supplied regardless of the action type. This means either having to create an empty parameter block for `Drop` which causes perpetual diffs, or create a parameter block with one of the parameters as an empty list to prevent the diff.

This PR makes the parameter block optional, and validates it is provided for non-Drop types during the plan

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_route_map` - make `property` optional when the action `type` is `Drop` [GH-26003]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
