### PR TITLE
azurerm_machine_learning_compute_cluster change subnet_resource_id constraint: Respect Managed Vnet when creating compute clusters fixes #25901 

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -202,6 +202,9 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
+	
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_machine_learning_compute_cluster", id.ID())
 
 	nodePublicIPEnabled, ok := d.Get("node_public_ip_enabled").(bool)
 	if !ok {

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -175,20 +175,20 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	workspace, err := mlWorkspacesClient.Get(ctx, *workspaceID)
 	if err != nil {
-		return err
+		return fmt.Errorf("retrieving %s: %+v, workspaceID, err)
 	}
 
 	workspaceModel := workspace.Model
 	if workspaceModel == nil {
-		return fmt.Errorf("machine learning %s Workspace: model was nil", id)
+		return fmt.Errorf("retrieving %s: `model` was nil", workspaceID)
 	}
 
 	if workspaceModel.Sku == nil || workspaceModel.Sku.Tier == nil || workspaceModel.Sku.Name == "" {
-		return fmt.Errorf("machine learning %s Workspace: `SKU` was nil or empty", id)
+		return fmt.Errorf("retrieving %s: `sku` was nil or empty", workspaceID)
 	}
 
 	if workspaceModel.Location == nil {
-		return fmt.Errorf("machine learning %s Workspace: `Location` was nil", id)
+		return fmt.Errorf("retrieving %s: `location` was nil", workspaceID)
 	}
 
 	identity, err := expandIdentity(d.Get("identity").([]interface{}))
@@ -204,7 +204,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if !d.Get("node_public_ip_enabled").(bool) && d.Get("subnet_resource_id").(string) == "" && *workspaceModel.Properties.ManagedNetwork.Status.Status != workspaces.ManagedNetworkStatusActive {
-		return fmt.Errorf("`subnet_resource_id` must be set if `node_public_ip_enabled` is set to `false` if the workspace is not in a managed network")
+		return fmt.Errorf("`subnet_resource_id` must be set if `node_public_ip_enabled` is set to `false` or the workspace is not in a managed network")
 	}
 
 	vmPriority := machinelearningcomputes.VMPriority(d.Get("vm_priority").(string))

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-10-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-10-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -202,10 +203,10 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
-	
+
 	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_machine_learning_compute_cluster", id.ID())
-
+	}
 	nodePublicIPEnabled, ok := d.Get("node_public_ip_enabled").(bool)
 	if !ok {
 		return fmt.Errorf("unable to assert type for `node_public_ip_enabled`")

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -175,7 +175,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	workspace, err := mlWorkspacesClient.Get(ctx, *workspaceID)
 	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v, workspaceID", err)
+		return fmt.Errorf("retrieving %s: %+v", workspaceID, err)
 	}
 
 	workspaceModel := workspace.Model


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

When a Managed Vnet Setup as described in [the Microsoft documentation](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/machine-learning/how-to-managed-network.md ) is used a compute cluster can have NO public IP and we don't need to provide a subnet_resource_id since this is managed by Microsoft.

I have tested this setup by creating a compute cluster via cli/sdk and also querying an existing compute cluster. I both cases the subnet_ressource_id can be / was empty/null.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_machine_learning_compute_cluster` - subnet_ressource_id is not mandatory when node_public_ip_enabled if in a managed vnet sceenario [GH-25901]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25901

