### PR TITLE
`azurerm_synapse_workspace` - deprecate `aad_admin` and `sql_aad_admin` 

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -38,7 +39,7 @@ const (
 )
 
 func resourceSynapseWorkspace() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceSynapseWorkspaceCreate,
 		Read:   resourceSynapseWorkspaceRead,
 		Update: resourceSynapseWorkspaceUpdate,
@@ -113,63 +114,6 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				ForceNew: true,
-			},
-
-			"aad_admin": {
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				Computed:   true,
-				MaxItems:   1,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"login": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-						},
-
-						"object_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-
-						"tenant_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-					},
-				},
-			},
-
-			"sql_aad_admin": {
-				Type:          pluginsdk.TypeList,
-				Optional:      true,
-				Computed:      true,
-				MaxItems:      1,
-				ConfigMode:    pluginsdk.SchemaConfigModeAttr,
-				ConflictsWith: []string{"customer_managed_key"},
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"login": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-						},
-
-						"object_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-
-						"tenant_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-					},
-				},
 			},
 
 			"connectivity_endpoints": {
@@ -326,6 +270,68 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 			"tags": tags.Schema(),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["aad_admin"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			Computed:   true,
+			MaxItems:   1,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Deprecated: "The `aad_admin` block has been superseded by the `azurerm_synapse_workspace_aad_admin` resource and will be removed in v4.0 of the AzureRM Provider.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"login": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"object_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+
+					"tenant_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+				},
+			},
+		}
+		resource.Schema["sql_aad_admin"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeList,
+			Optional:      true,
+			Computed:      true,
+			MaxItems:      1,
+			ConfigMode:    pluginsdk.SchemaConfigModeAttr,
+			ConflictsWith: []string{"customer_managed_key"},
+			Deprecated:    "The `sql_aad_admin` block has been superseded by the `azurerm_synapse_workspace_sql_aad_admin` resource and will be removed in v4.0 of the AzureRM Provider.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"login": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"object_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+
+					"tenant_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+				},
+			},
+		}
+	}
+
+	return resource
 }
 
 func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -420,27 +426,29 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
 	}
 
-	aadAdmin := expandArmWorkspaceAadAdminInfo(d.Get("aad_admin").([]interface{}))
-	if aadAdmin != nil {
-		future, err := aadAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *aadAdmin)
-		if err != nil {
-			return fmt.Errorf("configuring AzureAD Admin for %s: %+v", id, err)
+	if !features.FourPointOhBeta() {
+		aadAdmin := expandArmWorkspaceAadAdminInfo(d.Get("aad_admin").([]interface{}))
+		if aadAdmin != nil {
+			future, err := aadAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *aadAdmin)
+			if err != nil {
+				return fmt.Errorf("configuring AzureAD Admin for %s: %+v", id, err)
+			}
+
+			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for configuration of AzureAD Admin for %s: %+v", id, err)
+			}
 		}
 
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for configuration of AzureAD Admin for %s: %+v", id, err)
-		}
-	}
+		sqlAdmin := expandArmWorkspaceAadAdminInfo(d.Get("sql_aad_admin").([]interface{}))
+		if sqlAdmin != nil {
+			future, err := sqlAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlAdmin)
+			if err != nil {
+				return fmt.Errorf("configuring Sql Admin for %s: %+v", id, err)
+			}
 
-	sqlAdmin := expandArmWorkspaceAadAdminInfo(d.Get("sql_aad_admin").([]interface{}))
-	if sqlAdmin != nil {
-		future, err := sqlAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlAdmin)
-		if err != nil {
-			return fmt.Errorf("configuring Sql Admin for %s: %+v", id, err)
-		}
-
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for configuration of Sql Admin for %s: %+v", id, err)
+			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for configuration of Sql Admin for %s: %+v", id, err)
+			}
 		}
 	}
 
@@ -484,18 +492,27 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	aadAdmin, err := aadAdminClient.Get(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
-		// NOTE: AAD Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
-		if !utils.ResponseWasNotFound(aadAdmin.Response) && !utils.ResponseWasConflict(aadAdmin.Response) {
-			return fmt.Errorf("retrieving AzureAD Admin for %s: %+v", *id, err)
+	if !features.FourPointOhBeta() {
+		aadAdmin, err := aadAdminClient.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			// NOTE: AAD Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
+			if !utils.ResponseWasNotFound(aadAdmin.Response) && !utils.ResponseWasConflict(aadAdmin.Response) {
+				return fmt.Errorf("retrieving AzureAD Admin for %s: %+v", *id, err)
+			}
 		}
-	}
-	sqlAdmin, err := sqlAdminClient.Get(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
-		// NOTE: SQL Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
-		if !utils.ResponseWasNotFound(sqlAdmin.Response) && !utils.ResponseWasConflict(sqlAdmin.Response) {
-			return fmt.Errorf("retrieving Sql Admin for %s: %+v", *id, err)
+		sqlAdmin, err := sqlAdminClient.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			// NOTE: SQL Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
+			if !utils.ResponseWasNotFound(sqlAdmin.Response) && !utils.ResponseWasConflict(sqlAdmin.Response) {
+				return fmt.Errorf("retrieving Sql Admin for %s: %+v", *id, err)
+			}
+		}
+
+		if err := d.Set("aad_admin", flattenArmWorkspaceAadAdmin(aadAdmin.AadAdminProperties)); err != nil {
+			return fmt.Errorf("setting `aad_admin`: %+v", err)
+		}
+		if err := d.Set("sql_aad_admin", flattenArmWorkspaceAadAdmin(sqlAdmin.AadAdminProperties)); err != nil {
+			return fmt.Errorf("setting `sql_aad_admin`: %+v", err)
 		}
 	}
 
@@ -558,12 +575,7 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 			d.Set("purview_id", props.PurviewConfiguration.PurviewResourceID)
 		}
 	}
-	if err := d.Set("aad_admin", flattenArmWorkspaceAadAdmin(aadAdmin.AadAdminProperties)); err != nil {
-		return fmt.Errorf("setting `aad_admin`: %+v", err)
-	}
-	if err := d.Set("sql_aad_admin", flattenArmWorkspaceAadAdmin(sqlAdmin.AadAdminProperties)); err != nil {
-		return fmt.Errorf("setting `sql_aad_admin`: %+v", err)
-	}
+
 	if err := d.Set("sql_identity_control_enabled", flattenIdentityControlSQLSettings(sqlControlSettings)); err != nil {
 		return fmt.Errorf("setting `sql_identity_control_enabled`: %+v", err)
 	}
@@ -646,60 +658,62 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("aad_admin") {
-		aadAdmin := expandArmWorkspaceAadAdminInfo(d.Get("aad_admin").([]interface{}))
-		if aadAdmin != nil {
-			if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-				return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-			}
-			workspaceAadAdminsCreateOrUpdateFuture, err := aadAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *aadAdmin)
-			if err != nil {
-				return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
+	if !features.FourPointOh() {
+		if d.HasChange("aad_admin") {
+			aadAdmin := expandArmWorkspaceAadAdminInfo(d.Get("aad_admin").([]interface{}))
+			if aadAdmin != nil {
+				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
+					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
+				}
+				workspaceAadAdminsCreateOrUpdateFuture, err := aadAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *aadAdmin)
+				if err != nil {
+					return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 
-			if err = workspaceAadAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
-		} else {
-			if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-				return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-			}
-			workspaceAadAdminsDeleteFuture, err := aadAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
-			if err != nil {
-				return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
+				if err = workspaceAadAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
+			} else {
+				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
+					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
+				}
+				workspaceAadAdminsDeleteFuture, err := aadAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
+				if err != nil {
+					return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 
-			if err = workspaceAadAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				if err = workspaceAadAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 			}
 		}
-	}
 
-	if d.HasChange("sql_aad_admin") {
-		sqlAdmin := expandArmWorkspaceAadAdminInfo(d.Get("sql_aad_admin").([]interface{}))
-		if sqlAdmin != nil {
-			if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-				return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-			}
-			workspaceSqlAdminsCreateOrUpdateFuture, err := sqlAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlAdmin)
-			if err != nil {
-				return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
+		if d.HasChange("sql_aad_admin") {
+			sqlAdmin := expandArmWorkspaceAadAdminInfo(d.Get("sql_aad_admin").([]interface{}))
+			if sqlAdmin != nil {
+				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
+					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
+				}
+				workspaceSqlAdminsCreateOrUpdateFuture, err := sqlAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlAdmin)
+				if err != nil {
+					return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 
-			if err = workspaceSqlAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
-		} else {
-			if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-				return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-			}
-			workspaceSqlAdminsDeleteFuture, err := sqlAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
-			if err != nil {
-				return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-			}
+				if err = workspaceSqlAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
+			} else {
+				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
+					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
+				}
+				workspaceSqlAdminsDeleteFuture, err := sqlAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
+				if err != nil {
+					return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 
-			if err = workspaceSqlAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				if err = workspaceSqlAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+				}
 			}
 		}
 	}

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -761,12 +761,6 @@ resource "azurerm_synapse_workspace" "test" {
     user_assigned_identity_id = azurerm_user_assigned_identity.test.id
   }
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = data.azurerm_client_config.current.object_id
-    tenant_id = data.azurerm_client_config.current.tenant_id
-  }
-
   identity {
     type         = "SystemAssigned, UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]

--- a/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
+++ b/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
@@ -65,7 +65,7 @@ func resourceSynapseWorkspaceSqlAADAdmin() *pluginsdk.Resource {
 }
 
 func resourceSynapseWorkspaceSqlAADAdminCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.WorkspaceAadAdminsClient
+	client := meta.(*clients.Client).Synapse.WorkspaceSQLAadAdminsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -101,7 +101,7 @@ func resourceSynapseWorkspaceSqlAADAdminCreateUpdate(d *pluginsdk.ResourceData, 
 }
 
 func resourceSynapseWorkspaceSqlAADAdminRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.WorkspaceAadAdminsClient
+	client := meta.(*clients.Client).Synapse.WorkspaceSQLAadAdminsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -130,7 +130,7 @@ func resourceSynapseWorkspaceSqlAADAdminRead(d *pluginsdk.ResourceData, meta int
 }
 
 func resourceSynapseWorkspaceSqlAADAdminDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.WorkspaceAadAdminsClient
+	client := meta.(*clients.Client).Synapse.WorkspaceSQLAadAdminsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -41,12 +41,6 @@ resource "azurerm_synapse_workspace" "example" {
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -187,8 +181,6 @@ The following arguments are supported:
 
 ---
 
-* `aad_admin` - (Optional) An `aad_admin` block as defined below.
-
 * `compute_subnet_id` - (Optional) Subnet ID used for computes in workspace Changing this forces a new resource to be created.
 
 * `azure_devops_repo` - (Optional) An `azure_devops_repo` block as defined below.
@@ -209,21 +201,9 @@ The following arguments are supported:
 
 * `purview_id` - (Optional) The ID of purview account.
 
-* `sql_aad_admin` - (Optional) An `sql_aad_admin` block as defined below.
-
 * `sql_identity_control_enabled` - (Optional) Are pipelines (running as workspace's system assigned identity) allowed to access SQL pools?
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Workspace.
-
----
-
-An `aad_admin` block supports the following:
-
-* `login` - (Required) The login name of the Azure AD Administrator of this Synapse Workspace.
-
-* `object_id` - (Required) The object id of the Azure AD Administrator of this Synapse Workspace.
-
-* `tenant_id` - (Required) The tenant id of the Azure AD Administrator of this Synapse Workspace.
 
 ---
 
@@ -280,16 +260,6 @@ A `github_repo` block supports the following:
 * `git_url` - (Optional) Specifies the GitHub Enterprise host name. For example: <https://github.mydomain.com>.
 
 -> **Note:** You must log in to the Synapse UI to complete the authentication to the GitHub repository.
-
----
-
-An `sql_aad_admin` block supports the following:
-
-* `login` - (Required) The login name of the Azure AD Administrator of this Synapse Workspace SQL.
-
-* `object_id` - (Required) The object id of the Azure AD Administrator of this Synapse Workspace SQL.
-
-* `tenant_id` - (Required) The tenant id of the Azure AD Administrator of this Synapse Workspace SQL.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR deprecates the `aad_admin` and `sql_aad_admin` blocks in favour of the standalone resources that exist for them.

This also updated the `azurerm_synapse_workspace_sql_aad_admin` resource to use the dedicated SQL Admin Workspace client, otherwise it's identical to the `azurerm_synapse_workspace_aad_admin` resource and is modifying the same resource.


## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/35a0ea7c-370f-4240-b38c-d838e03fff72)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_synapse_workspace_sql_aad_admin` - use correct client for modifying this resource [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #16853


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
