### PR TITLE
`trafficmanager` - remove `Computed` and set defaults for `weight` ,`priority` and `profile_status`

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -234,10 +234,15 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 			},
 
 			"customer_managed_key": {
-				Type:          pluginsdk.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"sql_aad_admin"},
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ConflictsWith: func() []string {
+					if !features.FourPointOhBeta() {
+						return []string{"sql_aad_admin"}
+					}
+					return []string{}
+				}(),
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"key_versionless_id": {

--- a/internal/services/trafficmanager/azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceAzureEndpoint() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceAzureEndpointCreate,
 		Read:   resourceAzureEndpointRead,
 		Update: resourceAzureEndpointUpdate,
@@ -71,15 +71,9 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -115,15 +109,9 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -159,6 +147,23 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["priority"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+		resource.Schema["weight"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+	}
+
+	return resource
 }
 
 func resourceAzureEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/trafficmanager/azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource.go
@@ -5,6 +5,7 @@ package trafficmanager
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -70,9 +71,15 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -108,9 +115,15 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource.go
@@ -5,7 +5,6 @@ package trafficmanager
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/trafficmanager/azure_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource_test.go
@@ -145,7 +145,6 @@ resource "azurerm_public_ip" "test" {
 resource "azurerm_traffic_manager_azure_endpoint" "test" {
   name               = "acctestend-azure%[2]d"
   target_resource_id = azurerm_public_ip.test.id
-  weight             = 3
   profile_id         = azurerm_traffic_manager_profile.test.id
 }
 `, template, data.RandomInteger)

--- a/internal/services/trafficmanager/external_endpoint_resource.go
+++ b/internal/services/trafficmanager/external_endpoint_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceExternalEndpoint() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceExternalEndpointCreate,
 		Read:   resourceExternalEndpointRead,
 		Update: resourceExternalEndpointUpdate,
@@ -71,15 +71,9 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -115,15 +109,9 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -167,6 +155,23 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["priority"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+		resource.Schema["weight"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+	}
+
+	return resource
 }
 
 func resourceExternalEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/trafficmanager/external_endpoint_resource.go
+++ b/internal/services/trafficmanager/external_endpoint_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -70,9 +71,15 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -108,9 +115,15 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/external_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/external_endpoint_resource_test.go
@@ -150,7 +150,6 @@ provider "azurerm" {
 resource "azurerm_traffic_manager_external_endpoint" "test" {
   name       = "acctestend-azure%d"
   target     = "www.example.com"
-  weight     = 3
   profile_id = azurerm_traffic_manager_profile.test.id
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/trafficmanager/nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -70,9 +71,15 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -118,9 +125,15 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return 1
+				}(),
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceNestedEndpoint() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceNestedEndpointCreateUpdate,
 		Read:   resourceNestedEndpointRead,
 		Update: resourceNestedEndpointCreateUpdate,
@@ -71,15 +71,9 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 
 			"weight": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -125,15 +119,9 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return 1
-				}(),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -177,6 +165,23 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["priority"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+		resource.Schema["weight"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 1000),
+		}
+	}
+
+	return resource
 }
 
 func resourceNestedEndpointCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/trafficmanager/nested_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource_test.go
@@ -137,7 +137,6 @@ resource "azurerm_traffic_manager_nested_endpoint" "test" {
   target_resource_id      = azurerm_traffic_manager_profile.child.id
   profile_id              = azurerm_traffic_manager_profile.parent.id
   minimum_child_endpoints = 5
-  weight                  = 3
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/trafficmanager/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -52,16 +53,6 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"profile_status": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(profiles.ProfileStatusEnabled),
-					string(profiles.ProfileStatusDisabled),
-				}, false),
-			},
 
 			"traffic_routing_method": {
 				Type:     pluginsdk.TypeString,
@@ -174,9 +165,20 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 				},
 			},
 
-			"fqdn": {
+			"profile_status": {
 				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Optional: true,
+				Computed: !features.FourPointOh(),
+				Default: func() interface{} {
+					if !features.FourPointOhBeta() {
+						return nil
+					}
+					return string(profiles.ProfileStatusEnabled)
+				}(),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(profiles.ProfileStatusEnabled),
+					string(profiles.ProfileStatusDisabled),
+				}, false),
 			},
 
 			"max_return": {
@@ -188,6 +190,11 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			"traffic_view_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+			},
+
+			"fqdn": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -26,7 +26,7 @@ import (
 )
 
 func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceArmTrafficManagerProfileCreate,
 		Read:   resourceArmTrafficManagerProfileRead,
 		Update: resourceArmTrafficManagerProfileUpdate,
@@ -168,13 +168,7 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			"profile_status": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: !features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOhBeta() {
-						return nil
-					}
-					return string(profiles.ProfileStatusEnabled)
-				}(),
+				Default:  string(profiles.ProfileStatusEnabled),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(profiles.ProfileStatusEnabled),
 					string(profiles.ProfileStatusDisabled),
@@ -200,6 +194,19 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["profile_status"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(profiles.ProfileStatusEnabled),
+				string(profiles.ProfileStatusDisabled),
+			}, false),
+		}
+	}
+	return resource
 }
 
 func resourceArmTrafficManagerProfileCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
@@ -96,7 +96,7 @@ func TestAccTrafficManagerProfile_updateEnsureDoNotEraseEndpoints(t *testing.T) 
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_requiresImport(t *testing.T) {
+func TestAccTrafficManagerProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -112,7 +112,7 @@ func TestAccAzureRMTrafficManagerProfile_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_cycleMethod(t *testing.T) {
+func TestAccTrafficManagerProfile_cycleMethod(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -174,7 +174,7 @@ func TestAccAzureRMTrafficManagerProfile_cycleMethod(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_fastEndpointFailoverSettingsError(t *testing.T) {
+func TestAccTrafficManagerProfile_fastEndpointFailoverSettingsError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -186,7 +186,7 @@ func TestAccAzureRMTrafficManagerProfile_fastEndpointFailoverSettingsError(t *te
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_fastMaxReturnSettingError(t *testing.T) {
+func TestAccTrafficManagerProfile_fastMaxReturnSettingError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -198,7 +198,7 @@ func TestAccAzureRMTrafficManagerProfile_fastMaxReturnSettingError(t *testing.T)
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_trafficView(t *testing.T) {
+func TestAccTrafficManagerProfile_trafficView(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -221,7 +221,7 @@ func TestAccAzureRMTrafficManagerProfile_trafficView(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_updateTTL(t *testing.T) {
+func TestAccTrafficManagerProfile_updateTTL(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 

--- a/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
@@ -20,7 +20,7 @@ import (
 
 type TrafficManagerProfileResource struct{}
 
-func TestAccAzureRMTrafficManagerProfile_basic(t *testing.T) {
+func TestAccTrafficManagerProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -37,7 +37,7 @@ func TestAccAzureRMTrafficManagerProfile_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_complete(t *testing.T) {
+func TestAccTrafficManagerProfile_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -52,7 +52,7 @@ func TestAccAzureRMTrafficManagerProfile_complete(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_update(t *testing.T) {
+func TestAccTrafficManagerProfile_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 
@@ -74,7 +74,7 @@ func TestAccAzureRMTrafficManagerProfile_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMTrafficManagerProfile_updateEnsureDoNotEraseEndpoints(t *testing.T) {
+func TestAccTrafficManagerProfile_updateEnsureDoNotEraseEndpoints(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_profile", "test")
 	r := TrafficManagerProfileResource{}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

API is returning `1` as a default for `weight` and `priority` and `Enabled` for `profile_status`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change

