### PR TITLE
`azurerm_synapse_workspace` - return an empty workspace config repo object instead of nil

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -897,7 +897,8 @@ func expandWorkspaceRepositoryConfiguration(d *pluginsdk.ResourceData) *synapse.
 		}
 	}
 
-	return nil
+	// API won't clear an existing repository config with nil
+	return &synapse.WorkspaceRepositoryConfiguration{}
 }
 
 func expandIdentityControlSQLSettings(enabled bool) *synapse.ManagedIdentitySQLControlSettingsModel {

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -118,14 +118,16 @@ func TestAccSynapseWorkspace_azdo(t *testing.T) {
 			Config: r.azureDevOps(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.account_name").HasValue("myorg"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.project_name").HasValue("myproj"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.repository_name").HasValue("myrepo"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.branch_name").HasValue("dev"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.root_folder").HasValue("/"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.tenant_id").IsEmpty(),
 			),
 		},
+		data.ImportStep("sql_administrator_login_password"),
+		{
+			Config: r.repoConfigRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sql_administrator_login_password"),
 	})
 }
 
@@ -138,14 +140,9 @@ func TestAccSynapseWorkspace_azdoTenant(t *testing.T) {
 			Config: r.azureDevOpsTenant(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.account_name").HasValue("myorg"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.project_name").HasValue("myproj"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.repository_name").HasValue("myrepo"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.branch_name").HasValue("dev"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.root_folder").HasValue("/"),
-				check.That(data.ResourceName).Key("azure_devops_repo.0.tenant_id").Exists(),
 			),
 		},
+		data.ImportStep("sql_administrator_login_password"),
 	})
 }
 
@@ -158,13 +155,16 @@ func TestAccSynapseWorkspace_github(t *testing.T) {
 			Config: r.github(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("github_repo.0.account_name").HasValue("myuser"),
-				check.That(data.ResourceName).Key("github_repo.0.git_url").HasValue("https://github.mydomain.com"),
-				check.That(data.ResourceName).Key("github_repo.0.repository_name").HasValue("myrepo"),
-				check.That(data.ResourceName).Key("github_repo.0.branch_name").HasValue("dev"),
-				check.That(data.ResourceName).Key("github_repo.0.root_folder").HasValue("/"),
 			),
 		},
+		data.ImportStep("sql_administrator_login_password"),
+		{
+			Config: r.repoConfigRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sql_administrator_login_password"),
 	})
 }
 
@@ -504,6 +504,26 @@ resource "azurerm_synapse_workspace" "test" {
     root_folder     = "/"
     last_commit_id  = "1592393b38543d51feb12714cbd39501d697610c"
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r SynapseWorkspaceResource) repoConfigRemoved(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The API requires an empty object to clear an existing config instead of nil.


## Testing 

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/24072757-2a49-492a-b344-c517bd69a059)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_synapse_workspace` - fix issue where an existing `azure_devops_repo` and `github_repo` config could not be removed on the resource [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
