### PR TITLE
`express_route_*` - split createupdate in `express_route_`

### DIFF
--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -25,9 +25,9 @@ import (
 
 func resourceExpressRouteGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceExpressRouteGatewayCreateUpdate,
+		Create: resourceExpressRouteGatewayCreate,
 		Read:   resourceExpressRouteGatewayRead,
-		Update: resourceExpressRouteGatewayCreateUpdate,
+		Update: resourceExpressRouteGatewayUpdate,
 		Delete: resourceExpressRouteGatewayDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := expressroutegateways.ParseExpressRouteGatewayID(id)
@@ -77,27 +77,25 @@ func resourceExpressRouteGateway() *pluginsdk.Resource {
 	}
 }
 
-func resourceExpressRouteGatewayCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceExpressRouteGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.ExpressRouteGateways
 	connectionsClient := meta.(*clients.Client).Network.ExpressRouteConnections
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Println("[INFO] preparing arguments for ExpressRoute Gateway creation.")
 
 	id := expressroutegateways.NewExpressRouteGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		resp, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(resp.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
+	resp, err := client.Get(ctx, id)
+	if err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
-		if resp.Model != nil && resp.Model.Id != nil && *resp.Model.Id != "" {
-			return tf.ImportAsExistsError("azurerm_express_route_gateway", id.ID())
-		}
+	}
+	if resp.Model != nil && resp.Model.Id != nil && *resp.Model.Id != "" {
+		return tf.ImportAsExistsError("azurerm_express_route_gateway", id.ID())
 	}
 
 	gatewayId := expressrouteconnections.NewExpressRouteGatewayID(id.SubscriptionId, id.ResourceGroupName, id.ExpressRouteGatewayName)
@@ -131,6 +129,73 @@ func resourceExpressRouteGatewayCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceExpressRouteGatewayRead(d, meta)
+}
+
+func resourceExpressRouteGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.ExpressRouteGateways
+	connectionsClient := meta.(*clients.Client).Network.ExpressRouteConnections
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Println("[INFO] preparing arguments for ExpressRoute Gateway update.")
+
+	id := expressroutegateways.NewExpressRouteGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	existing, err := client.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	gatewayId, err := expressrouteconnections.ParseExpressRouteGatewayID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	respConnections, err := connectionsClient.List(ctx, *gatewayId)
+	if err != nil && !response.WasNotFound(respConnections.HttpResponse) {
+		return fmt.Errorf("retrieving %s: %+v", gatewayId, err)
+	}
+
+	payload := existing.Model
+
+	var connections *[]expressroutegateways.ExpressRouteConnection
+	if model := respConnections.Model; model != nil {
+		connections = convertConnectionsToGatewayConnections(model.Value)
+	}
+
+	payload.Properties.ExpressRouteConnections = connections
+
+	if d.HasChange("scale_units") {
+		payload.Properties.AutoScaleConfiguration = &expressroutegateways.ExpressRouteGatewayPropertiesAutoScaleConfiguration{
+			Bounds: &expressroutegateways.ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds{
+				Min: pointer.To(int64(d.Get("scale_units").(int))),
+			},
+		}
+	}
+
+	if d.HasChange("allow_non_virtual_wan_traffic") {
+		payload.Properties.AllowNonVirtualWanTraffic = pointer.To(d.Get("allow_non_virtual_wan_traffic").(bool))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -139,15 +139,17 @@ func resourceExpressRouteGatewayCreate(d *pluginsdk.ResourceData, meta interface
 func resourceExpressRouteGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.ExpressRouteGateways
 	connectionsClient := meta.(*clients.Client).Network.ExpressRouteConnections
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Println("[INFO] preparing arguments for ExpressRoute Gateway update.")
 
-	id := expressroutegateways.NewExpressRouteGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id, err := expressroutegateways.ParseExpressRouteGatewayID(d.Id())
+	if err != nil {
+		return err
+	}
 
-	existing, err := client.Get(ctx, id)
+	existing, err := client.Get(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -194,7 +196,7 @@ func resourceExpressRouteGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, *payload); err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -97,7 +97,7 @@ func resourcePublicIpPrefix() *pluginsdk.Resource {
 func resourcePublicIpPrefixCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.PublicIPPrefixes
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Public IP Prefix creation.")

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -182,7 +182,7 @@ func resourcePublicIp() *pluginsdk.Resource {
 func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.PublicIPAddresses
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Public IP creation.")
@@ -295,7 +295,7 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.PublicIPAddresses
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Public IP update.")


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This pr splits out the createupdate functions in the following resources:
- `azurerm_express_route_circuit_peering`
- `azurerm_express_route_circuit`
- `azurerm_express_route_gateway`
- `azurerm_express_route_port`

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests passing in TC aside from ones already failing in main

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
