### PR TITLE
New resource: postgresql_flexible_server_firewall_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 
+* `azurerm_kusto_cluster` - support `None` pattern for the `virtual_network_configuration` block [GH-24733]
 * `azurerm_linux_function_app` - support for the Node `20` runtime [GH-24073]
 * `azurerm_linux_function_app_slot` - support for the Node `20` runtime [GH-24073]
 * `azurerm_windows_function_app` - support for the Node `20` runtime [GH-24073]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * `azurerm_container_app_custom_domain` - fix resource ID parsing bug preventing import [GH-25192]
+* `azurerm_windows_web_app` - fix incorrect warning message when checking name availability [GH-25214]
 * `azurerm_virtual_machine_run_command` - prevent a bug during updates [GH-25186]
 
 ## 3.95.0 (March 08, 2024)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -196,6 +196,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		nginx.Registration{},
 		paloalto.Registration{},
 		policy.Registration{},
+		postgres.Registration{},
 		privatednsresolver.Registration{},
 		recoveryservices.Registration{},
 		redhatopenshift.Registration{},

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -98,7 +98,7 @@ func (r FlexibleServerFirewallRulesResource) ModelObject() interface{} {
 }
 
 func (r FlexibleServerFirewallRulesResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
-	return firewallrules.ValidateFirewallRuleID
+	return servers.ValidateFlexibleServerID
 }
 
 func (r FlexibleServerFirewallRulesResource) Create() sdk.ResourceFunc {

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -1,0 +1,185 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func resourcePostgresqlFlexibleServerFirewallRules() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate,
+		Read:   resourcePostgresqlFlexibleServerFirewallRulesRead,
+		Update: resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate,
+		Delete: resourcePostgresqlFlexibleServerFirewallRulesDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := firewallrules.ParseFirewallRuleID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"server_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: firewallrules.ValidateFlexibleServerID,
+			},
+
+			"address": {
+				Type:       pluginsdk.TypeSet,
+				Optional:   false,
+				ConfigMode: pluginsdk.SchemaConfigModeBlock,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validate.FlexibleServerFirewallRuleName,
+						},
+
+						"end_ip_address": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+
+						"start_ip_address": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+					},
+				},
+				Set: hashPostgresqlFlexibleServerFirewallRule,
+			},
+		},
+	}
+}
+
+func resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	serverId, err := firewallrules.ParseFlexibleServerID(d.Get("server_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := firewallrules.NewFirewallRuleID(subscriptionId, serverId.ResourceGroupName, serverId.FlexibleServerName, d.Get("name").(string))
+
+	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for present of existing %q: %+v", id, err)
+			}
+		}
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_postgresql_flexible_server_firewall_rule", id.ID())
+		}
+	}
+
+	properties := firewallrules.FirewallRule{
+		Properties: firewallrules.FirewallRuleProperties{
+			EndIPAddress:   d.Get("end_ip_address").(string),
+			StartIPAddress: d.Get("start_ip_address").(string),
+		},
+	}
+
+	if err = client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
+		return fmt.Errorf("creating/updating %q: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourcePostgresqlFlexibleServerFirewallRulesRead(d, meta)
+}
+
+func resourcePostgresqlFlexibleServerFirewallRulesRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := firewallrules.ParseFirewallRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] Postgresql Flexible Server Firewall Rule %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %q: %+v", id, err)
+	}
+	d.Set("name", id.FirewallRuleName)
+	d.Set("server_id", firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
+
+	if model := resp.Model; model != nil {
+		d.Set("end_ip_address", model.Properties.EndIPAddress)
+		d.Set("start_ip_address", model.Properties.StartIPAddress)
+	}
+	return nil
+}
+
+func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := firewallrules.ParseFirewallRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %q: %+v", id, err)
+	}
+
+	return nil
+}
+
+func hashPostgresqlFlexibleServerFirewallRule(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
+	buf.WriteString(m["range_end"].(string))
+
+	return pluginsdk.HashString(buf.String())
+}

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -54,9 +54,9 @@ func resourcePostgresqlFlexibleServerFirewallRules() *pluginsdk.Resource {
 				ValidateFunc: firewallrules.ValidateFlexibleServerID,
 			},
 
-			"address": {
+			"firewall_rule": {
 				Type:       pluginsdk.TypeSet,
-				Optional:   false,
+				Required:   true,
 				ConfigMode: pluginsdk.SchemaConfigModeBlock,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -122,7 +122,7 @@ func resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate(d *pluginsdk.Reso
 	// Build a list of what the firewall rules should look like
 	correctFirewallRules := make([]FirewallRuleWithId, 0)
 
-	for _, address := range d.Get("address").(*pluginsdk.Set).List() {
+	for _, address := range d.Get("firewall_rule").(*pluginsdk.Set).List() {
 		addressMap := address.(map[string]interface{})
 		fwRule := firewallrules.FirewallRule{
 			Properties: firewallrules.FirewallRuleProperties{
@@ -234,7 +234,7 @@ func resourcePostgresqlFlexibleServerFirewallRulesRead(d *pluginsdk.ResourceData
 			"start_ip_address": rule.Properties.StartIPAddress,
 		})
 	}
-	d.Set("address", addresses)
+	d.Set("firewall_rule", addresses)
 	return nil
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -290,11 +290,16 @@ func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceDa
 
 func hashPostgresqlFlexibleServerFirewallRule(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
-	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
-	buf.WriteString(m["range_end"].(string))
-
+	if m, ok := v.(map[string]interface{}); ok {
+		if v, ok := m["name"]; ok {
+			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
+		}
+		if v, ok := m["start_ip_address"]; ok {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+		if v, ok := m["end_ip_address"]; ok {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+	}
 	return pluginsdk.HashString(buf.String())
 }

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/servers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
@@ -20,6 +21,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+type FirewallRuleWithId struct {
+	Id           firewallrules.FirewallRuleId
+	FirewallRule firewallrules.FirewallRule
+}
 
 func resourcePostgresqlFlexibleServerFirewallRules() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -82,41 +88,112 @@ func resourcePostgresqlFlexibleServerFirewallRules() *pluginsdk.Resource {
 
 func resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	firewall_rules_client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	flexible_servers_client := meta.(*clients.Client).Postgres.FlexibleServersClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	serverId, err := firewallrules.ParseFlexibleServerID(d.Get("server_id").(string))
+	id, err := servers.ParseFlexibleServerID(d.Get("server_id").(string))
 	if err != nil {
 		return err
 	}
 
-	id := firewallrules.NewFirewallRuleID(subscriptionId, serverId.ResourceGroupName, serverId.FlexibleServerName, d.Get("name").(string))
-
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for present of existing %q: %+v", id, err)
+	resp, err := flexible_servers_client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] Postgresql Flexibleserver %q does not exist", d.Id())
+			return err
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	flexibleServerId := firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName)
+
+	listFirewallRulesResult, err := firewall_rules_client.ListByServerComplete(ctx, flexibleServerId)
+	if err != nil {
+		return err
+	}
+
+	currentFirewallRules := listFirewallRulesResult.Items
+
+	// Build a list of what the firewall rules should look like
+	correctFirewallRules := make([]FirewallRuleWithId, 0)
+
+	for _, address := range d.Get("address").(*pluginsdk.Set).List() {
+		addressMap := address.(map[string]interface{})
+		fwRule := firewallrules.FirewallRule{
+			Properties: firewallrules.FirewallRuleProperties{
+				EndIPAddress:   addressMap["end_ip_address"].(string),
+				StartIPAddress: addressMap["start_ip_address"].(string),
+			},
+		}
+		fwRuleId := firewallrules.NewFirewallRuleID(subscriptionId, flexibleServerId.ResourceGroupName, flexibleServerId.FlexibleServerName, addressMap["name"].(string))
+		correctFirewallRules = append(correctFirewallRules, FirewallRuleWithId{Id: fwRuleId, FirewallRule: fwRule})
+	}
+
+	rulesToDelete := make([]firewallrules.FirewallRuleId, 0)
+	rulesToCreateUpdate := make([]FirewallRuleWithId, 0)
+
+	// Iterate through the current firewall rules and compare them to the desired state
+	// Any firewall rules that do not appear in the desired state should be deleted
+	for _, currentRule := range currentFirewallRules {
+		found := false
+		for _, correctRule := range correctFirewallRules {
+			if *currentRule.Name == *&correctRule.Id.FirewallRuleName {
+				found = true
+				break
 			}
 		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_postgresql_flexible_server_firewall_rule", id.ID())
+		if !found {
+			rulesToDelete = append(rulesToDelete, firewallrules.NewFirewallRuleID(subscriptionId, flexibleServerId.ResourceGroupName, flexibleServerId.FlexibleServerName, *currentRule.Name))
 		}
 	}
 
-	properties := firewallrules.FirewallRule{
-		Properties: firewallrules.FirewallRuleProperties{
-			EndIPAddress:   d.Get("end_ip_address").(string),
-			StartIPAddress: d.Get("start_ip_address").(string),
-		},
+	// Iterate through the desired firewall rules and compare them to the current state
+	// Any firewall rules that do not appear in the current state should be created
+	// Any firewall rules that do appear in the current state but have different properties should be updated
+	for _, correctRule := range correctFirewallRules {
+		found := false
+		for _, currentRule := range currentFirewallRules {
+			if *currentRule.Name == *&correctRule.Id.FirewallRuleName {
+				found = true
+				if currentRule.Properties.StartIPAddress != correctRule.FirewallRule.Properties.StartIPAddress || currentRule.Properties.EndIPAddress != correctRule.FirewallRule.Properties.EndIPAddress {
+					rulesToCreateUpdate = append(rulesToCreateUpdate, correctRule)
+				}
+				break
+			}
+		}
+		if !found {
+			rulesToCreateUpdate = append(rulesToCreateUpdate, correctRule)
+		}
 	}
 
-	if err = client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
-		return fmt.Errorf("creating/updating %q: %+v", id, err)
+	// The lists of rules to Create/Update/Delete have been built
+	pollers := make([]pollers.Poller, 0)
+
+	for _, rule := range rulesToDelete {
+		poller, err := firewall_rules_client.Delete(ctx, rule)
+		if err != nil {
+			return fmt.Errorf("deleting %q: %+v", rule, err)
+		}
+		pollers = append(pollers, poller.Poller)
+	}
+
+	for _, rule := range rulesToCreateUpdate {
+		poller, err := firewall_rules_client.CreateOrUpdate(ctx, rule.Id, rule.FirewallRule)
+		if err != nil {
+			return fmt.Errorf("creating/updating %q: %+v", rule.Id, err)
+		}
+		pollers = append(pollers, poller.Poller)
+	}
+
+	for _, poller := range pollers {
+		if err := poller.PollUntilDone(ctx); err != nil {
+			return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+		}
 	}
 
 	d.SetId(id.ID())
@@ -125,40 +202,50 @@ func resourcePostgresqlFlexibleServerFirewallRulesCreateUpdate(d *pluginsdk.Reso
 
 func resourcePostgresqlFlexibleServerFirewallRulesRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	firewall_rules_client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	flexible_servers_client := meta.(*clients.Client).Postgres.FlexibleServersClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := firewallrules.ParseFirewallRuleID(d.Id())
+	id, err := servers.ParseFlexibleServerID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, *id)
+	resp, err := flexible_servers_client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[INFO] Postgresql Flexible Server Firewall Rule %q does not exist - removing from state", d.Id())
+			log.Printf("[INFO] Postgresql Flexibleserver %q does not exist - removing firewall rules from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("retrieving %q: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	d.Set("name", id.FirewallRuleName)
-	d.Set("server_id", firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
 
-	if model := resp.Model; model != nil {
-		d.Set("end_ip_address", model.Properties.EndIPAddress)
-		d.Set("start_ip_address", model.Properties.StartIPAddress)
+	flexibleServerId := firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName)
+
+	d.Set("server_id", id.ID())
+	addresses := make([]map[string]interface{}, 0)
+	fwRules, err := firewall_rules_client.ListByServerComplete(ctx, flexibleServerId)
+	for _, rule := range fwRules.Items {
+		addresses = append(addresses, map[string]interface{}{
+			"name":             rule.Name,
+			"end_ip_address":   rule.Properties.EndIPAddress,
+			"start_ip_address": rule.Properties.StartIPAddress,
+		})
 	}
+	d.Set("address", addresses)
 	return nil
 }
 
 func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	firewall_rules_client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
+	flexible_servers_client := meta.(*clients.Client).Postgres.FlexibleServersClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := firewallrules.ParseFirewallRuleID(d.Id())
+	id, err := servers.ParseFlexibleServerID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -166,8 +253,36 @@ func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceDa
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-	if err = client.DeleteThenPoll(ctx, *id); err != nil {
-		return fmt.Errorf("deleting %q: %+v", id, err)
+	resp, err := flexible_servers_client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] Postgresql Flexibleserver %q does not exist", d.Id())
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	flexibleServerId := firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName)
+
+	listFirewallRulesResult, err := firewall_rules_client.ListByServerComplete(ctx, flexibleServerId)
+	if err != nil {
+		return err
+	}
+
+	pollers := make([]pollers.Poller, 0)
+
+	for _, rule := range listFirewallRulesResult.Items {
+		poller, err := firewall_rules_client.Delete(ctx, firewallrules.NewFirewallRuleID(subscriptionId, flexibleServerId.ResourceGroupName, flexibleServerId.FlexibleServerName, *rule.Name))
+		if err != nil {
+			return fmt.Errorf("deleting %q: %+v", rule.Name, err)
+		}
+		pollers = append(pollers, poller.Poller)
+	}
+
+	for _, poller := range pollers {
+		if err := poller.PollUntilDone(ctx); err != nil {
+			return fmt.Errorf("polling after Delete: %+v", err)
+		}
 	}
 
 	return nil

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
@@ -85,11 +85,11 @@ func (PostgresqlFlexibleServerFirewallRulesResource) basic(data acceptance.TestD
 %s
 
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-  server_id        = azurerm_postgresql_flexible_server.test.id
+  server_id = azurerm_postgresql_flexible_server.test.id
   firewall_rule {
-	name             = "acctest-FSFR-%d"
-	start_ip_address = "122.122.0.0"
-	end_ip_address   = "122.122.0.0"
+    name             = "acctest-FSFR-%d"
+    start_ip_address = "122.122.0.0"
+    end_ip_address   = "122.122.0.0"
   }
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
@@ -100,12 +100,12 @@ func (r PostgresqlFlexibleServerFirewallRulesResource) update(data acceptance.Te
 %s
 
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-	server_id        = azurerm_postgresql_flexible_server.test.id
-		firewall_rule {
-		name             = "acctest-FSFR-%d"
-		start_ip_address = "123.0.0.0"
-		end_ip_address   = "123.0.0.0"
-	}
+  server_id = azurerm_postgresql_flexible_server.test.id
+  firewall_rule {
+    name             = "acctest-FSFR-%d"
+    start_ip_address = "123.0.0.0"
+    end_ip_address   = "123.0.0.0"
+  }
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
@@ -108,7 +108,7 @@ func (r PostgresqlFlexibleServerFirewallRulesResource) requiresImport(data accep
 %s
 
 resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
-  server_id        = azurerm_postgresql_flexible_server_firewall_rules.test.server_id
+  server_id        = azurerm_postgresql_flexible_server_firewall_rules.test.id
   firewall_rule {
 	name             = "acctest-FSFR"
 	start_ip_address = "122.122.0.0"

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
@@ -91,12 +91,13 @@ func (PostgresqlFlexibleServerFirewallRulesResource) Exists(ctx context.Context,
 func (PostgresqlFlexibleServerFirewallRulesResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-  server_id = azurerm_postgresql_flexible_server.test.id
+  server_id        = azurerm_postgresql_flexible_server.test.id
   firewall_rule {
-    name             = "acctest-FSFR-%d"
-    start_ip_address = "122.122.0.0"
-    end_ip_address   = "122.122.0.0"
+	name             = "acctest-FSFR-%d"
+	start_ip_address = "122.122.0.0"
+	end_ip_address   = "122.122.0.0"
   }
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
@@ -105,12 +106,13 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
 func (r PostgresqlFlexibleServerFirewallRulesResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+
 resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
-  server_id = azurerm_postgresql_flexible_server_firewall_rules.test.id
+  server_id        = azurerm_postgresql_flexible_server_firewall_rules.test.id
   firewall_rule {
-    name             = "acctest-FSFR"
-    start_ip_address = "122.122.0.0"
-    end_ip_address   = "122.122.0.0"
+	name             = "acctest-FSFR"
+	start_ip_address = "122.122.0.0"
+	end_ip_address   = "122.122.0.0"
   }
 }
 `, r.basic(data))
@@ -119,13 +121,14 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
 func (r PostgresqlFlexibleServerFirewallRulesResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-  server_id = azurerm_postgresql_flexible_server.test.id
-  firewall_rule {
-    name             = "acctest-FSFR-%d"
-    start_ip_address = "123.0.0.0"
-    end_ip_address   = "123.0.0.0"
-  }
+	server_id        = azurerm_postgresql_flexible_server.test.id
+		firewall_rule {
+		name             = "acctest-FSFR-%d"
+		start_ip_address = "123.0.0.0"
+		end_ip_address   = "123.0.0.0"
+	}
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
@@ -91,13 +91,12 @@ func (PostgresqlFlexibleServerFirewallRulesResource) Exists(ctx context.Context,
 func (PostgresqlFlexibleServerFirewallRulesResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-  server_id        = azurerm_postgresql_flexible_server.test.id
+  server_id = azurerm_postgresql_flexible_server.test.id
   firewall_rule {
-	name             = "acctest-FSFR-%d"
-	start_ip_address = "122.122.0.0"
-	end_ip_address   = "122.122.0.0"
+    name             = "acctest-FSFR-%d"
+    start_ip_address = "122.122.0.0"
+    end_ip_address   = "122.122.0.0"
   }
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
@@ -106,13 +105,12 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
 func (r PostgresqlFlexibleServerFirewallRulesResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
 resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
-  server_id        = azurerm_postgresql_flexible_server_firewall_rules.test.id
+  server_id = azurerm_postgresql_flexible_server_firewall_rules.test.id
   firewall_rule {
-	name             = "acctest-FSFR"
-	start_ip_address = "122.122.0.0"
-	end_ip_address   = "122.122.0.0"
+    name             = "acctest-FSFR"
+    start_ip_address = "122.122.0.0"
+    end_ip_address   = "122.122.0.0"
   }
 }
 `, r.basic(data))
@@ -121,14 +119,13 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
 func (r PostgresqlFlexibleServerFirewallRulesResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
 resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
-	server_id        = azurerm_postgresql_flexible_server.test.id
-		firewall_rule {
-		name             = "acctest-FSFR-%d"
-		start_ip_address = "123.0.0.0"
-		end_ip_address   = "123.0.0.0"
-	}
+  server_id = azurerm_postgresql_flexible_server.test.id
+  firewall_rule {
+    name             = "acctest-FSFR-%d"
+    start_ip_address = "123.0.0.0"
+    end_ip_address   = "123.0.0.0"
+  }
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
 }

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -48,6 +48,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_postgresql_active_directory_administrator":                 resourcePostgreSQLAdministrator(),
 		"azurerm_postgresql_flexible_server":                                resourcePostgresqlFlexibleServer(),
 		"azurerm_postgresql_flexible_server_firewall_rule":                  resourcePostgresqlFlexibleServerFirewallRule(),
+		"azurerm_postgresql_flexible_server_firewall_rules":                 resourcePostgresqlFlexibleServerFirewallRules(),
 		"azurerm_postgresql_flexible_server_configuration":                  resourcePostgresqlFlexibleServerConfiguration(),
 		"azurerm_postgresql_flexible_server_database":                       resourcePostgresqlFlexibleServerDatabase(),
 		"azurerm_postgresql_flexible_server_active_directory_administrator": resourcePostgresqlFlexibleServerAdministrator(),

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -11,6 +11,7 @@ import (
 type Registration struct{}
 
 var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var _ sdk.TypedServiceRegistration = Registration{}
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/postgresql"
@@ -48,9 +49,18 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_postgresql_active_directory_administrator":                 resourcePostgreSQLAdministrator(),
 		"azurerm_postgresql_flexible_server":                                resourcePostgresqlFlexibleServer(),
 		"azurerm_postgresql_flexible_server_firewall_rule":                  resourcePostgresqlFlexibleServerFirewallRule(),
-		"azurerm_postgresql_flexible_server_firewall_rules":                 resourcePostgresqlFlexibleServerFirewallRules(),
 		"azurerm_postgresql_flexible_server_configuration":                  resourcePostgresqlFlexibleServerConfiguration(),
 		"azurerm_postgresql_flexible_server_database":                       resourcePostgresqlFlexibleServerDatabase(),
 		"azurerm_postgresql_flexible_server_active_directory_administrator": resourcePostgresqlFlexibleServerAdministrator(),
+	}
+}
+
+func (Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		FlexibleServerFirewallRulesResource{},
 	}
 }

--- a/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a group of PostgreSQL Flexible Server Firewall Rules.
 
-~> **NOTE:** It's possible to define Flexible Server Firewall Rules individually with [the `postgresql_flexible_server_firewall_rule` resource](postgresql_flexible_server_firewall_rule.html) or in groups with [the `postgresql_flexible_server_firewall_rules` resource](postgresql_flexible_server_firewall_rules.html). But, it's not possible to use both methods to manage Firewall Rules within a PostgreSQL Flexible Server, since there will be conflicts.
+~> **NOTE:** It's possible to define Flexible Server Firewall Rules individually with [the `postgresql_flexible_server_firewall_rule` resource](postgresql_flexible_server_firewall_rule.html) or in groups with [the `postgresql_flexible_server_firewall_rules` resource](postgresql_flexible_server_firewall_rules.html). But, it's not possible to use both methods to manage Firewall Rules within a PostgreSQL Flexible Server, as this resource manages all the rules for a server, and will overwrite any rules not listed.
 
 ## Example Usage
 
@@ -38,7 +38,7 @@ resource "azurerm_postgresql_flexible_server" "example" {
 }
 
 resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
-  server_id        = azurerm_postgresql_flexible_server.example.id
+  server_id = azurerm_postgresql_flexible_server.example.id
 
   firewall_rule {
     name             = "ruleA"
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create these PostgreSQL Flexible Server Firewall Rules. Changing this forces a new resource to be created.
 
-* `firewall_rule` - (Optional) A `firewall_rule` object as defined below. Changing this forces a new resource to be created.
+* `firewall_rule` - (Required) One or more `firewall_rule` objects as defined below.
 
 ---
 

--- a/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_postgresql_flexible_server_firewall_rule"
+description: |-
+  Manages a PostgreSQL Flexible Server Firewall Rule.
+---
+
+# azurerm_postgresql_flexible_server_firewall_rules
+
+Manages a group of PostgreSQL Flexible Server Firewall Rules.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_postgresql_flexible_server" "example" {
+  name                   = "example-psqlflexibleserver"
+  resource_group_name    = azurerm_resource_group.example.name
+  location               = azurerm_resource_group.example.location
+  version                = "12"
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+
+  storage_mb = 32768
+
+  sku_name = "GP_Standard_D4s_v3"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
+  name             = "example-fw"
+  server_id        = azurerm_postgresql_flexible_server.example.id
+  start_ip_address = "122.122.0.0"
+  end_ip_address   = "122.122.0.0"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
+  server_id        = azurerm_postgresql_flexible_server.example.id
+
+  firewall_rule {
+    name             = "ruleA"
+    start_ip_address = "40.112.8.12"
+    end_ip_address   = "40.112.8.12"
+  }
+
+  firewall_rule {
+    name             = "ruleB"
+    start_ip_address = "40.112.8.200"
+    end_ip_address   = "40.112.8.205"
+  }
+
+  dynamic "firewall_rule" {
+    for_each = var.firewall_rules
+    content = {
+      name             = firewall_rule.value.name
+      start_ip_address = firewall_rule.value.key
+      end_ip_address   = firewall_rule.value.key
+    }
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create this PostgreSQL Flexible Server Firewall Rule. Changing this forces a new PostgreSQL Flexible Server Firewall Rule to be created.
+
+* `firewall_rule` - (Optional) A `site_config` object as defined below.
+
+---
+
+The `firewall_rule` block supports the following:
+
+* `name` - (Required) The name which should be used for this PostgreSQL Flexible Server Firewall Rule. Changing this forces a new PostgreSQL Flexible Server Firewall Rule to be created.
+
+* `start_ip_address` - (Required) The Start IP Address associated with this PostgreSQL Flexible Server Firewall Rule.
+
+* `end_ip_address` - (Required) The End IP Address associated with this PostgreSQL Flexible Server Firewall Rule.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Flexible Server Firewall Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Flexible Server Firewall Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Flexible Server Firewall Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Flexible Server Firewall Rule.

--- a/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
@@ -67,9 +67,9 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
 
 The following arguments are supported:
 
-* `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create these PostgreSQL Flexible Server Firewall Rules. Changing this forces a new PostgreSQL Flexible Server Firewall Rules resource to be created.
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create these PostgreSQL Flexible Server Firewall Rules. Changing this forces a new resource to be created.
 
-* `firewall_rule` - (Optional) A `firewall_rule` object as defined below.
+* `firewall_rule` - (Optional) A `firewall_rule` object as defined below. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
@@ -1,9 +1,9 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_postgresql_flexible_server_firewall_rule"
+page_title: "Azure Resource Manager: azurerm_postgresql_flexible_server_firewall_rules"
 description: |-
-  Manages a PostgreSQL Flexible Server Firewall Rule.
+  Manages a group of PostgreSQL Flexible Server Firewall Rules.
 ---
 
 # azurerm_postgresql_flexible_server_firewall_rules

--- a/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rules.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a group of PostgreSQL Flexible Server Firewall Rules.
 
+~> **NOTE:** It's possible to define Flexible Server Firewall Rules individually with [the `postgresql_flexible_server_firewall_rule` resource](postgresql_flexible_server_firewall_rule.html) or in groups with [the `postgresql_flexible_server_firewall_rules` resource](postgresql_flexible_server_firewall_rules.html). But, it's not possible to use both methods to manage Firewall Rules within a PostgreSQL Flexible Server, since there will be conflicts.
+
 ## Example Usage
 
 ```hcl
@@ -33,13 +35,6 @@ resource "azurerm_postgresql_flexible_server" "example" {
   storage_mb = 32768
 
   sku_name = "GP_Standard_D4s_v3"
-}
-
-resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
-  name             = "example-fw"
-  server_id        = azurerm_postgresql_flexible_server.example.id
-  start_ip_address = "122.122.0.0"
-  end_ip_address   = "122.122.0.0"
 }
 
 resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
@@ -72,15 +67,15 @@ resource "azurerm_postgresql_flexible_server_firewall_rules" "example" {
 
 The following arguments are supported:
 
-* `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create this PostgreSQL Flexible Server Firewall Rule. Changing this forces a new PostgreSQL Flexible Server Firewall Rule to be created.
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server from which to create these PostgreSQL Flexible Server Firewall Rules. Changing this forces a new PostgreSQL Flexible Server Firewall Rules resource to be created.
 
-* `firewall_rule` - (Optional) A `site_config` object as defined below.
+* `firewall_rule` - (Optional) A `firewall_rule` object as defined below.
 
 ---
 
 The `firewall_rule` block supports the following:
 
-* `name` - (Required) The name which should be used for this PostgreSQL Flexible Server Firewall Rule. Changing this forces a new PostgreSQL Flexible Server Firewall Rule to be created.
+* `name` - (Required) The name which should be used for this PostgreSQL Flexible Server Firewall Rule. 
 
 * `start_ip_address` - (Required) The Start IP Address associated with this PostgreSQL Flexible Server Firewall Rule.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

The current `postgresql_flexible_server_firewall_rule` resource can be slow when attempting to add many rules at once. Originally we attempted making the locking in that resource optional to speed things up but was advised to create a separate resource for large groups. This new resource implements that - allowing us to create multiple rules at once more quickly. Have tested with groups of up to 150 firewall rules and creation/destruction seems much faster using this approach.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Resource: `postgresql_flexible_server_firewall_rules`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes #23663


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
