### PR TITLE
`azurerm_cosmosdb_account` - update the nil check for `mongo_server_version`

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1266,9 +1266,9 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			account.Properties.RestoreParameters = expandCosmosdbAccountRestoreParameters(v.([]interface{}))
 		}
 
-		if v, ok := d.GetOk("mongo_server_version"); ok {
+		if !pluginsdk.IsExplicitlyNullInConfig(d, "mongo_server_version") {
 			account.Properties.ApiProperties = &cosmosdb.ApiProperties{
-				ServerVersion: pointer.To(cosmosdb.ServerVersion(v.(string))),
+				ServerVersion: pointer.To(cosmosdb.ServerVersion(d.Get("mongo_server_version").(string))),
 			}
 		}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently we received an issue ticket. User mentioned that updating CosmosDB Account would fail with below error after the kind property of CosmosDB Account is changed from "MongoDB" to "GlobalDocumentDB". After I investigated, I found this issue would happen at below scenario.

Error message:
```
azurerm_cosmosdb_account.test: Modifying... [id=/subscriptions/xx-xx-xx-xx/resourceGroups/acctestRG-cosmos-test04/providers/Microsoft.DocumentDB/databaseAccounts/acctest-ca-test04]
╷
│ Error: updating Database Account (Subscription: "xx-xx-xx-xx"
│ Resource Group Name: "acctestRG-cosmos-test04"
│ Database Account Name: "acctest-ca-test04"): creating/updating CosmosDB Account "acctest-ca-test04" (Resource Group "acctestRG-cosmos-test04"): performing DatabaseAccountsCreateOrUpdate: unexpected status 400 (400 Bad Request) with response: {"code":"BadRequest","message":"ServerVersion is not allowed for this API type.\r\n, Microsoft.Azure.Documents.Common/2.14.0"}
│
│   with azurerm_cosmosdb_account.test,
│   on main.tf line 10, in resource "azurerm_cosmosdb_account" "test":
│   10: resource "azurerm_cosmosdb_account" "test" {
```

Scenario:
```
1. Create resource with kind = "MongoDB" and mongo_server_version = 4.0 in tfconfig1 using TF
2. Delete resource outside of TF
3. Create resource with kind = "GlobalDocumentDB" outside of TF
4. Update kind to "GlobalDocumentDB" and remove mongo_server_version = 4.0 and change the unrelated property like tags in tfconfig1
5. Run `tf apply`. At this time, TF would throw above error.
```

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The failed test cases are also failed with same error on Teamcity Daily Run. So it's not related with this PR.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/f0e1b7ed-e52c-48ef-8dbd-5386f7c43173)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/2b64d78e-14fc-4033-b0e3-d209552349d8)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/7af377f0-2aa8-4f66-a74f-eb1a3f1e4165)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/eaf4aec6-ddc4-4d1b-bda9-dac96763ecec)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/d418d745-7a0f-406f-a256-a34d84403ba0)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cosmosdb_account` - update the nil check for `mongo_server_version`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
