### PR TITLE
`azurerm_lb_backend_address_pool` - support for the `synchronous_mode` property

### DIFF
--- a/internal/services/loadbalancer/backend_address_pool_resource_test.go
+++ b/internal/services/loadbalancer/backend_address_pool_resource_test.go
@@ -36,6 +36,21 @@ func TestAccBackendAddressPoolBasicSkuBasic(t *testing.T) {
 	})
 }
 
+func TestAccBackendAddressPoolSynchronousMode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb_backend_address_pool", "test")
+	r := LoadBalancerBackendAddressPool{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.syncMode(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccBackendAddressPoolBasicSkuDisappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_backend_address_pool", "test")
 	r := LoadBalancerBackendAddressPool{}
@@ -248,6 +263,24 @@ provider "azurerm" {
 resource "azurerm_lb_backend_address_pool" "test" {
   name            = "pool"
   loadbalancer_id = azurerm_lb.test.id
+}
+`, template)
+}
+
+func (r LoadBalancerBackendAddressPool) syncMode(data acceptance.TestData) string {
+	template := r.template(data, "Standard")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name               = "pool"
+  loadbalancer_id    = azurerm_lb.test.id
+  synchronous_mode   = "Automatic"
+  virtual_network_id = azurerm_virtual_network.test.id
 }
 `, template)
 }

--- a/internal/services/loadbalancer/backend_address_pool_resource_test.go
+++ b/internal/services/loadbalancer/backend_address_pool_resource_test.go
@@ -36,13 +36,28 @@ func TestAccBackendAddressPoolBasicSkuBasic(t *testing.T) {
 	})
 }
 
-func TestAccBackendAddressPoolSynchronousMode(t *testing.T) {
+func TestAccBackendAddressPoolSynchronousModeManual(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_backend_address_pool", "test")
 	r := LoadBalancerBackendAddressPool{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.syncMode(data),
+			Config: r.syncModeManual(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccBackendAddressPoolSynchronousModeAutomatic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb_backend_address_pool", "test")
+	r := LoadBalancerBackendAddressPool{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.syncModeAutomatic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -267,24 +282,6 @@ resource "azurerm_lb_backend_address_pool" "test" {
 `, template)
 }
 
-func (r LoadBalancerBackendAddressPool) syncMode(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  name               = "pool"
-  loadbalancer_id    = azurerm_lb.test.id
-  synchronous_mode   = "Automatic"
-  virtual_network_id = azurerm_virtual_network.test.id
-}
-`, template)
-}
-
 func (r LoadBalancerBackendAddressPool) basicSkuRequiresImport(data acceptance.TestData) string {
 	template := r.basicSkuBasic(data)
 	return fmt.Sprintf(`
@@ -467,4 +464,188 @@ resource "azurerm_lb" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (LoadBalancerBackendAddressPool) templateSyncMode(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet-%[1]d"
+  resource_group_name  = azurerm_virtual_network.test.resource_group_name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name      = "fe-lb"
+    subnet_id = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r LoadBalancerBackendAddressPool) syncModeManual(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%[1]s
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name               = "pool"
+  loadbalancer_id    = azurerm_lb.test.id
+  synchronous_mode   = "Manual"
+  virtual_network_id = azurerm_virtual_network.test.id
+}
+
+resource "azurerm_lb_backend_address_pool_address" "test" {
+  name                    = "address"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
+  ip_address              = "10.0.2.6"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctvmss-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  upgrade_policy_mode = "Manual"
+  priority            = "Regular"
+
+  sku {
+    name     = "Standard_F2"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  boot_diagnostics {
+    enabled     = false
+    storage_uri = ""
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%[2]d"
+    admin_username       = "adminuser"
+    admin_password       = "P@ssW0RD7890"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  storage_profile_os_disk {
+    name              = ""
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  depends_on = [azurerm_lb_backend_address_pool_address.test]
+}
+`, r.templateSyncMode(data), data.RandomInteger)
+}
+
+func (r LoadBalancerBackendAddressPool) syncModeAutomatic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%[1]s
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name               = "pool"
+  loadbalancer_id    = azurerm_lb.test.id
+  synchronous_mode   = "Automatic"
+  virtual_network_id = azurerm_virtual_network.test.id
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctvmss-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  upgrade_policy_mode = "Manual"
+  priority            = "Regular"
+
+  sku {
+    name     = "Standard_F2"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  boot_diagnostics {
+    enabled     = false
+    storage_uri = ""
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%[2]d"
+    admin_username       = "adminuser"
+    admin_password       = "P@ssW0RD7890"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name                                   = "TestIPConfiguration"
+      primary                                = true
+      subnet_id                              = azurerm_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+    }
+  }
+
+  storage_profile_os_disk {
+    name              = ""
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+`, r.templateSyncMode(data), data.RandomInteger)
 }

--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -52,6 +52,10 @@ The following arguments are supported:
   
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Backend Address Pool. Changing this forces a new resource to be created.
 
+* `synchronous_mode` - (Optional) The backend address synchronous mode for the Backend Address Pool. Possible values are `Automatic` and `Manual`. This is required with `virtual_network_id`. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `synchronous_mode` can set only for Load Balancer with `Standard` SKU.
+
 * `tunnel_interface` - (Optional) One or more `tunnel_interface` blocks as defined below.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network within which the Backend Address Pool should exist.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- Support for the `synchronous_mode` property. Swagger: https://github.com/Azure/azure-rest-api-specs/blob/13962fb6f539de6125f94cdfdf177bfcd24efcb4/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/loadBalancer.json#L1894

- Removing `RequiredWith` for `virtual_network_id` and `ip_address` of `azurerm_lb_backend_address_pool_address` is because of the following API behaviors:

> 1.  Only one of the `virtual_network_id` in `azurerm_lb_backend_address_pool` and the `azurerm_lb_backend_address_pool_address` can be specified.
> 2.  When `synchronous_mode` of `azurerm_lb_backend_address_pool` is specified, `virtual_network_id` is required to be specified at the same time.
> 3.  The `virtual_network_id` of `azurerm_lb_backend_address_pool_address` can be unspecified when `synchronous_mode` is specified as `Manual`.

- Fix dependency issue, which were missed in [PR ](https://github.com/hashicorp/terraform-provider-azurerm/pull/26264)- property values ​​other than `LoadBalancerBackendAddresses` were reset issue.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
PASS: TestAccBackendAddressPoolSynchronousModeManual (622.11s)
PASS: TestAccBackendAddressPoolSynchronousModeAutomatic (616.11s)

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_lb_backend_address_pool` - support for the `synchronous_mode` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

