### PR TITLE
`azurerm_vpn_server_configuration_policy_group` - split create and update function to fix lifecycle - ignore

### DIFF
--- a/internal/services/network/vpn_server_configuration_policy_group_resource.go
+++ b/internal/services/network/vpn_server_configuration_policy_group_resource.go
@@ -198,6 +198,9 @@ func resourceVPNServerConfigurationPolicyGroupUpdate(d *pluginsdk.ResourceData, 
 	defer locks.UnlockByID(vpnServerConfigurationId.ID())
 
 	existing, err := client.ConfigurationPolicyGroupsGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
 
 	if existing.Model == nil {
 		return fmt.Errorf("retrieving %s: `model` was nil", id)

--- a/internal/services/network/vpn_server_configuration_policy_group_resource.go
+++ b/internal/services/network/vpn_server_configuration_policy_group_resource.go
@@ -22,9 +22,9 @@ import (
 
 func resourceVPNServerConfigurationPolicyGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVPNServerConfigurationPolicyGroupCreateUpdate,
+		Create: resourceVPNServerConfigurationPolicyGroupCreate,
 		Read:   resourceVPNServerConfigurationPolicyGroupRead,
-		Update: resourceVPNServerConfigurationPolicyGroupCreateUpdate,
+		Update: resourceVPNServerConfigurationPolicyGroupUpdate,
 		Delete: resourceVPNServerConfigurationPolicyGroupDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -101,10 +101,10 @@ func resourceVPNServerConfigurationPolicyGroup() *pluginsdk.Resource {
 	}
 }
 
-func resourceVPNServerConfigurationPolicyGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVPNServerConfigurationPolicyGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	vpnServerConfigurationId, err := virtualwans.ParseVpnServerConfigurationID(d.Get("vpn_server_configuration_id").(string))
@@ -117,16 +117,14 @@ func resourceVPNServerConfigurationPolicyGroupCreateUpdate(d *pluginsdk.Resource
 
 	id := virtualwans.NewConfigurationPolicyGroupID(subscriptionId, vpnServerConfigurationId.ResourceGroupName, vpnServerConfigurationId.VpnServerConfigurationName, d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.ConfigurationPolicyGroupsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
-		}
+	existing, err := client.ConfigurationPolicyGroupsGet(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_vpn_server_configuration_policy_group", id.ID())
+			return fmt.Errorf("checking for existing %s: %+v", id, err)
 		}
+	}
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_vpn_server_configuration_policy_group", id.ID())
 	}
 
 	payload := virtualwans.VpnServerConfigurationPolicyGroup{
@@ -138,7 +136,7 @@ func resourceVPNServerConfigurationPolicyGroupCreateUpdate(d *pluginsdk.Resource
 	}
 
 	if err := client.ConfigurationPolicyGroupsCreateOrUpdateThenPoll(ctx, id, payload); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -182,6 +180,49 @@ func resourceVPNServerConfigurationPolicyGroupRead(d *pluginsdk.ResourceData, me
 	}
 
 	return nil
+}
+
+func resourceVPNServerConfigurationPolicyGroupUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualwans.ParseConfigurationPolicyGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	vpnServerConfigurationId := virtualwans.NewVpnServerConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.VpnServerConfigurationName)
+
+	locks.ByID(vpnServerConfigurationId.ID())
+	defer locks.UnlockByID(vpnServerConfigurationId.ID())
+
+	existing, err := client.ConfigurationPolicyGroupsGet(ctx, *id)
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("policy") {
+		payload.Properties.PolicyMembers = expandVPNServerConfigurationPolicyGroupPolicyMembers(d.Get("policy").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("priority") {
+		payload.Properties.Priority = pointer.To(int64(d.Get("priority").(int)))
+	}
+
+	if err := client.ConfigurationPolicyGroupsCreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceVPNServerConfigurationPolicyGroupRead(d, meta)
 }
 
 func resourceVPNServerConfigurationPolicyGroupDelete(d *pluginsdk.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR splits the CreateUpdate method into separate Create/Update methods

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_vpn_server_configuration_policy_group` - split create and update function to fix lifecycle - ignore [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
