### PR TITLE
`recoveryservices` - remove `ConfigModeAttr`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -155,10 +155,9 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			"target_edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
 			"unmanaged_disk": {
-				Type:       pluginsdk.TypeSet,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Optional:   true,
-				ForceNew:   true,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				ForceNew: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"disk_uri": {
@@ -192,11 +191,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			},
 
 			"managed_disk": {
-				Type:       pluginsdk.TypeSet,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Optional:   true,
-				ForceNew:   true,
-				Set:        resourceSiteRecoveryReplicatedVMDiskHash,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Set:      resourceSiteRecoveryReplicatedVMDiskHash,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"disk_id": {
@@ -252,11 +250,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 						},
 
 						"target_disk_encryption": {
-							Type:       pluginsdk.TypeList,
-							ConfigMode: pluginsdk.SchemaConfigModeAttr,
-							Optional:   true,
-							MaxItems:   1,
-							Elem:       diskEncryptionResource(),
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     diskEncryptionResource(),
 						},
 					},
 				},
@@ -287,11 +284,9 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			},
 
 			"network_interface": {
-				Type:       pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Computed:   true,
-				Optional:   true,
-				Elem:       networkInterfaceResource(),
+				Type:     pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
+				Optional: true,
+				Elem:     networkInterfaceResource(),
 			},
 		},
 	}
@@ -369,10 +364,9 @@ func diskEncryptionResource() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Schema: map[string]*pluginsdk.Schema{
 			"disk_encryption_key": {
-				Type:       pluginsdk.TypeList,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Required:   true,
-				MaxItems:   1,
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"secret_url": {
@@ -388,10 +382,9 @@ func diskEncryptionResource() *pluginsdk.Resource {
 			},
 
 			"key_encryption_key": {
-				Type:       pluginsdk.TypeList,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Optional:   true,
-				MaxItems:   1,
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"key_url": {

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -41,7 +41,7 @@ import (
 )
 
 func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceSiteRecoveryReplicatedItemCreate,
 		Read:   resourceSiteRecoveryReplicatedItemRead,
 		Update: resourceSiteRecoveryReplicatedItemUpdate,
@@ -286,11 +286,21 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			"network_interface": {
 				Type:     pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
 				Optional: true,
-				Computed: !features.FourPointOh(),
 				Elem:     networkInterfaceResource(),
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["network_interface"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeSet,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Computed:   true,
+			Optional:   true,
+			Elem:       networkInterfaceResource(),
+		}
+	}
+	return resource
 }
 
 func networkInterfaceResource() *pluginsdk.Resource {

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -286,6 +286,7 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			"network_interface": {
 				Type:     pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
 				Optional: true,
+				Computed: !features.FourPointOh(),
 				Elem:     networkInterfaceResource(),
 			},
 		},

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -444,11 +444,11 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
     target_replica_disk_type   = "Premium_LRS"
   }
 
-  network_interface {
-    source_network_interface_id   = azurerm_network_interface.test.id
-    target_subnet_name            = azurerm_subnet.test2.name
-    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
-  }
+  //network_interface {
+  //  source_network_interface_id   = azurerm_network_interface.test.id
+  //  target_subnet_name            = azurerm_subnet.test2.name
+  //  recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  //}
 
   depends_on = [
     azurerm_site_recovery_protection_container_mapping.test,

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -444,16 +444,14 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
     target_replica_disk_type   = "Premium_LRS"
   }
 
-  //network_interface {
-  //  source_network_interface_id   = azurerm_network_interface.test.id
-  //  target_subnet_name            = azurerm_subnet.test2.name
-  //  recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
-  //}
-
   depends_on = [
     azurerm_site_recovery_protection_container_mapping.test,
     azurerm_site_recovery_network_mapping.test,
   ]
+
+  lifecycle {
+    ignore_changes = ["network_interface"]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removes `ConfigModeAttr` from various properties that are `ForceNew`, so there is no need for it to be set to begin with.

Also removed from `network_interface` along with `Computed` and `ignore_changes` used in place.

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/7b9a6b83-b6dd-4501-b318-6f5552c2bdf5)

Test failures on main




<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change

