### PR TITLE
`azurerm_redhat_openshift_cluster` - support for the `preconfigured_network_security_group_enabled` property

### DIFF
--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
@@ -57,10 +57,10 @@ type ClusterProfile struct {
 }
 
 type NetworkProfile struct {
-	OutboundType            string `tfschema:"outbound_type"`
-	PodCidr                 string `tfschema:"pod_cidr"`
-	ServiceCidr             string `tfschema:"service_cidr"`
-	PreconfiguredNSGEnabled bool   `tfschema:"preconfigured_nsg_enabled"`
+	OutboundType                             string `tfschema:"outbound_type"`
+	PodCidr                                  string `tfschema:"pod_cidr"`
+	ServiceCidr                              string `tfschema:"service_cidr"`
+	PreconfiguredNetworkSecurityGroupEnabled bool   `tfschema:"preconfigured_network_security_group_enabled"`
 }
 
 type MainProfile struct {
@@ -194,7 +194,7 @@ func (r RedHatOpenShiftCluster) Arguments() map[string]*pluginsdk.Schema {
 							false,
 						),
 					},
-					"preconfigured_nsg_enabled": {
+					"preconfigured_network_security_group_enabled": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
 						ForceNew: true,
@@ -614,7 +614,7 @@ func expandOpenshiftNetworkProfile(input []NetworkProfile) *openshiftclusters.Ne
 	}
 
 	preconfiguredNSG := openshiftclusters.PreconfiguredNSGDisabled
-	if input[0].PreconfiguredNSGEnabled {
+	if input[0].PreconfiguredNetworkSecurityGroupEnabled {
 		preconfiguredNSG = openshiftclusters.PreconfiguredNSGEnabled
 	}
 
@@ -631,17 +631,17 @@ func flattenOpenShiftNetworkProfile(profile *openshiftclusters.NetworkProfile) [
 		return []NetworkProfile{}
 	}
 
-	preconfiguredNSGEnabled := false
+	preconfiguredNetworkSecurityGroupEnabled := false
 	if profile.PreconfiguredNSG != nil {
-		preconfiguredNSGEnabled = *profile.PreconfiguredNSG == openshiftclusters.PreconfiguredNSGEnabled
+		preconfiguredNetworkSecurityGroupEnabled = *profile.PreconfiguredNSG == openshiftclusters.PreconfiguredNSGEnabled
 	}
 
 	return []NetworkProfile{
 		{
-			OutboundType:            string(pointer.From(profile.OutboundType)),
-			PodCidr:                 pointer.From(profile.PodCidr),
-			ServiceCidr:             pointer.From(profile.ServiceCidr),
-			PreconfiguredNSGEnabled: preconfiguredNSGEnabled,
+			OutboundType:                             string(pointer.From(profile.OutboundType)),
+			PodCidr:                                  pointer.From(profile.PodCidr),
+			ServiceCidr:                              pointer.From(profile.ServiceCidr),
+			PreconfiguredNetworkSecurityGroupEnabled: preconfiguredNetworkSecurityGroupEnabled,
 		},
 	}
 }

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
@@ -57,9 +57,10 @@ type ClusterProfile struct {
 }
 
 type NetworkProfile struct {
-	OutboundType string `tfschema:"outbound_type"`
-	PodCidr      string `tfschema:"pod_cidr"`
-	ServiceCidr  string `tfschema:"service_cidr"`
+	OutboundType            string `tfschema:"outbound_type"`
+	PodCidr                 string `tfschema:"pod_cidr"`
+	ServiceCidr             string `tfschema:"service_cidr"`
+	PreconfiguredNSGEnabled bool   `tfschema:"preconfigured_nsg_enabled"`
 }
 
 type MainProfile struct {
@@ -192,6 +193,12 @@ func (r RedHatOpenShiftCluster) Arguments() map[string]*pluginsdk.Schema {
 							openshiftclusters.PossibleValuesForOutboundType(),
 							false,
 						),
+					},
+					"preconfigured_nsg_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+						Default:  false,
 					},
 				},
 			},
@@ -606,10 +613,16 @@ func expandOpenshiftNetworkProfile(input []NetworkProfile) *openshiftclusters.Ne
 		return nil
 	}
 
+	preconfiguredNSG := openshiftclusters.PreconfiguredNSGDisabled
+	if input[0].PreconfiguredNSGEnabled {
+		preconfiguredNSG = openshiftclusters.PreconfiguredNSGEnabled
+	}
+
 	return &openshiftclusters.NetworkProfile{
-		OutboundType: pointer.To(openshiftclusters.OutboundType(input[0].OutboundType)),
-		PodCidr:      pointer.To(input[0].PodCidr),
-		ServiceCidr:  pointer.To(input[0].ServiceCidr),
+		OutboundType:     pointer.To(openshiftclusters.OutboundType(input[0].OutboundType)),
+		PodCidr:          pointer.To(input[0].PodCidr),
+		ServiceCidr:      pointer.To(input[0].ServiceCidr),
+		PreconfiguredNSG: pointer.To(preconfiguredNSG),
 	}
 }
 
@@ -618,11 +631,17 @@ func flattenOpenShiftNetworkProfile(profile *openshiftclusters.NetworkProfile) [
 		return []NetworkProfile{}
 	}
 
+	preconfiguredNSGEnabled := false
+	if profile.PreconfiguredNSG != nil {
+		preconfiguredNSGEnabled = *profile.PreconfiguredNSG == openshiftclusters.PreconfiguredNSGEnabled
+	}
+
 	return []NetworkProfile{
 		{
-			OutboundType: string(pointer.From(profile.OutboundType)),
-			PodCidr:      pointer.From(profile.PodCidr),
-			ServiceCidr:  pointer.From(profile.ServiceCidr),
+			OutboundType:            string(pointer.From(profile.OutboundType)),
+			PodCidr:                 pointer.From(profile.PodCidr),
+			ServiceCidr:             pointer.From(profile.ServiceCidr),
+			PreconfiguredNSGEnabled: preconfiguredNSGEnabled,
 		},
 	}
 }

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -628,6 +628,18 @@ resource "azurerm_subnet_network_security_group_association" "test_worker" {
   network_security_group_id = azurerm_network_security_group.test.id
 }
 
+resource "azurerm_role_assignment" "role_network3" {
+  scope                = azurerm_network_security_group.test.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azuread_service_principal.test.object_id
+}
+
+resource "azurerm_role_assignment" "role_network4" {
+  scope                = azurerm_network_security_group.test.id
+  role_definition_name = "Network Contributor"
+  principal_id         = data.azuread_service_principal.redhatopenshift.object_id
+}
+
 resource "azurerm_redhat_openshift_cluster" "test" {
   name                = "acctestaro%[2]d"
   location            = azurerm_resource_group.test.location
@@ -672,6 +684,8 @@ resource "azurerm_redhat_openshift_cluster" "test" {
   depends_on = [
     "azurerm_role_assignment.role_network1",
     "azurerm_role_assignment.role_network2",
+    "azurerm_role_assignment.role_network3",
+    "azurerm_role_assignment.role_network4",
   ]
 }
   `, r.template(data), data.RandomInteger, data.RandomString)

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -108,13 +108,13 @@ func TestAccOpenShiftCluster_encryptionAtHost(t *testing.T) {
 	})
 }
 
-func TestAccOpenShiftCluster_preconfiguredNSG(t *testing.T) {
+func TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redhat_openshift_cluster", "test")
 	r := OpenShiftClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.preconfiguredNSG(data),
+			Config: r.preconfiguredNetworkSecurityGroup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -580,12 +580,12 @@ resource "azurerm_redhat_openshift_cluster" "test" {
   `, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (r OpenShiftClusterResource) preconfiguredNSG(data acceptance.TestData) string {
+func (r OpenShiftClusterResource) preconfiguredNetworkSecurityGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_network_security_group" "test" {
-  name                = "test-nsg"
+  name                = "test-network-security-group"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
@@ -639,9 +639,9 @@ resource "azurerm_redhat_openshift_cluster" "test" {
   }
 
   network_profile {
-    pod_cidr                  = "10.128.0.0/14"
-    service_cidr              = "172.30.0.0/16"
-    preconfigured_nsg_enabled = true
+    pod_cidr                                     = "10.128.0.0/14"
+    service_cidr                                 = "172.30.0.0/16"
+    preconfigured_network_security_group_enabled = true
   }
 
   api_server_profile {

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -634,8 +634,8 @@ resource "azurerm_redhat_openshift_cluster" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   cluster_profile {
-    domain       = "aro-%[3]s.com"
-    version      = "4.13.23"
+    domain  = "aro-%[3]s.com"
+    version = "4.13.23"
   }
 
   network_profile {

--- a/website/docs/r/redhat_openshift_cluster.html.markdown
+++ b/website/docs/r/redhat_openshift_cluster.html.markdown
@@ -217,7 +217,7 @@ A `network_profile` block supports the following:
 
 * `outbound_type` - (Optional) The outbound (egress) routing method. Possible values are `Loadbalancer` and `UserDefinedRouting`. Defaults to `Loadbalancer`. Changing this forces a new resource to be created.
 
-* `preconfigured_nsg_enabled` - (Optional) Whether a preconfigured network security group is being used on the subnets.  Defaults to `false`.  Changing this forces a new resource to be created.
+* `preconfigured_network_security_group_enabled` - (Optional) Whether a preconfigured network security group is being used on the subnets.  Defaults to `false`.  Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/redhat_openshift_cluster.html.markdown
+++ b/website/docs/r/redhat_openshift_cluster.html.markdown
@@ -217,6 +217,8 @@ A `network_profile` block supports the following:
 
 * `outbound_type` - (Optional) The outbound (egress) routing method. Possible values are `Loadbalancer` and `UserDefinedRouting`. Defaults to `Loadbalancer`. Changing this forces a new resource to be created.
 
+* `preconfigured_nsg_enabled` - (Optional) Whether a preconfigured network security group is being used on the subnets.  Defaults to `false`.  Changing this forces a new resource to be created.
+
 ---
 
 A `api_server_profile` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This adds support for using a preconfigured network security group for Azure Red Hat OpenShift clusters.  This brings parity with the Azure CLI and the recently released BYO-NSG feature in ARO and allows users to consume this feature.  See https://learn.microsoft.com/en-us/azure/openshift/howto-bring-nsg for more details.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


### Prior to Change

Prior to this change, the automation would exit with an error similar to the following, indicating that the `enabled-preconfigured-nsg` flag was not passed to tell the ARO resource provider that the BYO-NSG workflow needs to be enabled:

```
        API Response:
        
        ----[start]----
        {
            "id": "/subscriptions/xxxx/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7738694c-c0f3-4008-87a8-316ea61d78d5",
            "name": "7738694c-c0f3-4008-87a8-316ea61d78d5",
            "status": "Failed",
            "startTime": "2024-06-03T13:58:11.433094028Z",
            "endTime": "2024-06-03T13:58:12.839247755Z",
            "error": {
                "code": "InvalidLinkedVNet",
                "message": "The provided subnet '/subscriptions/xxxx/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/main-subnet' is invalid: must not have a network security group attached.",
                "target": "properties.masterProfile.subnetId"
            }
        }
        
        -----[end]-----
```

### After Change

After the change, the test that was added in this PR named `TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup` successfully passes.  This test adds in the creation of a network security group, linking it to the subnets, passing in the `preconfigured_network_security_group_enabled` flag, and setting the appropriate permissions as required by the ARO RP:

```
make acctests SERVICE='redhatopenshift' TESTARGS='-run=TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/redhatopenshift -run=TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup
=== PAUSE TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup
=== CONT  TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup
--- PASS: TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup (3387.58s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/redhatopenshift       3389.881s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_redhat_openshift_cluster` - support for the `preconfigured_network_security_group_enabled property` [GH-{number}]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25059


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
