### PR TITLE
fix: fix access policy and assignment on redis as only one can be configured at a time

### DIFF
--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -111,6 +113,10 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 					ObjectIdAlias:    model.ObjectIDAlias,
 				},
 			}
+
+			locks.ByID(model.RedisCacheID)
+			defer locks.UnlockByID(model.RedisCacheID)
+
 			if err := client.AccessPolicyAssignmentCreateUpdateThenPoll(ctx, id, createInput); err != nil {
 				return fmt.Errorf("failed to create Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
 			}
@@ -173,7 +179,10 @@ func (r RedisCacheAccessPolicyAssignmentResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			if _, err := client.AccessPolicyAssignmentDelete(ctx, *id); err != nil {
+			locks.ByID(model.RedisCacheID)
+			defer locks.UnlockByID(model.RedisCacheID)
+
+			if err := client.AccessPolicyAssignmentDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyAssignmentName, id.RedisName, id.ResourceGroupName, err)
 			}
 

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -97,6 +99,10 @@ func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
 					Type:        &policyTypeCustom,
 				},
 			}
+
+			locks.ByID(model.RedisCacheID)
+			defer locks.UnlockByID(model.RedisCacheID)
+
 			if err := client.AccessPolicyCreateUpdateThenPoll(ctx, id, createInput); err != nil {
 				return fmt.Errorf("failed to create Redis Cache Access Policy %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
 			}
@@ -157,7 +163,10 @@ func (r RedisCacheAccessPolicyResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("while parsing resource ID: %+v", err)
 			}
 
-			if _, err := client.AccessPolicyDelete(ctx, *id); err != nil {
+			locks.ByID(model.RedisCacheID)
+			defer locks.UnlockByID(model.RedisCacheID)
+
+			if err := client.AccessPolicyDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting Redis Cache Access Policy %s in Redis Cache %s in resource group %s: %s", id.AccessPolicyName, id.RedisName, id.ResourceGroupName, err)
 			}
 

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -33,6 +33,24 @@ func TestAccRedisCacheAccessPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccRedisCacheAccessPolicy_multi(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy", "test")
+	r := RedisCacheAccessPolicyResource{}
+	accessPolicyTwo := "azurerm_redis_cache_access_policy.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multi(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(accessPolicyTwo).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		data.ImportStep(accessPolicyTwo),
+	})
+}
+
 func TestAccRedisCacheAccessPolicy_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_cache_access_policy", "test")
 	r := RedisCacheAccessPolicyResource{}
@@ -105,6 +123,18 @@ resource "azurerm_redis_cache_access_policy" "import" {
   name           = azurerm_redis_cache_access_policy.test.name
   redis_cache_id = azurerm_redis_cache_access_policy.test.redis_cache_id
   permissions    = azurerm_redis_cache_access_policy.test.permissions
+}
+`, r.basic(data))
+}
+
+func (r RedisCacheAccessPolicyResource) multi(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_redis_cache_access_policy" "test2" {
+  name           = "acctestRedisAccessPolicytest2"
+  redis_cache_id = azurerm_redis_cache.test.id
+  permissions    = "+@read +@connection +cluster|info allkeys"
 }
 `, r.basic(data))
 }


### PR DESCRIPTION
Uses locks to prevent multiple resources trying to update the same redis cache in parallel, because Redis will error saying that another job is in progress.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_redis_cache_access_policy` - fix error when configuration occurs in parallel [GH-26085]
* `azurerm_redis_cache_access_policy_assignment` - fix error when configuration occurs in parallel [GH-26085]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes #25802


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
