### PR TITLE
`azurerm_bot_web_app` - remove `Computed` from `developer_app_insights_api_key`, `developer_app_insights_application_id` and `developer_app_insights_key`

### DIFF
--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -107,14 +107,12 @@ func resourceBotWebApp() *pluginsdk.Resource {
 			"developer_app_insights_key": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validation.IsUUID,
 			},
 
 			"developer_app_insights_api_key": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				Computed:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
@@ -122,7 +120,6 @@ func resourceBotWebApp() *pluginsdk.Resource {
 			"developer_app_insights_application_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -46,6 +46,13 @@ func TestAccBotWebApp_update(t *testing.T) {
 		},
 		data.ImportStep("developer_app_insights_api_key"),
 		{
+			Config: r.completeConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("developer_app_insights_api_key"),
+		{
 			Config: r.updateConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -189,6 +196,7 @@ resource "azurerm_bot_web_app" "test" {
   endpoint                              = "https://example.com"
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
+  developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 
   tags = {
     environment = "production"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to remove Computed from developer_app_insights_api_key, developer_app_insights_application_id and developer_app_insights_key.

For developer_app_insights_api_key, developer_app_insights_application_id and developer_app_insights_key, we can directly remove Computed since service API wouldn't return value when they aren't set.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Currently test case always doesn't set developer_app_insights_key. I think it's not enough. So I update the test scenario to test the case like updating developer_app_insights_key from a value to empty.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/4d9d0355-b09f-4ae9-9264-ecacdb86d60f)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_bot_web_app` - remove `Computed` from `developer_app_insights_api_key`, `developer_app_insights_application_id` and `developer_app_insights_key`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
