### PR TITLE
bugfix: fix a persistent diff for PIM role assignments with no ticket information

### DIFF
--- a/internal/services/authorization/parse/pim_role_assignment.go
+++ b/internal/services/authorization/parse/pim_role_assignment.go
@@ -5,11 +5,7 @@ package parse
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
-
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/roleeligibilityschedules"
 )
 
 type PimRoleAssignmentId struct {
@@ -38,13 +34,13 @@ func (id PimRoleAssignmentId) String() string {
 		fmt.Sprintf("Role Definition Id %q", id.RoleDefinitionId),
 	}
 	segmentsStr := strings.Join(segments, " / ")
-	return fmt.Sprintf("%s: (%s)", "Role Management Policy", segmentsStr)
+	return fmt.Sprintf("%s: (%s)", "PIM Role Assignment", segmentsStr)
 }
 
 func PimRoleAssignmentID(input string) (*PimRoleAssignmentId, error) {
 	parts := strings.Split(input, "|")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("could not parse Role Management Policy ID, invalid format %q", input)
+		return nil, fmt.Errorf("could not parse PIM Role Assignment ID, invalid format %q", input)
 	}
 
 	pimRoleAssignmentId := PimRoleAssignmentId{
@@ -54,17 +50,4 @@ func PimRoleAssignmentID(input string) (*PimRoleAssignmentId, error) {
 	}
 
 	return &pimRoleAssignmentId, nil
-}
-
-func (id PimRoleAssignmentId) ScopeID() commonids.ScopeId {
-	return commonids.NewScopeID(id.Scope)
-}
-
-func RoleEligibilityScheduleRequestIdFromSchedule(r *roleeligibilityschedules.RoleEligibilitySchedule) (*string, error) {
-	re := regexp.MustCompile(`^.+/providers/Microsoft.Authorization/roleEligibilityScheduleRequests/(.+)`)
-	matches := re.FindStringSubmatch(*r.Properties.RoleEligibilityScheduleRequestId)
-	if len(matches) != 2 {
-		return nil, fmt.Errorf("parsing %s", *r.Properties.RoleEligibilityScheduleRequestId)
-	}
-	return &matches[1], nil
 }

--- a/internal/services/authorization/pim_active_role_assignment_resource.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource.go
@@ -182,6 +182,7 @@ func (PimActiveRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schema 
 			Type:        pluginsdk.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			ForceNew:    true,
 			Description: "Ticket details relating to the assignment",
 			Elem: &pluginsdk.Resource{

--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -183,6 +183,7 @@ func (PimEligibleRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schem
 			Type:        pluginsdk.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			ForceNew:    true,
 			Description: "Ticket details relating to the eligible assignment",
 			Elem: &pluginsdk.Resource{

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -28,7 +28,7 @@ func TestAccPimEligibleRoleAssignment_noExpiration(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.noExpirationConfig(data),
+			Config: r.noExpiration(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("scope").Exists(),
@@ -38,7 +38,7 @@ func TestAccPimEligibleRoleAssignment_noExpiration(t *testing.T) {
 	})
 }
 
-func TestAccPimEligibleRoleAssignment_expirationByDurationHoursConfig(t *testing.T) {
+func TestAccPimEligibleRoleAssignment_expirationByDurationHours(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
 	r := PimEligibleRoleAssignmentResource{}
 
@@ -55,7 +55,7 @@ func TestAccPimEligibleRoleAssignment_expirationByDurationHoursConfig(t *testing
 	})
 }
 
-func TestAccPimEligibleRoleAssignment_expirationByDurationDaysConfig(t *testing.T) {
+func TestAccPimEligibleRoleAssignment_expirationByDurationDays(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
 	r := PimEligibleRoleAssignmentResource{}
 
@@ -105,7 +105,7 @@ func TestAccPimEligibleRoleAssignment_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccPimEligibleRoleAssignment_expirationByDateConfig(t *testing.T) {
+func TestAccPimEligibleRoleAssignment_expirationByDate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
 	r := PimEligibleRoleAssignmentResource{}
 
@@ -173,7 +173,7 @@ resource "azuread_group" "test" {
 `, data.RandomInteger, data.RandomString)
 }
 
-func (r PimEligibleRoleAssignmentResource) noExpirationConfig(data acceptance.TestData) string {
+func (r PimEligibleRoleAssignmentResource) noExpiration(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_subscription" "primary" {}
 
@@ -308,8 +308,7 @@ resource "time_offset" "test" {
 resource "azurerm_pim_eligible_role_assignment" "test" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-
-  principal_id = azuread_group.test.object_id
+  principal_id       = azuread_group.test.object_id
 
   schedule {
     start_date_time = time_static.test.rfc3339


### PR DESCRIPTION
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_pim_active_role_assignment` - fix a persistent diff when `ticket` is not specified
* `azurerm_pim_eligible_role_assignment` - fix a persistent diff when `ticket` is not specified


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Resolves: #26050
