### PR TITLE
`keyvault`: handling the Resources API returning key vaults that have been deleted

### DIFF
--- a/internal/services/keyvault/client/populate_cache.go
+++ b/internal/services/keyvault/client/populate_cache.go
@@ -91,6 +91,10 @@ func (c *Client) populateCache(ctx context.Context, subscriptionId commonids.Sub
 
 		keyVault, err := c.vaults20230701Client.Get(ctx, *id)
 		if err != nil {
+			if response.WasNotFound(keyVault.HttpResponse) {
+				log.Printf("[DEBUG] The %s appears to be gone, this is likely an ARM Caching bug - ignoring caching it", *id)
+				continue
+			}
 			if response.WasForbidden(keyVault.HttpResponse) {
 				log.Printf("[WARN] Unable to access %s with current credentials, skipping caching it", *id)
 				continue


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes this comment (https://github.com/hashicorp/terraform-provider-azurerm/pull/26070#issuecomment-2145207587) by @danielino where the ARM Resources API returns resources which don't exist - which then get a 404 when requesting them.

This is hard to test for, since it requires the Resources endpoint to be returning data which doesn't exist in the Key Vault endpoint - but this is returning a 404, so should be fine.

## Changelog

```
BUG FIXES

* `keyvault`: handling the Resources API returning Key Vaults that have been deleted when populating the cache 
```

## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/pull/26070#issuecomment-2145207587


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
