### PR TITLE
azurerm_nginx_deployment - Omit capacity when creating basic plans

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -6,6 +6,7 @@ package nginx
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -19,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+const defaultCapacity = 20
 
 type FrontendPrivate struct {
 	IpAddress        string `tfschema:"ip_address"`
@@ -123,7 +126,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:          pluginsdk.TypeInt,
 			Optional:      true,
 			ConflictsWith: []string{"auto_scale_profile"},
-			Default:       20,
+			Default:       defaultCapacity,
 			ValidateFunc:  validation.IntPositive,
 		},
 
@@ -435,7 +438,12 @@ func (m DeploymentResource) Create() sdk.ResourceFunc {
 				prop.NetworkProfile.NetworkInterfaceConfiguration.SubnetId = pointer.FromString(model.NetworkInterface[0].SubnetId)
 			}
 
-			if model.Capacity > 0 {
+			isBasicSKU := strings.HasPrefix(model.Sku, "basic")
+			if isBasicSKU && (model.Capacity != defaultCapacity || len(model.AutoScaleProfile) > 0) {
+				return fmt.Errorf("basic SKUs are incompatible with `capacity` or `auto_scale_profiles`")
+			}
+
+			if model.Capacity > 0 && !isBasicSKU {
 				prop.ScalingProperties = &nginxdeployment.NginxDeploymentScalingProperties{
 					Capacity: pointer.FromInt64(model.Capacity),
 				}

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `sku` - (Required) Specifies the NGINX Deployment SKU. Possible values are `standard_Monthly` and `basic_Monthly`. Changing this forces a new resource to be created.
 
--> **NOTE:** If you are setting the `sku` to `basic_Monthly`, you should use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
+-> **NOTE:** If you are setting the `sku` to `basic_Monthly`, setting a non-default `capacity` or `auto_scale_profile` will fail. You should use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
 
 * `managed_resource_group` - (Optional) Specify the managed resource group to deploy VNet injection related network resources. Changing this forces a new NGINX Deployment to be created.
 


### PR DESCRIPTION
The new [Basic SKU][0] does not support any scaling, and it is an error to provide `Capacity` or `AutoScaleSettings`. The resource is implemented in such a way that it was not possible to call
`DeploymentsCreateOrUpdateThenPoll` without one of these in the `ScalingProperties`, which is illegal for the Basic SKUs.

Currently the backend has a hack to silently drop `ScalingProperties` for Basic SKUs, but this is a confusing user experience:

- initial `terraform apply` submits a `PUT` with `"scalingProperties": {"capacity": 20}` - this validation error is currently suppressed and the server reports back `"scalingProperties": null`

- next `terraform plan` detects a `capacity 0 -> 20`

- applying that plan requests a `PATCH` with `"scalingProperties": {"capacity": 20}`, that fails with a `UnsupportedOnBasicPlan` error

It gets more misleading if users specify a capacity explicity; `capacity = 500` or `auto_scale_profile` will apply successfully, but get silently ignored server-side.

This patch checks for basic plans and omits the `scalingProperties` when the user hasn't changed from the default value. We already instruct users to ignore `capacity`, but the check is needed to prevent the implicit default value of 20 from getting into the `DeploymentsCreateOrUpdateThenPoll` request.

[0]: https://docs.nginx.com/nginxaas/azure/billing/overview/#basic-plan

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nginx_deployment` - support for the `basic_Monthly` skus [GH-26223]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
