### PR TITLE
Refactor - remove last remnants of int from `TypedSDK` resources

### DIFF
--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
@@ -39,7 +39,7 @@ type KeyVaultMHSMKeyResourceSchema struct {
 	ManagedHSMID   string                 `tfschema:"managed_hsm_id"`
 	KeyType        string                 `tfschema:"key_type"`
 	KeyOpts        []string               `tfschema:"key_opts"`
-	KeySize        int                    `tfschema:"key_size"`
+	KeySize        int64                  `tfschema:"key_size"`
 	Curve          string                 `tfschema:"curve"`
 	NotBeforeDate  string                 `tfschema:"not_before_date"`
 	ExpirationDate string                 `tfschema:"expiration_date"`
@@ -329,7 +329,7 @@ func (r KeyVaultMHSMKeyResource) Read() sdk.ResourceFunc {
 					if err != nil {
 						return fmt.Errorf("Could not decode N: %+v", err)
 					}
-					schema.KeySize = len(nBytes) * 8
+					schema.KeySize = int64(len(nBytes) * 8)
 				}
 
 				if attributes := resp.Attributes; attributes != nil {

--- a/internal/services/storage/storage_container_immutability_policy_resource.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource.go
@@ -26,7 +26,7 @@ var _ sdk.ResourceWithUpdate = StorageContainerImmutabilityPolicyResource{}
 
 type ContainerImmutabilityPolicyModel struct {
 	StorageContainerResourceManagerId string `tfschema:"storage_container_resource_manager_id"`
-	ImmutabilityPeriodInDays          int    `tfschema:"immutability_period_in_days"`
+	ImmutabilityPeriodInDays          int64  `tfschema:"immutability_period_in_days"`
 	Locked                            bool   `tfschema:"locked"`
 	ProtectedAppendWritesAllEnabled   bool   `tfschema:"protected_append_writes_all_enabled"`
 	ProtectedAppendWritesEnabled      bool   `tfschema:"protected_append_writes_enabled"`
@@ -155,7 +155,7 @@ func (r StorageContainerImmutabilityPolicyResource) Create() sdk.ResourceFunc {
 				Properties: blobcontainers.ImmutabilityPolicyProperty{
 					AllowProtectedAppendWrites:            pointer.To(model.ProtectedAppendWritesEnabled),
 					AllowProtectedAppendWritesAll:         pointer.To(model.ProtectedAppendWritesAllEnabled),
-					ImmutabilityPeriodSinceCreationInDays: pointer.To(int64(model.ImmutabilityPeriodInDays)),
+					ImmutabilityPeriodSinceCreationInDays: pointer.To(model.ImmutabilityPeriodInDays),
 				},
 			}
 
@@ -224,7 +224,7 @@ func (r StorageContainerImmutabilityPolicyResource) Update() sdk.ResourceFunc {
 				Properties: blobcontainers.ImmutabilityPolicyProperty{
 					AllowProtectedAppendWrites:            pointer.To(model.ProtectedAppendWritesEnabled),
 					AllowProtectedAppendWritesAll:         pointer.To(model.ProtectedAppendWritesAllEnabled),
-					ImmutabilityPeriodSinceCreationInDays: pointer.To(int64(model.ImmutabilityPeriodInDays)),
+					ImmutabilityPeriodSinceCreationInDays: pointer.To(model.ImmutabilityPeriodInDays),
 				},
 			}
 
@@ -293,7 +293,7 @@ func (r StorageContainerImmutabilityPolicyResource) Read() sdk.ResourceFunc {
 					state.ProtectedAppendWritesAllEnabled = *props.AllowProtectedAppendWritesAll
 				}
 				if props.ImmutabilityPeriodSinceCreationInDays != nil {
-					state.ImmutabilityPeriodInDays = int(*props.ImmutabilityPeriodSinceCreationInDays)
+					state.ImmutabilityPeriodInDays = *props.ImmutabilityPeriodSinceCreationInDays
 				}
 				if props.State != nil {
 					state.Locked = *props.State == blobcontainers.ImmutabilityPolicyStateLocked


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Refactors the last 2 instances of `int` where `int64` should be used.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_managed_hardware_security_module_key` - refactored `KeySize` internally to `int64` [GH-26109]
* `azurerm_storage_container_immutability_policy` - refactored `ImmutabilityPeriodInDays` internally to `int64` [GH-26109]
