### PR TITLE
`keyvault`: populating the cache using both the Key Vault List and Resources API to workaround incomplete/stale data being returned

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -475,7 +475,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	if client.IoTTimeSeriesInsights, err = timeseriesinsights.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for IoT TimeSeries Insights: %+v", err)
 	}
-	client.KeyVault = keyvault.NewClient(o)
+	if client.KeyVault, err = keyvault.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for Key Vault: %+v", err)
+	}
 	if client.Kusto, err = kusto.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Kusto: %+v", err)
 	}

--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -4,7 +4,11 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults"
+	vaults20230701 "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults"
+	resources20151101 "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	dataplane "github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
 )
@@ -16,21 +20,49 @@ type Client struct {
 	// services.
 	//
 	// As such this separation on our side is intentional to avoid code reuse given these differences.
-
 	VaultsClient *vaults.VaultsClient
 
-	ManagementClient *dataplane.BaseClient
+	ManagementClient *dataplane.BaseClient // TODO: we should rename this DataPlaneClient in time
+
+	// NOTE: @tombuildsstuff: this client is intentionally internal-only so that it's not used directly
+	resources20151101Client *resources20151101.ResourcesClient
+
+	// @tombuildsstuff: I'm intentionally vendoring this API version separately to take advantage
+	// of the updated List API behaviour/new base layer (since the API now always returns a nextLink)
+	// which `Azure/go-autorest` doesn't handle cleanly. Before migrating the Key Vault resources over
+	// to using this new API Version, there's a few Enum/casing related items to resolve, and as such
+	// that's intentionally split-out into a separate task. For now, please continue to use VaultsClient
+	// for regular operations, and we can remove this internal client one the newer API version is used
+	// across the Provider.
+	vaults20230701Client *vaults20230701.VaultsClient
 }
 
-func NewClient(o *common.ClientOptions) *Client {
-	managementClient := dataplane.New()
-	o.ConfigureClient(&managementClient.Client, o.KeyVaultAuthorizer)
+func NewClient(o *common.ClientOptions) (*Client, error) {
+	// These clients use `hashicorp/go-azure-sdk`
+	updatedVaultsClient, err := vaults20230701.NewVaultsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Vaults client: %+v", err)
+	}
+	o.Configure(updatedVaultsClient.Client, o.Authorizers.ResourceManager)
 
+	resources20151101Client, err := resources20151101.NewResourcesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building legacy Resources client: %+v", err)
+	}
+	o.Configure(resources20151101Client.Client, o.Authorizers.ResourceManager)
+
+	// These clients use `Azure/azure-sdk-for-go` and/or `Azure/go-autorest`
 	vaultsClient := vaults.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
+	managementClient := dataplane.New()
+	o.ConfigureClient(&managementClient.Client, o.KeyVaultAuthorizer)
 
 	return &Client{
 		ManagementClient: &managementClient,
 		VaultsClient:     &vaultsClient,
-	}
+
+		// intentionally internal to this package for now, see above.
+		resources20151101Client: resources20151101Client,
+		vaults20230701Client:    updatedVaultsClient,
+	}, nil
 }

--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults"
 )
 
 var (
@@ -130,49 +129,9 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, subscriptionId commo
 		return &v.keyVaultId, nil
 	}
 
-	// Pull out the list of Key Vaults available within the Subscription to re-populate the cache
-	//
-	// Whilst we've historically used the Resources API to query the single Key Vault in question
-	// this endpoint has caching related issues - and whilst the ResourceGraph API has been suggested
-	// as an alternative that fixes this, we've seen similar caching issues there.
-	// Therefore, we're falling back on querying all the Key Vaults within the specified Subscription, which
-	// comes from the `KeyVault` Resource Provider rather than the `Resources` Resource Provider - which
-	// is an approach we've used previously, but now with better caching.
-	//
-	// Whilst querying ALL Key Vaults within a Subscription IS excessive where only a single Key Vault
-	// is used - having the cache populated (one-time, per Provider launch) should alleviate problems
-	// in Terraform Configurations defining a large number of Key Vault items.
-	//
-	// @tombuildsstuff: I vaguely recall the `ListBySubscription` API having a low rate limit (5x/second?)
-	// however the rate-limits defined here seem to apply only to Managed HSMs and not Key Vaults?
-	// https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits
-	//
-	// Finally, it's worth noting that we intentionally List ALL the Key Vaults within a Subscription
-	// to be able to cache ALL of them - prior to looking up the specific Key Vault we're interested
-	// in from the freshly populated cache.
-	// This fixes an issue in the previous implementation where the Cache was being repeatedly semi-populated
-	// until the specified Key Vault was found, at which point we skipped populating the cache, which
-	// affected both the `Resources` API implementation:
-	// https://github.com/hashicorp/terraform-provider-azurerm/blob/3e88e5e74e12577d785f10298281b1b3c172254f/internal/services/keyvault/client/helpers.go#L133-L173
-	// and the `ListBySubscription` endpoint:
-	// https://github.com/hashicorp/terraform-provider-azurerm/blob/a5e728dc62e832e74d7bb0f40a79af0ae5a79e1e/azurerm/helpers/azure/key_vault.go#L42-L89
-	opts := vaults.DefaultListBySubscriptionOperationOptions()
-	results, err := c.VaultsClient.ListBySubscriptionComplete(ctx, subscriptionId, opts)
-	if err != nil {
-		return nil, fmt.Errorf("listing the Key Vaults within %s: %+v", subscriptionId, err)
-	}
-	for _, item := range results.Items {
-		if item.Id == nil || item.Properties.VaultUri == nil {
-			continue
-		}
-
-		// Populate the key vault into the cache
-		keyVaultId, err := commonids.ParseKeyVaultIDInsensitively(*item.Id)
-		if err != nil {
-			return nil, fmt.Errorf("parsing %q as a Key Vault ID: %+v", *item.Id, err)
-		}
-		vaultUri := *item.Properties.VaultUri
-		c.AddToCache(*keyVaultId, vaultUri)
+	// Populate the cache
+	if err := c.populateCache(ctx, subscriptionId); err != nil {
+		return nil, fmt.Errorf("populating the Key Vaults cache for %s: %+v", subscriptionId, err)
 	}
 
 	// Now that the cache has been repopulated, check if we have the key vault or not

--- a/internal/services/keyvault/client/populate_cache.go
+++ b/internal/services/keyvault/client/populate_cache.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"log"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	vaults20230701 "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults"
+	resources20151101 "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources"
+)
+
+func (c *Client) populateCache(ctx context.Context, subscriptionId commonids.SubscriptionId) error {
+	// Pull out the list of Key Vaults available within the Subscription to re-populate the cache
+	//
+	// Whilst we've historically used the Resources API to query the single Key Vault in question
+	// this endpoint has caching related issues - and whilst the ResourceGraph API has been suggested
+	// as an alternative that fixes this, we've seen similar caching issues there.
+	// Therefore, we're falling back on querying all the Key Vaults within the specified Subscription, which
+	// comes from the `KeyVault` Resource Provider rather than the `Resources` Resource Provider - which
+	// is an approach we've used previously, but now with better caching.
+	//
+	// Whilst querying ALL Key Vaults within a Subscription IS excessive where only a single Key Vault
+	// is used - having the cache populated (one-time, per Provider launch) should alleviate problems
+	// in Terraform Configurations defining a large number of Key Vault items.
+	//
+	// @tombuildsstuff: I vaguely recall the `ListBySubscription` API having a low rate limit (5x/second?)
+	// however the rate-limits defined here seem to apply only to Managed HSMs and not Key Vaults?
+	// https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits
+	//
+	// Finally, it's worth noting that we intentionally List ALL the Key Vaults within a Subscription
+	// to be able to cache ALL of them - prior to looking up the specific Key Vault we're interested
+	// in from the freshly populated cache.
+	// This fixes an issue in the previous implementation where the Cache was being repeatedly semi-populated
+	// until the specified Key Vault was found, at which point we skipped populating the cache, which
+	// affected both the `Resources` API implementation:
+	// https://github.com/hashicorp/terraform-provider-azurerm/blob/3e88e5e74e12577d785f10298281b1b3c172254f/internal/services/keyvault/client/helpers.go#L133-L173
+	// and the `ListBySubscription` endpoint:
+	// https://github.com/hashicorp/terraform-provider-azurerm/blob/a5e728dc62e832e74d7bb0f40a79af0ae5a79e1e/azurerm/helpers/azure/key_vault.go#L42-L89
+	opts := vaults20230701.DefaultListBySubscriptionOperationOptions()
+	results, err := c.vaults20230701Client.ListBySubscriptionComplete(ctx, subscriptionId, opts)
+	if err != nil {
+		return fmt.Errorf("listing the Key Vaults within %s: %+v", subscriptionId, err)
+	}
+	for _, item := range results.Items {
+		if item.Id == nil || item.Properties.VaultUri == nil {
+			continue
+		}
+
+		// Populate the key vault into the cache
+		keyVaultId, err := commonids.ParseKeyVaultIDInsensitively(*item.Id)
+		if err != nil {
+			return fmt.Errorf("parsing %q as a Key Vault ID: %+v", *item.Id, err)
+		}
+		vaultUri := *item.Properties.VaultUri
+		c.AddToCache(*keyVaultId, vaultUri)
+	}
+
+	// @tombuildsstuff: now despite what I've said above, it turns out that we ALSO need to hit the Resources endpoint to populate any items that we've missed.
+	// This is because the Key Vault List API appears to have a series of caching bugs where new items get added and removed from the cache, but when the cache
+	// falls out of sync, it's not invalidated and reloaded - meaning that we can have totally invalid results.
+	//
+	// Clearly this isn't ideal, but this matches the behaviour and API version (2015-11-01) used by the Azure CLI, which should at least allow users to have
+	// a consistent set of data - until the caching issues are resolved.
+	resourcesOpts := resources20151101.DefaultListOperationOptions()
+	resourcesOpts.Filter = pointer.To("resourceType eq 'Microsoft.KeyVault/vaults'")
+	resp, err := c.resources20151101Client.ListComplete(ctx, subscriptionId, resourcesOpts)
+	if err != nil {
+		return fmt.Errorf("performing Resources query within %s: %+v", subscriptionId, err)
+	}
+
+	for _, item := range resp.Items {
+		if item.Id == nil || item.Name == nil {
+			continue
+		}
+
+		id, err := commonids.ParseKeyVaultIDInsensitively(*item.Id)
+		if err != nil {
+			return fmt.Errorf("parsing %q as a Key Vault ID: %+v", *item.Id, err)
+		}
+		cacheKey := c.cacheKeyForKeyVault(id.VaultName)
+		if _, inCache := keyVaultsCache[cacheKey]; inCache {
+			// don't bother caching it if we've already got it
+			continue
+		}
+
+		keyVault, err := c.vaults20230701Client.Get(ctx, *id)
+		if err != nil {
+			if response.WasForbidden(keyVault.HttpResponse) {
+				log.Printf("[WARN] Unable to access %s with current credentials, skipping caching it", *id)
+				continue
+			}
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
+		}
+		if keyVault.Model == nil {
+			return fmt.Errorf("retrieving %s: `model` was nil", *id)
+		}
+		if keyVault.Model.Properties.VaultUri == nil {
+			return fmt.Errorf("retrieving %s: `model.Properties.VaultUri` was nil", *id)
+		}
+		dataPlaneUri := *keyVault.Model.Properties.VaultUri
+		c.AddToCache(*id, dataPlaneUri)
+	}
+
+	return nil
+}

--- a/internal/services/keyvault/client/populate_cache.go
+++ b/internal/services/keyvault/client/populate_cache.go
@@ -3,10 +3,10 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"log"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	vaults20230701 "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults"
 	resources20151101 "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources"

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/README.md
@@ -1,0 +1,229 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults` Documentation
+
+The `vaults` SDK allows for interaction with the Azure Resource Manager Service `keyvault` (API Version `2023-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults"
+```
+
+
+### Client Initialization
+
+```go
+client := vaults.NewVaultsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VaultsClient.CheckNameAvailability`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+payload := vaults.VaultCheckNameAvailabilityParameters{
+	// ...
+}
+
+
+read, err := client.CheckNameAvailability(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VaultsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+
+payload := vaults.VaultCreateOrUpdateParameters{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VaultsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VaultsClient.Get`
+
+```go
+ctx := context.TODO()
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VaultsClient.GetDeleted`
+
+```go
+ctx := context.TODO()
+id := vaults.NewDeletedVaultID("12345678-1234-9876-4563-123456789012", "locationValue", "deletedVaultValue")
+
+read, err := client.GetDeleted(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VaultsClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id, vaults.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, vaults.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VaultsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id, vaults.DefaultListByResourceGroupOperationOptions())` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id, vaults.DefaultListByResourceGroupOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VaultsClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id, vaults.DefaultListBySubscriptionOperationOptions())` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id, vaults.DefaultListBySubscriptionOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VaultsClient.ListDeleted`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListDeleted(ctx, id)` can be used to do batched pagination
+items, err := client.ListDeletedComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VaultsClient.PurgeDeleted`
+
+```go
+ctx := context.TODO()
+id := vaults.NewDeletedVaultID("12345678-1234-9876-4563-123456789012", "locationValue", "deletedVaultValue")
+
+if err := client.PurgeDeletedThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VaultsClient.Update`
+
+```go
+ctx := context.TODO()
+id := commonids.NewKeyVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+
+payload := vaults.VaultPatchParameters{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VaultsClient.UpdateAccessPolicy`
+
+```go
+ctx := context.TODO()
+id := vaults.NewOperationKindID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue", "add")
+
+payload := vaults.VaultAccessPolicyParameters{
+	// ...
+}
+
+
+read, err := client.UpdateAccessPolicy(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/client.go
@@ -1,0 +1,26 @@
+package vaults
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVaultsClientWithBaseURI(sdkApi sdkEnv.Api) (*VaultsClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "vaults", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VaultsClient: %+v", err)
+	}
+
+	return &VaultsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/constants.go
@@ -1,0 +1,878 @@
+package vaults
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessPolicyUpdateKind string
+
+const (
+	AccessPolicyUpdateKindAdd     AccessPolicyUpdateKind = "add"
+	AccessPolicyUpdateKindRemove  AccessPolicyUpdateKind = "remove"
+	AccessPolicyUpdateKindReplace AccessPolicyUpdateKind = "replace"
+)
+
+func PossibleValuesForAccessPolicyUpdateKind() []string {
+	return []string{
+		string(AccessPolicyUpdateKindAdd),
+		string(AccessPolicyUpdateKindRemove),
+		string(AccessPolicyUpdateKindReplace),
+	}
+}
+
+func (s *AccessPolicyUpdateKind) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAccessPolicyUpdateKind(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAccessPolicyUpdateKind(input string) (*AccessPolicyUpdateKind, error) {
+	vals := map[string]AccessPolicyUpdateKind{
+		"add":     AccessPolicyUpdateKindAdd,
+		"remove":  AccessPolicyUpdateKindRemove,
+		"replace": AccessPolicyUpdateKindReplace,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AccessPolicyUpdateKind(input)
+	return &out, nil
+}
+
+type ActionsRequired string
+
+const (
+	ActionsRequiredNone ActionsRequired = "None"
+)
+
+func PossibleValuesForActionsRequired() []string {
+	return []string{
+		string(ActionsRequiredNone),
+	}
+}
+
+func (s *ActionsRequired) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseActionsRequired(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseActionsRequired(input string) (*ActionsRequired, error) {
+	vals := map[string]ActionsRequired{
+		"none": ActionsRequiredNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ActionsRequired(input)
+	return &out, nil
+}
+
+type CertificatePermissions string
+
+const (
+	CertificatePermissionsAll            CertificatePermissions = "all"
+	CertificatePermissionsBackup         CertificatePermissions = "backup"
+	CertificatePermissionsCreate         CertificatePermissions = "create"
+	CertificatePermissionsDelete         CertificatePermissions = "delete"
+	CertificatePermissionsDeleteissuers  CertificatePermissions = "deleteissuers"
+	CertificatePermissionsGet            CertificatePermissions = "get"
+	CertificatePermissionsGetissuers     CertificatePermissions = "getissuers"
+	CertificatePermissionsImport         CertificatePermissions = "import"
+	CertificatePermissionsList           CertificatePermissions = "list"
+	CertificatePermissionsListissuers    CertificatePermissions = "listissuers"
+	CertificatePermissionsManagecontacts CertificatePermissions = "managecontacts"
+	CertificatePermissionsManageissuers  CertificatePermissions = "manageissuers"
+	CertificatePermissionsPurge          CertificatePermissions = "purge"
+	CertificatePermissionsRecover        CertificatePermissions = "recover"
+	CertificatePermissionsRestore        CertificatePermissions = "restore"
+	CertificatePermissionsSetissuers     CertificatePermissions = "setissuers"
+	CertificatePermissionsUpdate         CertificatePermissions = "update"
+)
+
+func PossibleValuesForCertificatePermissions() []string {
+	return []string{
+		string(CertificatePermissionsAll),
+		string(CertificatePermissionsBackup),
+		string(CertificatePermissionsCreate),
+		string(CertificatePermissionsDelete),
+		string(CertificatePermissionsDeleteissuers),
+		string(CertificatePermissionsGet),
+		string(CertificatePermissionsGetissuers),
+		string(CertificatePermissionsImport),
+		string(CertificatePermissionsList),
+		string(CertificatePermissionsListissuers),
+		string(CertificatePermissionsManagecontacts),
+		string(CertificatePermissionsManageissuers),
+		string(CertificatePermissionsPurge),
+		string(CertificatePermissionsRecover),
+		string(CertificatePermissionsRestore),
+		string(CertificatePermissionsSetissuers),
+		string(CertificatePermissionsUpdate),
+	}
+}
+
+func (s *CertificatePermissions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCertificatePermissions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCertificatePermissions(input string) (*CertificatePermissions, error) {
+	vals := map[string]CertificatePermissions{
+		"all":            CertificatePermissionsAll,
+		"backup":         CertificatePermissionsBackup,
+		"create":         CertificatePermissionsCreate,
+		"delete":         CertificatePermissionsDelete,
+		"deleteissuers":  CertificatePermissionsDeleteissuers,
+		"get":            CertificatePermissionsGet,
+		"getissuers":     CertificatePermissionsGetissuers,
+		"import":         CertificatePermissionsImport,
+		"list":           CertificatePermissionsList,
+		"listissuers":    CertificatePermissionsListissuers,
+		"managecontacts": CertificatePermissionsManagecontacts,
+		"manageissuers":  CertificatePermissionsManageissuers,
+		"purge":          CertificatePermissionsPurge,
+		"recover":        CertificatePermissionsRecover,
+		"restore":        CertificatePermissionsRestore,
+		"setissuers":     CertificatePermissionsSetissuers,
+		"update":         CertificatePermissionsUpdate,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CertificatePermissions(input)
+	return &out, nil
+}
+
+type CreateMode string
+
+const (
+	CreateModeDefault CreateMode = "default"
+	CreateModeRecover CreateMode = "recover"
+)
+
+func PossibleValuesForCreateMode() []string {
+	return []string{
+		string(CreateModeDefault),
+		string(CreateModeRecover),
+	}
+}
+
+func (s *CreateMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCreateMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCreateMode(input string) (*CreateMode, error) {
+	vals := map[string]CreateMode{
+		"default": CreateModeDefault,
+		"recover": CreateModeRecover,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CreateMode(input)
+	return &out, nil
+}
+
+type KeyPermissions string
+
+const (
+	KeyPermissionsAll               KeyPermissions = "all"
+	KeyPermissionsBackup            KeyPermissions = "backup"
+	KeyPermissionsCreate            KeyPermissions = "create"
+	KeyPermissionsDecrypt           KeyPermissions = "decrypt"
+	KeyPermissionsDelete            KeyPermissions = "delete"
+	KeyPermissionsEncrypt           KeyPermissions = "encrypt"
+	KeyPermissionsGet               KeyPermissions = "get"
+	KeyPermissionsGetrotationpolicy KeyPermissions = "getrotationpolicy"
+	KeyPermissionsImport            KeyPermissions = "import"
+	KeyPermissionsList              KeyPermissions = "list"
+	KeyPermissionsPurge             KeyPermissions = "purge"
+	KeyPermissionsRecover           KeyPermissions = "recover"
+	KeyPermissionsRelease           KeyPermissions = "release"
+	KeyPermissionsRestore           KeyPermissions = "restore"
+	KeyPermissionsRotate            KeyPermissions = "rotate"
+	KeyPermissionsSetrotationpolicy KeyPermissions = "setrotationpolicy"
+	KeyPermissionsSign              KeyPermissions = "sign"
+	KeyPermissionsUnwrapKey         KeyPermissions = "unwrapKey"
+	KeyPermissionsUpdate            KeyPermissions = "update"
+	KeyPermissionsVerify            KeyPermissions = "verify"
+	KeyPermissionsWrapKey           KeyPermissions = "wrapKey"
+)
+
+func PossibleValuesForKeyPermissions() []string {
+	return []string{
+		string(KeyPermissionsAll),
+		string(KeyPermissionsBackup),
+		string(KeyPermissionsCreate),
+		string(KeyPermissionsDecrypt),
+		string(KeyPermissionsDelete),
+		string(KeyPermissionsEncrypt),
+		string(KeyPermissionsGet),
+		string(KeyPermissionsGetrotationpolicy),
+		string(KeyPermissionsImport),
+		string(KeyPermissionsList),
+		string(KeyPermissionsPurge),
+		string(KeyPermissionsRecover),
+		string(KeyPermissionsRelease),
+		string(KeyPermissionsRestore),
+		string(KeyPermissionsRotate),
+		string(KeyPermissionsSetrotationpolicy),
+		string(KeyPermissionsSign),
+		string(KeyPermissionsUnwrapKey),
+		string(KeyPermissionsUpdate),
+		string(KeyPermissionsVerify),
+		string(KeyPermissionsWrapKey),
+	}
+}
+
+func (s *KeyPermissions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseKeyPermissions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseKeyPermissions(input string) (*KeyPermissions, error) {
+	vals := map[string]KeyPermissions{
+		"all":               KeyPermissionsAll,
+		"backup":            KeyPermissionsBackup,
+		"create":            KeyPermissionsCreate,
+		"decrypt":           KeyPermissionsDecrypt,
+		"delete":            KeyPermissionsDelete,
+		"encrypt":           KeyPermissionsEncrypt,
+		"get":               KeyPermissionsGet,
+		"getrotationpolicy": KeyPermissionsGetrotationpolicy,
+		"import":            KeyPermissionsImport,
+		"list":              KeyPermissionsList,
+		"purge":             KeyPermissionsPurge,
+		"recover":           KeyPermissionsRecover,
+		"release":           KeyPermissionsRelease,
+		"restore":           KeyPermissionsRestore,
+		"rotate":            KeyPermissionsRotate,
+		"setrotationpolicy": KeyPermissionsSetrotationpolicy,
+		"sign":              KeyPermissionsSign,
+		"unwrapkey":         KeyPermissionsUnwrapKey,
+		"update":            KeyPermissionsUpdate,
+		"verify":            KeyPermissionsVerify,
+		"wrapkey":           KeyPermissionsWrapKey,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := KeyPermissions(input)
+	return &out, nil
+}
+
+type NetworkRuleAction string
+
+const (
+	NetworkRuleActionAllow NetworkRuleAction = "Allow"
+	NetworkRuleActionDeny  NetworkRuleAction = "Deny"
+)
+
+func PossibleValuesForNetworkRuleAction() []string {
+	return []string{
+		string(NetworkRuleActionAllow),
+		string(NetworkRuleActionDeny),
+	}
+}
+
+func (s *NetworkRuleAction) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkRuleAction(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkRuleAction(input string) (*NetworkRuleAction, error) {
+	vals := map[string]NetworkRuleAction{
+		"allow": NetworkRuleActionAllow,
+		"deny":  NetworkRuleActionDeny,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkRuleAction(input)
+	return &out, nil
+}
+
+type NetworkRuleBypassOptions string
+
+const (
+	NetworkRuleBypassOptionsAzureServices NetworkRuleBypassOptions = "AzureServices"
+	NetworkRuleBypassOptionsNone          NetworkRuleBypassOptions = "None"
+)
+
+func PossibleValuesForNetworkRuleBypassOptions() []string {
+	return []string{
+		string(NetworkRuleBypassOptionsAzureServices),
+		string(NetworkRuleBypassOptionsNone),
+	}
+}
+
+func (s *NetworkRuleBypassOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkRuleBypassOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkRuleBypassOptions(input string) (*NetworkRuleBypassOptions, error) {
+	vals := map[string]NetworkRuleBypassOptions{
+		"azureservices": NetworkRuleBypassOptionsAzureServices,
+		"none":          NetworkRuleBypassOptionsNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkRuleBypassOptions(input)
+	return &out, nil
+}
+
+type PrivateEndpointConnectionProvisioningState string
+
+const (
+	PrivateEndpointConnectionProvisioningStateCreating     PrivateEndpointConnectionProvisioningState = "Creating"
+	PrivateEndpointConnectionProvisioningStateDeleting     PrivateEndpointConnectionProvisioningState = "Deleting"
+	PrivateEndpointConnectionProvisioningStateDisconnected PrivateEndpointConnectionProvisioningState = "Disconnected"
+	PrivateEndpointConnectionProvisioningStateFailed       PrivateEndpointConnectionProvisioningState = "Failed"
+	PrivateEndpointConnectionProvisioningStateSucceeded    PrivateEndpointConnectionProvisioningState = "Succeeded"
+	PrivateEndpointConnectionProvisioningStateUpdating     PrivateEndpointConnectionProvisioningState = "Updating"
+)
+
+func PossibleValuesForPrivateEndpointConnectionProvisioningState() []string {
+	return []string{
+		string(PrivateEndpointConnectionProvisioningStateCreating),
+		string(PrivateEndpointConnectionProvisioningStateDeleting),
+		string(PrivateEndpointConnectionProvisioningStateDisconnected),
+		string(PrivateEndpointConnectionProvisioningStateFailed),
+		string(PrivateEndpointConnectionProvisioningStateSucceeded),
+		string(PrivateEndpointConnectionProvisioningStateUpdating),
+	}
+}
+
+func (s *PrivateEndpointConnectionProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePrivateEndpointConnectionProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePrivateEndpointConnectionProvisioningState(input string) (*PrivateEndpointConnectionProvisioningState, error) {
+	vals := map[string]PrivateEndpointConnectionProvisioningState{
+		"creating":     PrivateEndpointConnectionProvisioningStateCreating,
+		"deleting":     PrivateEndpointConnectionProvisioningStateDeleting,
+		"disconnected": PrivateEndpointConnectionProvisioningStateDisconnected,
+		"failed":       PrivateEndpointConnectionProvisioningStateFailed,
+		"succeeded":    PrivateEndpointConnectionProvisioningStateSucceeded,
+		"updating":     PrivateEndpointConnectionProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointConnectionProvisioningState(input)
+	return &out, nil
+}
+
+type PrivateEndpointServiceConnectionStatus string
+
+const (
+	PrivateEndpointServiceConnectionStatusApproved     PrivateEndpointServiceConnectionStatus = "Approved"
+	PrivateEndpointServiceConnectionStatusDisconnected PrivateEndpointServiceConnectionStatus = "Disconnected"
+	PrivateEndpointServiceConnectionStatusPending      PrivateEndpointServiceConnectionStatus = "Pending"
+	PrivateEndpointServiceConnectionStatusRejected     PrivateEndpointServiceConnectionStatus = "Rejected"
+)
+
+func PossibleValuesForPrivateEndpointServiceConnectionStatus() []string {
+	return []string{
+		string(PrivateEndpointServiceConnectionStatusApproved),
+		string(PrivateEndpointServiceConnectionStatusDisconnected),
+		string(PrivateEndpointServiceConnectionStatusPending),
+		string(PrivateEndpointServiceConnectionStatusRejected),
+	}
+}
+
+func (s *PrivateEndpointServiceConnectionStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePrivateEndpointServiceConnectionStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePrivateEndpointServiceConnectionStatus(input string) (*PrivateEndpointServiceConnectionStatus, error) {
+	vals := map[string]PrivateEndpointServiceConnectionStatus{
+		"approved":     PrivateEndpointServiceConnectionStatusApproved,
+		"disconnected": PrivateEndpointServiceConnectionStatusDisconnected,
+		"pending":      PrivateEndpointServiceConnectionStatusPending,
+		"rejected":     PrivateEndpointServiceConnectionStatusRejected,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointServiceConnectionStatus(input)
+	return &out, nil
+}
+
+type Reason string
+
+const (
+	ReasonAccountNameInvalid Reason = "AccountNameInvalid"
+	ReasonAlreadyExists      Reason = "AlreadyExists"
+)
+
+func PossibleValuesForReason() []string {
+	return []string{
+		string(ReasonAccountNameInvalid),
+		string(ReasonAlreadyExists),
+	}
+}
+
+func (s *Reason) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseReason(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseReason(input string) (*Reason, error) {
+	vals := map[string]Reason{
+		"accountnameinvalid": ReasonAccountNameInvalid,
+		"alreadyexists":      ReasonAlreadyExists,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Reason(input)
+	return &out, nil
+}
+
+type SecretPermissions string
+
+const (
+	SecretPermissionsAll     SecretPermissions = "all"
+	SecretPermissionsBackup  SecretPermissions = "backup"
+	SecretPermissionsDelete  SecretPermissions = "delete"
+	SecretPermissionsGet     SecretPermissions = "get"
+	SecretPermissionsList    SecretPermissions = "list"
+	SecretPermissionsPurge   SecretPermissions = "purge"
+	SecretPermissionsRecover SecretPermissions = "recover"
+	SecretPermissionsRestore SecretPermissions = "restore"
+	SecretPermissionsSet     SecretPermissions = "set"
+)
+
+func PossibleValuesForSecretPermissions() []string {
+	return []string{
+		string(SecretPermissionsAll),
+		string(SecretPermissionsBackup),
+		string(SecretPermissionsDelete),
+		string(SecretPermissionsGet),
+		string(SecretPermissionsList),
+		string(SecretPermissionsPurge),
+		string(SecretPermissionsRecover),
+		string(SecretPermissionsRestore),
+		string(SecretPermissionsSet),
+	}
+}
+
+func (s *SecretPermissions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecretPermissions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecretPermissions(input string) (*SecretPermissions, error) {
+	vals := map[string]SecretPermissions{
+		"all":     SecretPermissionsAll,
+		"backup":  SecretPermissionsBackup,
+		"delete":  SecretPermissionsDelete,
+		"get":     SecretPermissionsGet,
+		"list":    SecretPermissionsList,
+		"purge":   SecretPermissionsPurge,
+		"recover": SecretPermissionsRecover,
+		"restore": SecretPermissionsRestore,
+		"set":     SecretPermissionsSet,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecretPermissions(input)
+	return &out, nil
+}
+
+type SkuFamily string
+
+const (
+	SkuFamilyA SkuFamily = "A"
+)
+
+func PossibleValuesForSkuFamily() []string {
+	return []string{
+		string(SkuFamilyA),
+	}
+}
+
+func (s *SkuFamily) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSkuFamily(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSkuFamily(input string) (*SkuFamily, error) {
+	vals := map[string]SkuFamily{
+		"a": SkuFamilyA,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SkuFamily(input)
+	return &out, nil
+}
+
+type SkuName string
+
+const (
+	SkuNamePremium  SkuName = "premium"
+	SkuNameStandard SkuName = "standard"
+)
+
+func PossibleValuesForSkuName() []string {
+	return []string{
+		string(SkuNamePremium),
+		string(SkuNameStandard),
+	}
+}
+
+func (s *SkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSkuName(input string) (*SkuName, error) {
+	vals := map[string]SkuName{
+		"premium":  SkuNamePremium,
+		"standard": SkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SkuName(input)
+	return &out, nil
+}
+
+type StoragePermissions string
+
+const (
+	StoragePermissionsAll           StoragePermissions = "all"
+	StoragePermissionsBackup        StoragePermissions = "backup"
+	StoragePermissionsDelete        StoragePermissions = "delete"
+	StoragePermissionsDeletesas     StoragePermissions = "deletesas"
+	StoragePermissionsGet           StoragePermissions = "get"
+	StoragePermissionsGetsas        StoragePermissions = "getsas"
+	StoragePermissionsList          StoragePermissions = "list"
+	StoragePermissionsListsas       StoragePermissions = "listsas"
+	StoragePermissionsPurge         StoragePermissions = "purge"
+	StoragePermissionsRecover       StoragePermissions = "recover"
+	StoragePermissionsRegeneratekey StoragePermissions = "regeneratekey"
+	StoragePermissionsRestore       StoragePermissions = "restore"
+	StoragePermissionsSet           StoragePermissions = "set"
+	StoragePermissionsSetsas        StoragePermissions = "setsas"
+	StoragePermissionsUpdate        StoragePermissions = "update"
+)
+
+func PossibleValuesForStoragePermissions() []string {
+	return []string{
+		string(StoragePermissionsAll),
+		string(StoragePermissionsBackup),
+		string(StoragePermissionsDelete),
+		string(StoragePermissionsDeletesas),
+		string(StoragePermissionsGet),
+		string(StoragePermissionsGetsas),
+		string(StoragePermissionsList),
+		string(StoragePermissionsListsas),
+		string(StoragePermissionsPurge),
+		string(StoragePermissionsRecover),
+		string(StoragePermissionsRegeneratekey),
+		string(StoragePermissionsRestore),
+		string(StoragePermissionsSet),
+		string(StoragePermissionsSetsas),
+		string(StoragePermissionsUpdate),
+	}
+}
+
+func (s *StoragePermissions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseStoragePermissions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseStoragePermissions(input string) (*StoragePermissions, error) {
+	vals := map[string]StoragePermissions{
+		"all":           StoragePermissionsAll,
+		"backup":        StoragePermissionsBackup,
+		"delete":        StoragePermissionsDelete,
+		"deletesas":     StoragePermissionsDeletesas,
+		"get":           StoragePermissionsGet,
+		"getsas":        StoragePermissionsGetsas,
+		"list":          StoragePermissionsList,
+		"listsas":       StoragePermissionsListsas,
+		"purge":         StoragePermissionsPurge,
+		"recover":       StoragePermissionsRecover,
+		"regeneratekey": StoragePermissionsRegeneratekey,
+		"restore":       StoragePermissionsRestore,
+		"set":           StoragePermissionsSet,
+		"setsas":        StoragePermissionsSetsas,
+		"update":        StoragePermissionsUpdate,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := StoragePermissions(input)
+	return &out, nil
+}
+
+type Type string
+
+const (
+	TypeMicrosoftPointKeyVaultVaults Type = "Microsoft.KeyVault/vaults"
+)
+
+func PossibleValuesForType() []string {
+	return []string{
+		string(TypeMicrosoftPointKeyVaultVaults),
+	}
+}
+
+func (s *Type) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseType(input string) (*Type, error) {
+	vals := map[string]Type{
+		"microsoft.keyvault/vaults": TypeMicrosoftPointKeyVaultVaults,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Type(input)
+	return &out, nil
+}
+
+type VaultListFilterTypes string
+
+const (
+	VaultListFilterTypesResourceTypeEqMicrosoftPointKeyVaultVaults VaultListFilterTypes = "resourceType eq 'Microsoft.KeyVault/vaults'"
+)
+
+func PossibleValuesForVaultListFilterTypes() []string {
+	return []string{
+		string(VaultListFilterTypesResourceTypeEqMicrosoftPointKeyVaultVaults),
+	}
+}
+
+func (s *VaultListFilterTypes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVaultListFilterTypes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVaultListFilterTypes(input string) (*VaultListFilterTypes, error) {
+	vals := map[string]VaultListFilterTypes{
+		"resourcetype eq 'microsoft.keyvault/vaults'": VaultListFilterTypesResourceTypeEqMicrosoftPointKeyVaultVaults,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VaultListFilterTypes(input)
+	return &out, nil
+}
+
+type VaultProvisioningState string
+
+const (
+	VaultProvisioningStateRegisteringDns VaultProvisioningState = "RegisteringDns"
+	VaultProvisioningStateSucceeded      VaultProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForVaultProvisioningState() []string {
+	return []string{
+		string(VaultProvisioningStateRegisteringDns),
+		string(VaultProvisioningStateSucceeded),
+	}
+}
+
+func (s *VaultProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVaultProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVaultProvisioningState(input string) (*VaultProvisioningState, error) {
+	vals := map[string]VaultProvisioningState{
+		"registeringdns": VaultProvisioningStateRegisteringDns,
+		"succeeded":      VaultProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VaultProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/id_deletedvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/id_deletedvault.go
@@ -1,0 +1,130 @@
+package vaults
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DeletedVaultId{})
+}
+
+var _ resourceids.ResourceId = &DeletedVaultId{}
+
+// DeletedVaultId is a struct representing the Resource ID for a Deleted Vault
+type DeletedVaultId struct {
+	SubscriptionId   string
+	LocationName     string
+	DeletedVaultName string
+}
+
+// NewDeletedVaultID returns a new DeletedVaultId struct
+func NewDeletedVaultID(subscriptionId string, locationName string, deletedVaultName string) DeletedVaultId {
+	return DeletedVaultId{
+		SubscriptionId:   subscriptionId,
+		LocationName:     locationName,
+		DeletedVaultName: deletedVaultName,
+	}
+}
+
+// ParseDeletedVaultID parses 'input' into a DeletedVaultId
+func ParseDeletedVaultID(input string) (*DeletedVaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DeletedVaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DeletedVaultId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDeletedVaultIDInsensitively parses 'input' case-insensitively into a DeletedVaultId
+// note: this method should only be used for API response data and not user input
+func ParseDeletedVaultIDInsensitively(input string) (*DeletedVaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DeletedVaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DeletedVaultId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DeletedVaultId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.DeletedVaultName, ok = input.Parsed["deletedVaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "deletedVaultName", input)
+	}
+
+	return nil
+}
+
+// ValidateDeletedVaultID checks that 'input' can be parsed as a Deleted Vault ID
+func ValidateDeletedVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDeletedVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Deleted Vault ID
+func (id DeletedVaultId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.KeyVault/locations/%s/deletedVaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.DeletedVaultName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Deleted Vault ID
+func (id DeletedVaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftKeyVault", "Microsoft.KeyVault", "Microsoft.KeyVault"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticDeletedVaults", "deletedVaults", "deletedVaults"),
+		resourceids.UserSpecifiedSegment("deletedVaultName", "deletedVaultValue"),
+	}
+}
+
+// String returns a human-readable description of this Deleted Vault ID
+func (id DeletedVaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Deleted Vault Name: %q", id.DeletedVaultName),
+	}
+	return fmt.Sprintf("Deleted Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/id_operationkind.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/id_operationkind.go
@@ -1,0 +1,147 @@
+package vaults
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OperationKindId{})
+}
+
+var _ resourceids.ResourceId = &OperationKindId{}
+
+// OperationKindId is a struct representing the Resource ID for a Operation Kind
+type OperationKindId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	VaultName         string
+	OperationKind     AccessPolicyUpdateKind
+}
+
+// NewOperationKindID returns a new OperationKindId struct
+func NewOperationKindID(subscriptionId string, resourceGroupName string, vaultName string, operationKind AccessPolicyUpdateKind) OperationKindId {
+	return OperationKindId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VaultName:         vaultName,
+		OperationKind:     operationKind,
+	}
+}
+
+// ParseOperationKindID parses 'input' into a OperationKindId
+func ParseOperationKindID(input string) (*OperationKindId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OperationKindId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OperationKindId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOperationKindIDInsensitively parses 'input' case-insensitively into a OperationKindId
+// note: this method should only be used for API response data and not user input
+func ParseOperationKindIDInsensitively(input string) (*OperationKindId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OperationKindId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OperationKindId{}
+	if err := id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OperationKindId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VaultName, ok = input.Parsed["vaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "vaultName", input)
+	}
+
+	if v, ok := input.Parsed["operationKind"]; true {
+		if !ok {
+			return resourceids.NewSegmentNotSpecifiedError(id, "operationKind", input)
+		}
+
+		operationKind, err := parseAccessPolicyUpdateKind(v)
+		if err != nil {
+			return fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.OperationKind = *operationKind
+	}
+
+	return nil
+}
+
+// ValidateOperationKindID checks that 'input' can be parsed as a Operation Kind ID
+func ValidateOperationKindID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOperationKindID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Operation Kind ID
+func (id OperationKindId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/accessPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName, string(id.OperationKind))
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Operation Kind ID
+func (id OperationKindId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftKeyVault", "Microsoft.KeyVault", "Microsoft.KeyVault"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultValue"),
+		resourceids.StaticSegment("staticAccessPolicies", "accessPolicies", "accessPolicies"),
+		resourceids.ConstantSegment("operationKind", PossibleValuesForAccessPolicyUpdateKind(), "add"),
+	}
+}
+
+// String returns a human-readable description of this Operation Kind ID
+func (id OperationKindId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+		fmt.Sprintf("Operation Kind: %q", string(id.OperationKind)),
+	}
+	return fmt.Sprintf("Operation Kind (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_checknameavailability.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_checknameavailability.go
@@ -1,0 +1,60 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckNameAvailabilityOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CheckNameAvailabilityResult
+}
+
+// CheckNameAvailability ...
+func (c VaultsClient) CheckNameAvailability(ctx context.Context, id commonids.SubscriptionId, input VaultCheckNameAvailabilityParameters) (result CheckNameAvailabilityOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.KeyVault/checkNameAvailability", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model CheckNameAvailabilityResult
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_createorupdate.go
@@ -1,0 +1,76 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Vault
+}
+
+// CreateOrUpdate ...
+func (c VaultsClient) CreateOrUpdate(ctx context.Context, id commonids.KeyVaultId, input VaultCreateOrUpdateParameters) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VaultsClient) CreateOrUpdateThenPoll(ctx context.Context, id commonids.KeyVaultId, input VaultCreateOrUpdateParameters) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_delete.go
@@ -1,0 +1,48 @@
+package vaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VaultsClient) Delete(ctx context.Context, id commonids.KeyVaultId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_get.go
@@ -1,0 +1,55 @@
+package vaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Vault
+}
+
+// Get ...
+func (c VaultsClient) Get(ctx context.Context, id commonids.KeyVaultId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model Vault
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_getdeleted.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_getdeleted.go
@@ -1,0 +1,54 @@
+package vaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetDeletedOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DeletedVault
+}
+
+// GetDeleted ...
+func (c VaultsClient) GetDeleted(ctx context.Context, id DeletedVaultId) (result GetDeletedOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DeletedVault
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_list.go
@@ -1,0 +1,124 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Resource
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Resource
+}
+
+type ListOperationOptions struct {
+	Filter *VaultListFilterTypes
+	Top    *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// List ...
+func (c VaultsClient) List(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/resources", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Resource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VaultsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, ResourceOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VaultsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions, predicate ResourceOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]Resource, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listbyresourcegroup.go
@@ -1,0 +1,120 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Vault
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Vault
+}
+
+type ListByResourceGroupOperationOptions struct {
+	Top *int64
+}
+
+func DefaultListByResourceGroupOperationOptions() ListByResourceGroupOperationOptions {
+	return ListByResourceGroupOperationOptions{}
+}
+
+func (o ListByResourceGroupOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByResourceGroupOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListByResourceGroupOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// ListByResourceGroup ...
+func (c VaultsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options ListByResourceGroupOperationOptions) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/providers/Microsoft.KeyVault/vaults", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Vault `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c VaultsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId, options ListByResourceGroupOperationOptions) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, options, VaultOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VaultsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, options ListByResourceGroupOperationOptions, predicate VaultOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]Vault, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listbysubscription.go
@@ -1,0 +1,120 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Vault
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Vault
+}
+
+type ListBySubscriptionOperationOptions struct {
+	Top *int64
+}
+
+func DefaultListBySubscriptionOperationOptions() ListBySubscriptionOperationOptions {
+	return ListBySubscriptionOperationOptions{}
+}
+
+func (o ListBySubscriptionOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListBySubscriptionOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListBySubscriptionOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// ListBySubscription ...
+func (c VaultsClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId, options ListBySubscriptionOperationOptions) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/providers/Microsoft.KeyVault/vaults", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Vault `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c VaultsClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId, options ListBySubscriptionOperationOptions) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, options, VaultOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VaultsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options ListBySubscriptionOperationOptions, predicate VaultOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]Vault, 0)
+
+	resp, err := c.ListBySubscription(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listdeleted.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_listdeleted.go
@@ -1,0 +1,92 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListDeletedOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DeletedVault
+}
+
+type ListDeletedCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DeletedVault
+}
+
+// ListDeleted ...
+func (c VaultsClient) ListDeleted(ctx context.Context, id commonids.SubscriptionId) (result ListDeletedOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.KeyVault/deletedVaults", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DeletedVault `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListDeletedComplete retrieves all the results into a single object
+func (c VaultsClient) ListDeletedComplete(ctx context.Context, id commonids.SubscriptionId) (ListDeletedCompleteResult, error) {
+	return c.ListDeletedCompleteMatchingPredicate(ctx, id, DeletedVaultOperationPredicate{})
+}
+
+// ListDeletedCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VaultsClient) ListDeletedCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate DeletedVaultOperationPredicate) (result ListDeletedCompleteResult, err error) {
+	items := make([]DeletedVault, 0)
+
+	resp, err := c.ListDeleted(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListDeletedCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_purgedeleted.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_purgedeleted.go
@@ -1,0 +1,70 @@
+package vaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PurgeDeletedOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// PurgeDeleted ...
+func (c VaultsClient) PurgeDeleted(ctx context.Context, id DeletedVaultId) (result PurgeDeletedOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/purge", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// PurgeDeletedThenPoll performs PurgeDeleted then polls until it's completed
+func (c VaultsClient) PurgeDeletedThenPoll(ctx context.Context, id DeletedVaultId) error {
+	result, err := c.PurgeDeleted(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing PurgeDeleted: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after PurgeDeleted: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_update.go
@@ -1,0 +1,60 @@
+package vaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Vault
+}
+
+// Update ...
+func (c VaultsClient) Update(ctx context.Context, id commonids.KeyVaultId, input VaultPatchParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model Vault
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_updateaccesspolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/method_updateaccesspolicy.go
@@ -1,0 +1,59 @@
+package vaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateAccessPolicyOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VaultAccessPolicyParameters
+}
+
+// UpdateAccessPolicy ...
+func (c VaultsClient) UpdateAccessPolicy(ctx context.Context, id OperationKindId, input VaultAccessPolicyParameters) (result UpdateAccessPolicyOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VaultAccessPolicyParameters
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_accesspolicyentry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_accesspolicyentry.go
@@ -1,0 +1,11 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessPolicyEntry struct {
+	ApplicationId *string     `json:"applicationId,omitempty"`
+	ObjectId      string      `json:"objectId"`
+	Permissions   Permissions `json:"permissions"`
+	TenantId      string      `json:"tenantId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_checknameavailabilityresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_checknameavailabilityresult.go
@@ -1,0 +1,10 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckNameAvailabilityResult struct {
+	Message       *string `json:"message,omitempty"`
+	NameAvailable *bool   `json:"nameAvailable,omitempty"`
+	Reason        *Reason `json:"reason,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_deletedvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_deletedvault.go
@@ -1,0 +1,11 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeletedVault struct {
+	Id         *string                 `json:"id,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *DeletedVaultProperties `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_deletedvaultproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_deletedvaultproperties.go
@@ -1,0 +1,43 @@
+package vaults
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeletedVaultProperties struct {
+	DeletionDate           *string            `json:"deletionDate,omitempty"`
+	Location               *string            `json:"location,omitempty"`
+	PurgeProtectionEnabled *bool              `json:"purgeProtectionEnabled,omitempty"`
+	ScheduledPurgeDate     *string            `json:"scheduledPurgeDate,omitempty"`
+	Tags                   *map[string]string `json:"tags,omitempty"`
+	VaultId                *string            `json:"vaultId,omitempty"`
+}
+
+func (o *DeletedVaultProperties) GetDeletionDateAsTime() (*time.Time, error) {
+	if o.DeletionDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.DeletionDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DeletedVaultProperties) SetDeletionDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.DeletionDate = &formatted
+}
+
+func (o *DeletedVaultProperties) GetScheduledPurgeDateAsTime() (*time.Time, error) {
+	if o.ScheduledPurgeDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ScheduledPurgeDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DeletedVaultProperties) SetScheduledPurgeDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ScheduledPurgeDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_iprule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_iprule.go
@@ -1,0 +1,8 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPRule struct {
+	Value string `json:"value"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_networkruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_networkruleset.go
@@ -1,0 +1,11 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkRuleSet struct {
+	Bypass              *NetworkRuleBypassOptions `json:"bypass,omitempty"`
+	DefaultAction       *NetworkRuleAction        `json:"defaultAction,omitempty"`
+	IPRules             *[]IPRule                 `json:"ipRules,omitempty"`
+	VirtualNetworkRules *[]VirtualNetworkRule     `json:"virtualNetworkRules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_permissions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_permissions.go
@@ -1,0 +1,11 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Permissions struct {
+	Certificates *[]CertificatePermissions `json:"certificates,omitempty"`
+	Keys         *[]KeyPermissions         `json:"keys,omitempty"`
+	Secrets      *[]SecretPermissions      `json:"secrets,omitempty"`
+	Storage      *[]StoragePermissions     `json:"storage,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpoint.go
@@ -1,0 +1,8 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpoint struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpointconnectionitem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpointconnectionitem.go
@@ -1,0 +1,10 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionItem struct {
+	Etag       *string                              `json:"etag,omitempty"`
+	Id         *string                              `json:"id,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privateendpointconnectionproperties.go
@@ -1,0 +1,10 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	PrivateEndpoint                   *PrivateEndpoint                            `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState          `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *PrivateEndpointConnectionProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_privatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionState struct {
+	ActionsRequired *ActionsRequired                        `json:"actionsRequired,omitempty"`
+	Description     *string                                 `json:"description,omitempty"`
+	Status          *PrivateEndpointServiceConnectionStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_resource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_resource.go
@@ -1,0 +1,12 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Resource struct {
+	Id       *string            `json:"id,omitempty"`
+	Location *string            `json:"location,omitempty"`
+	Name     *string            `json:"name,omitempty"`
+	Tags     *map[string]string `json:"tags,omitempty"`
+	Type     *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_sku.go
@@ -1,0 +1,9 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Family SkuFamily `json:"family"`
+	Name   SkuName   `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vault.go
@@ -1,0 +1,18 @@
+package vaults
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Vault struct {
+	Id         *string                `json:"id,omitempty"`
+	Location   *string                `json:"location,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties VaultProperties        `json:"properties"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Tags       *map[string]string     `json:"tags,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultaccesspolicyparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultaccesspolicyparameters.go
@@ -1,0 +1,12 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultAccessPolicyParameters struct {
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties VaultAccessPolicyProperties `json:"properties"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultaccesspolicyproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultaccesspolicyproperties.go
@@ -1,0 +1,8 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultAccessPolicyProperties struct {
+	AccessPolicies []AccessPolicyEntry `json:"accessPolicies"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultchecknameavailabilityparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultchecknameavailabilityparameters.go
@@ -1,0 +1,9 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCheckNameAvailabilityParameters struct {
+	Name string `json:"name"`
+	Type Type   `json:"type"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultcreateorupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultcreateorupdateparameters.go
@@ -1,0 +1,10 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCreateOrUpdateParameters struct {
+	Location   string             `json:"location"`
+	Properties VaultProperties    `json:"properties"`
+	Tags       *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultpatchparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultpatchparameters.go
@@ -1,0 +1,9 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultPatchParameters struct {
+	Properties *VaultPatchProperties `json:"properties,omitempty"`
+	Tags       *map[string]string    `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultpatchproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultpatchproperties.go
@@ -1,0 +1,20 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultPatchProperties struct {
+	AccessPolicies               *[]AccessPolicyEntry `json:"accessPolicies,omitempty"`
+	CreateMode                   *CreateMode          `json:"createMode,omitempty"`
+	EnablePurgeProtection        *bool                `json:"enablePurgeProtection,omitempty"`
+	EnableRbacAuthorization      *bool                `json:"enableRbacAuthorization,omitempty"`
+	EnableSoftDelete             *bool                `json:"enableSoftDelete,omitempty"`
+	EnabledForDeployment         *bool                `json:"enabledForDeployment,omitempty"`
+	EnabledForDiskEncryption     *bool                `json:"enabledForDiskEncryption,omitempty"`
+	EnabledForTemplateDeployment *bool                `json:"enabledForTemplateDeployment,omitempty"`
+	NetworkAcls                  *NetworkRuleSet      `json:"networkAcls,omitempty"`
+	PublicNetworkAccess          *string              `json:"publicNetworkAccess,omitempty"`
+	Sku                          *Sku                 `json:"sku,omitempty"`
+	SoftDeleteRetentionInDays    *int64               `json:"softDeleteRetentionInDays,omitempty"`
+	TenantId                     *string              `json:"tenantId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_vaultproperties.go
@@ -1,0 +1,24 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultProperties struct {
+	AccessPolicies               *[]AccessPolicyEntry             `json:"accessPolicies,omitempty"`
+	CreateMode                   *CreateMode                      `json:"createMode,omitempty"`
+	EnablePurgeProtection        *bool                            `json:"enablePurgeProtection,omitempty"`
+	EnableRbacAuthorization      *bool                            `json:"enableRbacAuthorization,omitempty"`
+	EnableSoftDelete             *bool                            `json:"enableSoftDelete,omitempty"`
+	EnabledForDeployment         *bool                            `json:"enabledForDeployment,omitempty"`
+	EnabledForDiskEncryption     *bool                            `json:"enabledForDiskEncryption,omitempty"`
+	EnabledForTemplateDeployment *bool                            `json:"enabledForTemplateDeployment,omitempty"`
+	HsmPoolResourceId            *string                          `json:"hsmPoolResourceId,omitempty"`
+	NetworkAcls                  *NetworkRuleSet                  `json:"networkAcls,omitempty"`
+	PrivateEndpointConnections   *[]PrivateEndpointConnectionItem `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState            *VaultProvisioningState          `json:"provisioningState,omitempty"`
+	PublicNetworkAccess          *string                          `json:"publicNetworkAccess,omitempty"`
+	Sku                          Sku                              `json:"sku"`
+	SoftDeleteRetentionInDays    *int64                           `json:"softDeleteRetentionInDays,omitempty"`
+	TenantId                     string                           `json:"tenantId"`
+	VaultUri                     *string                          `json:"vaultUri,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_virtualnetworkrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/model_virtualnetworkrule.go
@@ -1,0 +1,9 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkRule struct {
+	Id                               string `json:"id"`
+	IgnoreMissingVnetServiceEndpoint *bool  `json:"ignoreMissingVnetServiceEndpoint,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/predicates.go
@@ -1,0 +1,83 @@
+package vaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeletedVaultOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DeletedVaultOperationPredicate) Matches(input DeletedVault) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type ResourceOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ResourceOperationPredicate) Matches(input Resource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type VaultOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p VaultOperationPredicate) Matches(input Vault) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults/version.go
@@ -1,0 +1,12 @@
+package vaults
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-07-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/vaults/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/README.md
@@ -1,0 +1,141 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources` Documentation
+
+The `resources` SDK allows for interaction with the Azure Resource Manager Service `resources` (API Version `2015-11-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources"
+```
+
+
+### Client Initialization
+
+```go
+client := resources.NewResourcesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ResourcesClient.CheckExistence`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+read, err := client.CheckExistence(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourcesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+payload := resources.GenericResource{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourcesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourcesClient.Get`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ResourcesClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id, resources.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, resources.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ResourcesClient.MoveResources`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+payload := resources.ResourcesMoveInfo{
+	// ...
+}
+
+
+if err := client.MoveResourcesThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ResourcesClient.Update`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+payload := resources.GenericResource{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/client.go
@@ -1,0 +1,26 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourcesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewResourcesClientWithBaseURI(sdkApi sdkEnv.Api) (*ResourcesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "resources", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ResourcesClient: %+v", err)
+	}
+
+	return &ResourcesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_checkexistence.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_checkexistence.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckExistenceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// CheckExistence ...
+func (c ResourcesClient) CheckExistence(ctx context.Context, id commonids.ScopeId) (result CheckExistenceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodHead,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_createorupdate.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *GenericResource
+}
+
+// CreateOrUpdate ...
+func (c ResourcesClient) CreateOrUpdate(ctx context.Context, id commonids.ScopeId, input GenericResource) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model GenericResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_delete.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c ResourcesClient) Delete(ctx context.Context, id commonids.ScopeId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_get.go
@@ -1,0 +1,56 @@
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *GenericResource
+}
+
+// Get ...
+func (c ResourcesClient) Get(ctx context.Context, id commonids.ScopeId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model GenericResource
+	result.Model = &model
+
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_list.go
@@ -1,0 +1,128 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]GenericResourceExpanded
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []GenericResourceExpanded
+}
+
+type ListOperationOptions struct {
+	Expand *string
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+// List ...
+func (c ResourcesClient) List(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/resources", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]GenericResourceExpanded `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c ResourcesClient) ListComplete(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, GenericResourceExpandedOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ResourcesClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions, predicate GenericResourceExpandedOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]GenericResourceExpanded, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_moveresources.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_moveresources.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MoveResourcesOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// MoveResources ...
+func (c ResourcesClient) MoveResources(ctx context.Context, id commonids.ResourceGroupId, input ResourcesMoveInfo) (result MoveResourcesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/moveResources", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// MoveResourcesThenPoll performs MoveResources then polls until it's completed
+func (c ResourcesClient) MoveResourcesThenPoll(ctx context.Context, id commonids.ResourceGroupId, input ResourcesMoveInfo) error {
+	result, err := c.MoveResources(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing MoveResources: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after MoveResources: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/method_update.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *GenericResource
+}
+
+// Update ...
+func (c ResourcesClient) Update(ctx context.Context, id commonids.ScopeId, input GenericResource) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ResourcesClient) UpdateThenPoll(ctx context.Context, id commonids.ScopeId, input GenericResource) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_genericresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_genericresource.go
@@ -1,0 +1,14 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericResource struct {
+	Id         *string            `json:"id,omitempty"`
+	Location   string             `json:"location"`
+	Name       *string            `json:"name,omitempty"`
+	Plan       *Plan              `json:"plan,omitempty"`
+	Properties *interface{}       `json:"properties,omitempty"`
+	Tags       *map[string]string `json:"tags,omitempty"`
+	Type       *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_genericresourceexpanded.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_genericresourceexpanded.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericResourceExpanded struct {
+	ChangedTime       *string            `json:"changedTime,omitempty"`
+	CreatedTime       *string            `json:"createdTime,omitempty"`
+	Id                *string            `json:"id,omitempty"`
+	Location          string             `json:"location"`
+	Name              *string            `json:"name,omitempty"`
+	Plan              *Plan              `json:"plan,omitempty"`
+	Properties        *interface{}       `json:"properties,omitempty"`
+	ProvisioningState *string            `json:"provisioningState,omitempty"`
+	Tags              *map[string]string `json:"tags,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (o *GenericResourceExpanded) GetChangedTimeAsTime() (*time.Time, error) {
+	if o.ChangedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ChangedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *GenericResourceExpanded) SetChangedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ChangedTime = &formatted
+}
+
+func (o *GenericResourceExpanded) GetCreatedTimeAsTime() (*time.Time, error) {
+	if o.CreatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *GenericResourceExpanded) SetCreatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_plan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_plan.go
@@ -1,0 +1,11 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Plan struct {
+	Name          *string `json:"name,omitempty"`
+	Product       *string `json:"product,omitempty"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     *string `json:"publisher,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_resourcesmoveinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/model_resourcesmoveinfo.go
@@ -1,0 +1,9 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourcesMoveInfo struct {
+	Resources           *[]string `json:"resources,omitempty"`
+	TargetResourceGroup *string   `json:"targetResourceGroup,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/predicates.go
@@ -1,0 +1,52 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericResourceExpandedOperationPredicate struct {
+	ChangedTime       *string
+	CreatedTime       *string
+	Id                *string
+	Location          *string
+	Name              *string
+	Properties        *interface{}
+	ProvisioningState *string
+	Type              *string
+}
+
+func (p GenericResourceExpandedOperationPredicate) Matches(input GenericResourceExpanded) bool {
+
+	if p.ChangedTime != nil && (input.ChangedTime == nil || *p.ChangedTime != *input.ChangedTime) {
+		return false
+	}
+
+	if p.CreatedTime != nil && (input.CreatedTime == nil || *p.CreatedTime != *input.CreatedTime) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Properties != nil && (input.Properties == nil || *p.Properties != *input.Properties) {
+		return false
+	}
+
+	if p.ProvisioningState != nil && (input.ProvisioningState == nil || *p.ProvisioningState != *input.ProvisioningState) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources/version.go
@@ -1,0 +1,12 @@
+package resources
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2015-11-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/resources/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -576,6 +576,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremoni
 github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps
 github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults
 github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms
+github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults
 github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions
 github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/fluxconfiguration
 github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-08-15/attacheddatabaseconfigurations
@@ -931,6 +932,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2023-10-01-pr
 github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections
 github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces
 github.com/hashicorp/go-azure-sdk/resource-manager/resourceconnector/2022-10-27/appliances
+github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01/resources
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/privatelinkassociation
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Through a significant amount of testing and validation - plus open issues, we've identified an issue when populating the available Key Vaults for the cache, where the Key Vaults List API returns stale data. Having spend a significant amount of time investigating this issue, the API itself appears to only add and remove from the cache - rather than invalidating the cache when something changes - meaning that if there's an issue on the Azure side (or slow replication, etc) the list of available Key Vaults is invalid, and thus Key Vaults which exist are not returned through this API.

Digging into the Azure CLI implementation, the command `az keyvault list` returns a list of both Key Vaults and Managed HSMS (by default together, but this can be filtered to either type using an argument). Notably however, when loading Key Vaults this is done using an old version of the Resources API (`2015-11-01`) which is curious - and having spent a decent chunk of time digging into the Azure CLI source code, I can't find a documented reason for this, particularly for an API version this old. By contrast, when obtaining a list of Managed HSMs the Managed HSMs List API is used (that is `/subscriptions/XXX/providers/Microsoft.KeyVaults/managedHsms`).

Whilst for the life of me I can't find any meaningful context for why the Azure CLI is using this older API, since that's what the Azure CLI is using, it feels reasonable for us to also use that API version (so that users have a consistent experience when querying the available data).

Therefore.. this PR updates the Key Vault caching logic to first query using the Key Vaults List API (that is, `/subscriptions/XXX/providers/Microsoft.KeyVaults/vaults`) and then to query using the Resources API to populate the list of Key Vaults within the current Subscription. This means we are making an extra API call, but given that both of these APIs (in addition to the Resource Graph API) have known caching issues - I'm honestly not sure what we else we can do here, so this feels like a reasonable compromise.

In my testing this resolves the issues that we've been seeing (now that we can reproduce this) where there's 10 Key Vaults currently in our Subscription, but only 2 are returned when using the Key Vaults List API (even when crossing all pages) - and all 10 are returned via the Resources API - and as such I _believe_ this'll also solve #25548.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `keyvault` - populating the Key Vaults cache using both the Key Vaults List and Resources API to workaround incomplete/stale data being returned from the API [GH-26070]

## Related Issue(s)

Fixes #25548

Dependent on #26069 