### PR TITLE
azurerm_nginx_certificate - add new read only fields to data source

### DIFF
--- a/internal/services/nginx/nginx_certificate_data_source.go
+++ b/internal/services/nginx/nginx_certificate_data_source.go
@@ -18,11 +18,16 @@ import (
 )
 
 type CertificateDataSourceModel struct {
-	Name                   string `tfschema:"name"`
-	NginxDeploymentId      string `tfschema:"nginx_deployment_id"`
-	KeyVirtualPath         string `tfschema:"key_virtual_path"`
-	CertificateVirtualPath string `tfschema:"certificate_virtual_path"`
-	KeyVaultSecretId       string `tfschema:"key_vault_secret_id"`
+	Name                       string `tfschema:"name"`
+	NginxDeploymentId          string `tfschema:"nginx_deployment_id"`
+	CertificateVirtualPath     string `tfschema:"certificate_virtual_path"`
+	KeyVirtualPath             string `tfschema:"key_virtual_path"`
+	KeyVaultSecretId           string `tfschema:"key_vault_secret_id"`
+	SHA1Thumbprint             string `tfschema:"sha1_thumbprint"`
+	KeyVaultSecretVersion      string `tfschema:"key_vault_secret_version"`
+	KeyVaultSecretCreationDate string `tfschema:"key_vault_secret_creation_date"`
+	ErrorCode                  string `tfschema:"error_code"`
+	ErrorMessage               string `tfschema:"error_message"`
 }
 
 type CertificateDataSource struct{}
@@ -58,6 +63,31 @@ func (m CertificateDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"key_vault_secret_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"sha1_thumbprint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"key_vault_secret_version": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"key_vault_secret_creation_date": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"error_code": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"error_message": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
@@ -109,6 +139,13 @@ func (m CertificateDataSource) Read() sdk.ResourceFunc {
 				output.KeyVirtualPath = pointer.From(prop.KeyVirtualPath)
 				output.KeyVaultSecretId = pointer.From(prop.KeyVaultSecretId)
 				output.CertificateVirtualPath = pointer.From(prop.CertificateVirtualPath)
+				output.SHA1Thumbprint = pointer.From(prop.Sha1Thumbprint)
+				output.KeyVaultSecretVersion = pointer.From(prop.KeyVaultSecretVersion)
+				output.KeyVaultSecretCreationDate = pointer.From(prop.KeyVaultSecretCreated)
+				if prop.CertificateError != nil {
+					output.ErrorCode = pointer.From(prop.CertificateError.Code)
+					output.ErrorMessage = pointer.From(prop.CertificateError.Message)
+				}
 			}
 
 			metadata.SetID(id)

--- a/internal/services/nginx/nginx_certificate_data_source_test.go
+++ b/internal/services/nginx/nginx_certificate_data_source_test.go
@@ -24,6 +24,9 @@ func TestAccNginxCertificateDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate_virtual_path").Exists(),
 				check.That(data.ResourceName).Key("key_vault_secret_id").Exists(),
 				check.That(data.ResourceName).Key("key_virtual_path").Exists(),
+				check.That(data.ResourceName).Key("sha1_thumbprint").Exists(),
+				check.That(data.ResourceName).Key("key_vault_secret_version").Exists(),
+				check.That(data.ResourceName).Key("key_vault_secret_creation_date").Exists(),
 			),
 		},
 	})

--- a/website/docs/d/nginx_certificate.html.markdown
+++ b/website/docs/d/nginx_certificate.html.markdown
@@ -43,6 +43,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `key_vault_secret_id` - The ID of the Key Vault Secret for the certificate.
 
+* `sha1_thumbprint` - The SHA-1 thumbprint of the certificate.
+
+* `key_vault_secret_version` - The version of the certificate.
+
+* `key_vault_secret_creation_date` - The date/time the certificate was created in Azure Key Vault.
+
+* `error_code` - The error code of the certificate error, if any.
+
+* `error_message` - The error message of the certificate error, if any.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Since the [2023-09-01 version of the NGINXaaS API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/nginx/resource-manager/NGINX.NGINXPLUS/stable/2023-09-01/swagger.json#L905), there are new read-only certificate fields: `sha1Thumbprint`, `keyVaultSecretVersion`, `keyVaultSecretCreated`, and `certificateError`. This change adds those fields as attributes on the `azurerm_nginx_certificate` data source.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_nginx_certificate - add new read only fields to data source


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
