### PR TITLE
bugfix: fix a regression creating PIM role assignments with no expiration

### DIFF
--- a/internal/services/authorization/pim_active_role_assignment_resource.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource.go
@@ -117,6 +117,7 @@ func (PimActiveRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schema 
 			Type:        pluginsdk.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			ForceNew:    true,
 			Description: "The schedule details for this role assignment",
 			Elem: &pluginsdk.Resource{
@@ -236,11 +237,13 @@ func (r PimActiveRoleAssignmentResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			var scheduleInfo *roleassignmentschedulerequests.RoleAssignmentScheduleRequestPropertiesScheduleInfo
+			scheduleInfo := &roleassignmentschedulerequests.RoleAssignmentScheduleRequestPropertiesScheduleInfo{
+				Expiration: &roleassignmentschedulerequests.RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration{
+					Type: pointer.To(roleassignmentschedulerequests.TypeNoExpiration),
+				},
+			}
 
 			if len(config.ScheduleInfo) > 0 {
-				scheduleInfo = &roleassignmentschedulerequests.RoleAssignmentScheduleRequestPropertiesScheduleInfo{}
-
 				if config.ScheduleInfo[0].StartDateTime != "" {
 					scheduleInfo.StartDateTime = pointer.To(config.ScheduleInfo[0].StartDateTime)
 				}

--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -118,6 +118,7 @@ func (PimEligibleRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schem
 			Type:        pluginsdk.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			ForceNew:    true,
 			Description: "The schedule details for this eligible role assignment",
 			Elem: &pluginsdk.Resource{
@@ -237,11 +238,13 @@ func (r PimEligibleRoleAssignmentResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			var scheduleInfo *roleeligibilityschedulerequests.RoleEligibilityScheduleRequestPropertiesScheduleInfo
+			scheduleInfo := &roleeligibilityschedulerequests.RoleEligibilityScheduleRequestPropertiesScheduleInfo{
+				Expiration: &roleeligibilityschedulerequests.RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration{
+					Type: pointer.To(roleeligibilityschedulerequests.TypeNoExpiration),
+				},
+			}
 
 			if len(config.ScheduleInfo) > 0 {
-				scheduleInfo = &roleeligibilityschedulerequests.RoleEligibilityScheduleRequestPropertiesScheduleInfo{}
-
 				if config.ScheduleInfo[0].StartDateTime != "" {
 					scheduleInfo.StartDateTime = pointer.To(config.ScheduleInfo[0].StartDateTime)
 				}

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -22,23 +22,21 @@ import (
 
 type PimEligibleRoleAssignmentResource struct{}
 
-// TODO: update the management policy configuration so that it can have no expiration
-// Depends on new resource - azurerm_role_management_policy - https://github.com/hashicorp/terraform-provider-azurerm/pull/20496
-// func TestAccPimEligibleRoleAssignment_noExpiration(t *testing.T) {
-// 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
-// 	r := PimEligibleRoleAssignmentResource{}
+func TestAccPimEligibleRoleAssignment_noExpiration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
+	r := PimEligibleRoleAssignmentResource{}
 
-// 	data.ResourceTest(t, r, []acceptance.TestStep{
-// 		{
-// 			Config: r.noExpirationConfig(data),
-// 			Check: acceptance.ComposeTestCheckFunc(
-// 				check.That(data.ResourceName).ExistsInAzure(r),
-// 				check.That(data.ResourceName).Key("scope").Exists(),
-// 			),
-// 		},
-// 		data.ImportStep("schedule.0.start_date_time"),
-// 	})
-// }
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.noExpirationConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("scope").Exists(),
+			),
+		},
+		data.ImportStep("schedule.0.start_date_time"),
+	})
+}
 
 func TestAccPimEligibleRoleAssignment_expirationByDurationHoursConfig(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
@@ -155,7 +153,7 @@ func (r PimEligibleRoleAssignmentResource) Exists(ctx context.Context, client *c
 	return utils.Bool(false), nil
 }
 
-func aadUser(data acceptance.TestData) string {
+func (PimEligibleRoleAssignmentResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azuread_domains" "test" {
   only_initial = true
@@ -175,54 +173,34 @@ resource "azuread_group" "test" {
 `, data.RandomInteger, data.RandomString)
 }
 
-func aadGroup(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) noExpirationConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-data "azuread_domains" "test" {
-  only_initial = true
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "test" {}
+
+data "azurerm_role_definition" "test" {
+  name = "Disk Backup Reader"
 }
 
-resource "azuread_user" "test" {
-  user_principal_name = "acctestUser-%[1]d1@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "acctestUser-%[1]d1"
-  password            = "p@$$Wd%[2]s"
+%[1]s
+
+resource "azurerm_pim_eligible_role_assignment" "test" {
+  scope              = data.azurerm_subscription.primary.id
+  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
+  principal_id       = azuread_user.test.object_id
+
+  justification = "No Expiration"
+
+  ticket {
+    number = "1"
+    system = "example ticket system"
+  }
+}
+`, r.template(data))
 }
 
-resource "azuread_group" "test" {
-  display_name     = "acctest-group-%[1]d"
-  security_enabled = true
-}
-
-`, data.RandomInteger, data.RandomString)
-}
-
-// func (PimEligibleRoleAssignmentResource) noExpirationConfig(data acceptance.TestData) string {
-// 	return fmt.Sprintf(`
-// data "azurerm_subscription" "primary" {}
-
-// data "azurerm_client_config" "test" {}
-
-// data "azurerm_role_definition" "test" {
-//   name = "Disk Backup Reader"
-// }
-
-// %s
-
-// resource "azurerm_pim_eligible_role_assignment" "test" {
-//   scope              = data.azurerm_subscription.primary.id
-//   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-//   principal_id       = azuread_user.test.object_id
-
-//   justification = "No Expiration"
-
-//   ticket {
-//     number = "1"
-//     system = "example ticket system"
-//   }
-// }
-// `, aadUser(data))
-// }
-
-func (PimEligibleRoleAssignmentResource) expirationByDurationHours(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) expirationByDurationHours(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_subscription" "primary" {}
 
@@ -260,10 +238,10 @@ resource "azurerm_pim_eligible_role_assignment" "test" {
     system = "example ticket system"
   }
 }
-`, aadUser(data), data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
-func (PimEligibleRoleAssignmentResource) expirationByDurationDays(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) expirationByDurationDays(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_subscription" "primary" {}
 
@@ -307,58 +285,10 @@ resource "azurerm_pim_eligible_role_assignment" "test" {
     system = "example ticket system"
   }
 }
-`, aadUser(data), data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
-func (PimEligibleRoleAssignmentResource) importSetup(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-data "azurerm_subscription" "primary" {}
-
-data "azurerm_client_config" "test" {}
-
-data "azurerm_role_definition" "test" {
-  name = "AcrPull"
-}
-
-%s
-
-resource "time_static" "test" {}
-
-resource "azurerm_pim_eligible_role_assignment" "test" {
-  scope              = data.azurerm_subscription.primary.id
-  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-  principal_id       = azuread_user.test.object_id
-
-  schedule {
-    start_date_time = time_static.test.rfc3339
-    expiration {
-      duration_hours = 3
-    }
-  }
-
-  justification = "Expiration Duration Set"
-
-  ticket {
-    number = "1"
-    system = "example ticket system"
-  }
-}
-`, aadUser(data))
-}
-
-func (r PimEligibleRoleAssignmentResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_pim_eligible_role_assignment" "import" {
-  scope              = azurerm_pim_eligible_role_assignment.test.scope
-  role_definition_id = azurerm_pim_eligible_role_assignment.test.role_definition_id
-  principal_id       = azurerm_pim_eligible_role_assignment.test.principal_id
-}
-`, r.importSetup(data))
-}
-
-func (PimEligibleRoleAssignmentResource) expirationByDate(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) expirationByDate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_subscription" "primary" {}
 
@@ -368,7 +298,7 @@ data "azurerm_role_definition" "test" {
   name = "Workbook Reader"
 }
 
-%s
+%[1]s
 
 resource "time_static" "test" {}
 resource "time_offset" "test" {
@@ -395,10 +325,10 @@ resource "azurerm_pim_eligible_role_assignment" "test" {
     system = "example ticket system"
   }
 }
-`, aadGroup(data))
+`, r.template(data))
 }
 
-func (PimEligibleRoleAssignmentResource) pending(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) pending(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_subscription" "primary" {}
 
@@ -408,7 +338,7 @@ data "azurerm_role_definition" "test" {
   name = "Key Vault Contributor"
 }
 
-%s
+%[1]s
 
 resource "time_offset" "test" {
   offset_days = 1
@@ -433,5 +363,53 @@ resource "azurerm_pim_eligible_role_assignment" "test" {
     system = "example ticket system"
   }
 }
-`, aadGroup(data))
+`, r.template(data))
+}
+
+func (r PimEligibleRoleAssignmentResource) importSetup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "test" {}
+
+data "azurerm_role_definition" "test" {
+  name = "AcrPull"
+}
+
+%[1]s
+
+resource "time_static" "test" {}
+
+resource "azurerm_pim_eligible_role_assignment" "test" {
+  scope              = data.azurerm_subscription.primary.id
+  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
+  principal_id       = azuread_user.test.object_id
+
+  schedule {
+    start_date_time = time_static.test.rfc3339
+    expiration {
+      duration_hours = 3
+    }
+  }
+
+  justification = "Expiration Duration Set"
+
+  ticket {
+    number = "1"
+    system = "example ticket system"
+  }
+}
+`, r.template(data))
+}
+
+func (r PimEligibleRoleAssignmentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_pim_eligible_role_assignment" "import" {
+  scope              = azurerm_pim_eligible_role_assignment.test.scope
+  role_definition_id = azurerm_pim_eligible_role_assignment.test.role_definition_id
+  principal_id       = azurerm_pim_eligible_role_assignment.test.principal_id
+}
+`, r.importSetup(data))
 }


### PR DESCRIPTION
Fixes regressions in the `azurerm_pim_active_role_assignment` and `azurerm_pim_eligible_role_assignment` resources where assignments could not be created with no expiration.

## Changelog

* `azurerm_pim_active_role_assignment` - fix a regression where roles assignments could not be created with no expiration [GH-26029]
* `azurerm_pim_eligible_role_assignment` - fix a regression where roles assignments could not be created with no expiration [GH-26029]

## Related Issue(s)
Fixes #26023


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
