### PR TITLE
`network` - review `ConfigModeAttr` and split `CreateUpdate` for network connection monitor

### DIFF
--- a/internal/services/network/network_connection_monitor_resource.go
+++ b/internal/services/network/network_connection_monitor_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkwatchers"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -29,9 +31,9 @@ import (
 
 func resourceNetworkConnectionMonitor() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkConnectionMonitorCreateUpdate,
+		Create: resourceNetworkConnectionMonitorCreate,
 		Read:   resourceNetworkConnectionMonitorRead,
-		Update: resourceNetworkConnectionMonitorCreateUpdate,
+		Update: resourceNetworkConnectionMonitorUpdate,
 		Delete: resourceNetworkConnectionMonitorDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := connectionmonitors.ParseConnectionMonitorID(id)
@@ -50,7 +52,7 @@ func resourceNetworkConnectionMonitor() *pluginsdk.Resource {
 }
 
 func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -424,10 +426,8 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"output_workspace_resource_ids": {
-			Type:       pluginsdk.TypeSet,
-			Optional:   true,
-			Computed:   true,
-			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
 				ValidateFunc: workspaces.ValidateWorkspaceID,
@@ -436,15 +436,28 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
+
+	if !features.FourPointOhBeta() {
+		schema["output_workspace_resource_ids"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeSet,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: workspaces.ValidateWorkspaceID,
+			},
+		}
+	}
+
+	return schema
 }
 
-func resourceNetworkConnectionMonitorCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkConnectionMonitorCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.ConnectionMonitors
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	location := azure.NormalizeLocation(d.Get("location").(string))
 
 	watcherId, err := connectionmonitors.ParseNetworkWatcherID(d.Get("network_watcher_id").(string))
 	if err != nil {
@@ -453,21 +466,19 @@ func resourceNetworkConnectionMonitorCreateUpdate(d *pluginsdk.ResourceData, met
 
 	connectionMonitorId := connectionmonitors.NewConnectionMonitorID(subscriptionId, watcherId.ResourceGroupName, watcherId.NetworkWatcherName, d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, connectionMonitorId)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", connectionMonitorId, err)
-			}
-		}
-
-		if existing.Model != nil {
-			return tf.ImportAsExistsError("azurerm_network_connection_monitor", connectionMonitorId.ID())
+	existing, err := client.Get(ctx, connectionMonitorId)
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("checking for presence of existing %s: %s", connectionMonitorId, err)
 		}
 	}
 
+	if existing.Model != nil {
+		return tf.ImportAsExistsError("azurerm_network_connection_monitor", connectionMonitorId.ID())
+	}
+
 	properties := connectionmonitors.ConnectionMonitor{
-		Location: utils.String(location),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Properties: connectionmonitors.ConnectionMonitorParameters{
 			Outputs:            expandNetworkConnectionMonitorOutput(d.Get("output_workspace_resource_ids").(*pluginsdk.Set).List()),
@@ -479,7 +490,7 @@ func resourceNetworkConnectionMonitorCreateUpdate(d *pluginsdk.ResourceData, met
 	properties.Properties.Endpoints = expandNetworkConnectionMonitorEndpoint(d.Get("endpoint").(*pluginsdk.Set).List())
 
 	if notes, ok := d.GetOk("notes"); ok {
-		properties.Properties.Notes = utils.String(notes.(string))
+		properties.Properties.Notes = pointer.To(notes.(string))
 	}
 
 	if err = client.CreateOrUpdateThenPoll(ctx, connectionMonitorId, properties, connectionmonitors.DefaultCreateOrUpdateOperationOptions()); err != nil {
@@ -487,6 +498,73 @@ func resourceNetworkConnectionMonitorCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	d.SetId(connectionMonitorId.ID())
+
+	return resourceNetworkConnectionMonitorRead(d, meta)
+}
+
+func resourceNetworkConnectionMonitorUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.ConnectionMonitors
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := connectionmonitors.ParseConnectionMonitorID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := connectionmonitors.ConnectionMonitor{
+		Location: existing.Model.Location,
+		Properties: connectionmonitors.ConnectionMonitorParameters{
+			Endpoints:          existing.Model.Properties.Endpoints,
+			TestConfigurations: existing.Model.Properties.TestConfigurations,
+			TestGroups:         existing.Model.Properties.TestGroups,
+			Notes:              existing.Model.Properties.Notes,
+			Outputs:            existing.Model.Properties.Outputs,
+		},
+		Tags: existing.Model.Tags,
+	}
+
+	if d.HasChange("endpoint") {
+		payload.Properties.Endpoints = expandNetworkConnectionMonitorEndpoint(d.Get("endpoint").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("test_configuration") {
+		payload.Properties.TestConfigurations = expandNetworkConnectionMonitorTestConfiguration(d.Get("test_configuration").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("test_group") {
+		payload.Properties.TestGroups = expandNetworkConnectionMonitorTestGroup(d.Get("test_group").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("notes") {
+		payload.Properties.Notes = pointer.To(d.Get("notes").(string))
+	}
+
+	if d.HasChange("output_workspace_resource_ids") {
+		payload.Properties.Outputs = expandNetworkConnectionMonitorOutput(d.Get("output_workspace_resource_ids").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, payload, connectionmonitors.DefaultCreateOrUpdateOperationOptions()); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
 
 	return resourceNetworkConnectionMonitorRead(d, meta)
 }
@@ -578,7 +656,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) *[]connectionmo
 		}
 
 		if address := v["address"]; address != "" {
-			result.Address = utils.String(address.(string))
+			result.Address = pointer.To(address.(string))
 		}
 
 		if coverageLevel := v["coverage_level"]; coverageLevel != "" {
@@ -594,7 +672,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) *[]connectionmo
 				var excludedAddresses []connectionmonitors.ConnectionMonitorEndpointScopeItem
 				for _, v := range excludedItems {
 					excludedAddresses = append(excludedAddresses, connectionmonitors.ConnectionMonitorEndpointScopeItem{
-						Address: utils.String(v.(string)),
+						Address: pointer.To(v.(string)),
 					})
 				}
 				result.Scope.Exclude = &excludedAddresses
@@ -604,7 +682,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) *[]connectionmo
 				var includedAddresses []connectionmonitors.ConnectionMonitorEndpointScopeItem
 				for _, v := range includedItems {
 					includedAddresses = append(includedAddresses, connectionmonitors.ConnectionMonitorEndpointScopeItem{
-						Address: utils.String(v.(string)),
+						Address: pointer.To(v.(string)),
 					})
 				}
 				result.Scope.Include = &includedAddresses
@@ -612,7 +690,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) *[]connectionmo
 		}
 
 		if resourceId := v["target_resource_id"]; resourceId != "" {
-			result.ResourceId = utils.String(resourceId.(string))
+			result.ResourceId = pointer.To(resourceId.(string))
 		}
 
 		if endpointType := v["target_resource_type"]; endpointType != "" {
@@ -653,7 +731,7 @@ func expandNetworkConnectionMonitorEndpointFilterItem(input []interface{}) *[]co
 		}
 
 		if address := v["address"]; address != "" {
-			result.Address = utils.String(address.(string))
+			result.Address = pointer.To(address.(string))
 		}
 
 		results = append(results, result)
@@ -702,7 +780,7 @@ func expandNetworkConnectionMonitorHTTPConfiguration(input []interface{}) *conne
 	}
 
 	if path := v["path"]; path != "" {
-		props.Path = utils.String(path.(string))
+		props.Path = pointer.To(path.(string))
 	}
 
 	if port := v["port"]; port != 0 {
@@ -771,8 +849,8 @@ func expandNetworkConnectionMonitorHTTPHeader(input []interface{}) *[]connection
 		v := item.(map[string]interface{})
 
 		result := connectionmonitors.HTTPHeader{
-			Name:  utils.String(v["name"].(string)),
-			Value: utils.String(v["value"].(string)),
+			Name:  pointer.To(v["name"].(string)),
+			Value: pointer.To(v["value"].(string)),
 		}
 
 		results = append(results, result)
@@ -808,7 +886,7 @@ func expandNetworkConnectionMonitorOutput(input []interface{}) *[]connectionmoni
 		result := connectionmonitors.ConnectionMonitorOutput{
 			Type: pointer.To(connectionmonitors.OutputTypeWorkspace),
 			WorkspaceSettings: &connectionmonitors.ConnectionMonitorWorkspaceSettings{
-				WorkspaceResourceId: utils.String(item.(string)),
+				WorkspaceResourceId: pointer.To(item.(string)),
 			},
 		}
 

--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -57,7 +57,8 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"security_rule": {
-				Type:       pluginsdk.TypeSet,
+				Type: pluginsdk.TypeSet,
+				// TODO 5.0 Remove Computed and ConfigModeAttr and recommend adding this block to ignore_changes
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				Optional:   true,
 				Computed:   true,

--- a/internal/services/network/route_filter_resource.go
+++ b/internal/services/network/route_filter_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -24,7 +25,7 @@ import (
 )
 
 func resourceRouteFilter() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceRouteFilterCreate,
 		Read:   resourceRouteFilterRead,
 		Update: resourceRouteFilterUpdate,
@@ -54,11 +55,9 @@ func resourceRouteFilter() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"rule": {
-				Type:       pluginsdk.TypeList,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Optional:   true,
-				Computed:   true,
-				MaxItems:   1,
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
@@ -99,6 +98,52 @@ func resourceRouteFilter() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["rule"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Optional:   true,
+			Computed:   true,
+			MaxItems:   1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"access": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(routefilters.AccessAllow),
+						}, false),
+					},
+
+					"rule_type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"Community",
+						}, false),
+					},
+
+					"communities": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+		}
+	}
+	return resource
 }
 
 func resourceRouteFilterCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -56,7 +56,8 @@ func resourceRouteTable() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"route": {
-				Type:       pluginsdk.TypeSet,
+				Type: pluginsdk.TypeSet,
+				// TODO 5.0 Remove Computed and ConfigModeAttr and recommend adding this block to ignore_changes
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				Optional:   true,
 				Computed:   true,

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -147,9 +147,10 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"subnet": {
-			Type:       pluginsdk.TypeSet,
-			Optional:   true,
-			Computed:   true,
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Computed: true,
+			// TODO 5.0 Remove Computed and ConfigModeAttr and recommend adding this block to ignore_changes
 			ConfigMode: pluginsdk.SchemaConfigModeAttr,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removed `ConfigModeAttr` for `azurerm_route_filter` `rule` block
- Removed `ConfigModeAttr` for `azurerm_network_connection_monitor` `output_workspace_resource_ids`
- Splits `CreateUpdate` method for `azurerm_network_connection_monitor`
- Left `// TODO 5.0` comments on `ConfigModeAttr` for `azurerm_virtual_network` `subnet` block and `azurerm_network_security_group` `security_rule` block. Removing `ConfigModeAttr` would necessitate the removal of `Computed` on these blocks which forces users to have to add these to `ignore_changes` as there are standalone resources for these blocks as well. The impact was deemed too large for the next major release since these are heavily used resources.

## Testing 

Difficult to test the changes made to `azurerm_network_connection_monitor` since only one instance of a network watcher can be provisioned for a subscription. Going to merge this for now and check the overnight test run for results.



