### PR TITLE
`azurerm_virtual_desktop_scaling_plan` - update documentation example to use updated service principal `display_name`

### DIFF
--- a/website/docs/r/virtual_desktop_scaling_plan.html.markdown
+++ b/website/docs/r/virtual_desktop_scaling_plan.html.markdown
@@ -22,10 +22,12 @@ Manages a Virtual Desktop Scaling Plan.
 
 resource "random_uuid" "example" {
 }
+
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
+
 resource "azurerm_role_definition" "example" {
   name        = "AVD-AutoScale"
   scope       = azurerm_resource_group.example.id
@@ -53,9 +55,11 @@ resource "azurerm_role_definition" "example" {
     azurerm_resource_group.example.id,
   ]
 }
+
 data "azuread_service_principal" "example" {
-  display_name = "Windows Virtual Desktop"
+  display_name = "Azure Virtual Desktop"
 }
+
 resource "azurerm_role_assignment" "example" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.example.id
@@ -63,6 +67,7 @@ resource "azurerm_role_assignment" "example" {
   principal_id                     = data.azuread_service_principal.example.id
   skip_service_principal_aad_check = true
 }
+
 resource "azurerm_virtual_desktop_host_pool" "example" {
   name                 = "example-hostpool"
   location             = azurerm_resource_group.example.location
@@ -71,6 +76,7 @@ resource "azurerm_virtual_desktop_host_pool" "example" {
   validate_environment = true
   load_balancer_type   = "BreadthFirst"
 }
+
 resource "azurerm_virtual_desktop_scaling_plan" "example" {
   name                = "example-scaling-plan"
   location            = azurerm_resource_group.example.location


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
The minimal example in the [documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_desktop_scaling_plan) for `azurerm_virtual_desktop_scaling_plan` currently uses

```hcl
data "azuread_service_principal" "example" {
  display_name = "Windows Virtual Desktop"
}
```
This results in the following error:
```hcl
│ Error: Service principal not found
│ 
│   with data.azuread_service_principal.example,
│   on $FILENAME line $LINE, in data "azuread_service_principal" "example":
│   $LINE: data "azuread_service_principal" "example" {
│ 
│ No service principals found matching filter: "displayName eq 'Windows Virtual Desktop'"
```

This service principal `display_name` has been changed to `Azure Virtual Desktop`. This PR makes this change and adds some space for better readability.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change