### PR TITLE
`azurerm_data_protection_backup_instance_blob_storage` - support for the `storage_account_container_names` property

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
@@ -58,6 +58,13 @@ func TestAccDataProtectionBackupInstanceBlobStorage_complete(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -73,7 +80,7 @@ func TestAccDataProtectionBackupInstanceBlobStorage_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data),
+			Config: r.basicUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -111,24 +118,37 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctest-dataprotection-%d"
-  location = "%s"
+  name     = "acctest-dataprotection-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%d"
+  name                     = "acctestsa%[3]d"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
+resource "azurerm_storage_container" "test" {
+  name                  = "testaccsc%[3]d"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+
+resource "azurerm_storage_container" "another" {
+  name                  = "testaccsc2%[3]d"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+
 resource "azurerm_data_protection_backup_vault" "test" {
-  name                = "acctest-dataprotection-vault-%d"
+  name                = "acctest-dataprotection-vault-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
+  soft_delete         = "Off"
   identity {
     type = "SystemAssigned"
   }
@@ -141,17 +161,38 @@ resource "azurerm_role_assignment" "test" {
 }
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
-  name               = "acctest-dbp-%d"
-  vault_id           = azurerm_data_protection_backup_vault.test.id
-  retention_duration = "P30D"
+  name                                   = "acctest-dbp-%[1]d"
+  vault_id                               = azurerm_data_protection_backup_vault.test.id
+  operational_default_retention_duration = "P30D"
 }
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "another" {
-  name               = "acctest-dbp-other-%d"
-  vault_id           = azurerm_data_protection_backup_vault.test.id
-  retention_duration = "P30D"
+  name                                   = "acctest-dbp-other-%[1]d"
+  vault_id                               = azurerm_data_protection_backup_vault.test.id
+  operational_default_retention_duration = "P30D"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(8), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "hybrid" {
+  name                                   = "acctest-dbp-hybrid-%[1]d"
+  vault_id                               = azurerm_data_protection_backup_vault.test.id
+  operational_default_retention_duration = "P30D"
+
+  backup_repeating_time_intervals  = ["R/2024-05-08T11:30:00+00:00/P1W"]
+  vault_default_retention_duration = "P7D"
+
+  retention_rule {
+    name     = "Monthly"
+    priority = 15
+    life_cycle {
+      duration        = "P6M"
+      data_store_type = "VaultStore"
+    }
+    criteria {
+      days_of_month = [1, 2, 0]
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(8))
 }
 
 func (r DataProtectionBackupInstanceBlobStorageResource) basic(data acceptance.TestData) string {
@@ -164,6 +205,22 @@ resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
   vault_id           = azurerm_data_protection_backup_vault.test.id
   storage_account_id = azurerm_storage_account.test.id
   backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) basicUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
+  name               = "acctest-dbi-%d"
+  location           = azurerm_resource_group.test.location
+  vault_id           = azurerm_data_protection_backup_vault.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.another.id
 
   depends_on = [azurerm_role_assignment.test]
 }
@@ -191,11 +248,29 @@ func (r DataProtectionBackupInstanceBlobStorageResource) complete(data acceptanc
 	return fmt.Sprintf(`
 %s
 resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
-  name               = "acctest-dbi-%d"
-  location           = azurerm_resource_group.test.location
-  vault_id           = azurerm_data_protection_backup_vault.test.id
-  storage_account_id = azurerm_storage_account.test.id
-  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.another.id
+  name                            = "acctest-dbi-%d"
+  location                        = azurerm_resource_group.test.location
+  vault_id                        = azurerm_data_protection_backup_vault.test.id
+  storage_account_id              = azurerm_storage_account.test.id
+  backup_policy_id                = azurerm_data_protection_backup_policy_blob_storage.hybrid.id
+  storage_account_container_names = [azurerm_storage_container.test.name]
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) completeUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
+  name                            = "acctest-dbi-%d"
+  location                        = azurerm_resource_group.test.location
+  vault_id                        = azurerm_data_protection_backup_vault.test.id
+  storage_account_id              = azurerm_storage_account.test.id
+  backup_policy_id                = azurerm_data_protection_backup_policy_blob_storage.hybrid.id
+  storage_account_container_names = [azurerm_storage_container.another.name]
 
   depends_on = [azurerm_role_assignment.test]
 }

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) The ID of the Backup Policy.
 
-* `storage_account_container_names` - (Optional) The list of the container names within the source Storage Account.
+* `storage_account_container_names` - (Optional) The list of the container names of the source Storage Account.
 
 -> **Note:** The `storage_account_container_names` should be specified in the vaulted backup policy/operational and vaulted hybrid backup policy. Removing the `storage_account_container_names` will force a new resource to be created since it can't be removed once specified.
 

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -74,6 +74,10 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) The ID of the Backup Policy.
 
+* `storage_account_container_names` - (Optional) The list of the container names within the source Storage Account.
+
+-> **Note:** The `storage_account_container_names` should be specified in the vaulted backup policy/operational and vaulted hybrid backup policy. Removing the `storage_account_container_names` will force a new resource to be created since it can't be removed once specified.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for the `storage_account_container_names` property

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Test results:
```
PASS: TestAccDataProtectionBackupInstanceBlobStorage_requiresImport (783.56s)
PASS: TestAccDataProtectionBackupInstanceBlobStorage_update (1174.99s)
PASS: TestAccDataProtectionBackupInstanceBlobStorage_complete (1149.45s)
PASS: TestAccDataProtectionBackupInstanceBlobStorage_basic (570.27s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_protection_backup_instance_blob_storage` - support for the `storage_account_container_names` property 

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

