### PR TITLE
nginx: adding a TODO to rename `managed_resource_group` to be `managed_resource_group_name` as in other resources in 4.0

### DIFF
--- a/internal/services/nginx/nginx_deployment_data_source.go
+++ b/internal/services/nginx/nginx_deployment_data_source.go
@@ -70,6 +70,7 @@ func (m DeploymentDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"managed_resource_group": {
+			// TODO: rename this to `managed_resource_group_name` in 4.0
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -106,6 +106,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 		"managed_resource_group": {
+			// TODO: rename this to `managed_resource_group_name` in 4.0
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			Computed:     true,


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This is a minor nit, but I wanted to add a TODO for this since it's the only instance of the provider and we use `managed_resource_group_name` everywhere else.

