### PR TITLE
`machinelearning` - review `Optional`+`Computed`

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -24,7 +25,7 @@ import (
 )
 
 func resourceComputeCluster() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceComputeClusterCreate,
 		Read:   resourceComputeClusterRead,
 		Delete: resourceComputeClusterDelete,
@@ -149,7 +150,7 @@ func resourceComputeCluster() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Computed: true, // `ssh_public_access_enabled` sets to `true` by default even if unspecified
+				Default:  false,
 			},
 
 			"subnet_resource_id": {
@@ -161,6 +162,16 @@ func resourceComputeCluster() *pluginsdk.Resource {
 			"tags": commonschema.TagsForceNew(),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["ssh_public_access_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+			Computed: true,
+		}
+	}
+	return resource
 }
 
 func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
@@ -129,7 +129,6 @@ func (r MachineLearningDataStoreDataLakeGen2) Arguments() map[string]*pluginsdk.
 		"authority_url": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 

--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	components "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-02-02/componentsapis"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2024-04-01/workspaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -37,9 +37,9 @@ const (
 
 func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
-		Create: resourceMachineLearningWorkspaceCreateOrUpdate,
+		Create: resourceMachineLearningWorkspaceCreate,
 		Read:   resourceMachineLearningWorkspaceRead,
-		Update: resourceMachineLearningWorkspaceCreateOrUpdate,
+		Update: resourceMachineLearningWorkspaceUpdate,
 		Delete: resourceMachineLearningWorkspaceDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -146,13 +146,7 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 			"public_network_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Computed: true,
-				ConflictsWith: func() []string {
-					if !features.FourPointOhBeta() {
-						return []string{"public_access_behind_virtual_network_enabled"}
-					}
-					return []string{}
-				}(),
+				Default:  true,
 			},
 
 			"image_build_compute_name": {
@@ -192,14 +186,14 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 			"managed_network": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"isolation_mode": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      string(workspaces.IsolationModeDisabled),
+							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(workspaces.PossibleValuesForIsolationMode(), false),
 						},
 					},
@@ -275,28 +269,49 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 			Deprecated:    "`public_access_behind_virtual_network_enabled` will be removed in favour of the property `public_network_access_enabled` in version 4.0 of the AzureRM Provider.",
 			ConflictsWith: []string{"public_network_access_enabled"},
 		}
+		resource.Schema["public_network_access_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"public_access_behind_virtual_network_enabled"},
+		}
+		resource.Schema["managed_network"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"isolation_mode": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validation.StringInSlice(workspaces.PossibleValuesForIsolationMode(), false),
+					},
+				},
+			},
+		}
 	}
 
 	return resource
 }
 
-func resourceMachineLearningWorkspaceCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MachineLearning.Workspaces
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := workspaces.NewWorkspaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
+
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_machine_learning_workspace", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_machine_learning_workspace", id.ID())
 	}
 
 	expandedIdentity, err := expandMachineLearningWorkspaceIdentity(d.Get("identity").([]interface{}))
@@ -306,22 +321,27 @@ func resourceMachineLearningWorkspaceCreateOrUpdate(d *pluginsdk.ResourceData, m
 
 	expandedEncryption := expandMachineLearningWorkspaceEncryption(d.Get("encryption").([]interface{}))
 
-	networkAccessBehindVnetEnabled := false
-
-	// nolint: staticcheck
-	if v, ok := d.GetOkExists("public_network_access_enabled"); ok {
-		networkAccessBehindVnetEnabled = v.(bool)
+	networkAccessBehindVnetEnabled := workspaces.PublicNetworkAccessDisabled
+	if !features.FourPointOhBeta() {
+		// nolint: staticcheck
+		if v, ok := d.GetOkExists("public_network_access_enabled"); ok && v.(bool) {
+			networkAccessBehindVnetEnabled = workspaces.PublicNetworkAccessEnabled
+		}
+	} else {
+		if v := d.Get("public_network_access_enabled").(bool); v {
+			networkAccessBehindVnetEnabled = workspaces.PublicNetworkAccessEnabled
+		}
 	}
 
 	workspace := workspaces.Workspace{
 		Name:     pointer.To(id.WorkspaceName),
-		Location: pointer.To(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Sku: &workspaces.Sku{
 			Name: d.Get("sku_name").(string),
 			Tier: pointer.To(workspaces.SkuTier(d.Get("sku_name").(string))),
 		},
-		Kind: utils.String(d.Get("kind").(string)),
+		Kind: pointer.To(d.Get("kind").(string)),
 
 		Identity: expandedIdentity,
 		Properties: &workspaces.WorkspaceProperties{
@@ -329,7 +349,7 @@ func resourceMachineLearningWorkspaceCreateOrUpdate(d *pluginsdk.ResourceData, m
 			Encryption:          expandedEncryption,
 			KeyVault:            pointer.To(d.Get("key_vault_id").(string)),
 			ManagedNetwork:      expandMachineLearningWorkspaceManagedNetwork(d.Get("managed_network").([]interface{})),
-			PublicNetworkAccess: pointer.To(workspaces.PublicNetworkAccessDisabled),
+			PublicNetworkAccess: pointer.To(networkAccessBehindVnetEnabled),
 			StorageAccount:      pointer.To(d.Get("storage_account_id").(string)),
 			V1LegacyMode:        pointer.To(d.Get("v1_legacy_mode_enabled").(bool)),
 		},
@@ -337,23 +357,12 @@ func resourceMachineLearningWorkspaceCreateOrUpdate(d *pluginsdk.ResourceData, m
 
 	serverlessCompute := expandMachineLearningWorkspaceServerlessCompute(d.Get("serverless_compute").([]interface{}))
 	if serverlessCompute != nil {
-		if *serverlessCompute.ServerlessComputeNoPublicIP && serverlessCompute.ServerlessComputeCustomSubnet == nil && !networkAccessBehindVnetEnabled {
+		if *serverlessCompute.ServerlessComputeNoPublicIP && serverlessCompute.ServerlessComputeCustomSubnet == nil && networkAccessBehindVnetEnabled == workspaces.PublicNetworkAccessDisabled {
 			return fmt.Errorf("`public_ip_enabled` must be set to  `true` if `subnet_id` is not set and `public_network_access_enabled` is `false`")
-		}
-
-		if serverlessCompute.ServerlessComputeCustomSubnet == nil {
-			oldVal, newVal := d.GetChange("serverless_compute.0.public_ip_enabled")
-			if oldVal.(bool) && !newVal.(bool) {
-				return fmt.Errorf(" Not supported to update `public_ip_enabled` from `true` to `false` when `subnet_id` is null or empty")
-			}
 		}
 	}
 
 	workspace.Properties.ServerlessComputeSettings = serverlessCompute
-
-	if networkAccessBehindVnetEnabled {
-		workspace.Properties.PublicNetworkAccess = pointer.To(workspaces.PublicNetworkAccessEnabled)
-	}
 
 	if v, ok := d.GetOk("description"); ok {
 		workspace.Properties.Description = pointer.To(v.(string))
@@ -391,13 +400,130 @@ func resourceMachineLearningWorkspaceCreateOrUpdate(d *pluginsdk.ResourceData, m
 		workspace.Properties.FeatureStoreSettings = featureStore
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id, workspace)
-	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, id, workspace); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err = future.Poller.PollUntilDone(ctx); err != nil {
-		return fmt.Errorf("waiting for the creation of %s: %+v", id, err)
+	d.SetId(id.ID())
+	return resourceMachineLearningWorkspaceRead(d, meta)
+}
+
+func resourceMachineLearningWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MachineLearning.Workspaces
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := workspaces.ParseWorkspaceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("identity") {
+		expandedIdentity, err := expandMachineLearningWorkspaceIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		payload.Identity = expandedIdentity
+	}
+
+	if d.HasChange("kind") {
+		payload.Kind = pointer.To(d.Get("kind").(string))
+	}
+
+	if d.HasChange("feature_store") {
+		featureStore := expandMachineLearningWorkspaceFeatureStore(d.Get("feature_store").([]interface{}))
+		if strings.EqualFold(*payload.Kind, "Default") {
+			if featureStore != nil {
+				return fmt.Errorf("`feature_store` can only be set when `kind` is `FeatureStore`")
+			}
+		} else {
+			if featureStore == nil {
+				return fmt.Errorf("`feature_store` can not be empty when `kind` is `FeatureStore`")
+			}
+			payload.Properties.FeatureStoreSettings = featureStore
+		}
+	}
+
+	if d.HasChange("primary_user_assigned_identity") {
+		payload.Properties.PrimaryUserAssignedIdentity = pointer.To(d.Get("primary_user_assigned_identity").(string))
+	}
+
+	if d.HasChange("public_network_access_enabled") {
+		if d.Get("public_network_access_enabled").(bool) {
+			payload.Properties.PublicNetworkAccess = pointer.To(workspaces.PublicNetworkAccessEnabled)
+		} else {
+			payload.Properties.PublicNetworkAccess = pointer.To(workspaces.PublicNetworkAccessDisabled)
+		}
+	}
+
+	if d.HasChange("image_build_compute_name") {
+		payload.Properties.ImageBuildCompute = pointer.To(d.Get("image_build_compute_name").(string))
+	}
+
+	if d.HasChange("description") {
+		payload.Properties.Description = pointer.To(d.Get("description").(string))
+	}
+
+	if d.HasChange("friendly_name") {
+		payload.Properties.FriendlyName = pointer.To(d.Get("friendly_name").(string))
+	}
+
+	if d.HasChange("managed_network") {
+		payload.Properties.ManagedNetwork = expandMachineLearningWorkspaceManagedNetwork(d.Get("managed_network").([]interface{}))
+	}
+
+	if d.HasChange("sku_name") {
+		payload.Sku = &workspaces.Sku{
+			Name: d.Get("sku_name").(string),
+			Tier: pointer.To(workspaces.SkuTier(d.Get("sku_name").(string))),
+		}
+	}
+
+	if d.HasChange("v1_legacy_mode_enabled") {
+		payload.Properties.V1LegacyMode = pointer.To(d.Get("v1_legacy_mode_enabled").(bool))
+	}
+
+	if d.HasChange("serverless_compute") {
+		serverlessCompute := expandMachineLearningWorkspaceServerlessCompute(d.Get("serverless_compute").([]interface{}))
+		if serverlessCompute != nil {
+			networkAccessBehindVnetEnabled := false
+			if v := payload.Properties.PublicNetworkAccess; v != nil && *v == workspaces.PublicNetworkAccessEnabled {
+				networkAccessBehindVnetEnabled = true
+			}
+			if *serverlessCompute.ServerlessComputeNoPublicIP && serverlessCompute.ServerlessComputeCustomSubnet == nil && !networkAccessBehindVnetEnabled {
+				return fmt.Errorf("`public_ip_enabled` must be set to  `true` if `subnet_id` is not set and `public_network_access_enabled` is `false`")
+			}
+
+			if serverlessCompute.ServerlessComputeCustomSubnet == nil {
+				oldVal, newVal := d.GetChange("serverless_compute.0.public_ip_enabled")
+				if oldVal.(bool) && !newVal.(bool) {
+					return fmt.Errorf("`public_ip_enabled` cannot be updated from `true` to `false` when `subnet_id` is null or empty")
+				}
+			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -411,7 +537,7 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 
 	id, err := workspaces.ParseWorkspaceID(d.Id())
 	if err != nil {
-		return fmt.Errorf("parsing Machine Learning Workspace ID `%q`: %+v", d.Id(), err)
+		return err
 	}
 
 	resp, err := client.Get(ctx, *id)
@@ -420,80 +546,78 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("making Read request on Workspace %q (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroupName, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.Set("name", id.WorkspaceName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if location := resp.Model.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if sku := model.Sku; sku != nil {
+			d.Set("sku_name", sku.Name)
+		}
+		d.Set("kind", model.Kind)
 
-	if sku := resp.Model.Sku; sku != nil {
-		d.Set("sku_name", sku.Name)
-	}
+		flattenedIdentity, err := flattenMachineLearningWorkspaceIdentity(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
 
-	d.Set("kind", resp.Model.Kind)
+		if err := d.Set("identity", flattenedIdentity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
 
-	if props := resp.Model.Properties; props != nil {
-		appInsightsId := ""
-		if props.ApplicationInsights != nil {
-			applicationInsightsId, err := components.ParseComponentIDInsensitively(*props.ApplicationInsights)
+		if props := model.Properties; props != nil {
+			appInsightsId := ""
+			if props.ApplicationInsights != nil {
+				applicationInsightsId, err := components.ParseComponentIDInsensitively(*props.ApplicationInsights)
+				if err != nil {
+					return err
+				}
+				appInsightsId = applicationInsightsId.ID()
+			}
+			d.Set("application_insights_id", appInsightsId)
+			d.Set("storage_account_id", props.StorageAccount)
+			d.Set("container_registry_id", props.ContainerRegistry)
+			d.Set("description", props.Description)
+			d.Set("friendly_name", props.FriendlyName)
+			d.Set("high_business_impact", props.HbiWorkspace)
+			d.Set("image_build_compute_name", props.ImageBuildCompute)
+			d.Set("discovery_url", props.DiscoveryUrl)
+			d.Set("primary_user_assigned_identity", props.PrimaryUserAssignedIdentity)
+			d.Set("public_network_access_enabled", *props.PublicNetworkAccess == workspaces.PublicNetworkAccessEnabled)
+			d.Set("v1_legacy_mode_enabled", props.V1LegacyMode)
+			d.Set("workspace_id", props.WorkspaceId)
+			d.Set("managed_network", flattenMachineLearningWorkspaceManagedNetwork(props.ManagedNetwork))
+			d.Set("serverless_compute", flattenMachineLearningWorkspaceServerlessCompute(props.ServerlessComputeSettings))
+
+			kvId, err := commonids.ParseKeyVaultIDInsensitively(*props.KeyVault)
 			if err != nil {
 				return err
 			}
-			appInsightsId = applicationInsightsId.ID()
+			d.Set("key_vault_id", kvId.ID())
+
+			if !features.FourPointOhBeta() {
+				d.Set("public_access_behind_virtual_network_enabled", props.AllowPublicAccessWhenBehindVnet)
+			}
+
+			featureStoreSettings := flattenMachineLearningWorkspaceFeatureStore(props.FeatureStoreSettings)
+			if err := d.Set("feature_store", featureStoreSettings); err != nil {
+				return fmt.Errorf("setting `feature_store`: %+v", err)
+			}
+
+			flattenedEncryption, err := flattenMachineLearningWorkspaceEncryption(props.Encryption)
+			if err != nil {
+				return fmt.Errorf("flattening `encryption`: %+v", err)
+			}
+			if err := d.Set("encryption", flattenedEncryption); err != nil {
+				return fmt.Errorf("setting `encryption`: %+v", err)
+			}
 		}
-		d.Set("application_insights_id", appInsightsId)
-		d.Set("storage_account_id", props.StorageAccount)
-		d.Set("container_registry_id", props.ContainerRegistry)
-		d.Set("description", props.Description)
-		d.Set("friendly_name", props.FriendlyName)
-		d.Set("high_business_impact", props.HbiWorkspace)
-		d.Set("image_build_compute_name", props.ImageBuildCompute)
-		d.Set("discovery_url", props.DiscoveryUrl)
-		d.Set("primary_user_assigned_identity", props.PrimaryUserAssignedIdentity)
-		d.Set("public_network_access_enabled", *props.PublicNetworkAccess == workspaces.PublicNetworkAccessEnabled)
-		d.Set("v1_legacy_mode_enabled", props.V1LegacyMode)
-		d.Set("workspace_id", props.WorkspaceId)
-		d.Set("managed_network", flattenMachineLearningWorkspaceManagedNetwork(props.ManagedNetwork))
-		d.Set("serverless_compute", flattenMachineLearningWorkspaceServerlessCompute(props.ServerlessComputeSettings))
-
-		kvId, err := commonids.ParseKeyVaultIDInsensitively(*props.KeyVault)
-		if err != nil {
-			return err
-		}
-		d.Set("key_vault_id", kvId.ID())
-
-		if !features.FourPointOhBeta() {
-			d.Set("public_access_behind_virtual_network_enabled", props.AllowPublicAccessWhenBehindVnet)
-		}
+		return tags.FlattenAndSet(d, model.Tags)
 	}
-
-	flattenedIdentity, err := flattenMachineLearningWorkspaceIdentity(resp.Model.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-
-	if err := d.Set("identity", flattenedIdentity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
-	featureStoreSettings := flattenMachineLearningWorkspaceFeatureStore(resp.Model.Properties.FeatureStoreSettings)
-	if err := d.Set("feature_store", featureStoreSettings); err != nil {
-		return fmt.Errorf("setting `feature_store`: %+v", err)
-	}
-
-	flattenedEncryption, err := flattenMachineLearningWorkspaceEncryption(resp.Model.Properties.Encryption)
-	if err != nil {
-		return fmt.Errorf("flattening `encryption`: %+v", err)
-	}
-	if err := d.Set("encryption", flattenedEncryption); err != nil {
-		return fmt.Errorf("flattening encryption on Workspace %q (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroupName, err)
-	}
-
-	return tags.FlattenAndSet(d, resp.Model.Tags)
+	return nil
 }
 
 func resourceMachineLearningWorkspaceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -647,16 +771,16 @@ func expandMachineLearningWorkspaceFeatureStore(input []interface{}) *workspaces
 
 	if raw["computer_spark_runtime_version"].(string) != "" {
 		out.ComputeRuntime = &workspaces.ComputeRuntimeDto{
-			SparkRuntimeVersion: utils.String(raw["computer_spark_runtime_version"].(string)),
+			SparkRuntimeVersion: pointer.To(raw["computer_spark_runtime_version"].(string)),
 		}
 	}
 
 	if raw["offline_connection_name"].(string) != "" {
-		out.OfflineStoreConnectionName = utils.String(raw["offline_connection_name"].(string))
+		out.OfflineStoreConnectionName = pointer.To(raw["offline_connection_name"].(string))
 	}
 
 	if raw["online_connection_name"].(string) != "" {
-		out.OnlineStoreConnectionName = utils.String(raw["online_connection_name"].(string))
+		out.OnlineStoreConnectionName = pointer.To(raw["online_connection_name"].(string))
 	}
 	return &out
 }

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -434,6 +434,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -472,8 +476,12 @@ resource "azurerm_machine_learning_workspace" "test" {
   tags = {
     ENV = "Test"
   }
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
-`, template, data.RandomIntOfLength(16))
+`, template, data.RandomInteger)
 }
 
 func (r WorkspaceResource) complete(data acceptance.TestData) string {
@@ -499,6 +507,10 @@ resource "azurerm_container_registry" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "Premium"
   admin_enabled       = true
+
+  lifecycle {
+    ignore_changes = [network_rule_set]
+  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -578,6 +590,10 @@ resource "azurerm_container_registry" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "Premium"
   admin_enabled       = true
+
+  lifecycle {
+    ignore_changes = [network_rule_set]
+  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -620,6 +636,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   encryption {
     key_vault_id = azurerm_key_vault.test.id
     key_id       = azurerm_key_vault_key.test.id
+  }
+
+  managed_network {
+    isolation_mode = "AllowInternetOutbound"
   }
 
   tags = {
@@ -746,6 +766,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   }
 
   depends_on = [azurerm_role_assignment.test]
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -807,6 +831,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   }
 
   depends_on = [azurerm_role_assignment.test]
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, r.template(data), data.RandomInteger, data.RandomIntOfLength(8))
 }
@@ -847,6 +875,10 @@ resource "azurerm_machine_learning_workspace" "test" {
       azurerm_user_assigned_identity.test.id,
     ]
   }
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -883,6 +915,10 @@ resource "azurerm_machine_learning_workspace" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [managed_network]
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -952,6 +988,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   }
 
   depends_on = [azurerm_role_assignment.test]
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -1086,6 +1126,10 @@ resource "azurerm_machine_learning_workspace" "test" {
     azurerm_role_assignment.test_sa1,
     azurerm_key_vault_access_policy.test-policy1,
   ]
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -1125,6 +1169,10 @@ resource "azurerm_machine_learning_workspace" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [managed_network]
   }
 }
 `, template, data.RandomInteger)
@@ -1166,6 +1214,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -1198,6 +1250,10 @@ resource "azurerm_machine_learning_workspace" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [managed_network]
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -1221,12 +1277,13 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_machine_learning_workspace" "test" {
-  name                    = "acctest-MLW-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  application_insights_id = azurerm_application_insights.test.id
-  key_vault_id            = azurerm_key_vault.test.id
-  storage_account_id      = azurerm_storage_account.test.id
+  name                          = "acctest-MLW-%[2]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  application_insights_id       = azurerm_application_insights.test.id
+  key_vault_id                  = azurerm_key_vault.test.id
+  storage_account_id            = azurerm_storage_account.test.id
+  public_network_access_enabled = false
 
   serverless_compute {
     subnet_id = azurerm_subnet.test.id
@@ -1234,6 +1291,10 @@ resource "azurerm_machine_learning_workspace" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [managed_network]
   }
 }
 `, template, data.RandomInteger)
@@ -1268,8 +1329,13 @@ resource "azurerm_machine_learning_workspace" "test" {
   serverless_compute {
     public_ip_enabled = true
   }
+
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [managed_network]
   }
 }
 `, template, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removes `Computed` from `ssh_public_access_enabled` by setting the default to `false` since that is what the API is defaulting to
- Removes `Computed` from `authority_url` since the API doesn't appear to be returning any defaults for this
- Removes `Computed` from `public_network_access_enabled` by setting the default to `true` which is what the default in the API is
- Split the `CreateUpdate` method so that `Computed` can be removed from `managed_network`, this block manages the outbound traffic allowed for machine learning workspaces and will probably be extended in future to add the remaining configuration options in that block. Since this has security implications for the workspace I think it's fair to have to explicitly add this block to `ignore_changes`

## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/f33611d1-d6d0-4fbf-89ad-f691b1e52803)

Failed tests are flaky
