### PR TITLE
azurerm_storate_account,azurerm_storage_container - fix authenticatio…

### DIFF
--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -33,9 +33,11 @@ const (
 )
 
 type accountDetails struct {
-	Kind             storageaccounts.Kind
-	IsHnsEnabled     bool
-	StorageAccountId commonids.StorageAccountId
+	Kind                 storageaccounts.Kind
+	IsHnsEnabled         bool
+	StorageAccountId     commonids.StorageAccountId
+	AllowSharedKeyAccess bool
+	NetworkRuleSetExists bool
 
 	accountKey *string
 
@@ -185,9 +187,13 @@ func (c Client) FindAccount(ctx context.Context, subscriptionIdRaw, accountName 
 }
 
 func populateAccountDetails(accountId commonids.StorageAccountId, account storageaccounts.StorageAccount) (*accountDetails, error) {
+	networkRuleSetExists := account.Properties.NetworkAcls != nil
+
 	out := accountDetails{
-		Kind:             pointer.From(account.Kind),
-		StorageAccountId: accountId,
+		Kind:                 pointer.From(account.Kind),
+		StorageAccountId:     accountId,
+		AllowSharedKeyAccess: pointer.From(account.Properties.AllowSharedKeyAccess),
+		NetworkRuleSetExists: networkRuleSetExists,
 	}
 
 	if account.Properties == nil {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1991,7 +1991,13 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("unable to locate %s", *id)
 		}
 
-		queueClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		// check authentication method.
+		authMethod := storageClient.DataPlaneOperationSupportingAnyAuthMethod()
+		if !d.Get("shared_access_key_enabled").(bool) || d.Get("network_rules") != nil {
+			authMethod = storageClient.DataPlaneOperationSupportingNoSharedKeyAuth()
+		}
+
+		queueClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, authMethod)
 		if err != nil {
 			return fmt.Errorf("building Queues Client: %s", err)
 		}
@@ -2046,7 +2052,13 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("unable to locate %s", *id)
 		}
 
-		accountsClient, err := storageClient.AccountsDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		// check authentication method.
+		authMethod := storageClient.DataPlaneOperationSupportingAnyAuthMethod()
+		if !d.Get("shared_access_key_enabled").(bool) || d.Get("network_rules") != nil {
+			authMethod = storageClient.DataPlaneOperationSupportingNoSharedKeyAuth()
+		}
+
+		accountsClient, err := storageClient.AccountsDataPlaneClient(ctx, *account, authMethod)
 		if err != nil {
 			return fmt.Errorf("building Data Plane client for %s: %+v", *id, err)
 		}
@@ -2330,7 +2342,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
-	//check authentication method.
+	// check authentication method.
 	authMethod := storageClient.DataPlaneOperationSupportingAnyAuthMethod()
 	if !d.Get("shared_access_key_enabled").(bool) || d.Get("network_rules") != nil {
 		authMethod = storageClient.DataPlaneOperationSupportingNoSharedKeyAuth()

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2330,8 +2330,14 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
+	//check authentication method.
+	authMethod := storageClient.DataPlaneOperationSupportingAnyAuthMethod()
+	if !d.Get("shared_access_key_enabled").(bool) || d.Get("network_rules") != nil {
+		authMethod = storageClient.DataPlaneOperationSupportingNoSharedKeyAuth()
+	}
+
 	if supportLevel.supportQueue {
-		queueClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		queueClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, authMethod)
 		if err != nil {
 			return fmt.Errorf("building Queues Client: %s", err)
 		}
@@ -2360,7 +2366,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if supportLevel.supportStaticWebsite {
-		accountsClient, err := storageClient.AccountsDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		accountsClient, err := storageClient.AccountsDataPlaneClient(ctx, *account, authMethod)
 		if err != nil {
 			return fmt.Errorf("building Accounts Data Plane Client: %s", err)
 		}

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -131,7 +131,14 @@ func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("locating Storage Account %q", accountName)
 	}
 
-	containersDataPlaneClient, err := storageClient.ContainersDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+	//change authentication method by accountKey
+	authMethod := storageClient.DataPlaneOperationSupportingAnyAuthMethod()
+
+	if !account.AllowSharedKeyAccess || account.NetworkRuleSetExists {
+		authMethod = storageClient.DataPlaneOperationSupportingNoSharedKeyAuth()
+	}
+
+	containersDataPlaneClient, err := storageClient.ContainersDataPlaneClient(ctx, *account, authMethod)
 	if err != nil {
 		return fmt.Errorf("building storage client: %v", err)
 	}


### PR DESCRIPTION
FIX authentication issues with the following two resources:
`azurerm_storate_account`
`azurerm_storage_container`

There where currently a lot of different issues opened where users run into issues because the `shared_access_key_enabled` setting was set to `false` or `network_rules` where applied to a `azurerm_storate_account`

The "AD" authentication is only applied when storage azuread feature is enabled:
`storage_use_azuread = true`

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storate_account` - update storage_account provisioning with network_rules or disabled shared_access_key


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #2977


Please let me know you think the "way" how I resolve the authentication errors is fine for you!

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
