### PR TITLE
`azurerm_container_app_job` Rename plural properties to singular for consistency with other Container App resources

### DIFF
--- a/internal/services/containerapps/container_app_job_resource.go
+++ b/internal/services/containerapps/container_app_job_resource.go
@@ -93,6 +93,7 @@ func (r ContainerAppJobResource) Arguments() map[string]*schema.Schema {
 
 		"template": helpers.JobTemplateSchema(),
 
+		// TODO rename `secrets` to `secrets` in 4.0
 		"secrets": helpers.SecretsSchema(),
 
 		"replica_retry_limit": {
@@ -101,6 +102,7 @@ func (r ContainerAppJobResource) Arguments() map[string]*schema.Schema {
 			ValidateFunc: validation.IntAtLeast(0),
 		},
 
+		// TODO rename `registries` to `registry` in 4.0
 		"registries": helpers.ContainerAppRegistrySchema(),
 
 		"event_trigger_config": {

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -637,11 +637,11 @@ resource "azurerm_container_app_job" "test" {
     parallelism              = 4
     replica_completion_count = 1
   }
-  secrets {
+  secret {
     name  = "registry-password"
     value = azurerm_container_registry.test.admin_password
   }
-  registries {
+  registry {
     server               = azurerm_container_registry.test.login_server
     username             = azurerm_container_registry.test.admin_username
     password_secret_name = "registry-password"
@@ -738,17 +738,17 @@ resource "azurerm_container_app_job" "test" {
     replica_completion_count = 2
   }
 
-  secrets {
+  secret {
     name  = "registry-password"
     value = azurerm_container_registry.test.admin_password
   }
 
-  secrets {
+  secret {
     name  = "foo"
     value = "bar"
   }
 
-  registries {
+  registry {
     server               = azurerm_container_registry.test.login_server
     username             = azurerm_container_registry.test.admin_username
     password_secret_name = "registry-password"

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -221,6 +222,24 @@ func TestAccContainerAppJob_complete(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_completeDeprecated(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Skipped as `secrets` and `registries` removed in 4.0")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeDeprecated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -642,6 +661,104 @@ resource "azurerm_container_app_job" "test" {
     value = azurerm_container_registry.test.admin_password
   }
   registry {
+    server               = azurerm_container_registry.test.login_server
+    username             = azurerm_container_registry.test.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  template {
+    volume {
+      name         = azurerm_container_app_environment_storage.test.name
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.test.name
+    }
+    container {
+      args = [
+        "-c",
+        "while true; do echo hello; sleep 10;done",
+      ]
+      command = [
+        "/bin/sh",
+      ]
+      image = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name  = "testcontainerappsjob0"
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        interval_seconds        = 20
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      cpu    = 0.5
+      memory = "1Gi"
+      volume_mounts {
+        path = "/appsettings"
+        name = azurerm_container_app_environment_storage.test.name
+      }
+    }
+
+    init_container {
+      name   = "init-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/appsettings"
+      }
+    }
+  }
+  tags = {
+    ENV = "test"
+  }
+}
+`, ContainerAppResource{}.templatePlusExtras(data), data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) completeDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%[1]s
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+  secrets {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+  registries {
     server               = azurerm_container_registry.test.login_server
     username             = azurerm_container_registry.test.admin_username
     password_secret_name = "registry-password"

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -102,9 +102,9 @@ The following arguments are supported:
 
 * `replica_retry_limit` - (Optional) The maximum number of times a replica is allowed to retry.
 
-* `secrets` - (Optional) A `secrets` block as defined below.
+* `secret` - (Optional) One or more `secret` blocks as defined below.
 
-* `registries` - (Optional) A `registries` block as defined below.
+* `registry` - (Optional) One or more `registry` blocks as defined below.
 
 * `manual_trigger_config` - (Optional) A `manual_trigger_config` block as defined below.
 
@@ -312,7 +312,7 @@ A `volume` block supports the following:
 
 ---
 
-A `secrets` block supports the following:
+A `secret` block supports the following:
 
 * `name` - (required) Name of the secret.
 
@@ -320,7 +320,7 @@ A `secrets` block supports the following:
 
 ---
 
-A `registries` block supports the following:
+A `registry` block supports the following:
 
 * `identity` - (Optional) A Managed Identity to use to authenticate with Azure Container Registry.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR just adds two TODOs to the `azurerm_container_app_job` resource to rename the `secrets` and `registries` properties from plural to singular to match the properties in the `azurerm_container_app` resource for consistency.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app_job` - rename `secrets` to `secret` [GH-26063]
* `azurerm_container_app_job` - rename `registries` to `registry` [GH-26063]


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change
