### PR TITLE
`azurerm_private_endpoint` - Remove internal lock on subnet while processing private endpoint

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -349,8 +349,6 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		//goland:noinspection GoDeferInLoop
 		defer locks.UnlockByName(cosmosDbResId, "azurerm_private_endpoint")
 	}
-	locks.ByName(subnetId, "azurerm_private_endpoint")
-	defer locks.UnlockByName(subnetId, "azurerm_private_endpoint")
 
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if err = client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
@@ -509,9 +507,6 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-
-	locks.ByName(subnetId, "azurerm_private_endpoint")
-	defer locks.UnlockByName(subnetId, "azurerm_private_endpoint")
 
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if err = client.CreateOrUpdateThenPoll(ctx, *id, parameters); err != nil {
@@ -740,8 +735,6 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		//goland:noinspection GoDeferInLoop
 		defer locks.UnlockByName(cosmosDbResId, "azurerm_private_endpoint")
 	}
-	locks.ByName(subnetId, "azurerm_private_endpoint")
-	defer locks.UnlockByName(subnetId, "azurerm_private_endpoint")
 
 	log.Printf("[DEBUG] Deleting %s", id)
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -317,7 +317,6 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	privateDnsZoneGroup := d.Get("private_dns_zone_group").([]interface{})
-	subnetId := d.Get("subnet_id").(string)
 
 	parameters := privateendpoints.PrivateEndpoint{
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -942,8 +942,8 @@ resource "azurerm_private_endpoint" "test" {
   subnet_id           = azurerm_subnet.endpoint.id
 
   private_service_connection {
-    name                           = azurerm_private_link_service.test.name
-    is_manual_connection           = true
+    name                 = azurerm_private_link_service.test.name
+    is_manual_connection = true
     %s
   }
 }

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -943,7 +943,7 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                 = azurerm_private_link_service.test.name
-    is_manual_connection = true
+    is_manual_connection = false
     %s
   }
 }

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -926,11 +926,9 @@ resource "azurerm_private_endpoint" "test" {
 
 func (r PrivateEndpointResource) multipleInstances(data acceptance.TestData, count int, useAlias bool) string {
 	privateConnectionAssignment := "private_connection_resource_id = azurerm_private_link_service.test.id"
-	var reqMsgSet bool
 	if useAlias {
 		privateConnectionAssignment = `private_connection_resource_alias = azurerm_private_link_service.test.alias
                                        request_message                   = "test"`
-		reqMsgSet = true
 	}
 
 	return fmt.Sprintf(`
@@ -949,7 +947,7 @@ resource "azurerm_private_endpoint" "test" {
     %s
   }
 }
-`, r.template(data, r.serviceAutoApprove(data)), count, data.RandomInteger, !reqMsgSet, privateConnectionAssignment)
+`, r.template(data, r.serviceAutoApprove(data)), count, data.RandomInteger, useAlias, privateConnectionAssignment)
 }
 
 func (r PrivateEndpointResource) recoveryServiceVaultWithMultiIpConfig(data acceptance.TestData) string {

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -926,9 +926,11 @@ resource "azurerm_private_endpoint" "test" {
 
 func (r PrivateEndpointResource) multipleInstances(data acceptance.TestData, count int, useAlias bool) string {
 	privateConnectionAssignment := "private_connection_resource_id = azurerm_private_link_service.test.id"
+	var reqMsgSet bool
 	if useAlias {
 		privateConnectionAssignment = `private_connection_resource_alias = azurerm_private_link_service.test.alias
                                        request_message                   = "test"`
+		reqMsgSet = true
 	}
 
 	return fmt.Sprintf(`
@@ -943,11 +945,11 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                 = azurerm_private_link_service.test.name
-    is_manual_connection = false
+    is_manual_connection = %t
     %s
   }
 }
-`, r.template(data, r.serviceAutoApprove(data)), count, data.RandomInteger, privateConnectionAssignment)
+`, r.template(data, r.serviceAutoApprove(data)), count, data.RandomInteger, !reqMsgSet, privateConnectionAssignment)
 }
 
 func (r PrivateEndpointResource) recoveryServiceVaultWithMultiIpConfig(data acceptance.TestData) string {


### PR DESCRIPTION
Remove internal lock on subnet while processing private endpoint since the [API issue](https://github.com/Azure/azure-rest-api-specs/issues/20289) no longer exist under API version 2023-09-01

This pr should solve #26005

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

A new acc test `TestAccPrivateEndpoint_multipleInstancesWithLinkAlias` has been added to verify creating multiple private endpoint with private link alias is good.

=== RUN   TestAccPrivateEndpoint_basic
=== PAUSE TestAccPrivateEndpoint_basic
=== CONT  TestAccPrivateEndpoint_basic
--- PASS: TestAccPrivateEndpoint_basic (376.22s)
=== RUN   TestAccPrivateEndpoint_updateTag
=== PAUSE TestAccPrivateEndpoint_updateTag
=== CONT  TestAccPrivateEndpoint_updateTag
--- PASS: TestAccPrivateEndpoint_updateTag (519.56s)
=== RUN   TestAccPrivateEndpoint_updateNicName
=== PAUSE TestAccPrivateEndpoint_updateNicName
=== CONT  TestAccPrivateEndpoint_updateNicName
--- PASS: TestAccPrivateEndpoint_updateNicName (589.14s)
=== RUN   TestAccPrivateEndpoint_requestMessage
=== PAUSE TestAccPrivateEndpoint_requestMessage
=== CONT  TestAccPrivateEndpoint_requestMessage
--- PASS: TestAccPrivateEndpoint_requestMessage (426.08s)
=== RUN   TestAccPrivateEndpoint_privateDnsZoneGroup
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneGroup
=== CONT  TestAccPrivateEndpoint_privateDnsZoneGroup
--- PASS: TestAccPrivateEndpoint_privateDnsZoneGroup (466.67s)
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRename
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRename
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRename
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRename (559.39s)
=== RUN   TestAccPrivateEndpoint_privateDnsZoneUpdate
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneUpdate
=== CONT  TestAccPrivateEndpoint_privateDnsZoneUpdate
--- PASS: TestAccPrivateEndpoint_privateDnsZoneUpdate (611.53s)
=== RUN   TestAccPrivateEndpoint_statiIpAddress
=== PAUSE TestAccPrivateEndpoint_statiIpAddress
=== CONT  TestAccPrivateEndpoint_statiIpAddress
--- PASS: TestAccPrivateEndpoint_statiIpAddress (345.48s)
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRemove
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRemove
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRemove
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRemove (594.01s)
=== RUN   TestAccPrivateEndpoint_privateConnectionAlias
=== PAUSE TestAccPrivateEndpoint_privateConnectionAlias
=== CONT  TestAccPrivateEndpoint_privateConnectionAlias
--- PASS: TestAccPrivateEndpoint_privateConnectionAlias (325.23s)
=== RUN   TestAccPrivateEndpoint_updateToPrivateConnectionAlias
=== PAUSE TestAccPrivateEndpoint_updateToPrivateConnectionAlias
=== CONT  TestAccPrivateEndpoint_updateToPrivateConnectionAlias
--- PASS: TestAccPrivateEndpoint_updateToPrivateConnectionAlias (445.43s)
=== RUN   TestAccPrivateEndpoint_multipleInstances
=== PAUSE TestAccPrivateEndpoint_multipleInstances
=== CONT  TestAccPrivateEndpoint_multipleInstances
--- PASS: TestAccPrivateEndpoint_multipleInstances (322.07s)
=== RUN   TestAccPrivateEndpoint_multipleIpConfigurations
=== PAUSE TestAccPrivateEndpoint_multipleIpConfigurations
=== CONT  TestAccPrivateEndpoint_multipleIpConfigurations
--- PASS: TestAccPrivateEndpoint_multipleIpConfigurations (455.78s)
=== RUN   TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
=== PAUSE TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
=== CONT  TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
--- PASS: TestAccPrivateEndpoint_multipleInstancesWithLinkAlias (364.07s)
PASS



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_endpoint` - Remove internal lock on subnet while processing private endpoint [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26005


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
