### PR TITLE
`azurerm_role_assignment` - Normalize case of the `scope` property

### DIFF
--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -58,9 +58,10 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 			},
 
 			"scope": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.Any(
 					// Elevated access for a global admin is needed to assign roles in this scope:
 					// https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin#azure-cli


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This relates to https://github.com/hashicorp/terraform-provider-azurerm/issues/20138

The azurerm_role_assignment resource can be incorrectly replaced because of a casing change in the scope field:

```
  # azurerm_role_assignment.foo must be replaced
-/+ resource "azurerm_role_assignment" "doo" {
      ~ id                               = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/example/providers/Microsoft.Authorization/roleAssignments/11111111-1111-1111-1111-111111111111" -> (known after apply)
      ~ name                             = "11111111-1111-1111-1111-111111111111" -> (known after apply)
      ~ principal_type                   = "Group" -> (known after apply)
      ~ role_definition_id               = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/22222222-2222-2222-2222-222222222222" -> (known after apply)
      ~ scope                            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example" -> "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/example" # forces replacement
      + skip_service_principal_aad_check = (known after apply)
        # (2 unchanged attributes hidden)
    }
```

Notice that the old scope contained `resourceGroups` and the new scope contains `resourcegroups`. I confirmed that removing and reimporting the resource in the terraform state does not fix the issue. Instead we add a DiffSuppressFunc on scope to match other fields on this resource.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The following tests passed. I dont have access to an environment with the necessary permissions to run the remaining acceptance tests.

```
TF_ACC=1 go test -v ./internal/services/authorization -run=TestAccRoleAssignment -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccRoleAssignment_emptyName
=== PAUSE TestAccRoleAssignment_emptyName
=== RUN   TestAccRoleAssignment_roleName
--- PASS: TestAccRoleAssignment_roleName (44.46s)
=== RUN   TestAccRoleAssignment_requiresImport
--- PASS: TestAccRoleAssignment_requiresImport (46.96s)
=== RUN   TestAccRoleAssignment_dataActions
=== PAUSE TestAccRoleAssignment_dataActions
=== RUN   TestAccRoleAssignment_builtin
=== PAUSE TestAccRoleAssignment_builtin
=== RUN   TestAccRoleAssignment_custom
=== PAUSE TestAccRoleAssignment_custom
=== RUN   TestAccRoleAssignment_ServicePrincipal
=== PAUSE TestAccRoleAssignment_ServicePrincipal
=== RUN   TestAccRoleAssignment_ServicePrincipalWithType
=== PAUSE TestAccRoleAssignment_ServicePrincipalWithType
=== RUN   TestAccRoleAssignment_ServicePrincipalGroup
=== PAUSE TestAccRoleAssignment_ServicePrincipalGroup
=== RUN   TestAccRoleAssignment_managementGroup
=== PAUSE TestAccRoleAssignment_managementGroup
=== RUN   TestAccRoleAssignment_condition
=== PAUSE TestAccRoleAssignment_condition
=== RUN   TestAccRoleAssignment_resourceScoped
=== PAUSE TestAccRoleAssignment_resourceScoped
=== RUN   TestAccRoleAssignment_subscriptionScoped
    role_assignment_resource_test.go:237: Skipping this test as only elevated user account is able to run the test (i.e. via CLI auth)
--- SKIP: TestAccRoleAssignment_subscriptionScoped (0.00s)
=== RUN   TestAccRoleAssignment_resourceGroupScoped
=== PAUSE TestAccRoleAssignment_resourceGroupScoped
=== CONT  TestAccRoleAssignment_custom
=== CONT  TestAccRoleAssignmentMarketplace_emptyName
=== CONT  TestAccRoleAssignmentMarketplace_ServicePrincipalGroup
=== CONT  TestAccRoleAssignmentMarketplace_ServicePrincipal
=== CONT  TestAccRoleAssignmentMarketplace_ServicePrincipalWithType
=== CONT  TestAccRoleAssignment_dataActions
=== CONT  TestAccRoleAssignment_builtin
=== CONT  TestAccRoleAssignment_emptyName
=== CONT  TestAccRoleAssignmentMarketplace_builtin
=== CONT  TestAccRoleAssignment_managementGroup
--- PASS: TestAccRoleAssignment_dataActions (50.83s)
--- PASS: TestAccRoleAssignment_emptyName (51.61s)
--- PASS: TestAccRoleAssignment_builtin (52.52s)
--- PASS: TestAccRoleAssignment_resourceGroupScoped (134.27s)
--- PASS: TestAccRoleAssignment_custom (746.52s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_assignment` - normalize case of the `scope` property during reads [#26086]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
This relates to https://github.com/hashicorp/terraform-provider-azurerm/issues/20138


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
