### PR TITLE
`azurerm_eventhub_namespace_customer_managed_key` - drop tests from cluster to premium SKU

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -208,32 +208,20 @@ resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
 func (r EventHubNamespaceCustomerManagedKeyResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
-    }
-  }
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-namespacecmk-%d"
-  location = "%s"
-}
-
-resource "azurerm_eventhub_cluster" "test" {
-  name                = "acctest-cluster-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku_name            = "Dedicated_1"
+  name     = "acctestRG-namespacecmk-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_eventhub_namespace" "test" {
-  name                 = "acctest-namespace-%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  sku                  = "Standard"
-  dedicated_cluster_id = azurerm_eventhub_cluster.test.id
+  name                = "acctest-namespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium"
+  zone_redundant      = true
 
   identity {
     type = "SystemAssigned"
@@ -243,12 +231,11 @@ resource "azurerm_eventhub_namespace" "test" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "test" {
-  name                     = "acctestkv%s"
-  location                 = azurerm_resource_group.test.location
-  resource_group_name      = azurerm_resource_group.test.name
-  tenant_id                = data.azurerm_client_config.current.tenant_id
-  sku_name                 = "standard"
-  purge_protection_enabled = true
+  name                = "acctestkv%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -276,7 +263,7 @@ resource "azurerm_key_vault_access_policy" "test2" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "acctestkvkey%s"
+  name         = "acctestkvkey%[2]s"
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
@@ -287,44 +274,32 @@ resource "azurerm_key_vault_key" "test" {
     azurerm_key_vault_access_policy.test2,
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (r EventHubNamespaceCustomerManagedKeyResource) templateWithUserAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
-    }
-  }
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-namespacecmk-%d"
-  location = "%s"
-}
-
-resource "azurerm_eventhub_cluster" "test" {
-  name                = "acctest-cluster-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku_name            = "Dedicated_1"
+  name     = "acctestRG-namespacecmk-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_user_assigned_identity" "test" {
   location            = azurerm_resource_group.test.location
-  name                = "acctest-identity-%s"
+  name                = "acctest-identity-%[3]s"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_eventhub_namespace" "test" {
-  name                 = "acctest-namespace-%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  sku                  = "Standard"
-  dedicated_cluster_id = azurerm_eventhub_cluster.test.id
+  name                = "acctest-namespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium"
+  zone_redundant      = true
 
   identity {
     type         = "UserAssigned"
@@ -335,12 +310,11 @@ resource "azurerm_eventhub_namespace" "test" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "test" {
-  name                     = "acctestkv%s"
-  location                 = azurerm_resource_group.test.location
-  resource_group_name      = azurerm_resource_group.test.name
-  tenant_id                = data.azurerm_client_config.current.tenant_id
-  sku_name                 = "standard"
-  purge_protection_enabled = true
+  name                = "acctestkv%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -368,7 +342,7 @@ resource "azurerm_key_vault_access_policy" "test2" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "acctestkvkey%s"
+  name         = "acctestkvkey%[3]s"
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
@@ -379,5 +353,5 @@ resource "azurerm_key_vault_key" "test" {
     azurerm_key_vault_access_policy.test2,
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates test to use Premium SKU instead of Dedicated Cluster for Cost and execution time improvements.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

