### PR TITLE
`azurerm_synapse_spark_pool` - Set `spark_version` defaults to `v3.4`

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -213,7 +214,12 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  "3.4", // TODO: make this field Required in 4.0 since the default value changes over time
+				Default: func() string {
+					if !features.FourPointOh() {
+						return "2.4"
+					}
+					return "3.4"
+				}(),
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -22,7 +22,7 @@ import (
 )
 
 func resourceSynapseSparkPool() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceSynapseSparkPoolCreate,
 		Read:   resourceSynapseSparkPoolRead,
 		Update: resourceSynapseSparkPoolUpdate,
@@ -214,12 +214,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default: func() string {
-					if !features.FourPointOh() {
-						return "2.4"
-					}
-					return "3.4"
-				}(),
+				Default:  "2.4",
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",
@@ -232,6 +227,20 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"tags": tags.Schema(),
 		},
 	}
+
+	if features.FourPointOh() {
+		resource.Schema["spark_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"3.2",
+				"3.3",
+				"3.4",
+			}, false),
+		}
+	}
+
+	return resource
 }
 
 func resourceSynapseSparkPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -213,7 +213,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  "2.4", // TODO: make this field Required in 4.0 since the default value changes over time
+				Default:  "3.4", // TODO: make this field Required in 4.0 since the default value changes over time
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -313,6 +313,7 @@ resource "azurerm_synapse_spark_pool" "test" {
   node_size                 = "XXXLarge"
   node_count                = 3
   compute_isolation_enabled = true
+  spark_version             = "3.4"
 }
 `, template, data.RandomString)
 }

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -55,7 +55,7 @@ func TestAccSynapseSparkPool_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, "2.4"),
+			Config: r.complete(data, "3.4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -78,7 +78,7 @@ func TestAccSynapseSparkPool_update(t *testing.T) {
 		},
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
-			Config: r.complete(data, "2.4"),
+			Config: r.complete(data, "3.4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -99,20 +99,6 @@ func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
 	r := SynapseSparkPoolResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.sparkVersion(data, "2.4"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		// not returned by service
-		data.ImportStep("spark_events_folder", "spark_log_folder"),
-		{
-			Config: r.sparkVersion(data, "3.1"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
 		// not returned by service
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
@@ -164,7 +150,7 @@ func TestAccSynapseSpark3Pool_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, "3.1"),
+			Config: r.complete(data, "3.4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -187,7 +173,7 @@ func TestAccSynapseSpark3Pool_update(t *testing.T) {
 		},
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
-			Config: r.complete(data, "3.1"),
+			Config: r.complete(data, "3.3"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -231,6 +217,7 @@ resource "azurerm_synapse_spark_pool" "test" {
   node_size_family     = "MemoryOptimized"
   node_size            = "Small"
   node_count           = 3
+  spark_version        = "3.4"
 }
 `, template, data.RandomString)
 }

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -99,8 +99,6 @@ func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
 	r := SynapseSparkPoolResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		// not returned by service
-		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
 			Config: r.sparkVersion(data, "3.2"),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `3.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `3.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000
Spark version `v2.4` has been retired ([Supported Azure Synapse runtime releases](https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-version-support)) . Set `spark_version` defaults to `v3.4`

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
