### PR TITLE
`azurerm_api_management` - remove `ForceNew` from `zones` in `additional_location`

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -212,7 +212,7 @@ func resourceApiManagementSchema() map[string]*pluginsdk.Schema {
 						ValidateFunc: validation.IntBetween(0, 12),
 					},
 
-					"zones": commonschema.ZonesMultipleOptionalForceNew(),
+					"zones": commonschema.ZonesMultipleOptional(),
 
 					"gateway_regional_url": {
 						Type:     pluginsdk.TypeString,

--- a/internal/services/apimanagement/api_management_resource_test.go
+++ b/internal/services/apimanagement/api_management_resource_test.go
@@ -188,6 +188,22 @@ func TestAccApiManagement_completeUpdateAdditionalLocations(t *testing.T) {
 			"hostname_configuration.0.proxy.2.certificate",                     // not returned from API, sensitive
 			"hostname_configuration.0.proxy.2.certificate_password",            // not returned from API, sensitive
 		),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("certificate", // not returned from API, sensitive
+			"hostname_configuration.0.portal.0.certificate",                    // not returned from API, sensitive
+			"hostname_configuration.0.portal.0.certificate_password",           // not returned from API, sensitive
+			"hostname_configuration.0.developer_portal.0.certificate",          // not returned from API, sensitive
+			"hostname_configuration.0.developer_portal.0.certificate_password", // not returned from API, sensitive
+			"hostname_configuration.0.proxy.1.certificate",                     // not returned from API, sensitive
+			"hostname_configuration.0.proxy.1.certificate_password",            // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate",                     // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate_password",            // not returned from API, sensitive
+		),
 	})
 }
 
@@ -1615,6 +1631,7 @@ resource "azurerm_api_management" "test" {
   sku_name = "Premium_2"
 
   additional_location {
+    zones    = [1]
     location = azurerm_resource_group.test2.location
     capacity = 2
   }

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -117,7 +117,7 @@ A `additional_location` block supports the following:
 
 * `capacity` - (Optional) The number of compute units in this region. Defaults to the capacity of the main region.
 
-* `zones` - (Optional) A list of availability zones. Changing this forces a new resource to be created.
+* `zones` - (Optional) A list of availability zones.
 
 * `public_ip_address_id` - (Optional) ID of a standard SKU IPv4 Public IP.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

After validating the behavior of the API, the `zones` of `additional_location` is allowed to be updated. Submit this PR to remove the `ForceNew` for from `zones` of `additional_location` to fix https://github.com/hashicorp/terraform-provider-azurerm/issues/26244 .

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

PASS: TestAccApiManagement_completeUpdateAdditionalLocations (5403.73s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management` - remove `ForceNew` from `zones` in `additional_location` [GH-26244]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26244


