### PR TITLE
`azurerm_cdn_frontdoor_origin`: Adding a `private_link` block should not force re-creation.

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_origin_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource.go
@@ -122,7 +122,7 @@ func resourceCdnFrontDoorOrigin() *pluginsdk.Resource {
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"location": commonschema.Location(),
+						"location": commonschema.LocationWithoutForceNew(),
 
 						"private_link_target_id": {
 							Type:         pluginsdk.TypeString,

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -257,7 +257,7 @@ A `private_link` block supports the following:
 
 -> **NOTE:** `target_type` cannot be specified when using a Load Balancer as an Origin.
 
-* `location` - (Required) Specifies the location where the Private Link resource should exist. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the location where the Private Link resource should exist.
 
 * `private_link_target_id` - (Required) The ID of the Azure Resource to connect to via the Private Link.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The location attribute for the `private_link` block was using the default location schema, which uses `ForceNew`. 

This simply changes the attribute to use `LocationWithoutForceNew()`, as the private link config should be updatable without re-creation of the entire origin.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you 


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_origin`: Adding a `private_link` block should not force re-creation. [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
fixes #26413


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
