### PR TITLE
provider: support subscription ID hinting when using Azure CLI authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-azure-helpers v0.69.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240604.1114748
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240604.1114748
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240610.1112704
+	github.com/hashicorp/go-azure-sdk/sdk v0.20240610.1112704
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -95,10 +95,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.69.0 h1:JwUWXyDgyr6OafU4CgSvrbEP1wcMjfz4gxRQciDQkBQ=
 github.com/hashicorp/go-azure-helpers v0.69.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240604.1114748 h1:sJEw1sYmLpBFUY+4UpE88GimbuAcvmo4ZvTPYenEdp4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240604.1114748/go.mod h1:1kTyma4K4ZtSWbtCNQfv8H2NZMsIyF+6S8GRbchmUCI=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240604.1114748 h1:DJi4uLd/aUmAcXbTuQXeI6HukIG2ydrnq9aDM2o6D5A=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240604.1114748/go.mod h1:Ts5vRL3KPw8iLit+4WSi1hOWlRCx++wJrCkMGj69xBY=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240610.1112704 h1:APaOXyzHnmXF8SSVck0XJxFe+Y7OUHlGPt3dJ4YnU48=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240610.1112704/go.mod h1:iRfW3HSkKTYgoqUg9oOOvd3dRDwzNUUbvtLjWUwrWT0=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240610.1112704 h1:UDcE9AU+O5sAJobSdjAW0a0K87tiEEtAs3o9axJtpGQ=
+github.com/hashicorp/go-azure-sdk/sdk v0.20240610.1112704/go.mod h1:Ts5vRL3KPw8iLit+4WSi1hOWlRCx++wJrCkMGj69xBY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -428,6 +428,8 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 			CustomManagedIdentityEndpoint: d.Get("msi_endpoint").(string),
 
+			AzureCliSubscriptionIDHint: d.Get("subscription_id").(string),
+
 			EnableAuthenticatingUsingClientCertificate: true,
 			EnableAuthenticatingUsingClientSecret:      true,
 			EnableAuthenticatingUsingAzureCLI:          enableAzureCli,

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
@@ -126,9 +126,10 @@ func NewAuthorizerFromCredentials(ctx context.Context, c Credentials, api enviro
 
 	if c.EnableAuthenticatingUsingAzureCLI {
 		opts := AzureCliAuthorizerOptions{
-			Api:          api,
-			TenantId:     c.TenantID,
-			AuxTenantIds: c.AuxiliaryTenantIDs,
+			Api:                api,
+			TenantId:           c.TenantID,
+			AuxTenantIds:       c.AuxiliaryTenantIDs,
+			SubscriptionIdHint: c.AzureCliSubscriptionIDHint,
 		}
 		a, err := NewAzureCliAuthorizer(ctx, opts)
 		if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
@@ -21,6 +21,9 @@ type Credentials struct {
 
 	// EnableAuthenticatingUsingAzureCLI specifies whether Azure CLI authentication should be checked.
 	EnableAuthenticatingUsingAzureCLI bool
+	// AzureCliSubscriptionIDHint is the subscription to target when selecting an account with which to obtain an access token
+	// Used to hint to Azure CLI which of its signed-in accounts it should select, based on apparent access to the subscription.
+	AzureCliSubscriptionIDHint string
 
 	// EnableAuthenticatingUsingClientCertificate specifies whether Client Certificate authentication should be checked.
 	EnableAuthenticatingUsingClientCertificate bool

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/interfaces.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/interfaces.go
@@ -3,6 +3,10 @@
 
 package environments
 
+import (
+	"strings"
+)
+
 type Api interface {
 	// AppId is a GUID that identifies the application/API in the cloud environment
 	AppId() (*string, bool)
@@ -25,4 +29,20 @@ type Api interface {
 
 	// WithResourceIdentifier overrides the default resource ID for the API and is useful for APIs that offer multiple authorization scopes
 	WithResourceIdentifier(string) Api
+}
+
+// ApiIsKnownPublished determines whether the provided Api represents the specified known API as published in PublishedApis
+func ApiIsKnownPublished(api Api, apiName string) bool {
+	appId, ok := api.AppId()
+	if !ok || appId == nil {
+		return false
+	}
+	knownApiAppId, ok := PublishedApis[apiName]
+	if !ok {
+		return false
+	}
+	if !strings.EqualFold(*appId, knownApiAppId) {
+		return false
+	}
+	return true
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azurecli/azcli.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azurecli/azcli.go
@@ -103,6 +103,23 @@ func GetDefaultSubscriptionID() (*string, error) {
 	return account.Id, nil
 }
 
+// ListAvailableSubscriptionIDs lists the available subscriptions
+func ListAvailableSubscriptionIDs() (*[]string, error) {
+	accounts, err := listAzAccounts()
+	if err != nil {
+		return nil, fmt.Errorf("obtaining subscription ID: %s", err)
+	}
+	subscriptionIds := make([]string, 0)
+	if accounts != nil {
+		for _, account := range *accounts {
+			if account.Id != nil {
+				subscriptionIds = append(subscriptionIds, *account.Id)
+			}
+		}
+	}
+	return &subscriptionIds, nil
+}
+
 // GetAccountName returns the name of the authenticated principal
 func GetAccountName() (*string, error) {
 	account, err := getAzAccount()
@@ -131,6 +148,15 @@ func GetAccountType() (*string, error) {
 func getAzAccount() (*azAccount, error) {
 	var account azAccount
 	if err := JSONUnmarshalAzCmd(true, &account, "account", "show"); err != nil {
+		return nil, fmt.Errorf("obtaining account details: %s", err)
+	}
+	return &account, nil
+}
+
+// listAzAccounts returns the output of `az account list`
+func listAzAccounts() (*[]azAccount, error) {
+	var account []azAccount
+	if err := JSONUnmarshalAzCmd(true, &account, "account", "list"); err != nil {
 		return nil, fmt.Errorf("obtaining account details: %s", err)
 	}
 	return &account, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240604.1114748
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20240610.1112704
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -1116,7 +1116,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saplands
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/saprecommendations
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapsupportedsku
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2023-04-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240604.1114748
+# github.com/hashicorp/go-azure-sdk/sdk v0.20240610.1112704
 ## explicit; go 1.21
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Send the subscription ID to Azure CLI instead of the tenant ID, in order to hint to Azure CLI which user account it should use when acquiring an access token. This affects scenarios where multiple user accounts are "signed in" to Azure CLI, each with segregated access to different subscriptions.

See https://github.com/hashicorp/go-azure-sdk/pull/1008 for more details.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

ENHANCEMENTS:

* provider: support subscription ID hinting when using Azure CLI authentication [GH-26282]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23068


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
