### PR TITLE
`azurerm_lb_backend_address_pool_address` - when using this resource, values are no longer reset on `azurerm_lb_backend_address_pool`

### DIFF
--- a/internal/services/loadbalancer/backend_address_pool_address_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_address_resource.go
@@ -475,11 +475,7 @@ func (r BackendAddressPoolAddressResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			backendAddressPool := loadbalancers.BackendAddressPool{
-				Properties: &loadbalancers.BackendAddressPoolPropertiesFormat{
-					LoadBalancerBackendAddresses: &addresses,
-				},
-			}
+			pool.Model.Properties.LoadBalancerBackendAddresses = &addresses
 
 			timeout, _ := ctx.Deadline()
 			lbStatus := &pluginsdk.StateChangeConf{
@@ -496,7 +492,7 @@ func (r BackendAddressPoolAddressResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for parent resource loadbalancer status to be ready error: %+v", err)
 			}
 
-			err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, backendAddressPool)
+			err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)
 			if err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/loadbalancer/backend_address_pool_address_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_address_resource.go
@@ -211,13 +211,10 @@ func (r BackendAddressPoolAddressResource) Create() sdk.ResourceFunc {
 					})
 				}
 
-				backendAddressPool := loadbalancers.BackendAddressPool{
-					Properties: &loadbalancers.BackendAddressPoolPropertiesFormat{
-						LoadBalancerBackendAddresses: &addresses,
-					},
-				}
+				pool.Model.Properties.LoadBalancerBackendAddresses = &addresses
+
 				metadata.Logger.Infof("adding %s..", id)
-				err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, *poolId, backendAddressPool)
+				err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, *poolId, *pool.Model)
 				if err != nil {
 					return fmt.Errorf("updating %s: %+v", id, err)
 				}

--- a/internal/services/loadbalancer/backend_address_pool_address_resource_test.go
+++ b/internal/services/loadbalancer/backend_address_pool_address_resource_test.go
@@ -190,12 +190,9 @@ func (BackendAddressPoolAddressResourceTests) Destroy(ctx context.Context, clien
 		}
 	}
 
-	backendAddressPool := loadbalancers.BackendAddressPool{
-		Properties: &loadbalancers.BackendAddressPoolPropertiesFormat{
-			LoadBalancerBackendAddresses: &newAddresses,
-		},
-	}
-	err = client.LoadBalancers.LoadBalancersClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, backendAddressPool)
+	pool.Model.Properties.LoadBalancerBackendAddresses = &newAddresses
+
+	err = client.LoadBalancers.LoadBalancersClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)
 	if err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When creating `azurerm_lb_backend_address_pool_address` resource, a new `loadbalancers.BackendAddressPool` is redefined instead of using `pool.Model.Properties` returned by the get API, which causes the property values ​​other than `LoadBalancerBackendAddresses` to be cleared. Submit this PR to fix this issue.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Test Results:
```
PASS: TestAccBackendAddressPoolAddress_regionalLbBasic (418.48s)
PASS: TestAccBackendAddressPoolAddress_regionalLbRequiresImport (476.33s)
PASS: TestAccBackendAddressPoolAddress_regionalLbDisappears (358.43s)
PASS: TestAccBackendAddressPoolAddress_regionalLbUpdate (654.89s)
PASS: TestAccBackendAddressPoolAddress_globalLbRemoval (786.70s)
PASS: TestAccBackendAddressPoolAddress_globalLbUpdate (779.29s)
```

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

