### PR TITLE
`azurerm_virtual_network_peering` - support for the `peer_complete_virtual_networks_enabled`, `only_ipv6_peering_enabled`, `local_subnet_names` and `remote_subnet_names` properties

### DIFF
--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -94,12 +94,14 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 			"only_ipv6_peering_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"peer_complete_virtual_networks_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 
 			"remote_subnet_names": {
@@ -244,12 +246,6 @@ func resourceVirtualNetworkPeeringUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 	if d.HasChange("allow_virtual_network_access") {
 		existing.Model.Properties.AllowVirtualNetworkAccess = pointer.To(d.Get("allow_virtual_network_access").(bool))
-	}
-	if d.HasChange("peer_complete_virtual_networks_enabled") {
-		existing.Model.Properties.PeerCompleteVnets = pointer.To(d.Get("peer_complete_virtual_networks_enabled").(bool))
-	}
-	if d.HasChange("only_ipv6_peering_enabled") {
-		existing.Model.Properties.EnableOnlyIPv6Peering = pointer.To(d.Get("only_ipv6_peering_enabled").(bool))
 	}
 	if d.HasChange("local_subnet_names") {
 		existing.Model.Properties.LocalSubnetNames = utils.ExpandStringSlice(d.Get("local_subnet_names").([]interface{}))

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -81,6 +82,35 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"local_subnet_names": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
+			"only_ipv6_peering_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"peer_complete_virtual_networks_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"remote_subnet_names": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			"use_remote_gateways": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -121,11 +151,24 @@ func resourceVirtualNetworkPeeringCreate(d *pluginsdk.ResourceData, meta interfa
 			AllowVirtualNetworkAccess: pointer.To(d.Get("allow_virtual_network_access").(bool)),
 			AllowForwardedTraffic:     pointer.To(d.Get("allow_forwarded_traffic").(bool)),
 			AllowGatewayTransit:       pointer.To(d.Get("allow_gateway_transit").(bool)),
+			PeerCompleteVnets:         pointer.To(d.Get("peer_complete_virtual_networks_enabled").(bool)),
 			UseRemoteGateways:         pointer.To(d.Get("use_remote_gateways").(bool)),
 			RemoteVirtualNetwork: &virtualnetworkpeerings.SubResource{
 				Id: pointer.To(d.Get("remote_virtual_network_id").(string)),
 			},
 		},
+	}
+
+	if v, ok := d.GetOk("only_ipv6_peering_enabled"); ok {
+		peer.Properties.EnableOnlyIPv6Peering = pointer.To(v.(bool))
+	}
+
+	if v, ok := d.GetOk("local_subnet_names"); ok {
+		peer.Properties.LocalSubnetNames = utils.ExpandStringSlice(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("remote_subnet_names"); ok {
+		peer.Properties.RemoteSubnetNames = utils.ExpandStringSlice(v.([]interface{}))
 	}
 
 	locks.ByID(virtualNetworkPeeringResourceType)
@@ -202,6 +245,18 @@ func resourceVirtualNetworkPeeringUpdate(d *pluginsdk.ResourceData, meta interfa
 	if d.HasChange("allow_virtual_network_access") {
 		existing.Model.Properties.AllowVirtualNetworkAccess = pointer.To(d.Get("allow_virtual_network_access").(bool))
 	}
+	if d.HasChange("peer_complete_virtual_networks_enabled") {
+		existing.Model.Properties.PeerCompleteVnets = pointer.To(d.Get("peer_complete_virtual_networks_enabled").(bool))
+	}
+	if d.HasChange("only_ipv6_peering_enabled") {
+		existing.Model.Properties.EnableOnlyIPv6Peering = pointer.To(d.Get("only_ipv6_peering_enabled").(bool))
+	}
+	if d.HasChange("local_subnet_names") {
+		existing.Model.Properties.LocalSubnetNames = utils.ExpandStringSlice(d.Get("local_subnet_names").([]interface{}))
+	}
+	if d.HasChange("remote_subnet_names") {
+		existing.Model.Properties.RemoteSubnetNames = utils.ExpandStringSlice(d.Get("remote_subnet_names").([]interface{}))
+	}
 	if d.HasChange("use_remote_gateways") {
 		existing.Model.Properties.UseRemoteGateways = pointer.To(d.Get("use_remote_gateways").(bool))
 	}
@@ -246,6 +301,10 @@ func resourceVirtualNetworkPeeringRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("allow_virtual_network_access", peer.AllowVirtualNetworkAccess)
 			d.Set("allow_forwarded_traffic", peer.AllowForwardedTraffic)
 			d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
+			d.Set("peer_complete_virtual_networks_enabled", pointer.From(peer.PeerCompleteVnets))
+			d.Set("only_ipv6_peering_enabled", pointer.From(peer.EnableOnlyIPv6Peering))
+			d.Set("local_subnet_names", pointer.From(peer.LocalSubnetNames))
+			d.Set("remote_subnet_names", pointer.From(peer.RemoteSubnetNames))
 			d.Set("use_remote_gateways", peer.UseRemoteGateways)
 
 			remoteVirtualNetworkId := ""

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -235,28 +235,28 @@ resource "azurerm_subnet" "test1" {
   name                 = "internal1"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test1.name
-  address_prefixes     = ["10.0.2.0/24"]
+  address_prefixes     = ["10.0.1.0/28"]
 }
 
 resource "azurerm_subnet" "test2" {
   name                 = "internal2"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test1.name
-  address_prefixes     = ["10.0.3.0/24"]
+  address_prefixes     = ["10.0.1.80/29"]
 }
 
 resource "azurerm_subnet" "test3" {
   name                 = "internal3"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test2.name
-  address_prefixes     = ["10.0.4.0/24"]
+  address_prefixes     = ["10.0.2.0/28"]
 }
 
 resource "azurerm_subnet" "test4" {
   name                 = "internal4"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test2.name
-  address_prefixes     = ["10.0.5.0/24"]
+  address_prefixes     = ["10.0.2.80/29"]
 }
 
 resource "azurerm_virtual_network_peering" "test1" {
@@ -270,6 +270,8 @@ resource "azurerm_virtual_network_peering" "test1" {
   only_ipv6_peering_enabled              = true
   local_subnet_names                     = [azurerm_subnet.test1.name]
   remote_subnet_names                    = [azurerm_subnet.test3.name]
+
+  depends_on = [azurerm_subnet.test2, azurerm_subnet.test4]
 }
 
 resource "azurerm_virtual_network_peering" "test2" {
@@ -283,6 +285,8 @@ resource "azurerm_virtual_network_peering" "test2" {
   only_ipv6_peering_enabled              = true
   local_subnet_names                     = [azurerm_subnet.test2.name]
   remote_subnet_names                    = [azurerm_subnet.test4.name]
+
+  depends_on = [azurerm_subnet.test1, azurerm_subnet.test3]
 }
 `, template, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -290,7 +290,6 @@ resource "azurerm_virtual_network" "test2" {
 }
 
 func (r VirtualNetworkPeeringResource) subnetPeering(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -324,5 +323,5 @@ resource "azurerm_virtual_network_peering" "test1" {
   local_subnet_names                     = [azurerm_subnet.test1.name]
   remote_subnet_names                    = [azurerm_subnet.test2.name]
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -122,6 +122,21 @@ func TestAccVirtualNetworkPeering_update(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkPeering_subnetPeering(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subnetPeering(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r VirtualNetworkPeeringResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualnetworkpeerings.ParseVirtualNetworkPeeringID(state.ID)
 	if err != nil {
@@ -231,62 +246,22 @@ provider "azurerm" {
 
 %[1]s
 
-resource "azurerm_subnet" "test1" {
-  name                 = "internal1"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test1.name
-  address_prefixes     = ["10.0.1.0/28"]
-}
-
-resource "azurerm_subnet" "test2" {
-  name                 = "internal2"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test1.name
-  address_prefixes     = ["10.0.1.80/29"]
-}
-
-resource "azurerm_subnet" "test3" {
-  name                 = "internal3"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test2.name
-  address_prefixes     = ["10.0.2.0/28"]
-}
-
-resource "azurerm_subnet" "test4" {
-  name                 = "internal4"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test2.name
-  address_prefixes     = ["10.0.2.80/29"]
-}
-
 resource "azurerm_virtual_network_peering" "test1" {
-  name                                   = "acctestpeer-1-%[2]d"
-  resource_group_name                    = azurerm_resource_group.test.name
-  virtual_network_name                   = azurerm_virtual_network.test1.name
-  remote_virtual_network_id              = azurerm_virtual_network.test2.id
-  allow_forwarded_traffic                = true
-  allow_virtual_network_access           = true
-  peer_complete_virtual_networks_enabled = false
-  only_ipv6_peering_enabled              = true
-  local_subnet_names                     = [azurerm_subnet.test1.name]
-  remote_subnet_names                    = [azurerm_subnet.test3.name]
-
-  depends_on = [azurerm_subnet.test2, azurerm_subnet.test4]
+  name                         = "acctestpeer-1-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test1.name
+  remote_virtual_network_id    = azurerm_virtual_network.test2.id
+  allow_forwarded_traffic      = true
+  allow_virtual_network_access = true
 }
 
 resource "azurerm_virtual_network_peering" "test2" {
-  name                                   = "acctestpeer-2-%[2]d"
-  resource_group_name                    = azurerm_resource_group.test.name
-  virtual_network_name                   = azurerm_virtual_network.test2.name
-  remote_virtual_network_id              = azurerm_virtual_network.test1.id
-  allow_forwarded_traffic                = true
-  allow_virtual_network_access           = true
-  peer_complete_virtual_networks_enabled = false
-  only_ipv6_peering_enabled              = true
-  local_subnet_names                     = [azurerm_subnet.test2.name]
-  remote_subnet_names                    = [azurerm_subnet.test4.name]
-
-  depends_on = [azurerm_subnet.test1, azurerm_subnet.test3]
+  name                         = "acctestpeer-2-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test2.name
+  remote_virtual_network_id    = azurerm_virtual_network.test1.id
+  allow_forwarded_traffic      = true
+  allow_virtual_network_access = true
 }
 `, template, data.RandomInteger)
 }
@@ -301,15 +276,53 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_virtual_network" "test1" {
   name                = "acctestvirtnet-1-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.1.0/24"]
+  address_space       = ["10.0.1.0/24", "1001:1001::/64"]
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_virtual_network" "test2" {
   name                = "acctestvirtnet-2-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.2.0/24"]
+  address_space       = ["10.0.2.0/24", "1001:1002::/64"]
   location            = azurerm_resource_group.test.location
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r VirtualNetworkPeeringResource) subnetPeering(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_subnet" "test1" {
+  name                 = "internal1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test1.name
+  address_prefixes     = ["10.0.1.0/27", "1001:1001::/64"]
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "internal2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test2.name
+  address_prefixes     = ["10.0.2.0/27", "1001:1002::/64"]
+}
+
+resource "azurerm_virtual_network_peering" "test1" {
+  name                                   = "acctestpeer-1-%[2]d"
+  resource_group_name                    = azurerm_resource_group.test.name
+  virtual_network_name                   = azurerm_virtual_network.test1.name
+  remote_virtual_network_id              = azurerm_virtual_network.test2.id
+  allow_forwarded_traffic                = true
+  allow_virtual_network_access           = true
+  peer_complete_virtual_networks_enabled = false
+  only_ipv6_peering_enabled              = true
+  local_subnet_names                     = [azurerm_subnet.test1.name]
+  remote_subnet_names                    = [azurerm_subnet.test2.name]
+}
+`, template, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -231,22 +231,58 @@ provider "azurerm" {
 
 %[1]s
 
+resource "azurerm_subnet" "test1" {
+  name                 = "internal1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test1.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "internal2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test1.name
+  address_prefixes     = ["10.0.3.0/24"]
+}
+
+resource "azurerm_subnet" "test3" {
+  name                 = "internal3"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test2.name
+  address_prefixes     = ["10.0.4.0/24"]
+}
+
+resource "azurerm_subnet" "test4" {
+  name                 = "internal4"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test2.name
+  address_prefixes     = ["10.0.5.0/24"]
+}
+
 resource "azurerm_virtual_network_peering" "test1" {
-  name                         = "acctestpeer-1-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  virtual_network_name         = azurerm_virtual_network.test1.name
-  remote_virtual_network_id    = azurerm_virtual_network.test2.id
-  allow_forwarded_traffic      = true
-  allow_virtual_network_access = true
+  name                                   = "acctestpeer-1-%[2]d"
+  resource_group_name                    = azurerm_resource_group.test.name
+  virtual_network_name                   = azurerm_virtual_network.test1.name
+  remote_virtual_network_id              = azurerm_virtual_network.test2.id
+  allow_forwarded_traffic                = true
+  allow_virtual_network_access           = true
+  peer_complete_virtual_networks_enabled = false
+  only_ipv6_peering_enabled              = true
+  local_subnet_names                     = [azurerm_subnet.test1.name]
+  remote_subnet_names                    = [azurerm_subnet.test3.name]
 }
 
 resource "azurerm_virtual_network_peering" "test2" {
-  name                         = "acctestpeer-2-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  virtual_network_name         = azurerm_virtual_network.test2.name
-  remote_virtual_network_id    = azurerm_virtual_network.test1.id
-  allow_forwarded_traffic      = true
-  allow_virtual_network_access = true
+  name                                   = "acctestpeer-2-%[2]d"
+  resource_group_name                    = azurerm_resource_group.test.name
+  virtual_network_name                   = azurerm_virtual_network.test2.name
+  remote_virtual_network_id              = azurerm_virtual_network.test1.id
+  allow_forwarded_traffic                = true
+  allow_virtual_network_access           = true
+  peer_complete_virtual_networks_enabled = false
+  only_ipv6_peering_enabled              = true
+  local_subnet_names                     = [azurerm_subnet.test2.name]
+  remote_subnet_names                    = [azurerm_subnet.test4.name]
 }
 `, template, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -51,7 +51,7 @@ func TestAccVirtualNetworkPeering_withTriggers(t *testing.T) {
 				check.That(secondResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("allow_virtual_network_access").HasValue("true"),
 				check.That(data.ResourceName).Key("triggers.remote_address_space").Exists(),
-				check.That(data.ResourceName).Key("triggers.remote_address_space").HasValue("10.0.2.0/24"),
+				check.That(data.ResourceName).Key("triggers.remote_address_space").HasValue("10.0.2.0/24,1001:1002::/64"),
 				check.That(secondResourceName).Key("allow_virtual_network_access").HasValue("true"),
 			),
 		},

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -12,8 +12,6 @@ description: |-
 Manages a virtual network peering which allows resources to access other
 resources in the linked virtual network.
 
--> **Note:** Before using the feature of Subnet Peering, it's required to submit the request of registering the providers and features with Azure CLI `az provider register --namespace Microsoft.Network/AllowMultiplePeeringLinksBetweenVnets`.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -12,6 +12,8 @@ description: |-
 Manages a virtual network peering which allows resources to access other
 resources in the linked virtual network.
 
+-> **Note:** Before using the feature of Subnet Peering, it's required to submit the request of registering the providers and features with Azure CLI `az provider register --namespace Microsoft.Network/AllowMultiplePeeringLinksBetweenVnets`.
+
 ## Example Usage
 
 ```hcl
@@ -173,6 +175,14 @@ The following arguments are supported:
 * `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from VMs in the remote virtual network is allowed. Defaults to `false`.
 
 * `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network. Defaults to `false`.
+
+* `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`.
+
+* `only_ipv6_peering_enabled` - (Optional) Specifies whether only IPv6 address space is peered for Subnet peering.
+
+* `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network.
+
+* `remote_subnet_names` - (Optional) A list of remote Subnet names from remote Virtual Network that are Subnet peered.
 
 * `use_remote_gateways` - (Optional) Controls if remote gateways can be used on the local virtual network. If the flag is set to `true`, and `allow_gateway_transit` on the remote peering is also `true`, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to `true`. This flag cannot be set if virtual network already has a gateway. Defaults to `false`.
 

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -174,9 +174,9 @@ The following arguments are supported:
 
 * `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network. Defaults to `false`.
 
-* `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`.
+* `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`. Changing this forces a new resource to be created.
 
-* `only_ipv6_peering_enabled` - (Optional) Specifies whether only IPv6 address space is peered for Subnet peering.
+* `only_ipv6_peering_enabled` - (Optional) Specifies whether only IPv6 address space is peered for Subnet peering. Changing this forces a new resource to be created.
 
 * `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network.
 

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -174,11 +174,11 @@ The following arguments are supported:
 
 * `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network. Defaults to `false`.
 
-* `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`. Changing this forces a new resource to be created.
+* `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network.
 
 * `only_ipv6_peering_enabled` - (Optional) Specifies whether only IPv6 address space is peered for Subnet peering. Changing this forces a new resource to be created.
 
-* `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network.
+* `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`. Changing this forces a new resource to be created.
 
 * `remote_subnet_names` - (Optional) A list of remote Subnet names from remote Virtual Network that are Subnet peered.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
Service team is requesting this new feature Subnet Peering in Virtual Network Peering.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/976c85ce-7c1c-4829-b7ea-a5e659b01ffb)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network_peering` - support for the `peer_complete_virtual_networks_enabled`, `only_ipv6_peering_enabled`, `local_subnet_names` and `remote_subnet_names` properties


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
