### PR TITLE
`azurerm_api_management_identity_provider_aad`, `azurerm_api_management_identity_provider_aadb2c` - support `client_library` property

### DIFF
--- a/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
@@ -63,6 +63,13 @@ func resourceApiManagementIdentityProviderAAD() *pluginsdk.Resource {
 					ValidateFunc: validation.IsUUID,
 				},
 			},
+
+			"client_library": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 16),
+			},
+
 			"signin_tenant": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -80,6 +87,7 @@ func resourceApiManagementIdentityProviderAADCreateUpdate(d *pluginsdk.ResourceD
 
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
+	clientLibrary := d.Get("client_library").(string)
 	allowedTenants := d.Get("allowed_tenants").([]interface{})
 	signinTenant := d.Get("signin_tenant").(string)
 	id := identityprovider.NewIdentityProviderID(subscriptionId, d.Get("resource_group_name").(string), d.Get("api_management_name").(string), identityprovider.IdentityProviderTypeAad)
@@ -100,6 +108,7 @@ func resourceApiManagementIdentityProviderAADCreateUpdate(d *pluginsdk.ResourceD
 	parameters := identityprovider.IdentityProviderCreateContract{
 		Properties: &identityprovider.IdentityProviderCreateContractProperties{
 			ClientId:       clientID,
+			ClientLibrary:  pointer.To(clientLibrary),
 			ClientSecret:   clientSecret,
 			Type:           pointer.To(identityprovider.IdentityProviderTypeAad),
 			AllowedTenants: utils.ExpandStringSlice(allowedTenants),
@@ -145,6 +154,7 @@ func resourceApiManagementIdentityProviderAADRead(d *pluginsdk.ResourceData, met
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("client_id", props.ClientId)
+			d.Set("client_library", props.ClientLibrary)
 			d.Set("allowed_tenants", pointer.From(props.AllowedTenants))
 			d.Set("signin_tenant", pointer.From(props.SigninTenant))
 		}

--- a/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -88,6 +88,12 @@ func resourceArmApiManagementIdentityProviderAADB2C() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"client_library": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 16),
+			},
+
 			"profile_editing_policy": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -113,6 +119,7 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *pluginsdk.Res
 
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
+	clientLibrary := d.Get("client_library").(string)
 
 	allowedTenant := d.Get("allowed_tenant").(string)
 	signinTenant := d.Get("signin_tenant").(string)
@@ -139,6 +146,7 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *pluginsdk.Res
 	parameters := identityprovider.IdentityProviderCreateContract{
 		Properties: &identityprovider.IdentityProviderCreateContractProperties{
 			ClientId:                 clientID,
+			ClientLibrary:            pointer.To(clientLibrary),
 			ClientSecret:             clientSecret,
 			Type:                     pointer.To(identityprovider.IdentityProviderTypeAadBTwoC),
 			AllowedTenants:           utils.ExpandStringSlice([]interface{}{allowedTenant}),
@@ -186,6 +194,7 @@ func resourceArmApiManagementIdentityProviderAADB2CRead(d *pluginsdk.ResourceDat
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("client_id", props.ClientId)
+			d.Set("client_library", pointer.From(props.ClientLibrary))
 			d.Set("signin_tenant", props.SigninTenant)
 			d.Set("authority", props.Authority)
 			d.Set("signup_policy", props.SignupPolicyName)

--- a/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
@@ -45,6 +45,36 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_clientLibrary(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+	r := ApiManagementIdentityProviderAADB2CResource{}
+	b2cConfig := testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.clientLibrary(data, b2cConfig),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("client_secret"),
+		{
+			Config: r.clientLibraryUpdate(data, b2cConfig),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("client_secret"),
+		{
+			Config: r.clientLibrary(data, b2cConfig),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("client_secret"),
+	})
+}
+
 func TestAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
 	r := ApiManagementIdentityProviderAADB2CResource{}
@@ -148,6 +178,126 @@ resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   resource_group_name    = azurerm_resource_group.test.name
   api_management_name    = azurerm_api_management.test.name
   client_id              = azuread_application.test.application_id
+  client_secret          = azuread_application_password.test.value
+  allowed_tenant         = "%[4]s.onmicrosoft.com"
+  signin_tenant          = "%[4]s.onmicrosoft.com"
+  authority              = "%[4]s.b2clogin.com"
+  signin_policy          = "B2C_1_Login"
+  signup_policy          = "B2C_1_Signup"
+  profile_editing_policy = "B2C_1_EditProfile"
+  password_reset_policy  = "B2C_1_ResetPassword"
+
+  depends_on = [azuread_application_password.test]
+}
+`, b2cConfig["tenant_id"], b2cConfig["client_id"], b2cConfig["client_secret"], b2cConfig["tenant_slug"], data.RandomInteger, data.Locations.Primary)
+}
+
+func (ApiManagementIdentityProviderAADB2CResource) clientLibrary(data acceptance.TestData, b2cConfig map[string]string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {
+  tenant_id     = "%[1]s"
+  client_id     = "%[2]s"
+  client_secret = "%[3]s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[5]d"
+  location = "%[6]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[5]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azuread_application" "test" {
+  display_name = "acctestAM-%[5]d"
+  web {
+    redirect_uris = [azurerm_api_management.test.developer_portal_url]
+
+    implicit_grant {
+      access_token_issuance_enabled = true
+    }
+  }
+}
+
+resource "azuread_application_password" "test" {
+  application_object_id = azuread_application.test.object_id
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "test" {
+  resource_group_name    = azurerm_resource_group.test.name
+  api_management_name    = azurerm_api_management.test.name
+  client_id              = azuread_application.test.application_id
+  client_library         = "MSAL"
+  client_secret          = azuread_application_password.test.value
+  allowed_tenant         = "%[4]s.onmicrosoft.com"
+  signin_tenant          = "%[4]s.onmicrosoft.com"
+  authority              = "%[4]s.b2clogin.com"
+  signin_policy          = "B2C_1_Login"
+  signup_policy          = "B2C_1_Signup"
+  profile_editing_policy = "B2C_1_EditProfile"
+  password_reset_policy  = "B2C_1_ResetPassword"
+
+  depends_on = [azuread_application_password.test]
+}
+`, b2cConfig["tenant_id"], b2cConfig["client_id"], b2cConfig["client_secret"], b2cConfig["tenant_slug"], data.RandomInteger, data.Locations.Primary)
+}
+
+func (ApiManagementIdentityProviderAADB2CResource) clientLibraryUpdate(data acceptance.TestData, b2cConfig map[string]string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {
+  tenant_id     = "%[1]s"
+  client_id     = "%[2]s"
+  client_secret = "%[3]s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[5]d"
+  location = "%[6]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[5]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azuread_application" "test" {
+  display_name = "acctestAM-%[5]d"
+  web {
+    redirect_uris = [azurerm_api_management.test.developer_portal_url]
+
+    implicit_grant {
+      access_token_issuance_enabled = true
+    }
+  }
+}
+
+resource "azuread_application_password" "test" {
+  application_object_id = azuread_application.test.object_id
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "test" {
+  resource_group_name    = azurerm_resource_group.test.name
+  api_management_name    = azurerm_api_management.test.name
+  client_id              = azuread_application.test.application_id
+  client_library         = "MSAL-2"
   client_secret          = azuread_application_password.test.value
   allowed_tenant         = "%[4]s.onmicrosoft.com"
   signin_tenant          = "%[4]s.onmicrosoft.com"

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -50,7 +50,9 @@ The following arguments are supported:
 
 * `allowed_tenants` - (Required) List of allowed AAD Tenants.
 
-* `signin_tenant` - (Optional) The AAD Tenant to use instead of Common when logging into Active Directory
+* `client_library` - (Optional) The client library to be used in the AAD Identity Provider.
+
+* `signin_tenant` - (Optional) The AAD Tenant to use instead of Common when logging into Active Directory.
 
 ---
 

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `signup_policy` - (Required) Signup Policy Name.
 
+* `client_library` - (Optional) The client library to be used in the Azure AD B2C Identity Provider.
+
 ---
 
 * `password_reset_policy` - (Optional) Password reset Policy Name.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support `client_library` property for resources `azurerm_api_management_identity_provider_aad` and `azurerm_api_management_identity_provider_aadb2c`.

Swagger: https://github.com/Azure/azure-rest-api-specs/blob/8322ff8ff0b9818c49e2e6ef7d02e3d0b0333839/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/definitions.json#L3149

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
PASS: TestAccAzureRMApiManagementIdentityProviderAADB2C_clientLibrary (2653.77s)
PASS: TestAccAzureRMApiManagementIdentityProviderAADB2C_basic (1714.90s)
PASS: TestAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport (1900.35s)

```
```
PASS: TestAccApiManagementIdentityProviderAAD_clientLibrary (2021.26s)
PASS: TestAccApiManagementIdentityProviderAAD_basic (2148.77s)
PASS: TestAccApiManagementIdentityProviderAAD_update (1976.15s)
PASS: TestAccApiManagementIdentityProviderAAD_requiresImport (1852.06s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_identity_provider_aad` - support for the `client_library` property [GH-18901]
* `azurerm_api_management_identity_provider_aadb2c` - support for the `client_library` property [GH-18901]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #18901


