### PR TITLE
new datasource `azurerm_elastic_san_volume_group`

### DIFF
--- a/internal/services/elasticsan/elastic_san_volume_group_data_source.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_data_source.go
@@ -1,0 +1,171 @@
+package elasticsan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/volumegroups"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ElasticSANVolumeGroupDataSource struct{}
+
+var _ sdk.DataSource = ElasticSANVolumeGroupDataSource{}
+
+type ElasticSANVolumeGroupDataSourceModel struct {
+	SanId          string                                          `tfschema:"elastic_san_id"`
+	EncryptionType string                                          `tfschema:"encryption_type"`
+	Encryption     []ElasticSANVolumeGroupResourceEncryptionModel  `tfschema:"encryption"`
+	Identity       []identity.ModelSystemAssignedUserAssigned      `tfschema:"identity"`
+	Name           string                                          `tfschema:"name"`
+	NetworkRule    []ElasticSANVolumeGroupResourceNetworkRuleModel `tfschema:"network_rule"`
+	ProtocolType   string                                          `tfschema:"protocol_type"`
+}
+
+func (r ElasticSANVolumeGroupDataSource) ResourceType() string {
+	return "azurerm_elastic_san_volume_group"
+}
+
+func (r ElasticSANVolumeGroupDataSource) ModelObject() interface{} {
+	return &ElasticSANVolumeGroupDataSourceModel{}
+}
+
+func (r ElasticSANVolumeGroupDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.ElasticSanVolumeGroupName,
+		},
+
+		"elastic_san_id": commonschema.ResourceIDReferenceRequired(&volumegroups.ElasticSanId{}),
+	}
+}
+
+func (r ElasticSANVolumeGroupDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"encryption_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"encryption": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"key_vault_key_id": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+					"user_assigned_identity_id": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+					"current_versioned_key_expiration_timestamp": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+					"current_versioned_key_id": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+					"last_key_rotation_timestamp": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+				},
+			},
+		},
+
+		"network_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"subnet_id": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+					"action": {
+						Computed: true,
+						Type:     pluginsdk.TypeString,
+					},
+				},
+			},
+		},
+
+		"protocol_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
+	}
+}
+
+func (r ElasticSANVolumeGroupDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ElasticSan.VolumeGroups
+
+			var state ElasticSANVolumeGroupDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			elasticSanId, err := volumegroups.ParseElasticSanID(state.SanId)
+			if err != nil {
+				return err
+			}
+
+			id := volumegroups.NewVolumeGroupID(elasticSanId.SubscriptionId, elasticSanId.ResourceGroupName, elasticSanId.ElasticSanName, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s does not exist", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				state.SanId = elasticSanId.ID()
+				state.Name = id.VolumeGroupName
+
+				flattenedIdentity, err := identity.FlattenSystemOrUserAssignedMapToModel(model.Identity)
+				if err != nil {
+					return fmt.Errorf("flattening identity: %+v", err)
+				}
+				state.Identity = *flattenedIdentity
+
+				if model.Properties != nil {
+					state.EncryptionType = string(pointer.From(model.Properties.Encryption))
+					state.NetworkRule = FlattenVolumeGroupNetworkRules(model.Properties.NetworkAcls)
+
+					if model.Properties.ProtocolType != nil {
+						state.ProtocolType = string(pointer.From(model.Properties.ProtocolType))
+					}
+
+					state.Encryption, err = FlattenVolumeGroupEncryption(model.Properties.EncryptionProperties)
+					if err != nil {
+						return fmt.Errorf("flattening encryption: %+v", err)
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/elasticsan/elastic_san_volume_group_data_source.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_data_source.go
@@ -138,13 +138,13 @@ func (r ElasticSANVolumeGroupDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			if model := resp.Model; model != nil {
-				state.SanId = elasticSanId.ID()
-				state.Name = id.VolumeGroupName
+			state.SanId = elasticSanId.ID()
+			state.Name = id.VolumeGroupName
 
+			if model := resp.Model; model != nil {
 				flattenedIdentity, err := identity.FlattenSystemOrUserAssignedMapToModel(model.Identity)
 				if err != nil {
-					return fmt.Errorf("flattening identity: %+v", err)
+					return fmt.Errorf("flattening `identity`: %+v", err)
 				}
 				state.Identity = *flattenedIdentity
 
@@ -158,7 +158,7 @@ func (r ElasticSANVolumeGroupDataSource) Read() sdk.ResourceFunc {
 
 					state.Encryption, err = FlattenVolumeGroupEncryption(model.Properties.EncryptionProperties)
 					if err != nil {
-						return fmt.Errorf("flattening encryption: %+v", err)
+						return fmt.Errorf("flattening `encryption`: %+v", err)
 					}
 				}
 			}

--- a/internal/services/elasticsan/elastic_san_volume_group_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_data_source_test.go
@@ -42,7 +42,7 @@ func (d ElasticSANVolumeGroupDataSource) basic(data acceptance.TestData) string 
 %s
 
 data "azurerm_elastic_san_volume_group" "test" {
-  name           = azurerm_elastic_san_volume_group.test.nameelastic_san_id
+  name           = azurerm_elastic_san_volume_group.test.name
   elastic_san_id = azurerm_elastic_san_volume_group.test.elastic_san_id
 }
 `, ElasticSANVolumeGroupTestResource{}.complete(data))

--- a/internal/services/elasticsan/elastic_san_volume_group_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_data_source_test.go
@@ -1,0 +1,49 @@
+package elasticsan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ElasticSANVolumeGroupDataSource struct{}
+
+func TestAccElasticSANVolumeGroupDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_elastic_san_volume_group", "test")
+	d := ElasticSANVolumeGroupDataSource{}
+
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("encryption_type").HasValue("EncryptionAtRestWithCustomerManagedKey"),
+				check.That(data.ResourceName).Key("protocol_type").HasValue("Iscsi"),
+				check.That(data.ResourceName).Key("encryption.#").HasValue("1"),
+				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("encryption.0.user_assigned_identity_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("encryption.0.current_versioned_key_expiration_timestamp").IsNotEmpty(),
+				check.That(data.ResourceName).Key("encryption.0.current_versioned_key_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("encryption.0.last_key_rotation_timestamp").IsNotEmpty(),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("network_rule.#").HasValue("2"),
+				check.That(data.ResourceName).Key("network_rule.0.subnet_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("network_rule.0.action").HasValue("Allow"),
+			),
+		},
+	})
+}
+
+func (d ElasticSANVolumeGroupDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_elastic_san_volume_group" "test" {
+  name           = azurerm_elastic_san_volume_group.test.nameelastic_san_id
+  elastic_san_id = azurerm_elastic_san_volume_group.test.elastic_san_id
+}
+`, ElasticSANVolumeGroupTestResource{}.complete(data))
+}

--- a/internal/services/elasticsan/registration.go
+++ b/internal/services/elasticsan/registration.go
@@ -20,6 +20,7 @@ func (Registration) Name() string {
 func (Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		ElasticSANDataSource{},
+		ElasticSANVolumeGroupDataSource{},
 	}
 }
 

--- a/website/docs/d/elastic_san_volume_group.html.markdown
+++ b/website/docs/d/elastic_san_volume_group.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "Elastic SAN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_elastic_san_volume_group"
+description: |-
+  Gets information about an existing Elastic SAN Volume Group.
+---
+
+# Data Source: azurerm_elastic_san_volume_group
+
+Use this data source to access information about an existing Elastic SAN Volume Group.
+
+## Example Usage
+
+```hcl
+data "azurerm_elastic_san" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+data "azurerm_elastic_san_volume_group" "example" {
+  name           = "existing"
+  elastic_san_id = data.azurerm_elastic_san.example.id
+}
+
+output "id" {
+  value = data.azurerm_elastic_san_volume_group.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - The name of the Elastic SAN Volume Group.
+
+* `elastic_san_id` - The Elastic SAN ID within which the Elastic SAN Volume Group exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Elastic SAN.
+
+* `encryption_type` - The type of the key used to encrypt the data of the disk.
+
+* `encryption` - An `encryption` block as defined below.
+
+* `identity` - An `identity` block as defined below.
+
+* `network_rule` - One or more `network_rule` blocks as defined below.
+
+* `protocol_type` - The type of the storage target.
+
+---
+
+An `encryption` block exports the following arguments:
+
+* `key_vault_key_id` - The Key Vault key URI for Customer Managed Key encryption, which can be either a full URI or a versionless URI.
+
+* `user_assigned_identity_id` - The ID of the User Assigned Identity used by this Elastic SAN Volume Group.
+
+* `current_versioned_key_expiration_timestamp` - The timestamp of the expiration time for the current version of the customer managed key.
+
+* `current_versioned_key_id` - The ID of the current versioned Key Vault Key in use.
+
+* `last_key_rotation_timestamp` - The timestamp of the last rotation of the Key Vault Key.
+
+---
+
+An `identity` block exports the following arguments:
+
+* `type` - The type of Managed Identity assigned to this Elastic SAN Volume Group.
+
+* `identity_ids` - A list of the User Assigned Identity IDs assigned to this Elastic SAN Volume Group.
+
+* `principal_id` - The Principal ID associated with the Managed Service Identity assigned to this Elastic SAN Volume Group.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity assigned to this Elastic SAN Volume Group.
+
+---
+
+A `network_rule` block exports the following arguments:
+
+* `subnet_id` - The ID of the Subnet which is allowed to access this Elastic SAN Volume Group.
+
+* `action` - The action to take when the Subnet attempts to access this Elastic SAN Volume Group.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Elastic SAN Volume Group.

--- a/website/docs/d/elastic_san_volume_group.html.markdown
+++ b/website/docs/d/elastic_san_volume_group.html.markdown
@@ -56,11 +56,11 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 An `encryption` block exports the following arguments:
 
-* `key_vault_key_id` - The Key Vault key URI for Customer Managed Key encryption, which can be either a full URI or a versionless URI.
+* `key_vault_key_id` - The Key Vault Key URI for Customer Managed Key encryption, which can be either a full URI or a versionless URI.
 
 * `user_assigned_identity_id` - The ID of the User Assigned Identity used by this Elastic SAN Volume Group.
 
-* `current_versioned_key_expiration_timestamp` - The timestamp of the expiration time for the current version of the customer managed key.
+* `current_versioned_key_expiration_timestamp` - The timestamp of the expiration time for the current version of the Customer Managed Key.
 
 * `current_versioned_key_id` - The ID of the current versioned Key Vault Key in use.
 
@@ -82,9 +82,9 @@ An `identity` block exports the following arguments:
 
 A `network_rule` block exports the following arguments:
 
-* `subnet_id` - The ID of the Subnet which is allowed to access this Elastic SAN Volume Group.
+* `subnet_id` - The ID of the Subnet from which access to this Elastic SAN Volume Group is allowed.
 
-* `action` - The action to take when the Subnet attempts to access this Elastic SAN Volume Group.
+* `action` - The action to take when an access attempt to this Elastic SAN Volume Group from this Subnet is made.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
new datasource `azurerm_elastic_san_volume_group`
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
TF_ACC=1 go test -v ./internal/services/elasticsan -parallel 5 -run TestAccElasticSANVolumeGroupData -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccElasticSANVolumeGroupDataSource_basic
--- PASS: TestAccElasticSANVolumeGroupDataSource_basic (323.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan    323.645s
```
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* new datasource `azurerm_elastic_san_volume_group`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
