### PR TITLE
`azurerm_private_dns_resolver_inbound_endpoint` - remove `Computed` from `private_ip_address`

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -6,6 +6,7 @@ package privatednsresolver
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"time"
 
@@ -80,7 +81,7 @@ func (r PrivateDNSResolverInboundEndpointResource) Arguments() map[string]*plugi
 					"private_ip_address": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						Computed: true,
+						Computed: !features.FourPointOhBeta(),
 					},
 
 					"private_ip_allocation_method": {

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -6,7 +6,6 @@ package privatednsresolver
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
@@ -96,6 +96,27 @@ func TestAccDNSResolverInboundEndpoint_static(t *testing.T) {
 	})
 }
 
+func TestAccDNSResolverInboundEndpoint_staticToDynamic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_private_dns_resolver_inbound_endpoint", "test")
+	r := DNSResolverInboundEndpointResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.static(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r DNSResolverInboundEndpointResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := inboundendpoints.ParseInboundEndpointID(state.ID)
 	if err != nil {
@@ -168,6 +189,10 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
   ip_configurations {
     subnet_id = azurerm_subnet.test.id
   }
+
+  lifecycle {
+    ignore_changes = [ip_configurations.0.private_ip_address]
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -183,6 +208,10 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "import" {
   location                = azurerm_private_dns_resolver_inbound_endpoint.test.location
   ip_configurations {
     subnet_id = azurerm_subnet.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [ip_configurations.0.private_ip_address]
   }
 }
 `, config)
@@ -203,6 +232,10 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
   }
   tags = {
     key = "value"
+  }
+
+  lifecycle {
+    ignore_changes = [ip_configurations.0.private_ip_address]
   }
 }
 `, template, data.RandomInteger)
@@ -236,6 +269,10 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
   }
   tags = {
     key = "updated value"
+  }
+
+  lifecycle {
+    ignore_changes = [ip_configurations.0.private_ip_address]
   }
 }
 `, template, data.RandomInteger)

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
@@ -96,27 +96,6 @@ func TestAccDNSResolverInboundEndpoint_static(t *testing.T) {
 	})
 }
 
-func TestAccDNSResolverInboundEndpoint_staticToDynamic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_private_dns_resolver_inbound_endpoint", "test")
-	r := DNSResolverInboundEndpointResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.static(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (r DNSResolverInboundEndpointResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := inboundendpoints.ParseInboundEndpointID(state.ID)
 	if err != nil {
@@ -208,10 +187,6 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "import" {
   location                = azurerm_private_dns_resolver_inbound_endpoint.test.location
   ip_configurations {
     subnet_id = azurerm_subnet.test.id
-  }
-
-  lifecycle {
-    ignore_changes = [ip_configurations.0.private_ip_address]
   }
 }
 `, config)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to remove `Computed` from `private_ip_address`.

When private_ip_allocation_method is Static, private_ip_address must be set and API would return the corresponding value.

When private_ip_allocation_method is Dynmaic, private_ip_address cannot be set and API would dynamically return default value per virtual network address space. So we need to use ignore_changes instead of Computed for this situation.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/9838c480-2950-42fa-a4f2-7baccc22addc)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_dns_resolver_inbound_endpoint` - remove `Computed` from `private_ip_address`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
