### PR TITLE
`elastic` - remove `Computed` on `logs`

### DIFF
--- a/internal/services/elastic/elasticsearch_resource.go
+++ b/internal/services/elastic/elasticsearch_resource.go
@@ -43,7 +43,6 @@ func resourceElasticsearch() *pluginsdk.Resource {
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
-			// Required
 			"name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
@@ -68,7 +67,6 @@ func resourceElasticsearch() *pluginsdk.Resource {
 				ValidateFunc: validate.ElasticEmailAddress,
 			},
 
-			// Optional
 			"monitoring_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -79,7 +77,6 @@ func resourceElasticsearch() *pluginsdk.Resource {
 			"logs": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -133,7 +130,6 @@ func resourceElasticsearch() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 
-			// Computed
 			"elastic_cloud_deployment_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,

--- a/internal/services/elastic/elasticsearch_resource.go
+++ b/internal/services/elastic/elasticsearch_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2023-06-01/rules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/elastic/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -77,6 +78,7 @@ func resourceElasticsearch() *pluginsdk.Resource {
 			"logs": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: !features.FourPointOhBeta(),
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/elastic/elasticsearch_resource_test.go
+++ b/internal/services/elastic/elasticsearch_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -158,6 +159,26 @@ func (r ElasticsearchResourceTest) Exists(ctx context.Context, client *clients.C
 }
 
 func (r ElasticsearchResourceTest) basic(data acceptance.TestData) string {
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-elastic-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_elastic_cloud_elasticsearch" "test" {
+  name                        = "acctest-estc%[1]d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  sku_name                    = "ess-consumption-2024_Monthly"
+  elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
+}
+`, data.RandomInteger, data.Locations.Primary)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -174,6 +195,10 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
   location                    = azurerm_resource_group.test.location
   sku_name                    = "ess-consumption-2024_Monthly"
   elastic_cloud_email_address = "terraform-acctest@hashicorp.com"
+
+  lifecycle {
+    ignore_changes = [logs]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

API doesn't appear to return any default for this unless it has been set previously. Removing `Computed` for 4.0.

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/f35cfe60-7102-44da-bb27-2970432e4a48)
