### PR TITLE
`azurerm_nginx_deployment`- add `ForceNew` to nested fields

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -195,6 +195,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"ip_address": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
+						ForceNew: true,
 						Elem: &pluginsdk.Schema{
 							Type:         pluginsdk.TypeString,
 							ValidateFunc: validation.StringIsNotEmpty,
@@ -214,17 +215,20 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"ip_address": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 
 					"allocation_method": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
+						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice(nginxdeployment.PossibleValuesForNginxPrivateIPAllocationMethod(), false),
 					},
 
 					"subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 				},
 			},
@@ -239,6 +243,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 				},
 			},

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -132,17 +132,17 @@ A `identity` block supports the following:
 
 A `frontend_private` block supports the following:
 
-* `allocation_method` - (Required) Specify the method for allocating the private IP. Possible values are `Static` and `Dynamic`.
+* `allocation_method` - (Required) Specify the method for allocating the private IP. Possible values are `Static` and `Dynamic`. Changing this forces a new NGINX Deployment to be created.
 
-* `ip_address` - (Required) Specify the private IP Address.
+* `ip_address` - (Required) Specify the private IP Address. Changing this forces a new NGINX Deployment to be created.
 
-* `subnet_id` - (Required) Specify the Subnet Resource ID for this NGINX Deployment.
+* `subnet_id` - (Required) Specify the Subnet Resource ID for this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
 
 ---
 
 A `frontend_public` block supports the following:
 
-* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this NGINX Deployment.
+* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
 
 ---
 
@@ -156,7 +156,7 @@ A `logging_storage_account` block supports the following:
 
 A `network_interface` block supports the following:
 
-* `subnet_id` - (Required) Specify The Subnet Resource ID for this NGINX Deployment.
+* `subnet_id` - (Required) Specify The Subnet Resource ID for this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
 
 ---
 


### PR DESCRIPTION
A bug was found when trying to update a deployment's private IP. The expected behavior is that the deployment should be recreated. However, the actual behavior was that terraform plan showed an in-place update. For example, given the initial applied configuration:
```
resource "azurerm_nginx_deployment" "dep" {
  name                      = var.dep_name
  resource_group_name       = module.prerequisites.resource_group_name
  sku                       = var.sku
  location                  = var.location
  capacity                  = 20
  automatic_upgrade_channel = "stable"

  frontend_private {
    allocation_method = "Static"
    ip_address        = "10.0.1.100"
    subnet_id         = module.prerequisites.subnet_id
  }

  network_interface {
    subnet_id = module.prerequisites.subnet_id
  }

  tags = var.tags
}
```
If the following change is then made to the configuration:
```
- ip_address        = "10.0.1.100"
+ ip_address        = "10.0.1.101"
``` 
`terraform plan` will output the following:
```
  # azurerm_nginx_deployment.dep will be updated in-place
  ~ resource "azurerm_nginx_deployment" "dep" {
        id                        = "/subscriptions/ee920d60-90f3-4a92-b5e7-bb284c3a6ce2/resourceGroups/valyria-tf-test/providers/Nginx.NginxPlus/nginxDeployments/valyria-tf-dep"
        name                      = "valyria-tf-dep"
        tags                      = {
            "env" = "test"
        }
        # (10 unchanged attributes hidden)

      ~ frontend_private {
          ~ ip_address        = "10.0.1.100" -> "10.0.1.101"
            # (2 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This is odd because the `frontend_private` field, the parent field for the private IP address, has `ForceNew` set to true. However, there seems to be a bug where if the field is a list type and the `Elem` is of type `pluginsdk.Resource`, the `ForceNew` does not get propagated down to the child fields. 

This aligns with [this comment](https://github.com/hashicorp/terraform/issues/34691#issuecomment-1949446464) from an existing issue with the plugin SDK. The comment links [this segment of code](https://github.com/hashicorp/terraform-plugin-sdk/blob/43cfd3282307f68ea77eb4c15548100386f3a317/helper/schema/schema.go#L1258-L1287) from the plugin SDK indicating that `ForceNew` only gets copied from the parent schema when the `Elem` is of type `Schema`. 

This change adds `ForceNew: true` to the nested fields whose parents have `ForceNew: true`. I manually verified that with this change, the bug is now fixed. The `terraform plan` output from the above example becomes
```
  # azurerm_nginx_deployment.dep must be replaced
-/+ resource "azurerm_nginx_deployment" "dep" {
      ~ id                        = "/subscriptions/ee920d60-90f3-4a92-b5e7-bb284c3a6ce2/resourceGroups/valyria-tf-test/providers/Nginx.NginxPlus/nginxDeployments/valyria-tf-dep" -> (known after apply)
      ~ ip_address                = "10.0.1.100" -> (known after apply)
      ~ managed_resource_group    = "NGX_valyria-tf-test_valyria-tf-dep_eastus2" -> (known after apply)
        name                      = "valyria-tf-dep"
      ~ nginx_version             = "1.25.1 (nginx-plus-r30-p2)" -> (known after apply)
        tags                      = {
            "env" = "test"
        }
        # (7 unchanged attributes hidden)

      ~ frontend_private {
          ~ ip_address        = "10.0.1.100" -> "10.0.1.101" # forces replacement
            # (2 unchanged attributes hidden)
        }

      ~ identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nginx_deployment`- add `ForceNew` to nested fields


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
