### PR TITLE
azurerm_cdn_frontdoor_rule - allow conditions.x.url_path_condition.x.match_values to be set to / (any length)

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -392,6 +392,20 @@ func TestAccCdnFrontDoorRule_allowForwardSlashUrlConditionMatchValue(t *testing.
 	})
 }
 
+func TestAccCdnFrontDoorRule_allowForwardSlashUrl2ConditionMatchValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
+	r := CdnFrontDoorRuleResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allowForwardSlashUrl2ConditionMatchValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCdnFrontDoorRule_urlFilenameConditionOperatorAny(t *testing.T) {
 	// NOTE: Regression test case for issue #23504
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
@@ -1341,6 +1355,42 @@ resource "azurerm_cdn_frontdoor_rule" "test" {
   conditions {
     url_path_condition {
       match_values     = ["/"]
+      negate_condition = false
+      operator         = "EndsWith"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorRuleResource) allowForwardSlashUrl2ConditionMatchValue(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_cdn_frontdoor_rule" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                      = "accTestRule%d"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.test.id
+
+  order = 0
+
+  actions {
+    route_configuration_override_action {
+      cache_behavior                = "HonorOrigin"
+      compression_enabled           = true
+      query_string_caching_behavior = "IgnoreQueryString"
+    }
+  }
+
+  conditions {
+    url_path_condition {
+      match_values     = ["/legacy-login"]
       negate_condition = false
       operator         = "EndsWith"
     }

--- a/internal/services/cdn/validate/front_door_validation_helpers.go
+++ b/internal/services/cdn/validate/front_door_validation_helpers.go
@@ -54,13 +54,8 @@ func CdnFrontDoorCacheDuration(i interface{}, k string) (_ []string, errors []er
 }
 
 func CdnFrontDoorUrlPathConditionMatchValue(i interface{}, k string) (_ []string, errors []error) {
-	v, ok := i.(string)
-	if !ok {
+	if _, ok := i.(string); !ok {
 		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
-	}
-
-	if strings.HasPrefix(v, "/") && len(v) != 1 {
-		return nil, []error{fmt.Errorf(`%q must not begin with the URLs leading slash(e.g. /), got %q`, k, v)}
 	}
 
 	return nil, nil


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes #26016 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]
* `azurerm_cdn_frontdoor_rule` - allow conditions.x.url_path_condition.x.match_values to be set to / (any length) [GH-26016]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26016


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
