### PR TITLE
`azurerm_storage_sync_server_endpoint` create/update polling

### DIFF
--- a/internal/services/storage/custompollers/storage_sync_server_endpoint_poller.go
+++ b/internal/services/storage/custompollers/storage_sync_server_endpoint_poller.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/serverendpointresource"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &storageSyncServerEndpointPoller{}
+
+type storageSyncServerEndpointPoller struct {
+	client *serverendpointresource.ServerEndpointResourceClient
+	id     serverendpointresource.ServerEndpointId
+}
+
+// The `ServerEndpointsCreateThenPoll` and `ServerEndpointsUpdateThenPoll` methods do not properly await, so a custom poller is required
+func NewStorageSyncServerEndpointPoller(client *serverendpointresource.ServerEndpointResourceClient, id serverendpointresource.ServerEndpointId) *storageSyncServerEndpointPoller {
+	return &storageSyncServerEndpointPoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (p storageSyncServerEndpointPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.ServerEndpointsGet(ctx, p.id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+
+	provisioningState := ""
+	if model := resp.Model; model != nil && model.Properties != nil {
+		provisioningState = pointer.From(model.Properties.ProvisioningState)
+	}
+
+	if strings.EqualFold(provisioningState, "Succeeded") {
+		return &pollers.PollResult{
+			HttpResponse: &client.Response{
+				Response: resp.HttpResponse,
+			},
+			PollInterval: 10 * time.Second,
+			Status:       pollers.PollingStatusSucceeded,
+		}, nil
+	}
+
+	if strings.EqualFold(provisioningState, "runServerJob") {
+		return &pollers.PollResult{
+			HttpResponse: &client.Response{
+				Response: resp.HttpResponse,
+			},
+			PollInterval: 10 * time.Second,
+			Status:       pollers.PollingStatusInProgress,
+		}, nil
+	}
+
+	return nil, pollers.PollingFailedError{
+		HttpResponse: &client.Response{
+			Response: resp.HttpResponse,
+		},
+		Message: fmt.Sprintf("unexpected provisioningState %q", provisioningState),
+	}
+}

--- a/website/docs/r/storage_sync_server_endpoint.html.markdown
+++ b/website/docs/r/storage_sync_server_endpoint.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Storage Sync Server Endpoint.
 
+~> **NOTE:** The parent `azurerm_storage_sync_group` must have an `azurerm_storage_sync_cloud_endpoint` available before an `azurerm_storage_sync_server_endpoint` resource can be created.
+
 ## Example Usage
 
 ```hcl
@@ -50,10 +52,19 @@ resource "azurerm_storage_share" "example" {
   }
 }
 
+resource "azurerm_storage_sync_cloud_endpoint" "example" {
+  name                  = "example-ss-ce"
+  storage_sync_group_id = azurerm_storage_sync_group.example.id
+  file_share_name       = azurerm_storage_share.example.name
+  storage_account_id    = azurerm_storage_account.example.id
+}
+
 resource "azurerm_storage_sync_server_endpoint" "example" {
   name                  = "example-storage-sync-server-endpoint"
   storage_sync_group_id = azurerm_storage_sync_group.example.id
   registered_server_id  = azurerm_storage_sync.example.registered_servers[0]
+
+  depends_on = [azurerm_storage_sync_cloud_endpoint.example]
 }
 ```
 
@@ -67,7 +78,7 @@ The following arguments are supported:
 
 * `registered_server_id` - (Required) The ID of the Registered Server that will be associate with the Storage Sync Server Endpoint. Changing this forces a new Storage Sync Server Endpoint to be created.
 
-~> **NOTE:** For more information on registering a server see the [Microsoft documentation](https://learn.microsoft.com/azure/storage/file-sync/file-sync-server-registration)
+~> **NOTE:** The target server must already be registered with the parent `azurerm_storage_sync` prior to creating this endpoint. For more information on registering a server see the [Microsoft documentation](https://learn.microsoft.com/azure/storage/file-sync/file-sync-server-registration)
 
 * `server_local_path` - (Required) The path on the Windows Server to be synced to the Azure file share. Changing this forces a new Storage Sync Server Endpoint to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

This corrects a bug in the `azurerm_storage_sync_server_endpoint` resource that would cause it to fail to recognize created endpoints. There is a delay in the API between creation and reading, and often the lookup done after creation would fail.

- This PR just adds a custom poller and an initial delay to allow the API time to return the resource.
- Notes were added to the docs as well to help guide usage

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”
