### PR TITLE
`azurerm_service_plan` Add support for new Flex Consumption plan

### DIFF
--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	ServicePlanTypeConsumption = "consumption"
-	ServicePlanTypeElastic     = "elastic"
-	ServicePlanTypeIsolated    = "isolated"
-	ServicePlanTypeAppPlan     = "app"
+	ServicePlanTypeConsumption     = "consumption"
+	ServicePlanTypeFlexConsumption = "flexconsumption"
+	ServicePlanTypeElastic         = "elastic"
+	ServicePlanTypeIsolated        = "isolated"
+	ServicePlanTypeAppPlan         = "app"
 )
 
 var appServicePlanSkus = []string{
@@ -42,6 +43,10 @@ var consumptionSkus = []string{
 	"Y1",
 }
 
+var flexConsumptionSkus = []string{
+	"FC1",
+}
+
 var elasticSkus = []string{
 	"EP1", "EP2", "EP3",
 }
@@ -61,6 +66,7 @@ func AllKnownServicePlanSkus() []string {
 	allSkus = append(allSkus, appServicePlanSkus...)
 	allSkus = append(allSkus, consumptionSkus...)
 	allSkus = append(allSkus, elasticSkus...)
+	allSkus = append(allSkus, flexConsumptionSkus...)
 	allSkus = append(allSkus, freeSkus...)
 	allSkus = append(allSkus, isolatedSkus...)
 	allSkus = append(allSkus, sharedSkus...)
@@ -74,6 +80,19 @@ func PlanIsConsumption(input *string) bool {
 		return false
 	}
 	for _, v := range consumptionSkus {
+		if strings.EqualFold(*input, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func PlanIsFlexConsumption(input *string) bool {
+	if input == nil {
+		return false
+	}
+	for _, v := range flexConsumptionSkus {
 		if strings.EqualFold(*input, v) {
 			return true
 		}

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -40,6 +40,21 @@ func TestAccServicePlan_linuxConsumption(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.linuxFlexConsumption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServicePlan_linuxFlexConsumption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
+	r := ServicePlanResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
 			Config: r.linuxConsumption(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -259,6 +274,32 @@ resource "azurerm_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "Y1"
+  os_type             = "Linux"
+
+  tags = {
+    environment = "AccTest"
+    Foo         = "bar"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ServicePlanResource) linuxFlexConsumption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appserviceplan-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctest-SP-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku_name            = "FC1"
   os_type             = "Linux"
 
   tags = {

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -43,11 +43,11 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Service Plan should exist. Changing this forces a new Service Plan to be created.
 
-* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `I4v2`, `I5v2`, `I6v2`, `P1v2`, `P2v2`, `P3v2`, `P0v3`, `P1v3`, `P2v3`, `P3v3`, `P1mv3`, `P2mv3`, `P3mv3`, `P4mv3`, `P5mv3`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `WS1`, `WS2`, `WS3`, and `Y1`.
+* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `I4v2`, `I5v2`, `I6v2`, `P1v2`, `P2v2`, `P3v2`, `P0v3`, `P1v3`, `P2v3`, `P3v3`, `P1mv3`, `P2mv3`, `P3mv3`, `P4mv3`, `P5mv3`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `FC1`, `WS1`, `WS2`, `WS3`, and `Y1`.
 
 ~> **NOTE:** Isolated SKUs (`I1`, `I2`, `I3`, `I1v2`, `I2v2`, and `I3v2`) can only be used with App Service Environments
 
-~> **NOTE:** Elastic and Consumption SKUs (`Y1`, `EP1`, `EP2`, and `EP3`) are for use with Function Apps.
+~> **NOTE:** Elastic and Consumption SKUs (`Y1`, `FC1`, `EP1`, `EP2`, and `EP3`) are for use with Function Apps.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add support for the new [Flex Consumption](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/announcing-public-preview-of-azure-functions-flex-consumption/ba-p/4139028) function app SKU currently in preview.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccServicePlan_requiresImport (142.78s)
--- PASS: TestAccServicePlan_linuxFlexConsumption (154.57s)
--- PASS: TestAccServicePlan_basic (155.03s)
--- PASS: TestAccServicePlan_linuxConsumption (158.35s)
--- PASS: TestAccServicePlan_complete (200.69s)
--- PASS: TestAccServicePlan_completeUpdate (208.61s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_service_plan` - support the `FC1` flex consumption plan [GH-26351]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26043
