### PR TITLE
`azurerm_vpn_server_configuration` - split create and update function to fix lifecycle - ignore

### DIFF
--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -564,7 +564,7 @@ func resourceVPNServerConfigurationUpdate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	// parameter:VpnServerConfigVpnClientRootCertificates is not specified when VpnAuthenticationType as Certificate is selected.
-	if supportsCertificates && payload.Properties.RadiusClientRootCertificates != nil && len(*payload.Properties.RadiusClientRootCertificates) == 0 {
+	if supportsCertificates && payload.Properties.VpnClientRootCertificates != nil && len(*payload.Properties.VpnClientRootCertificates) == 0 {
 		return fmt.Errorf("`client_root_certificate` must be specified when `vpn_authentication_type` is set to `Certificate`")
 	}
 

--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -25,9 +25,9 @@ import (
 
 func resourceVPNServerConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVPNServerConfigurationCreateUpdate,
+		Create: resourceVPNServerConfigurationCreate,
 		Read:   resourceVPNServerConfigurationRead,
-		Update: resourceVPNServerConfigurationCreateUpdate,
+		Update: resourceVPNServerConfigurationUpdate,
 		Delete: resourceVPNServerConfigurationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := virtualwans.ParseVpnServerConfigurationID(id)
@@ -269,24 +269,22 @@ func resourceVPNServerConfiguration() *pluginsdk.Resource {
 	}
 }
 
-func resourceVPNServerConfigurationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVPNServerConfigurationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := virtualwans.NewVpnServerConfigurationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.VpnServerConfigurationsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.VpnServerConfigurationsGet(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_vpn_server_configuration", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_vpn_server_configuration", id.ID())
 	}
 
 	aadAuthenticationRaw := d.Get("azure_active_directory_authentication").([]interface{})
@@ -458,6 +456,129 @@ func resourceVPNServerConfigurationRead(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	return nil
+}
+
+func resourceVPNServerConfigurationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualwans.ParseVpnServerConfigurationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.VpnServerConfigurationsGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("azure_active_directory_authentication") {
+		payload.Properties.AadAuthenticationParameters = expandVpnServerConfigurationAADAuthentication(d.Get("azure_active_directory_authentication").([]interface{}))
+	}
+
+	if d.HasChange("client_revoked_certificate") {
+		payload.Properties.VpnClientRevokedCertificates = expandVpnServerConfigurationClientRevokedCertificates(d.Get("client_revoked_certificate").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("client_root_certificate") {
+		payload.Properties.VpnClientRootCertificates = expandVpnServerConfigurationClientRootCertificates(d.Get("client_root_certificate").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("ipsec_policy") {
+		payload.Properties.VpnClientIPsecPolicies = expandVpnServerConfigurationIPSecPolicies(d.Get("ipsec_policy").([]interface{}))
+	}
+
+	if d.HasChange("vpn_protocols") {
+		payload.Properties.VpnProtocols = expandVpnServerConfigurationVPNProtocols(d.Get("vpn_protocols").(*pluginsdk.Set).List())
+	}
+
+	supportsAAD := false
+	supportsCertificates := false
+	supportsRadius := false
+
+	vpnAuthenticationTypesRaw := d.Get("vpn_authentication_types").([]interface{})
+	vpnAuthenticationTypes := make([]virtualwans.VpnAuthenticationType, 0)
+	for _, v := range vpnAuthenticationTypesRaw {
+		authType := virtualwans.VpnAuthenticationType(v.(string))
+
+		switch authType {
+		case virtualwans.VpnAuthenticationTypeAAD:
+			supportsAAD = true
+
+		case virtualwans.VpnAuthenticationTypeCertificate:
+			supportsCertificates = true
+
+		case virtualwans.VpnAuthenticationTypeRadius:
+			supportsRadius = true
+
+		default:
+			return fmt.Errorf("Unsupported `vpn_authentication_type`: %q", authType)
+		}
+
+		vpnAuthenticationTypes = append(vpnAuthenticationTypes, authType)
+	}
+
+	if d.HasChange("vpn_authentication_types") {
+		payload.Properties.VpnAuthenticationTypes = &vpnAuthenticationTypes
+	}
+
+	if d.HasChange("radius") {
+		// if radius has changed, we'll nil out the radius attributes and update them to new values if needed
+		payload.Properties.RadiusServerAddress = nil
+		payload.Properties.RadiusServerSecret = nil
+		payload.Properties.RadiusClientRootCertificates = nil
+		payload.Properties.RadiusServerRootCertificates = nil
+		payload.Properties.RadiusServers = nil
+
+		radius := expandVpnServerConfigurationRadius(d.Get("radius").([]interface{}))
+		if supportsRadius {
+			if radius == nil {
+				return fmt.Errorf("`radius` must be specified when `vpn_authentication_type` is set to `Radius`")
+			}
+
+			if radius.servers != nil && len(*radius.servers) != 0 {
+				payload.Properties.RadiusServers = radius.servers
+			}
+
+			payload.Properties.RadiusServerAddress = utils.String(radius.address)
+			payload.Properties.RadiusServerSecret = utils.String(radius.secret)
+
+			payload.Properties.RadiusClientRootCertificates = radius.clientRootCertificates
+			payload.Properties.RadiusServerRootCertificates = radius.serverRootCertificates
+		}
+	}
+
+	if supportsAAD && payload.Properties.AadAuthenticationParameters == nil {
+		return fmt.Errorf("`azure_active_directory_authentication` must be specified when `vpn_authentication_type` is set to `AAD`")
+	}
+
+	// parameter:VpnServerConfigVpnClientRootCertificates is not specified when VpnAuthenticationType as Certificate is selected.
+	if supportsCertificates && payload.Properties.RadiusClientRootCertificates != nil && len(*payload.Properties.RadiusClientRootCertificates) == 0 {
+		return fmt.Errorf("`client_root_certificate` must be specified when `vpn_authentication_type` is set to `Certificate`")
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.VpnServerConfigurationsCreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVPNServerConfigurationRead(d, meta)
 }
 
 func resourceVPNServerConfigurationDelete(d *pluginsdk.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR splits the CreateUpdate method into separate Create/Update methods

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_vpn_server_configuration` - split create and update function to fix lifecycle - ignore property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
