### PR TITLE
`azurerm_virtual_hub_*` - split CreateUpdate 

### DIFF
--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -31,9 +31,9 @@ const virtualHubResourceName = "azurerm_virtual_hub"
 
 func resourceVirtualHub() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVirtualHubCreateUpdate,
+		Create: resourceVirtualHubCreate,
 		Read:   resourceVirtualHubRead,
-		Update: resourceVirtualHubCreateUpdate,
+		Update: resourceVirtualHubUpdate,
 		Delete: resourceVirtualHubDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.VirtualHubID(id)
@@ -146,10 +146,10 @@ func resourceVirtualHub() *pluginsdk.Resource {
 	}
 }
 
-func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVirtualHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	if _, ok := ctx.Deadline(); !ok {
@@ -161,16 +161,14 @@ func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	locks.ByName(id.VirtualHubName, virtualHubResourceName)
 	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
 
-	if d.IsNewResource() {
-		existing, err := client.VirtualHubsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for present of existing %s: %+v", id, err)
-			}
-		}
+	existing, err := client.VirtualHubsGet(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_virtual_hub", id.ID())
+			return fmt.Errorf("checking for present of existing %s: %+v", id, err)
 		}
+	}
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_virtual_hub", id.ID())
 	}
 
 	parameters := virtualwans.VirtualHub{
@@ -220,7 +218,86 @@ func resourceVirtualHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 		ContinuousTargetOccurence: 3,
 		Timeout:                   time.Until(timeout),
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for %s provisioning route: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVirtualHubRead(d, meta)
+}
+
+func resourceVirtualHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	if _, ok := ctx.Deadline(); !ok {
+		return fmt.Errorf("deadline is not properly set for Virtual Hub")
+	}
+
+	id, err := virtualwans.ParseVirtualHubID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(id.VirtualHubName, virtualHubResourceName)
+
+	existing, err := client.VirtualHubsGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	payload := existing.Model
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+	}
+
+	if d.HasChange("route") {
+		payload.Properties.RouteTable = expandVirtualHubRoute(d.Get("route").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("hub_routing_preference") {
+		payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(d.Get("hub_routing_preference").(string)))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if d.HasChange("virtual_router_auto_scale_min_capacity") {
+		if v, ok := d.GetOk("virtual_router_auto_scale_min_capacity"); ok {
+			payload.Properties.VirtualRouterAutoScaleConfiguration = &virtualwans.VirtualRouterAutoScaleConfiguration{
+				MinCapacity: pointer.To(int64(v.(int))),
+			}
+		}
+	}
+
+	if err := client.VirtualHubsCreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	// Hub returns provisioned while the routing state is still "provisioning". This might cause issues with following hubvnet connection operations.
+	// https://github.com/Azure/azure-rest-api-specs/issues/10391
+	// As a workaround, we will poll the routing state and ensure it is "Provisioned".
+
+	// deadline is checked at the entry point of this function
+	timeout, _ := ctx.Deadline()
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{"Provisioning"},
+		Target:                    []string{"Provisioned", "Failed", "None"},
+		Refresh:                   virtualHubCreateRefreshFunc(ctx, client, *id),
+		PollInterval:              15 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   time.Until(timeout),
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for %s provisioning route: %+v", id, err)
 	}

--- a/internal/services/network/virtual_hub_route_table_resource.go
+++ b/internal/services/network/virtual_hub_route_table_resource.go
@@ -24,9 +24,9 @@ import (
 
 func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVirtualHubRouteTableCreateUpdate,
+		Create: resourceVirtualHubRouteTableCreate,
 		Read:   resourceVirtualHubRouteTableRead,
-		Update: resourceVirtualHubRouteTableCreateUpdate,
+		Update: resourceVirtualHubRouteTableUpdate,
 		Delete: resourceVirtualHubRouteTableDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -116,9 +116,9 @@ func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 	}
 }
 
-func resourceVirtualHubRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVirtualHubRouteTableCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
@@ -131,17 +131,15 @@ func resourceVirtualHubRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	id := virtualwans.NewHubRouteTableID(virtHubId.SubscriptionId, virtHubId.ResourceGroupName, virtHubId.VirtualHubName, d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.HubRouteTablesGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.HubRouteTablesGet(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_virtual_hub_route_table", id.ID())
+			return fmt.Errorf("checking for presence of %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_virtual_hub_route_table", id.ID())
 	}
 
 	parameters := virtualwans.HubRouteTable{
@@ -153,7 +151,58 @@ func resourceVirtualHubRouteTableCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVirtualHubRouteTableRead(d, meta)
+}
+
+func resourceVirtualHubRouteTableUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(virtHubId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(virtHubId.VirtualHubName, virtualHubResourceName)
+
+	id, err := virtualwans.ParseHubRouteTableID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.HubRouteTablesGet(ctx, *id)
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
+		}
+	}
+
+	payload := existing.Model
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+	}
+
+	if d.HasChange("labels") {
+		payload.Properties.Labels = utils.ExpandStringSlice(d.Get("labels").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("route") {
+		payload.Properties.Routes = expandVirtualHubRouteTableHubRoutes(d.Get("route").(*pluginsdk.Set).List())
+	}
+
+	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/virtual_hub_route_table_route_resource.go
+++ b/internal/services/network/virtual_hub_route_table_route_resource.go
@@ -25,9 +25,9 @@ import (
 
 func resourceVirtualHubRouteTableRoute() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVirtualHubRouteTableRouteCreateUpdate,
+		Create: resourceVirtualHubRouteTableRouteCreate,
 		Read:   resourceVirtualHubRouteTableRouteRead,
-		Update: resourceVirtualHubRouteTableRouteCreateUpdate,
+		Update: resourceVirtualHubRouteTableRouteUpdate,
 		Delete: resourceVirtualHubRouteTableRouteDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -94,9 +94,9 @@ func resourceVirtualHubRouteTableRoute() *pluginsdk.Resource {
 	}
 }
 
-func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVirtualHubRouteTableRouteCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	routeTableId, err := virtualwans.ParseHubRouteTableID(d.Get("route_table_id").(string))
@@ -128,15 +128,13 @@ func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, me
 	id := parse.NewHubRouteTableRouteID(routeTableId.SubscriptionId, routeTableId.ResourceGroupName, routeTableId.VirtualHubName, routeTableId.HubRouteTableName, name)
 
 	routes := make([]virtualwans.HubRoute, 0)
-	if d.IsNewResource() {
-		if hubRoutes := props.Routes; hubRoutes != nil {
-			for _, r := range *hubRoutes {
-				if r.Name == name {
-					return tf.ImportAsExistsError("azurerm_virtual_hub_route_table_route", id.ID())
-				}
+	if hubRoutes := props.Routes; hubRoutes != nil {
+		for _, r := range *hubRoutes {
+			if r.Name == name {
+				return tf.ImportAsExistsError("azurerm_virtual_hub_route_table_route", id.ID())
 			}
-			routes = *props.Routes
 		}
+		routes = *props.Routes
 
 		result := virtualwans.HubRoute{
 			Name:            d.Get("name").(string),
@@ -147,24 +145,75 @@ func resourceVirtualHubRouteTableRouteCreateUpdate(d *pluginsdk.ResourceData, me
 		}
 
 		routes = append(routes, result)
+	}
 
-	} else {
-		routes = *props.Routes
-		for i := range routes {
-			if routes[i].Name == name {
+	routeTable.Model.Properties.Routes = pointer.To(routes)
+
+	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, *routeTableId, *routeTable.Model); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVirtualHubRouteTableRouteRead(d, meta)
+}
+
+func resourceVirtualHubRouteTableRouteUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	routeTableId, err := virtualwans.ParseHubRouteTableID(d.Get("route_table_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(routeTableId.VirtualHubName, virtualHubResourceName)
+	defer locks.UnlockByName(routeTableId.VirtualHubName, virtualHubResourceName)
+
+	routeTable, err := client.HubRouteTablesGet(ctx, *routeTableId)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", routeTableId, err)
+	}
+
+	if routeTable.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", routeTableId)
+	}
+	if routeTable.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", routeTableId)
+	}
+
+	props := routeTable.Model.Properties
+
+	id, err := parse.HubRouteTableRouteID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	routes := make([]virtualwans.HubRoute, 0)
+	routes = *props.Routes
+	for i := range routes {
+		if routes[i].Name == id.RouteName {
+			if d.HasChange("destinations_type") {
 				routes[i].DestinationType = d.Get("destinations_type").(string)
-				routes[i].Destinations = pointer.From(utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List()))
-				routes[i].NextHopType = d.Get("next_hop_type").(string)
-				routes[i].NextHop = d.Get("next_hop").(string)
-				break
 			}
+			if d.HasChange("destinations") {
+				routes[i].Destinations = pointer.From(utils.ExpandStringSlice(d.Get("destinations").(*pluginsdk.Set).List()))
+			}
+			if d.HasChange("next_hop_type") {
+				routes[i].NextHopType = d.Get("next_hop_type").(string)
+			}
+			if d.HasChange("next_hop") {
+				routes[i].NextHop = d.Get("next_hop").(string)
+			}
+			break
 		}
 	}
 
 	routeTable.Model.Properties.Routes = pointer.To(routes)
 
 	if err := client.HubRouteTablesCreateOrUpdateThenPoll(ctx, *routeTableId, *routeTable.Model); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/virtual_hub_route_table_route_resource.go
+++ b/internal/services/network/virtual_hub_route_table_route_resource.go
@@ -190,8 +190,7 @@ func resourceVirtualHubRouteTableRouteUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	routes := make([]virtualwans.HubRoute, 0)
-	routes = *props.Routes
+	routes := *props.Routes
 	for i := range routes {
 		if routes[i].Name == id.RouteName {
 			if d.HasChange("destinations_type") {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR splits the CreateUpdate functions in `azurerm_virtual_hub`, `azurerm_virtual_hub_route_table` and `azurerm_virtual_hub_route_table_route` into separate Create and Update functions so ignore_changes can be used.

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests passing aside from those currently failing in main


