### PR TITLE
`azurerm_machine_learning_compute_cluster` - add validation for `name`

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -41,9 +42,10 @@ func resourceComputeCluster() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.ComputeClusterName,
 			},
 
 			"machine_learning_workspace_id": {

--- a/internal/services/machinelearning/validate/compute_cluster_name.go
+++ b/internal/services/machinelearning/validate/compute_cluster_name.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func ComputeClusterName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	// The portal says: It can include letters, digits and dashes. It must start with a letter, end with a letter or digit, and be between 3 and 32 characters in length.
+	// If you provide invalid name, the rest api will return an error with the following regex.
+	if matched := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{1,30}[a-zA-Z0-9]$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%s must be between 3 and 32 characters, may only include alphanumeric characters and '-' and must start with a letter, end with a letter or digit", k))
+	}
+	return
+}

--- a/internal/services/machinelearning/validate/compute_cluster_name_test.go
+++ b/internal/services/machinelearning/validate/compute_cluster_name_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestComputeClusterName(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// basic example
+			input:    "hello",
+			expected: true,
+		},
+		{
+			// cannot start with a hyphen
+			input:    "-hello",
+			expected: false,
+		},
+		{
+			// cannot start with a digit
+			input:    "1hello",
+			expected: false,
+		},
+		{
+			// can end with a digit
+			input:    "hello2",
+			expected: true,
+		},
+		{
+			// cannot end with a hyphen
+			input:    "hello-",
+			expected: false,
+		},
+		{
+			// cannot contain other special symbols other than hyphens
+			input:    "hello.world",
+			expected: false,
+		},
+		{
+			// cannot contain underscore
+			input:    "hello_world",
+			expected: false,
+		},
+		{
+			// hyphen in the middle
+			input:    "hello-world",
+			expected: true,
+		},
+		{
+			// 2 chars
+			input:    "ab",
+			expected: false,
+		},
+		{
+			// 3 chars
+			input:    "abc",
+			expected: true,
+		},
+		{
+			// 32 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdef",
+			expected: true,
+		},
+		{
+			// 33 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefg",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.input)
+
+		_, errors := ComputeClusterName(v.input, "name")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
