### PR TITLE
Adding cluster_id to HDInsight Data Source

### DIFF
--- a/internal/services/hdinsight/hdinsight_cluster_data_source.go
+++ b/internal/services/hdinsight/hdinsight_cluster_data_source.go
@@ -110,6 +110,10 @@ func dataSourceHDInsightSparkCluster() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+			"cluster_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -151,6 +155,7 @@ func dataSourceHDInsightClusterRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
+			d.Set("cluster_id", props.ClusterId)
 			d.Set("cluster_version", props.ClusterVersion)
 			d.Set("tier", string(pointer.From(props.Tier)))
 			d.Set("tls_min_version", props.MinSupportedTlsVersion)

--- a/internal/services/hdinsight/hdinsight_cluster_data_source_test.go
+++ b/internal/services/hdinsight/hdinsight_cluster_data_source_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceHDInsightCluster_hadoop(t *testing.T) {
 				check.That(data.ResourceName).Key("edge_ssh_endpoint").HasValue(""),
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})
@@ -42,6 +43,7 @@ func TestAccDataSourceHDInsightCluster_hbase(t *testing.T) {
 				check.That(data.ResourceName).Key("edge_ssh_endpoint").HasValue(""),
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})
@@ -59,6 +61,7 @@ func TestAccDataSourceHDInsightCluster_interactiveQuery(t *testing.T) {
 				check.That(data.ResourceName).Key("edge_ssh_endpoint").HasValue(""),
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})
@@ -76,6 +79,7 @@ func TestAccDataSourceHDInsightCluster_kafka(t *testing.T) {
 				check.That(data.ResourceName).Key("edge_ssh_endpoint").HasValue(""),
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})
@@ -94,6 +98,7 @@ func TestAccDataSourceHDInsightCluster_kafkaWithRestProxy(t *testing.T) {
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
 				check.That(data.ResourceName).Key("kafka_rest_proxy_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})
@@ -111,6 +116,7 @@ func TestAccDataSourceHDInsightCluster_spark(t *testing.T) {
 				check.That(data.ResourceName).Key("edge_ssh_endpoint").HasValue(""),
 				check.That(data.ResourceName).Key("https_endpoint").Exists(),
 				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
 			),
 		},
 	})

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -22,6 +22,10 @@ data "azurerm_hdinsight_cluster" "example" {
 output "https_endpoint" {
   value = data.azurerm_hdinsight_cluster.example.https_endpoint
 }
+
+output "cluster_id" {
+  value = data.azurerm_hdinsight_cluster.example.cluster_id
+}
 ```
 
 ## Argument Reference

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -32,6 +32,12 @@ output "https_endpoint" {
 
 ## Attributes Reference
 
+* `id` - The fully qualified HDInsight resource ID.
+
+* `name` - The HDInsight Cluster name.
+
+* `cluster_id` - The HDInsight Cluster ID.
+
 * `location` - The Azure Region in which this HDInsight Cluster exists.
 
 * `cluster_version` - The version of HDInsights which is used on this HDInsight Cluster.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adding `cluster_id` to `azurerm_hdinsight_cluster` data source.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

I did a `make build` and the build was successful. Then I was able to use the new provider to output the new `cluster_id` attribute and it worked as expected. HDInsight is a very expensive service. Running all the tests cases would have been very expensive on my personal subscription. Here is a sample output:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/664891/a4b54e82-4a1a-459d-a33c-bca0ccd89d48)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Data Source: `azurerm_hdinsight_cluster` - support for `cluster_id` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26180


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
