### PR TITLE
`azurerm_linux_web_app`/`azurerm_windows_web_app` - Support for Storage Mount add "Deployment Slot Setting"

### DIFF
--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -1571,8 +1571,9 @@ func FlattenSiteCredentials(input *webapps.User) []SiteCredential {
 }
 
 type StickySettings struct {
-	AppSettingNames       []string `tfschema:"app_setting_names"`
-	ConnectionStringNames []string `tfschema:"connection_string_names"`
+	AppSettingNames         []string `tfschema:"app_setting_names"`
+	AzureStorageConfigNames []string `tfschema:"azure_storage_config_names"`
+	ConnectionStringNames   []string `tfschema:"connection_string_names"`
 }
 
 func StickySettingsSchema() *pluginsdk.Schema {
@@ -1592,6 +1593,22 @@ func StickySettingsSchema() *pluginsdk.Schema {
 					},
 					AtLeastOneOf: []string{
 						"sticky_settings.0.app_setting_names",
+						"sticky_settings.0.azure_storage_config_names",
+						"sticky_settings.0.connection_string_names",
+					},
+				},
+
+				"azure_storage_config_names": {
+					Type:     pluginsdk.TypeList,
+					MinItems: 1,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					AtLeastOneOf: []string{
+						"sticky_settings.0.app_setting_names",
+						"sticky_settings.0.azure_storage_config_names",
 						"sticky_settings.0.connection_string_names",
 					},
 				},
@@ -1606,6 +1623,7 @@ func StickySettingsSchema() *pluginsdk.Schema {
 					},
 					AtLeastOneOf: []string{
 						"sticky_settings.0.app_setting_names",
+						"sticky_settings.0.azure_storage_config_names",
 						"sticky_settings.0.connection_string_names",
 					},
 				},
@@ -1621,6 +1639,14 @@ func StickySettingsComputedSchema() *pluginsdk.Schema {
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"app_setting_names": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"azure_storage_config_names": {
 					Type:     pluginsdk.TypeList,
 					Computed: true,
 					Elem: &pluginsdk.Schema{
@@ -1646,19 +1672,25 @@ func ExpandStickySettings(input []StickySettings) *webapps.SlotConfigNames {
 	}
 
 	return &webapps.SlotConfigNames{
-		AppSettingNames:       &input[0].AppSettingNames,
-		ConnectionStringNames: &input[0].ConnectionStringNames,
+		AppSettingNames:         &input[0].AppSettingNames,
+		AzureStorageConfigNames: &input[0].AzureStorageConfigNames,
+		ConnectionStringNames:   &input[0].ConnectionStringNames,
 	}
 }
 
 func FlattenStickySettings(input *webapps.SlotConfigNames) []StickySettings {
 	result := StickySettings{}
-	if input == nil || (input.AppSettingNames == nil && input.ConnectionStringNames == nil) || (len(*input.AppSettingNames) == 0 && len(*input.ConnectionStringNames) == 0) {
+	if input == nil || (input.AppSettingNames == nil && input.AzureStorageConfigNames == nil && input.ConnectionStringNames == nil) ||
+		(len(*input.AppSettingNames) == 0 && len(*input.AzureStorageConfigNames) == 0 && len(*input.ConnectionStringNames) == 0) {
 		return []StickySettings{}
 	}
 
 	if input.AppSettingNames != nil && len(*input.AppSettingNames) > 0 {
 		result.AppSettingNames = *input.AppSettingNames
+	}
+
+	if input.AzureStorageConfigNames != nil && len(*input.AzureStorageConfigNames) > 0 {
+		result.AzureStorageConfigNames = *input.AzureStorageConfigNames
 	}
 
 	if input.ConnectionStringNames != nil && len(*input.ConnectionStringNames) > 0 {

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -873,14 +873,18 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 				stickySettings := helpers.ExpandStickySettings(state.StickySettings)
 				stickySettingsUpdate := webapps.SlotConfigNamesResource{
 					Properties: &webapps.SlotConfigNames{
-						AppSettingNames:       &emptySlice,
-						ConnectionStringNames: &emptySlice,
+						AppSettingNames:         &emptySlice,
+						AzureStorageConfigNames: &emptySlice,
+						ConnectionStringNames:   &emptySlice,
 					},
 				}
 
 				if stickySettings != nil {
 					if stickySettings.AppSettingNames != nil {
 						stickySettingsUpdate.Properties.AppSettingNames = stickySettings.AppSettingNames
+					}
+					if stickySettings.AzureStorageConfigNames != nil {
+						stickySettingsUpdate.Properties.AzureStorageConfigNames = stickySettings.AzureStorageConfigNames
 					}
 					if stickySettings.ConnectionStringNames != nil {
 						stickySettingsUpdate.Properties.ConnectionStringNames = stickySettings.ConnectionStringNames

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1448,6 +1448,9 @@ func TestAccLinuxWebApp_stickySettings(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("Second"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.1").HasValue("Fourth"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -1477,6 +1480,9 @@ func TestAccLinuxWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("Second"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.1").HasValue("Fourth"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -1489,6 +1495,9 @@ func TestAccLinuxWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("4"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("First"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.1").HasValue("Second"),
 			),
 		},
 		data.ImportStep("site_credential.0.password"),
@@ -1499,6 +1508,9 @@ func TestAccLinuxWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("Second"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.1").HasValue("Fourth"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -2290,12 +2302,49 @@ resource "azurerm_linux_web_app" "test" {
     type  = "PostgreSQL"
   }
 
+	storage_account {
+    name         = "First"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/first"
+  }
+
+	storage_account {
+    name         = "Second"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/third"
+  }
+
+  storage_account {
+    name         = "Fourth"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.fourth.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/fourth"
+  }
+
   sticky_settings {
-    app_setting_names       = ["foo", "secret"]
-    connection_string_names = ["First", "Third"]
+    app_setting_names          = ["foo", "secret"]
+    azure_storage_config_names = ["Second", "Fourth"]
+    connection_string_names    = ["First", "Third"]
   }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) stickySettingsRemoved(data acceptance.TestData) string {
@@ -2337,8 +2386,44 @@ resource "azurerm_linux_web_app" "test" {
     value = "some-postgresql-connection-string"
     type  = "PostgreSQL"
   }
+
+  storage_account {
+    name         = "First"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/first"
+  }
+
+  storage_account {
+    name         = "Second"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/third"
+  }
+
+  storage_account {
+    name         = "Fourth"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.fourth.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/fourth"
+  }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) stickySettingsUpdate(data acceptance.TestData) string {
@@ -2381,11 +2466,48 @@ resource "azurerm_linux_web_app" "test" {
     type  = "PostgreSQL"
   }
 
+	storage_account {
+    name         = "First"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/first"
+  }
+
+	storage_account {
+    name         = "Second"
+    type         = "AzureBlob"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_container.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/third"
+  }
+
+  storage_account {
+    name         = "Fourth"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.fourth.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/fourth"
+  }
+
   sticky_settings {
     app_setting_names = ["foo", "secret", "third"]
+    azure_storage_config_names = ["First", "Second", "Third", "Fourth"]
   }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) secondServicePlan(data acceptance.TestData) string {
@@ -3705,6 +3827,45 @@ data "azurerm_storage_account_sas" "test" {
   }
 }
 `, r.standardPlanTemplate(data), data.RandomInteger, data.RandomString)
+}
+
+func (r LinuxWebAppResource) templateWithStorageAccount2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "first" {
+  name                  = "first"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "second" {
+  name                  = "second"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_share" "third" {
+  name                 = "third"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 1
+}
+
+resource "azurerm_storage_share" "fourth" {
+  name                 = "fourth"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 1
+}
+`, r.standardPlanTemplate(data), data.RandomString)
 }
 
 func (r LinuxWebAppResource) vNetIntegrationWebApp_basic(data acceptance.TestData) string {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -2344,7 +2344,7 @@ resource "azurerm_linux_web_app" "test" {
     connection_string_names    = ["First", "Third"]
   }
 }
-`, r.templateWithStorageAccount2(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) stickySettingsRemoved(data acceptance.TestData) string {
@@ -2423,7 +2423,7 @@ resource "azurerm_linux_web_app" "test" {
     mount_path   = "/fourth"
   }
 }
-`, r.templateWithStorageAccount2(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) stickySettingsUpdate(data acceptance.TestData) string {
@@ -2507,7 +2507,7 @@ resource "azurerm_linux_web_app" "test" {
     azure_storage_config_names = ["First", "Second", "Third", "Fourth"]
   }
 }
-`, r.templateWithStorageAccount2(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r LinuxWebAppResource) secondServicePlan(data acceptance.TestData) string {
@@ -3829,7 +3829,7 @@ data "azurerm_storage_account_sas" "test" {
 `, r.standardPlanTemplate(data), data.RandomInteger, data.RandomString)
 }
 
-func (r LinuxWebAppResource) templateWithStorageAccount2(data acceptance.TestData) string {
+func (r LinuxWebAppResource) templateWithStorageAccount_stickySettings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 %s

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -933,14 +933,18 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				stickySettings := helpers.ExpandStickySettings(state.StickySettings)
 				stickySettingsUpdate := webapps.SlotConfigNamesResource{
 					Properties: &webapps.SlotConfigNames{
-						AppSettingNames:       &emptySlice,
-						ConnectionStringNames: &emptySlice,
+						AppSettingNames:         &emptySlice,
+						AzureStorageConfigNames: &emptySlice,
+						ConnectionStringNames:   &emptySlice,
 					},
 				}
 
 				if stickySettings != nil {
 					if stickySettings.AppSettingNames != nil {
 						stickySettingsUpdate.Properties.AppSettingNames = stickySettings.AppSettingNames
+					}
+					if stickySettings.AzureStorageConfigNames != nil {
+						stickySettingsUpdate.Properties.AzureStorageConfigNames = stickySettings.AzureStorageConfigNames
 					}
 					if stickySettings.ConnectionStringNames != nil {
 						stickySettingsUpdate.Properties.ConnectionStringNames = stickySettings.ConnectionStringNames

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -3651,7 +3651,7 @@ resource "azurerm_windows_web_app" "test" {
     connection_string_names    = ["First", "Third", "Special chars: !@#$%%^&*()_+-=' \";/?"]
   }
 }
-`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) stickySettingsRemoved(data acceptance.TestData) string {
@@ -3721,7 +3721,7 @@ resource "azurerm_windows_web_app" "test" {
     mount_path   = "/mounts/third"
   }
 }
-`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) stickySettingsUpdate(data acceptance.TestData) string {
@@ -3797,7 +3797,7 @@ resource "azurerm_windows_web_app" "test" {
     connection_string_names    = ["First", "Second", "Third"]
   }
 }
-`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
+`, r.templateWithStorageAccount_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) zipDeploy(data acceptance.TestData) string {
@@ -3977,7 +3977,7 @@ data "azurerm_storage_account_sas" "test" {
 `, r.baseTemplate(data), data.RandomInteger, data.RandomString)
 }
 
-func (r WindowsWebAppResource) templateWithStorageAccount2_stickySettings(data acceptance.TestData) string {
+func (r WindowsWebAppResource) templateWithStorageAccount_stickySettings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 %s

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1463,6 +1463,8 @@ func TestAccWindowsWebApp_stickySettings(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("First"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -1492,6 +1494,8 @@ func TestAccWindowsWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("First"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -1504,6 +1508,8 @@ func TestAccWindowsWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("3"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("First"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -1516,6 +1522,8 @@ func TestAccWindowsWebApp_stickySettingsUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("app_settings.foo").HasValue("bar"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.app_setting_names.0").HasValue("foo"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("sticky_settings.0.azure_storage_config_names.0").HasValue("First"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.#").HasValue("3"),
 				check.That(data.ResourceName).Key("sticky_settings.0.connection_string_names.0").HasValue("First"),
 			),
@@ -3610,12 +3618,40 @@ resource "azurerm_windows_web_app" "test" {
     type  = "Custom"
   }
 
+	storage_account {
+    name         = "First"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/first"
+  }
+
+	storage_account {
+    name         = "Second"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/third"
+  }
+
   sticky_settings {
-    app_setting_names       = ["foo", "secret", "Special chars: !@#$%%^&*()_+-=' \";/?"]
-    connection_string_names = ["First", "Third", "Special chars: !@#$%%^&*()_+-=' \";/?"]
+    app_setting_names          = ["foo", "secret", "Special chars: !@#$%%^&*()_+-=' \";/?"]
+    azure_storage_config_names = ["First", "Third"]
+    connection_string_names    = ["First", "Third", "Special chars: !@#$%%^&*()_+-=' \";/?"]
   }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) stickySettingsRemoved(data acceptance.TestData) string {
@@ -3657,8 +3693,35 @@ resource "azurerm_windows_web_app" "test" {
     value = "some-postgresql-connection-string"
     type  = "PostgreSQL"
   }
+
+	storage_account {
+    name         = "First"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/first"
+  }
+
+	storage_account {
+    name         = "Second"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/third"
+  }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) stickySettingsUpdate(data acceptance.TestData) string {
@@ -3701,12 +3764,40 @@ resource "azurerm_windows_web_app" "test" {
     type  = "PostgreSQL"
   }
 
+	storage_account {
+    name         = "First"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.first.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/first"
+  }
+
+	storage_account {
+    name         = "Second"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.second.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/second"
+  }
+
+  storage_account {
+    name         = "Third"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.third.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/mounts/third"
+  }
+
   sticky_settings {
-    app_setting_names       = ["foo", "secret", "third"]
-    connection_string_names = ["First", "Second", "Third"]
+    app_setting_names          = ["foo", "secret", "third"]
+    azure_storage_config_names = ["First", "Second", "Third"]
+    connection_string_names    = ["First", "Second", "Third"]
   }
 }
-`, r.baseTemplate(data), data.RandomInteger)
+`, r.templateWithStorageAccount2_stickySettings(data), data.RandomInteger)
 }
 
 func (r WindowsWebAppResource) zipDeploy(data acceptance.TestData) string {
@@ -3884,6 +3975,39 @@ data "azurerm_storage_account_sas" "test" {
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, data.RandomString)
+}
+
+func (r WindowsWebAppResource) templateWithStorageAccount2_stickySettings(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "first" {
+  name                  = "first"
+  storage_account_name  = azurerm_storage_account.test.name
+  quota                = 1
+}
+
+resource "azurerm_storage_share" "second" {
+  name                  = "second"
+  storage_account_name  = azurerm_storage_account.test.name
+  quota                = 1
+}
+
+resource "azurerm_storage_share" "third" {
+  name                 = "third"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 1
+}
+`, r.baseTemplate(data), data.RandomString)
 }
 
 func (r WindowsWebAppResource) vNetIntegrationWebApp_basic(data acceptance.TestData) string {

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -685,6 +685,8 @@ A `sticky_settings` block exports the following:
 
 * `app_setting_names` - A list of `app_setting` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
 
+* `azure_storage_config_names` - A list of external Azure storage account identifier names that the Linux Web App will not swap between Slots when a swap operation is triggered.
+
 * `connection_string_names` - A list of `connection_string` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
 
 ---

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -693,6 +693,8 @@ A `sticky_settings` block exports the following:
 
 * `app_setting_names` - A list of `app_setting` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
+* `azure_storage_config_names` - A list of external Azure storage account identifier names that the Windows Web App will not swap between Slots when a swap operation is triggered.
+
 * `connection_string_names` - A list of `connection_string` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
 ---

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -794,6 +794,8 @@ A `sticky_settings` block supports the following:
 
 * `app_setting_names` - (Optional) A list of `app_setting` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
 
+* `azure_storage_config_names` - (Optional) A list of external Azure storage account identifier names that the Linux Web App will not swap between Slots when a swap operation is triggered.
+
 * `connection_string_names` - (Optional) A list of `connection_string` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
 
 ---

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -821,6 +821,8 @@ A `sticky_settings` block supports the following:
 
 * `app_setting_names` - (Optional) A list of `app_setting` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
+* `azure_storage_config_names` - (Optional) A list of external Azure storage account identifier names that the Windows Web App will not swap between Slots when a swap operation is triggered.
+
 * `connection_string_names` - (Optional) A list of `connection_string` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add support for the 'Deployment Slot Setting' property of storage accounts mounted to Azure Web Apps (Linux/Windows).
This is achieved by adding the `azure_storage_config_names` property to the `sticky_settings` block.

Relevant documentation:

- https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/update-slot-configuration-names?view=rest-appservice-2023-01-01
- https://learn.microsoft.com/en-us/azure/app-service/configure-connect-to-azure-storage?tabs=basic%2Cportal&pivots=container-linux

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

- linux_web_app_resource_test.go

    <img width="1352" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/28830925/d68a552b-0a9b-4d4e-819d-ae991aae555c">

- windows_web_app_resource_test.go

    <img width="1367" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/28830925/1ad10354-2d30-462d-a9fc-e4179221af6e">

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_web_app`/`azurerm_windows_web_app` - support for the `azure_storage_config_names` property [GH-26021]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23845


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
