### PR TITLE
r/container_app_environmnet_custom_domain: parsing the Workspace ID insensitively since this comes from the API

### DIFF
--- a/internal/services/containerapps/container_app_environment_custom_domain_resource.go
+++ b/internal/services/containerapps/container_app_environment_custom_domain_resource.go
@@ -318,7 +318,7 @@ func findLogAnalyticsWorkspaceSecret(ctx context.Context, client *workspaces.Wor
 
 	for _, law := range *resp.Model.Value {
 		if law.Properties != nil && law.Properties.CustomerId != nil && *law.Properties.CustomerId == targetCustomerId && law.Id != nil {
-			id, err := workspaces.ParseWorkspaceID(*law.Id)
+			id, err := workspaces.ParseWorkspaceIDInsensitively(*law.Id)
 			if err != nil {
 				return "", fmt.Errorf("parsing ID or %s: %+v", *law.Id, err)
 			}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Parsing the Log Analytics Workspace ID insensitively since this is coming from the API response - and the API is returning `resourcegroups` rather than `resourceGroups`

Fixes #26007

## Changelog

```
* `azurerm_container_app_environmnet_custom_domain`: parsing the Log Analytics Workspace ID insensitively to workaround the API returning this inconsistently [GH-26074]
```
