### PR TITLE
`azurerm_signalr_service` -  remove optional and computed from `cors`

### DIFF
--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/migration"
 	signalrValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/validate"
@@ -991,7 +992,7 @@ func resourceArmSignalRServiceSchema() map[string]*pluginsdk.Schema {
 		"cors": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			Computed: true,
+			Computed: !features.FourPointOhBeta(),
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"allowed_origins": {

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -604,7 +604,7 @@ resource "azurerm_signalr_service" "test" {
     name     = "Standard_S1"
     capacity = 1
   }
-  
+
   lifecycle {
     ignore_changes = [cors]
   }
@@ -750,7 +750,7 @@ resource "azurerm_signalr_service" "test" {
     capacity = %d
   }
 
-    lifecycle {
+  lifecycle {
     ignore_changes = [cors]
   }
 }

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -604,6 +604,10 @@ resource "azurerm_signalr_service" "test" {
     name     = "Standard_S1"
     capacity = 1
   }
+  
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -634,6 +638,10 @@ resource "azurerm_signalr_service" "test" {
   aad_auth_enabled                         = false
   tls_client_cert_enabled                  = false
   serverless_connection_timeout_in_seconds = 5
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -675,6 +683,10 @@ resource "azurerm_signalr_service" "test" {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -709,6 +721,10 @@ resource "azurerm_signalr_service" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -732,6 +748,10 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "%s"
     capacity = %d
+  }
+
+    lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, planSku, capacity)
@@ -773,6 +793,10 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = %d
+  }
+
+  lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, capacity)
@@ -833,6 +857,10 @@ resource "azurerm_signalr_service" "test" {
   service_mode              = "%[3]s"
   connectivity_logs_enabled = false
   messaging_logs_enabled    = false
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, serviceMode)
 }
@@ -889,6 +917,10 @@ resource "azurerm_signalr_service" "test" {
     hub_pattern      = ["*"]
     url_template     = "http://foo4.com"
   }
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -938,6 +970,10 @@ resource "azurerm_signalr_service" "test" {
     url_template              = "http://foo.com"
     user_assigned_identity_id = azurerm_user_assigned_identity.test.client_id
   }
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -968,6 +1004,9 @@ resource "azurerm_signalr_service" "test" {
   live_trace_enabled        = true
   service_mode              = "Serverless"
 
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -998,6 +1037,9 @@ resource "azurerm_signalr_service" "test" {
   live_trace_enabled        = false
   service_mode              = "Classic"
 
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1024,6 +1066,9 @@ resource "azurerm_signalr_service" "test" {
   }
   tags = {
     ENV = "test"
+  }
+  lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -1054,6 +1099,10 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = 1
+  }
+
+  lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -1086,6 +1135,10 @@ resource "azurerm_signalr_service" "test" {
     name     = "Standard_S1"
     capacity = 1
   }
+
+  lifecycle {
+    ignore_changes = [cors]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1112,6 +1165,10 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = 1
+  }
+
+  lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -1140,6 +1197,10 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = 1
+  }
+
+  lifecycle {
+    ignore_changes = [cors]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

If the value of `cors.allowed_origins` is removed or not specified, the api returns a default value which we can use `ignore_changes` to ignore.

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

=== RUN   TestAccSignalRService_basic
=== PAUSE TestAccSignalRService_basic
=== CONT  TestAccSignalRService_basic
--- PASS: TestAccSignalRService_basic (455.93s)
=== RUN   TestAccSignalRService_complete
=== PAUSE TestAccSignalRService_complete
=== CONT  TestAccSignalRService_complete
--- PASS: TestAccSignalRService_complete (399.02s)
=== RUN   TestAccSignalRService_propertyUpdate
=== PAUSE TestAccSignalRService_propertyUpdate
=== CONT  TestAccSignalRService_propertyUpdate
--- PASS: TestAccSignalRService_propertyUpdate (646.41s)
=== RUN   TestAccSignalRService_identity
=== PAUSE TestAccSignalRService_identity
=== CONT  TestAccSignalRService_identity
--- PASS: TestAccSignalRService_identity (900.98s)
=== RUN   TestAccSignalRService_premiumP1
=== PAUSE TestAccSignalRService_premiumP1
=== CONT  TestAccSignalRService_premiumP1
--- PASS: TestAccSignalRService_premiumP1 (396.33s)
=== RUN   TestAccSignalRService_premiumP2
=== PAUSE TestAccSignalRService_premiumP2
=== CONT  TestAccSignalRService_premiumP2
--- PASS: TestAccSignalRService_premiumP2 (1047.72s)
=== RUN   TestAccSignalRService_requiresImport
=== PAUSE TestAccSignalRService_requiresImport
=== CONT  TestAccSignalRService_requiresImport
--- PASS: TestAccSignalRService_requiresImport (385.51s)
=== RUN   TestAccSignalRService_standard
=== PAUSE TestAccSignalRService_standard
=== CONT  TestAccSignalRService_standard
--- PASS: TestAccSignalRService_standard (385.14s)
=== RUN   TestAccSignalRService_standardWithCap2
=== PAUSE TestAccSignalRService_standardWithCap2
=== CONT  TestAccSignalRService_standardWithCap2
--- PASS: TestAccSignalRService_standardWithCap2 (405.40s)
=== RUN   TestAccSignalRService_skuUpdate
=== PAUSE TestAccSignalRService_skuUpdate
=== CONT  TestAccSignalRService_skuUpdate
--- PASS: TestAccSignalRService_skuUpdate (404.55s)
=== RUN   TestAccSignalRService_capacityUpdate
=== PAUSE TestAccSignalRService_capacityUpdate
=== CONT  TestAccSignalRService_capacityUpdate
--- PASS: TestAccSignalRService_capacityUpdate (997.23s)
=== RUN   TestAccSignalRService_skuAndCapacityUpdate
=== PAUSE TestAccSignalRService_skuAndCapacityUpdate
=== CONT  TestAccSignalRService_skuAndCapacityUpdate
--- PASS: TestAccSignalRService_skuAndCapacityUpdate (942.46s)
=== RUN   TestAccSignalRService_serviceMode
=== PAUSE TestAccSignalRService_serviceMode
=== CONT  TestAccSignalRService_serviceMode
--- PASS: TestAccSignalRService_serviceMode (530.39s)
=== RUN   TestAccSignalRService_featureFlags
=== PAUSE TestAccSignalRService_featureFlags
=== CONT  TestAccSignalRService_featureFlags
--- PASS: TestAccSignalRService_featureFlags (718.70s)
=== RUN   TestAccSignalRService_cors
=== PAUSE TestAccSignalRService_cors
=== CONT  TestAccSignalRService_cors
--- PASS: TestAccSignalRService_cors (462.23s)
=== RUN   TestAccSignalRService_upstreamSetting
=== PAUSE TestAccSignalRService_upstreamSetting
=== CONT  TestAccSignalRService_upstreamSetting
--- PASS: TestAccSignalRService_upstreamSetting (388.62s)
=== RUN   TestAccSignalRService_upstreamSettingAuth
=== PAUSE TestAccSignalRService_upstreamSettingAuth
=== CONT  TestAccSignalRService_upstreamSettingAuth
--- PASS: TestAccSignalRService_upstreamSettingAuth (938.52s)
=== RUN   TestAccSignalRService_withTags
=== PAUSE TestAccSignalRService_withTags
=== CONT  TestAccSignalRService_withTags
--- PASS: TestAccSignalRService_withTags (397.80s)
=== RUN   TestAccSignalRService_liveTrace
=== PAUSE TestAccSignalRService_liveTrace
=== CONT  TestAccSignalRService_liveTrace
--- PASS: TestAccSignalRService_liveTrace (712.94s)
=== RUN   TestAccSignalRService_resourceLogs
=== PAUSE TestAccSignalRService_resourceLogs
=== CONT  TestAccSignalRService_resourceLogs
--- PASS: TestAccSignalRService_resourceLogs (721.26s)
PASS




