### PR TITLE
azurerm_linux_web_app  - support 8.3 for the php_version property

### DIFF
--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -488,6 +488,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					"8.0",
 					"8.1",
 					"8.2",
+					"8.3",
 				}, false),
 				ExactlyOneOf: linuxApplicationStackConstraint,
 			},

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -846,6 +846,21 @@ func TestAccLinuxWebApp_withPhp82(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebApp_withPhp83(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.php(data, "8.3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("site_credential.0.password"),
+	})
+}
+
 func TestAccLinuxWebApp_withPython37(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
 	r := LinuxWebAppResource{}
@@ -3017,6 +3032,8 @@ resource "azurerm_linux_web_app" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
+	ftp_publish_basic_authentication_enabled = false
+	webdeploy_publish_basic_authentication_enabled = false
 
   site_config {
     application_stack {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -3028,12 +3028,12 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_web_app" "test" {
-  name                = "acctestWA-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  service_plan_id     = azurerm_service_plan.test.id
-	ftp_publish_basic_authentication_enabled = false
-	webdeploy_publish_basic_authentication_enabled = false
+  name                                           = "acctestWA-%d"
+  location                                       = azurerm_resource_group.test.location
+  resource_group_name                            = azurerm_resource_group.test.name
+  service_plan_id                                = azurerm_service_plan.test.id
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   site_config {
     application_stack {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -3028,12 +3028,10 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_web_app" "test" {
-  name                                           = "acctestWA-%d"
-  location                                       = azurerm_resource_group.test.location
-  resource_group_name                            = azurerm_resource_group.test.name
-  service_plan_id                                = azurerm_service_plan.test.id
-  ftp_publish_basic_authentication_enabled       = false
-  webdeploy_publish_basic_authentication_enabled = false
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
     application_stack {

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2484,9 +2484,9 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_web_app_slot" "test" {
-  name           = "acctestWAS-%d"
-  app_service_id = azurerm_linux_web_app.test.id
-  ftp_publish_basic_authentication_enabled = false
+  name                                           = "acctestWAS-%d"
+  app_service_id                                 = azurerm_linux_web_app.test.id
+  ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
   site_config {
@@ -2495,6 +2495,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     }
   }
 }
+
 
 `, r.baseTemplate(data), data.RandomInteger, phpVersion)
 }
@@ -2989,12 +2990,12 @@ resource "azurerm_service_plan" "test" {
 }
 
 resource "azurerm_linux_web_app" "test" {
-  name                = "acctestWA-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  service_plan_id     = azurerm_service_plan.test.id
- ftp_publish_basic_authentication_enabled = false
- webdeploy_publish_basic_authentication_enabled = false
+  name                                           = "acctestWA-%[1]d"
+  location                                       = azurerm_resource_group.test.location
+  resource_group_name                            = azurerm_resource_group.test.name
+  service_plan_id                                = azurerm_service_plan.test.id
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}
 }

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -877,6 +877,21 @@ func TestAccLinuxWebAppSlot_withPhp82(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebAppSlot_withPhp83(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.php(data, "8.3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("site_credential.0.password"),
+	})
+}
+
 func TestAccLinuxWebAppSlot_withPython37(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
 	r := LinuxWebAppSlotResource{}
@@ -2471,6 +2486,8 @@ provider "azurerm" {
 resource "azurerm_linux_web_app_slot" "test" {
   name           = "acctestWAS-%d"
   app_service_id = azurerm_linux_web_app.test.id
+  ftp_publish_basic_authentication_enabled = false
+  webdeploy_publish_basic_authentication_enabled = false
 
   site_config {
     application_stack {
@@ -2976,6 +2993,8 @@ resource "azurerm_linux_web_app" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
+ ftp_publish_basic_authentication_enabled = false
+ webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}
 }

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2990,10 +2990,10 @@ resource "azurerm_service_plan" "test" {
 }
 
 resource "azurerm_linux_web_app" "test" {
-  name                                           = "acctestWA-%[1]d"
-  location                                       = azurerm_resource_group.test.location
-  resource_group_name                            = azurerm_resource_group.test.name
-  service_plan_id                                = azurerm_service_plan.test.id
+  name                = "acctestWA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
 
   site_config {}
 }

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2484,10 +2484,8 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_web_app_slot" "test" {
-  name                                           = "acctestWAS-%d"
-  app_service_id                                 = azurerm_linux_web_app.test.id
-  ftp_publish_basic_authentication_enabled       = false
-  webdeploy_publish_basic_authentication_enabled = false
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
 
   site_config {
     application_stack {
@@ -2495,6 +2493,8 @@ resource "azurerm_linux_web_app_slot" "test" {
     }
   }
 }
+
+
 
 
 `, r.baseTemplate(data), data.RandomInteger, phpVersion)

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2994,8 +2994,6 @@ resource "azurerm_linux_web_app" "test" {
   location                                       = azurerm_resource_group.test.location
   resource_group_name                            = azurerm_resource_group.test.name
   service_plan_id                                = azurerm_service_plan.test.id
-  ftp_publish_basic_authentication_enabled       = false
-  webdeploy_publish_basic_authentication_enabled = false
 
   site_config {}
 }

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -176,7 +176,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 
-* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1` and `8.2`.
+* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2` and `8.3`.
 
 ~> **NOTE:** version `7.4` is deprecated and will be removed from the provider in a future version.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -178,7 +178,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 
-* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1` and `8.2`.
+* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2` and `8.3`.
 
 ~> **NOTE:** version `7.4` is deprecated and will be removed from the provider in a future version.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adding support for PHP 8.3 in Linux Web Apps and Linux WebApp Slot.
Updated documentation with new version support.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Linux WebApp test log:

```bash
$ make acctests SERVICE='appservice' TESTARGS=' -run=TestAccLinuxWebApp_withPhp83' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccLinuxWebApp_withPhp83 -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLinuxWebApp_withPhp83
=== PAUSE TestAccLinuxWebApp_withPhp83
=== CONT  TestAccLinuxWebApp_withPhp83
--- PASS: TestAccLinuxWebApp_withPhp83 (138.99s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    139.010s
```

Linuz WebApp Slot test log:

```bash
$ make acctests SERVICE='appservice' TESTARGS=' -run=TestAccLinuxWebAppSlot_withPhp83' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccLinuxWebAppSlot_withPhp83 -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLinuxWebAppSlot_withPhp83
=== PAUSE TestAccLinuxWebAppSlot_withPhp83
=== CONT  TestAccLinuxWebAppSlot_withPhp83
--- PASS: TestAccLinuxWebAppSlot_withPhp83 (223.50s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    223.519s
```




## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_web_app` - support for `PHP 8.3`
* `azurerm_linux_web_app_slot` - support for `PHP 8.3`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26121


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
