### PR TITLE
`network` - update service endpoint storage policy to use `go-azure-sdk`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -440,7 +440,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	clustersClient := containersClient.KubernetesClustersClient
 	poolsClient := containersClient.AgentPoolsClient
 	subnetClient := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/network/subnet_nat_gateway_association_resource.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource.go
@@ -57,7 +57,7 @@ func resourceSubnetNatGatewayAssociation() *pluginsdk.Resource {
 
 func resourceSubnetNatGatewayAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -57,7 +57,7 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 
 func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -275,7 +275,7 @@ func resourceSubnet() *pluginsdk.Resource {
 // TODO: refactor the create/flatten functions
 func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -438,7 +438,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_route_table_association_resource_test.go
+++ b/internal/services/network/subnet_route_table_association_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/subnets"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubnetRouteTableAssociationResource struct{}
@@ -105,42 +105,42 @@ func (SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *
 
 	resp, err := clients.Network.Client.Subnets.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading Subnet Route Table Association (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	model := resp.Model
 	if model == nil {
-		return nil, fmt.Errorf("model was nil for Subnet %q (Virtual Network %q / Resource Group: %q)", id.SubnetName, id.VirtualNetworkName, id.ResourceGroupName)
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", id)
 	}
 
 	props := model.Properties
 	if props == nil || props.RouteTable == nil {
-		return nil, fmt.Errorf("properties was nil for Subnet %q (Virtual Network %q / Resource Group: %q)", id.SubnetName, id.VirtualNetworkName, id.ResourceGroupName)
+		return nil, fmt.Errorf("retrieving %s: `properties` was nil", id)
 	}
 
-	return utils.Bool(props.RouteTable.Id != nil), nil
+	return pointer.To(props.RouteTable.Id != nil), nil
 }
 
 func (SubnetRouteTableAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(15*time.Minute))
 	defer cancel()
 
-	parsedId, err := commonids.ParseSubnetID(state.Attributes["subnet_id"])
+	id, err := commonids.ParseSubnetID(state.Attributes["subnet_id"])
 	if err != nil {
 		return err
 	}
 
-	read, err := client.Network.Client.Subnets.Get(ctx, *parsedId, subnets.DefaultGetOperationOptions())
+	read, err := client.Network.Client.Subnets.Get(ctx, *id, subnets.DefaultGetOperationOptions())
 	if err != nil {
 		if !response.WasNotFound(read.HttpResponse) {
-			return fmt.Errorf("retrieving Subnet %q (Network %q / Resource Group %q): %+v", parsedId.SubnetName, parsedId.VirtualNetworkName, parsedId.ResourceGroupName, err)
+			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 	}
 
 	read.Model.Properties.RouteTable = nil
 
-	if err := client.Network.Client.Subnets.CreateOrUpdateThenPoll(ctx, *parsedId, *read.Model); err != nil {
-		return fmt.Errorf("updating Subnet %q (Network %q / Resource Group %q): %+v", parsedId.SubnetName, parsedId.VirtualNetworkName, parsedId.ResourceGroupName, err)
+	if err := client.Network.Client.Subnets.CreateOrUpdateThenPoll(ctx, *id, *read.Model); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
@@ -8,19 +8,21 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/serviceendpointpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	mgValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
@@ -31,7 +33,7 @@ func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
 		Delete: resourceSubnetServiceEndpointStoragePolicyDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.SubnetServiceEndpointStoragePolicyID(id)
+			_, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(id)
 			return err
 		}),
 
@@ -106,123 +108,113 @@ func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 		},
 	}
 }
 
 func resourceSubnetServiceEndpointStoragePolicyCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.ServiceEndpointPoliciesClient
+	client := meta.(*clients.Client).Network.ServiceEndpointPolicies
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceId := parse.NewSubnetServiceEndpointStoragePolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := serviceendpointpolicies.NewServiceEndpointPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		resp, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.ServiceEndpointPolicyName, "")
+		resp, err := client.Get(ctx, id, serviceendpointpolicies.DefaultGetOperationOptions())
 		if err != nil {
-			if !utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("checking for existing %s: %+v", resourceId, err)
+			if !response.WasNotFound(resp.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(resp.Response) {
-			return tf.ImportAsExistsError("azurerm_subnet_service_endpoint_storage_policy", resourceId.ID())
+		if !response.WasNotFound(resp.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_subnet_service_endpoint_storage_policy", id.ID())
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	param := network.ServiceEndpointPolicy{
-		Location: &location,
-		ServiceEndpointPolicyPropertiesFormat: &network.ServiceEndpointPolicyPropertiesFormat{
+	param := serviceendpointpolicies.ServiceEndpointPolicy{
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Properties: &serviceendpointpolicies.ServiceEndpointPolicyPropertiesFormat{
 			ServiceEndpointPolicyDefinitions: expandServiceEndpointPolicyDefinitions(d.Get("definition").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.ServiceEndpointPolicyName, param)
-	if err != nil {
-		return fmt.Errorf("creating Subnet Service Endpoint Storage Policy %q (Resource Group %q): %+v", resourceId.ServiceEndpointPolicyName, resourceId.ResourceGroup, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Subnet Service Endpoint Storage Policy %q (Resource Group %q): %+v", resourceId.ServiceEndpointPolicyName, resourceId.ResourceGroup, err)
-	}
-
-	d.SetId(resourceId.ID())
+	d.SetId(id.ID())
 
 	return resourceSubnetServiceEndpointStoragePolicyRead(d, meta)
 }
 
 func resourceSubnetServiceEndpointStoragePolicyRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.ServiceEndpointPoliciesClient
+	client := meta.(*clients.Client).Network.ServiceEndpointPolicies
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	id, err := parse.SubnetServiceEndpointStoragePolicyID(d.Id())
+
+	id, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceEndpointPolicyName, "")
+	resp, err := client.Get(ctx, *id, serviceendpointpolicies.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Subnet Service Endpoint Storage Policy %q was not found in Resource Group %q - removing from state!", id.ServiceEndpointPolicyName, id.ResourceGroup)
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[DEBUG] %s was not found - removing from state!", id)
 			d.SetId("")
 			return nil
 		}
-
-		return fmt.Errorf("retrieving Subnet Service Endpoint Storage Policy %q (Resource Group %q): %+v", id.ServiceEndpointPolicyName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.Set("name", id.ServiceEndpointPolicyName)
-	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
-	if prop := resp.ServiceEndpointPolicyPropertiesFormat; prop != nil {
-		if err := d.Set("definition", flattenServiceEndpointPolicyDefinitions(prop.ServiceEndpointPolicyDefinitions)); err != nil {
-			return fmt.Errorf("setting `definition`: %v", err)
-		}
-	}
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if props := model.Properties; props != nil {
+			if err := d.Set("definition", flattenServiceEndpointPolicyDefinitions(props.ServiceEndpointPolicyDefinitions)); err != nil {
+				return fmt.Errorf("setting `definition`: %v", err)
+			}
+		}
+		return tags.FlattenAndSet(d, model.Tags)
+	}
+	return nil
 }
 
 func resourceSubnetServiceEndpointStoragePolicyDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.ServiceEndpointPoliciesClient
+	client := meta.(*clients.Client).Network.ServiceEndpointPolicies
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SubnetServiceEndpointStoragePolicyID(d.Id())
+	id, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.ServiceEndpointPolicyName)
-	if err != nil {
-		return fmt.Errorf("deleting Subnet Service Endpoint Storage Policy %q (Resource Group %q): %+v", id.ServiceEndpointPolicyName, id.ResourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %q: %+v", id, err)
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func expandServiceEndpointPolicyDefinitions(input []interface{}) *[]network.ServiceEndpointPolicyDefinition {
+func expandServiceEndpointPolicyDefinitions(input []interface{}) *[]serviceendpointpolicies.ServiceEndpointPolicyDefinition {
 	if len(input) == 0 {
 		return nil
 	}
 
-	output := make([]network.ServiceEndpointPolicyDefinition, 0)
+	output := make([]serviceendpointpolicies.ServiceEndpointPolicyDefinition, 0)
 	for _, e := range input {
 		e := e.(map[string]interface{})
-		output = append(output, network.ServiceEndpointPolicyDefinition{
-			Name: utils.String(e["name"].(string)),
-			ServiceEndpointPolicyDefinitionPropertiesFormat: &network.ServiceEndpointPolicyDefinitionPropertiesFormat{
-				Description:      utils.String(e["description"].(string)),
-				Service:          utils.String(e["service"].(string)),
+		output = append(output, serviceendpointpolicies.ServiceEndpointPolicyDefinition{
+			Name: pointer.To(e["name"].(string)),
+			Properties: &serviceendpointpolicies.ServiceEndpointPolicyDefinitionPropertiesFormat{
+				Description:      pointer.To(e["description"].(string)),
+				Service:          pointer.To(e["service"].(string)),
 				ServiceResources: utils.ExpandStringSlice(e["service_resources"].(*pluginsdk.Set).List()),
 			},
 		})
@@ -231,7 +223,7 @@ func expandServiceEndpointPolicyDefinitions(input []interface{}) *[]network.Serv
 	return &output
 }
 
-func flattenServiceEndpointPolicyDefinitions(input *[]network.ServiceEndpointPolicyDefinition) []interface{} {
+func flattenServiceEndpointPolicyDefinitions(input *[]serviceendpointpolicies.ServiceEndpointPolicyDefinition) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -248,7 +240,7 @@ func flattenServiceEndpointPolicyDefinitions(input *[]network.ServiceEndpointPol
 			service         = ""
 			serviceResource = []interface{}{}
 		)
-		if b := e.ServiceEndpointPolicyDefinitionPropertiesFormat; b != nil {
+		if b := e.Properties; b != nil {
 			if b.Description != nil {
 				description = *b.Description
 			}

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource_test.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/serviceendpointpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubnetServiceEndpointPolicyStorageResource struct{}
@@ -181,17 +181,17 @@ func TestAccSubnetServiceEndpointStoragePolicy_requiresImport(t *testing.T) {
 }
 
 func (t SubnetServiceEndpointPolicyStorageResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.SubnetServiceEndpointStoragePolicyID(state.ID)
+	id, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Network.ServiceEndpointPoliciesClient.Get(ctx, id.ResourceGroup, id.ServiceEndpointPolicyName, "")
+	resp, err := clients.Network.ServiceEndpointPolicies.Get(ctx, *id, serviceendpointpolicies.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("reading Service Endpoint Policy Storage (%s): %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SubnetServiceEndpointPolicyStorageResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_dns_servers_resource.go
+++ b/internal/services/network/virtual_network_dns_servers_resource.go
@@ -105,7 +105,7 @@ func resourceVirtualNetworkDnsServersCreateUpdate(d *pluginsdk.ResourceData, met
 	vnetStateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(network.ProvisioningStateUpdating)},
 		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, client, *vnetId),
+		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, meta.(*clients.Client).Network.VirtualNetworks, *vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	azureNetwork "github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceAppServiceSlotVirtualNetworkSwiftConnection() *pluginsdk.Resource {
@@ -66,7 +66,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Web.AppServicesClient
 	subnetClient := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -132,8 +132,8 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 	timeout, _ := ctx.Deadline()
 
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
-		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    network.SubnetProvisioningStateRefreshFunc(ctx, subnetClient, *subnetID),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -144,8 +144,8 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 
 	vnetId := commonids.NewVirtualNetworkID(subnetID.SubscriptionId, subnetID.ResourceGroupName, subnetID.VirtualNetworkName)
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
-		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    network.VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	azureNetwork "github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 func resourceAppServiceVirtualNetworkSwiftConnection() *pluginsdk.Resource {
@@ -60,7 +60,7 @@ func resourceAppServiceVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Web.AppServicesClient
 	subnetClient := meta.(*clients.Client).Network.Client.Subnets
-	vnetClient := meta.(*clients.Client).Network.VnetClient
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -118,8 +118,8 @@ func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.Re
 	timeout, _ := ctx.Deadline()
 
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
-		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    network.SubnetProvisioningStateRefreshFunc(ctx, subnetClient, *subnetID),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
@@ -130,8 +130,8 @@ func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.Re
 
 	vnetId := commonids.NewVirtualNetworkID(subnetID.SubscriptionId, subnetID.ResourceGroupName, subnetID.VirtualNetworkName)
 	vnetStateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
-		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Pending:    []string{string(subnets.ProvisioningStateUpdating)},
+		Target:     []string{string(subnets.ProvisioningStateSucceeded)},
 		Refresh:    network.VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Update `azurerm_subnet_service_endpoint_storage_policies` to use `hashicorp/go-azure-sdk`

Also updates the Virtual Network polling function to use the Virtual Network client from `hashicorp/go-azure-sdk`.

## Testing

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/45fc133a-9c25-46c2-a430-35084dda4adb)