### PR TITLE
`azurerm_container_app_envrionment` - add support for Azure Monitor as a log destination

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -32,6 +32,7 @@ type ContainerAppEnvironmentModel struct {
 	Location                                string                         `tfschema:"location"`
 	DaprApplicationInsightsConnectionString string                         `tfschema:"dapr_application_insights_connection_string"`
 	LogAnalyticsWorkspaceId                 string                         `tfschema:"log_analytics_workspace_id"`
+	LogsDestination                         string                         `tfschema:"logs_destination"`
 	InfrastructureSubnetId                  string                         `tfschema:"infrastructure_subnet_id"`
 	InternalLoadBalancerEnabled             bool                           `tfschema:"internal_load_balancer_enabled"`
 	ZoneRedundant                           bool                           `tfschema:"zone_redundancy_enabled"`
@@ -90,9 +91,16 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 		"log_analytics_workspace_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: workspaces.ValidateWorkspaceID,
 			Description:  "The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to.",
+		},
+
+		"logs_destination": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringInSlice([]string{"log-analytics", "azure-monitor"}, false),
+			Description:  "The destination for the application logs. Possible values are `log-analytics` or `azure-monitor`.",
 		},
 
 		"infrastructure_resource_group_name": {
@@ -221,6 +229,12 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				managedEnvironment.Properties.InfrastructureResourceGroup = pointer.To(containerAppEnvironment.InfrastructureResourceGroup)
 			}
 
+			if containerAppEnvironment.LogsDestination != "" && containerAppEnvironment.LogsDestination != "log-analytics" {
+				managedEnvironment.Properties.AppLogsConfiguration = &managedenvironments.AppLogsConfiguration{
+					Destination: pointer.To(containerAppEnvironment.LogsDestination),
+				}
+			}
+
 			if containerAppEnvironment.LogAnalyticsWorkspaceId != "" {
 				logAnalyticsId, err := workspaces.ParseWorkspaceID(containerAppEnvironment.LogAnalyticsWorkspaceId)
 				if err != nil {
@@ -308,6 +322,10 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 						state.DockerBridgeCidr = pointer.From(vnet.DockerBridgeCidr)
 						state.PlatformReservedCidr = pointer.From(vnet.PlatformReservedCidr)
 						state.PlatformReservedDnsIP = pointer.From(vnet.PlatformReservedDnsIP)
+					}
+
+					if appLogsConfig := props.AppLogsConfiguration; appLogsConfig != nil {
+						state.LogsDestination = *appLogsConfig.Destination
 					}
 
 					state.CustomDomainVerificationId = pointer.From(props.CustomDomainConfiguration.CustomDomainVerificationId)
@@ -476,6 +494,14 @@ func (r ContainerAppEnvironmentResource) CustomizeDiff() sdk.ResourceFunc {
 						return err
 					}
 				}
+			}
+
+			if env.LogsDestination == "log-analytics" && env.LogAnalyticsWorkspaceId == "" {
+				return fmt.Errorf("`log_analytics_workspace_id` must be set when `logs_destination` is set to `log-analytics`")
+			}
+
+			if env.LogAnalyticsWorkspaceId != "" && env.LogsDestination != "log-analytics" {
+				return fmt.Errorf("`log_analytics_workspace_id` can only be set when `logs_destination` is set to `log-analytics`")
 			}
 
 			return nil

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -231,7 +231,7 @@ resource "azurerm_container_app_environment" "test" {
   name                       = "acctest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  logs_destination           = "azure-monitor"
   infrastructure_subnet_id   = azurerm_subnet.control.id
 
   internal_load_balancer_enabled = true
@@ -247,6 +247,21 @@ resource "azurerm_container_app_environment" "test" {
   tags = {
     Foo    = "Bar"
     secret = "sauce"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "diagnostics"
+  target_resource_id         = azurerm_container_app_environment.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  enabled_log {
+    category_group = "allLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true 
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -290,7 +305,6 @@ resource "azurerm_container_app_environment" "test" {
   name                       = "acctest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
 
   workload_profile {
     name                  = "Consumption"
@@ -312,6 +326,7 @@ resource "azurerm_container_app_environment" "test" {
   name                       = "acctest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
+  logs_destination           = "log-analytics"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   infrastructure_subnet_id   = azurerm_subnet.control.id
 
@@ -346,7 +361,6 @@ resource "azurerm_container_app_environment" "test" {
   name                       = "acctest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   infrastructure_subnet_id   = azurerm_subnet.control.id
 
   internal_load_balancer_enabled = true
@@ -394,7 +408,6 @@ resource "azurerm_container_app_environment" "test" {
   name                           = "acctest-CAEnv%[2]d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.test.id
   infrastructure_subnet_id       = azurerm_subnet.control.id
   zone_redundancy_enabled        = true
   internal_load_balancer_enabled = true

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -30,6 +30,7 @@ resource "azurerm_container_app_environment" "example" {
   name                       = "my-environment"
   location                   = azurerm_resource_group.example.location
   resource_group_name        = azurerm_resource_group.example.name
+  logs_destination           = "log-analytics"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
 }
 ```
@@ -64,7 +65,11 @@ The following arguments are supported:
 
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
 
-* `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
+* `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. 
+
+~> **Note:** required if `logs_destination` is set to `log-analytics`.
+
+* `logs_destination` - (Optional) Where the application logs will be saved for this Container Apps Managed Environment. Options are `log-analytics` or `azure-monitor`.
 
 * `workload_profile` - (Optional) The profile of the workload to scope the container app execution. A `workload_profile` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add the `logs_destination` property to `azurerm_container_app_environment` to allow specifying Azure Monitor as a log target. 

Since changing the `log_analytics_workspace_id` no longer requires recreating the environment, I have also removed this from the configuration.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app_envrionment` - add support for Azure Monitor as a log destination [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25426
