### PR TITLE
dependencies: updating `hashicorp/go-azure-sdk` to `v0.20240603.1222802`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-azure-helpers v0.69.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1222802
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-azure-helpers v0.69.0
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1145333
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.69.0 h1:JwUWXyDgyr6OafU4CgSvrbEP1wcMjfz4gxRQciDQkBQ=
 github.com/hashicorp/go-azure-helpers v0.69.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333 h1:fxgVEzfDCe0gid1TDEyf52OxU4JNwuN+rQrSFZhhEgo=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333/go.mod h1:hYttKKBgAF/o/zyi4CMpHIUFRvfLQyC/RlpwUxXoJyE=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1222802 h1:5a938R6ONgt4OPCmvG31gSUJaEaIjdgh9eqmZPAcxgc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1222802/go.mod h1:J6h0XEnGvoPf/RwqRuPXalklcVtObUhuNUgb+ciVAWQ=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802 h1:POvYtaN1qRYSb8b3C1vgBHmQQqglfShCOh06fcWgiis=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802/go.mod h1:Ts5vRL3KPw8iLit+4WSi1hOWlRCx++wJrCkMGj69xBY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/hashicorp/go-azure-helpers v0.69.0 h1:JwUWXyDgyr6OafU4CgSvrbEP1wcMjfz
 github.com/hashicorp/go-azure-helpers v0.69.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333 h1:fxgVEzfDCe0gid1TDEyf52OxU4JNwuN+rQrSFZhhEgo=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333/go.mod h1:hYttKKBgAF/o/zyi4CMpHIUFRvfLQyC/RlpwUxXoJyE=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1145333 h1:d+NG6lH1DJB1vficilll1iZuCYJdIiwJR+Pqa3FOIVI=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1145333/go.mod h1:Ts5vRL3KPw8iLit+4WSi1hOWlRCx++wJrCkMGj69xBY=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802 h1:POvYtaN1qRYSb8b3C1vgBHmQQqglfShCOh06fcWgiis=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802/go.mod h1:Ts5vRL3KPw8iLit+4WSi1hOWlRCx++wJrCkMGj69xBY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro_statuses.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro_statuses.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package resourcemanager
 
 import "github.com/hashicorp/go-azure-sdk/sdk/client/pollers"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1145333
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240603.1222802
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1114,7 +1114,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saplands
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saprecommendations
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapsupportedsku
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1145333
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240603.1222802
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest


### PR DESCRIPTION
This PR updates `hashicorp/go-azure-sdk` to `v0.20240603.1222802` - further details can be found in a comment.