### PR TITLE
`azurerm_databricks_workspace`: Fix disabling default firewall

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -630,8 +630,9 @@ func resourceDatabricksWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta int
 		}
 
 		workspace.Properties.AccessConnector = &accessConnectorProperties
-		workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
 	}
+
+	workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
 
 	if requireNsgRules != "" {
 		requiredNsgRulesConst := workspaces.RequiredNsgRules(requireNsgRules)

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -630,9 +630,12 @@ func resourceDatabricksWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta int
 		}
 
 		workspace.Properties.AccessConnector = &accessConnectorProperties
+		workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
 	}
 
-	workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
+	if !d.IsNewResource() && d.HasChange("default_storage_firewall_enabled") {
+		workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
+	}
 
 	if requireNsgRules != "" {
 		requiredNsgRulesConst := workspaces.RequiredNsgRules(requireNsgRules)
@@ -735,7 +738,9 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 
 		if defaultStorageFirewall := model.Properties.DefaultStorageFirewall; defaultStorageFirewall != nil {
 			d.Set("default_storage_firewall_enabled", *defaultStorageFirewall != workspaces.DefaultStorageFirewallDisabled)
-			d.Set("access_connector_id", model.Properties.AccessConnector.Id)
+			if model.Properties.AccessConnector != nil {
+				d.Set("access_connector_id", model.Properties.AccessConnector.Id)
+			}
 		}
 
 		publicNetworkAccess := model.Properties.PublicNetworkAccess

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -52,6 +52,13 @@ func TestAccDatabricksWorkspace_defaultStorageFirewall(t *testing.T) {
 			),
 		},
 		data.ImportStep("custom_parameters.0.public_subnet_network_security_group_association_id", "custom_parameters.0.private_subnet_network_security_group_association_id"),
+		{
+			Config: r.defaultStorageFirewallUpdateToDisabled(data, "premium"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("custom_parameters.0.public_subnet_network_security_group_association_id", "custom_parameters.0.private_subnet_network_security_group_association_id", "access_connector_id"),
 	})
 }
 
@@ -533,7 +540,6 @@ resource "azurerm_subnet_network_security_group_association" "private" {
   network_security_group_id = azurerm_network_security_group.nsg.id
 }
 
-
 resource "azurerm_databricks_access_connector" "test" {
   name                = "acctestDBWACC%[1]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -562,6 +568,115 @@ resource "azurerm_databricks_workspace" "test" {
 
   access_connector_id              = azurerm_databricks_access_connector.test.id
   default_storage_firewall_enabled = true
+
+}
+`, data.RandomInteger, data.Locations.Primary, sku)
+}
+
+func (DatabricksWorkspaceResource) defaultStorageFirewallUpdateToDisabled(data acceptance.TestData, sku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-databricks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-vnet-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "public" {
+  name                 = "acctest-sn-public-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet" "private" {
+  name                 = "acctest-sn-private-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "acctest-nsg-private-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "public" {
+  subnet_id                 = azurerm_subnet.public.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+resource "azurerm_subnet_network_security_group_association" "private" {
+  subnet_id                 = azurerm_subnet.private.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+resource "azurerm_databricks_access_connector" "test" {
+  name                = "acctestDBWACC%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_databricks_workspace" "test" {
+  name                = "acctestDBW-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "%[3]s"
+
+  custom_parameters {
+    no_public_ip        = false
+    public_subnet_name  = azurerm_subnet.public.name
+    private_subnet_name = azurerm_subnet.private.name
+    virtual_network_id  = azurerm_virtual_network.test.id
+
+    public_subnet_network_security_group_association_id  = azurerm_subnet_network_security_group_association.public.id
+    private_subnet_network_security_group_association_id = azurerm_subnet_network_security_group_association.private.id
+  }
+
+  access_connector_id              = azurerm_databricks_access_connector.test.id
+  default_storage_firewall_enabled = false
 
 }
 `, data.RandomInteger, data.Locations.Primary, sku)


### PR DESCRIPTION
Bugfix: explicitly set firewallEnabled to `false`, instead of only setting it when enabled, thus supporting disabling it too.

```
[16:05](⎈|eastus2-fxs-atlas-prod-fxc:ops)➜  hashicorp/terraform-provider-azurerm git:(favoretti/26213) ✗ TF_ACC=1 go test -v ./internal/services/databricks -timeout=1000m -run='TestAccDatabricksWorkspace_defaultStorageFirewall'
=== RUN   TestAccDatabricksWorkspace_defaultStorageFirewall
=== PAUSE TestAccDatabricksWorkspace_defaultStorageFirewall
=== CONT  TestAccDatabricksWorkspace_defaultStorageFirewall
--- PASS: TestAccDatabricksWorkspace_defaultStorageFirewall (679.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/databricks	681.305s
[16:21](⎈|eastus2-fxs-atlas-prod-fxc:ops)  hashicorp/terraform-provider-azurerm git:(favoretti/26213) ✗ TF_ACC=1 go test -v ./internal/services/databricks -timeout=1000m -run='TestAccDatabricksWorkspace_basic'
=== RUN   TestAccDatabricksWorkspace_basic
=== PAUSE TestAccDatabricksWorkspace_basic
=== CONT  TestAccDatabricksWorkspace_basic
--- PASS: TestAccDatabricksWorkspace_basic (441.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/databricks	443.146s
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_databricks_workspace`: Fix disabling default firewall [GH-26339]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26213


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
