### PR TITLE
`azurerm_network_interface` - removes `Computed` from `dns_server` and renames `enable_*` to `*_enabled`

### DIFF
--- a/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
+++ b/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
@@ -2512,11 +2512,11 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                          = "acctestni-%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  enable_ip_forwarding          = false
-  enable_accelerated_networking = true
+  name                           = "acctestni-%d"
+  location                       = azurerm_resource_group.test.location
+  resource_group_name            = azurerm_resource_group.test.name
+  ip_forwarding_enabled          = false
+  accelerated_networking_enabled = true
 
   ip_configuration {
     name                          = "testconfiguration1"

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -179,12 +179,13 @@ func dataSourceNetworkInterface() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		dataSource.Schema["enable_ip_forwarding"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
-		}
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "The property `enable_ip_forwarding` has been superseded by `ip_forwarding_enabled` and will be removed in v4.0 of the AzureRM Provider."}
 		dataSource.Schema["enable_accelerated_networking"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "The property `enable_accelerated_networking` has been superseded by `accelerated_networking_enabled` and will be removed in v4.0 of the AzureRM Provider.",
 		}
 	}
 	return dataSource

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"time"
 
@@ -143,7 +144,7 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 			"dns_servers": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Computed: true,
+				Computed: !features.FourPointOhBeta(),
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -374,14 +374,18 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 	payload := existing.Model
 
 	if d.HasChange("auxiliary_mode") {
-		if auxiliaryMode, hasAuxiliaryMode := d.GetOk("auxiliary_mode"); hasAuxiliaryMode {
-			payload.Properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode.(string)))
+		if auxiliaryMode := d.Get("auxiliary_mode").(string); auxiliaryMode != "" {
+			payload.Properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode))
+		} else {
+			payload.Properties.AuxiliaryMode = nil
 		}
 	}
 
 	if d.HasChange("auxiliary_sku") {
-		if auxiliarySku, hasAuxiliarySku := d.GetOk("auxiliary_sku"); hasAuxiliarySku {
-			payload.Properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku.(string)))
+		if auxiliarySku := d.Get("auxiliary_sku").(string); auxiliarySku != "" {
+			payload.Properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku))
+		} else {
+			payload.Properties.AuxiliarySku = nil
 		}
 	}
 

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"time"
 
@@ -16,9 +15,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/networkinterfaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	lbvalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -26,13 +25,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var networkInterfaceResourceName = "azurerm_network_interface"
 
 func resourceNetworkInterface() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceNetworkInterfaceCreate,
 		Read:   resourceNetworkInterfaceRead,
 		Update: resourceNetworkInterfaceUpdate,
@@ -153,18 +151,28 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_accelerated_networking": {
+			"accelerated_networking_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: !features.FourPointOhBeta(),
+				ConflictsWith: func() []string {
+					if !features.FourPointOhBeta() {
+						return []string{"enable_accelerated_networking"}
+					}
+					return []string{}
+				}(),
 			},
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_ip_forwarding": {
+			"ip_forwarding_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: !features.FourPointOhBeta(),
+				ConflictsWith: func() []string {
+					if !features.FourPointOhBeta() {
+						return []string{"enable_ip_forwarding"}
+					}
+					return []string{}
+				}(),
 			},
 
 			"internal_dns_name_label": {
@@ -214,6 +222,24 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["enable_accelerated_networking"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"accelerated_networking_enabled"},
+			Deprecated:    "The property `enable_accelerated_networking` has been superseded by `accelerated_networking_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+		resource.Schema["enable_ip_forwarding"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"ip_forwarding_enabled"},
+			Deprecated:    "The property `enable_ip_forwarding` has been superseded by `ip_forwarding_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+	}
+	return resource
 }
 
 func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -234,10 +260,18 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 		return tf.ImportAsExistsError("azurerm_network_interface", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	enableIpForwarding := d.Get("enable_ip_forwarding").(bool)
-	enableAcceleratedNetworking := d.Get("enable_accelerated_networking").(bool)
-	t := d.Get("tags").(map[string]interface{})
+	var enableIpForwarding, enableAcceleratedNetworking bool
+
+	enableIpForwarding = d.Get("ip_forwarding_enabled").(bool)
+	enableAcceleratedNetworking = d.Get("accelerated_networking_enabled").(bool)
+
+	if v, ok := d.GetOk("enable_ip_forwarding"); ok && !features.FourPointOhBeta() {
+		enableIpForwarding = v.(bool)
+	}
+
+	if v, ok := d.GetOk("enable_accelerated_networking"); ok && !features.FourPointOhBeta() {
+		enableAcceleratedNetworking = v.(bool)
+	}
 
 	properties := networkinterfaces.NetworkInterfacePropertiesFormat{
 		EnableIPForwarding:          &enableIpForwarding,
@@ -267,7 +301,7 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if hasNameLabel {
-			dnsSettings.InternalDnsNameLabel = utils.String(nameLabel.(string))
+			dnsSettings.InternalDnsNameLabel = pointer.To(nameLabel.(string))
 		}
 
 		properties.DnsSettings = &dnsSettings
@@ -293,9 +327,9 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 	iface := networkinterfaces.NetworkInterface{
 		Name:             pointer.To(id.NetworkInterfaceName),
 		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
-		Location:         utils.String(location),
+		Location:         pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties:       &properties,
-		Tags:             tags.Expand(t),
+		Tags:             tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	err = client.CreateOrUpdateThenPoll(ctx, id, iface)
@@ -337,52 +371,45 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 	// then pull out things we need to lock on
 	info := parseFieldsFromNetworkInterface(*existing.Model.Properties)
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	update := networkinterfaces.NetworkInterface{
-		Name:             utils.String(id.NetworkInterfaceName),
-		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
-		Location:         utils.String(location),
-		Properties: &networkinterfaces.NetworkInterfacePropertiesFormat{
-			EnableAcceleratedNetworking: utils.Bool(d.Get("enable_accelerated_networking").(bool)),
-			DnsSettings:                 &networkinterfaces.NetworkInterfaceDnsSettings{},
-		},
-	}
+	payload := existing.Model
 
 	if d.HasChange("auxiliary_mode") {
 		if auxiliaryMode, hasAuxiliaryMode := d.GetOk("auxiliary_mode"); hasAuxiliaryMode {
-			update.Properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode.(string)))
+			payload.Properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode.(string)))
 		}
-	} else {
-		update.Properties.AuxiliaryMode = existing.Model.Properties.AuxiliaryMode
 	}
 
 	if d.HasChange("auxiliary_sku") {
 		if auxiliarySku, hasAuxiliarySku := d.GetOk("auxiliary_sku"); hasAuxiliarySku {
-			update.Properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku.(string)))
+			payload.Properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku.(string)))
 		}
-	} else {
-		update.Properties.AuxiliarySku = existing.Model.Properties.AuxiliarySku
 	}
 
 	if d.HasChange("dns_servers") {
 		dnsServersRaw := d.Get("dns_servers").([]interface{})
 		dnsServers := expandNetworkInterfaceDnsServers(dnsServersRaw)
 
-		update.Properties.DnsSettings.DnsServers = &dnsServers
-	} else {
-		update.Properties.DnsSettings.DnsServers = existing.Model.Properties.DnsSettings.DnsServers
+		payload.Properties.DnsSettings.DnsServers = &dnsServers
 	}
 
-	if d.HasChange("enable_ip_forwarding") {
-		update.Properties.EnableIPForwarding = utils.Bool(d.Get("enable_ip_forwarding").(bool))
-	} else {
-		update.Properties.EnableIPForwarding = existing.Model.Properties.EnableIPForwarding
+	if d.HasChange("accelerated_networking_enabled") {
+		payload.Properties.EnableAcceleratedNetworking = pointer.To(d.Get("accelerated_networking_enabled").(bool))
+	}
+
+	if !features.FourPointOhBeta() && d.HasChange("enable_accelerated_networking") {
+		payload.Properties.EnableAcceleratedNetworking = pointer.To(d.Get("enable_accelerated_networking").(bool))
+	}
+
+	if d.HasChange("ip_forwarding_enabled") {
+		payload.Properties.EnableIPForwarding = pointer.To(d.Get("ip_forwarding_enabled").(bool))
+	}
+
+	if !features.FourPointOhBeta() && d.HasChange("enable_ip_forwarding") {
+		payload.Properties.EnableIPForwarding = pointer.To(d.Get("enable_ip_forwarding").(bool))
 	}
 
 	if d.HasChange("internal_dns_name_label") {
-		update.Properties.DnsSettings.InternalDnsNameLabel = utils.String(d.Get("internal_dns_name_label").(string))
-	} else {
-		update.Properties.DnsSettings.InternalDnsNameLabel = existing.Model.Properties.DnsSettings.InternalDnsNameLabel
+		payload.Properties.DnsSettings.InternalDnsNameLabel = pointer.To(d.Get("internal_dns_name_label").(string))
 	}
 
 	if d.HasChange("ip_configuration") {
@@ -402,22 +429,15 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		// then map the fields managed in other resources back
 		ipConfigs = mapFieldsToNetworkInterface(ipConfigs, info)
 
-		update.Properties.IPConfigurations = ipConfigs
-	} else {
-		update.Properties.IPConfigurations = existing.Model.Properties.IPConfigurations
+		payload.Properties.IPConfigurations = ipConfigs
 	}
 
 	if d.HasChange("tags") {
 		tagsRaw := d.Get("tags").(map[string]interface{})
-		update.Tags = tags.Expand(tagsRaw)
-	} else {
-		update.Tags = existing.Model.Tags
+		payload.Tags = tags.Expand(tagsRaw)
 	}
 
-	// this can be managed in another resource, so just port it over
-	update.Properties.NetworkSecurityGroup = existing.Model.Properties.NetworkSecurityGroup
-
-	err = client.CreateOrUpdateThenPoll(ctx, *id, update)
+	err = client.CreateOrUpdateThenPoll(ctx, *id, *payload)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
@@ -514,8 +534,12 @@ func resourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 			}
 
 			d.Set("auxiliary_sku", auxiliarySku)
-			d.Set("enable_ip_forwarding", props.EnableIPForwarding)
-			d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
+			d.Set("ip_forwarding_enabled", props.EnableIPForwarding)
+			d.Set("accelerated_networking_enabled", props.EnableAcceleratedNetworking)
+			if !features.FourPointOhBeta() {
+				d.Set("enable_ip_forwarding", props.EnableIPForwarding)
+				d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
+			}
 			d.Set("internal_dns_name_label", internalDnsNameLabel)
 			d.Set("internal_domain_name_suffix", internalDomainNameSuffix)
 			d.Set("mac_address", props.MacAddress)
@@ -624,7 +648,7 @@ func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]networkinte
 		}
 
 		if v, ok := data["primary"]; ok {
-			properties.Primary = utils.Bool(v.(bool))
+			properties.Primary = pointer.To(v.(bool))
 		}
 
 		if v := data["gateway_load_balancer_frontend_ip_configuration_id"].(string); v != "" {

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -90,6 +90,13 @@ func TestAccNetworkInterface_dnsServers(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.dnsServersRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -566,6 +573,24 @@ resource "azurerm_network_interface" "test" {
     "10.0.0.6",
     "10.0.0.5"
   ]
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r NetworkInterfaceResource) dnsServersRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   ip_configuration {
     name                          = "primary"

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -655,10 +655,11 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  name                            = "internal"
+  resource_group_name             = azurerm_resource_group.test.name
+  virtual_network_name            = azurerm_virtual_network.test.name
+  address_prefixes                = ["10.0.2.0/24"]
+  default_outbound_access_enabled = false
 }
 
 resource "azurerm_network_interface" "test" {

--- a/internal/services/recoveryservices/recovery_services_vault_hyperv_host_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_hyperv_host_test.go
@@ -364,7 +364,7 @@ resource "azurerm_network_interface" "host" {
   location            = azurerm_resource_group.hybrid.location
   resource_group_name = azurerm_resource_group.hybrid.name
 
-  enable_ip_forwarding = true
+  ip_forwarding_enabled = true
 
   ip_configuration {
     name                          = "internal"

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -31,12 +31,12 @@ output "network_interface_id" {
 ## Attributes Reference
 
 * `id` - The ID of the Network Interface.
+* `accelerated_networking_enabled` - Indicates if accelerated networking is set on the specified Network Interface.
 * `applied_dns_servers` - List of DNS servers applied to the specified Network Interface.
-* `enable_accelerated_networking` - Indicates if accelerated networking is set on the specified Network Interface.
-* `enable_ip_forwarding` - Indicate if IP forwarding is set on the specified Network Interface.
 * `dns_servers` - The list of DNS servers used by the specified Network Interface.
 * `internal_dns_name_label` - The internal DNS name label of the specified Network Interface.
 * `ip_configuration` - One or more `ip_configuration` blocks as defined below.
+* `ip_forwarding_enabled` - Indicate if IP forwarding is set on the specified Network Interface.
 * `location` - The location of the specified Network Interface.
 * `mac_address` - The MAC address used by the specified Network Interface.
 * `network_security_group_id` - The ID of the network security group associated to the specified Network Interface.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -74,9 +74,9 @@ The following arguments are supported:
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Network Interface should exist. Changing this forces a new Network Interface to be created.
 
-* `enable_ip_forwarding` - (Optional) Should IP Forwarding be enabled? Defaults to `false`.
+* `ip_forwarding_enabled` - (Optional) Should IP Forwarding be enabled? Defaults to `false`.
 
-* `enable_accelerated_networking` - (Optional) Should Accelerated Networking be enabled? Defaults to `false`.
+* `accelerated_networking_enabled` - (Optional) Should Accelerated Networking be enabled? Defaults to `false`.
 
 -> **Note:** Only certain Virtual Machine sizes are supported for Accelerated Networking - [more information can be found in this document](https://docs.microsoft.com/azure/virtual-network/create-vm-accelerated-networking-cli).
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removed `Computed` from `dns_servers`
- Renamed `enable_ip_forwarding` to `ip_forwarding_enabled`
- Renamed `enable_accelerated_networking` to `accelerated_networking_enabled`
- Updated the update function to patch the existing resource model instead of populating a new model

## Testing 

<img width="419" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/9d53c0a8-e84f-474a-8398-e0b0a254542f">

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #21225


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
