### PR TITLE
`azurerm_container_groups` - allow windows container groups to be created with a User Assigned Identity

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -796,15 +796,11 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Zones: &zones,
 	}
 
-	// Container Groups with OS Type Windows do not support managed identities but the API also does not accept Identity Type: None
-	// https://github.com/Azure/azure-rest-api-specs/issues/18122
-	if OSType != string(containerinstance.OperatingSystemTypesWindows) {
-		expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `identity`: %+v", err)
-		}
-		containerGroup.Identity = expandedIdentity
+	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
+	containerGroup.Identity = expandedIdentity
 
 	if IPAddressType != "None" {
 		containerGroup.Properties.IPAddress = &containerinstance.IPAddress{

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -1835,6 +1835,13 @@ resource "azurerm_log_analytics_solution" "test" {
   }
 }
 
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  name = "acctest%s"
+}
+
 resource "azurerm_container_group" "test" {
   name                = "acctestcontainergroup-%d"
   location            = azurerm_resource_group.test.location
@@ -1843,6 +1850,11 @@ resource "azurerm_container_group" "test" {
   dns_name_label      = "acctestcontainergroup-%d"
   os_type             = "Windows"
   restart_policy      = "Never"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
 
   container {
     name   = "windowsservercore"
@@ -1911,7 +1923,7 @@ resource "azurerm_container_group" "test" {
     environment = "Testing"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func (ContainerGroupResource) linuxComplete(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The linked Azure Rest API specs issues appears to have been resolved, so this is closed now.

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/ea11ba3f-dd45-4250-89e1-9f348c9bdca2)

Failed test cases are on main


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_group` - Container Groups running on Windows can be created with a User Assigned Identity [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24809


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
