### PR TITLE
fix(26428): data azurerm_network_service_tags AzureFrontDoor.Frontend support

### DIFF
--- a/internal/services/network/network_service_tags_data_source.go
+++ b/internal/services/network/network_service_tags_data_source.go
@@ -156,5 +156,15 @@ func isServiceTagOf(stName, serviceName string) bool {
 	if len(stNameComponents) != 1 && len(stNameComponents) != 2 {
 		return false
 	}
-	return stNameComponents[0] == serviceName
+
+	// Adds support for "AzureFrontDoor.Frontend" service tag
+	serviceNameComponents := strings.Split(serviceName, ".")
+	if len(serviceNameComponents) != 1 && len(serviceNameComponents) != 2 {
+		return false
+	}
+
+	if len(serviceNameComponents) == 1 {
+		return stNameComponents[0] == serviceNameComponents[0]
+	}
+	return stNameComponents[0] == serviceNameComponents[0] && stNameComponents[1] == serviceNameComponents[1]
 }

--- a/internal/services/network/network_service_tags_data_source_test.go
+++ b/internal/services/network/network_service_tags_data_source_test.go
@@ -157,28 +157,28 @@ func (NetworkServiceTagsDataSource) tagName() string {
 
 func (NetworkServiceTagsDataSource) azureFrontDoor() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location        = "northeurope"
-  service         = "AzureFrontDoor"
+  location = "northeurope"
+  service  = "AzureFrontDoor"
 }`
 }
 
 func (NetworkServiceTagsDataSource) azureFrontDoorBackend() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location        = "northeurope"
-  service         = "AzureFrontDoor.Backend"
+  location = "northeurope"
+  service  = "AzureFrontDoor.Backend"
 }`
 }
 
 func (NetworkServiceTagsDataSource) azureFrontDoorFrontend() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location        = "northeurope"
-  service         = "AzureFrontDoor.Frontend"
+  location = "northeurope"
+  service  = "AzureFrontDoor.Frontend"
 }`
 }
 
 func (NetworkServiceTagsDataSource) azureFrontDoorFirstParty() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location        = "northeurope"
-  service         = "AzureFrontDoor.FirstParty"
+  location = "northeurope"
+  service  = "AzureFrontDoor.FirstParty"
 }`
 }

--- a/internal/services/network/network_service_tags_data_source_test.go
+++ b/internal/services/network/network_service_tags_data_source_test.go
@@ -64,6 +64,74 @@ func TestAccDataSourceAzureRMServiceTags_region(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMServiceTags_AzureFrontDoor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_service_tags", "test")
+	r := NetworkServiceTagsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.azureFrontDoor(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("address_prefixes.#").Exists(),
+				check.That(data.ResourceName).Key("ipv4_cidrs.#").Exists(),
+				check.That(data.ResourceName).Key("ipv6_cidrs.#").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMServiceTags_AzureFrontDoorBackend(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_service_tags", "test")
+	r := NetworkServiceTagsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.azureFrontDoorBackend(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("address_prefixes.#").Exists(),
+				check.That(data.ResourceName).Key("ipv4_cidrs.#").Exists(),
+				check.That(data.ResourceName).Key("ipv6_cidrs.#").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFrontend(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_service_tags", "test")
+	r := NetworkServiceTagsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.azureFrontDoorFrontend(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("address_prefixes.#").Exists(),
+				check.That(data.ResourceName).Key("ipv4_cidrs.#").Exists(),
+				check.That(data.ResourceName).Key("ipv6_cidrs.#").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_service_tags", "test")
+	r := NetworkServiceTagsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.azureFrontDoorFirstParty(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("address_prefixes.#").Exists(),
+				check.That(data.ResourceName).Key("ipv4_cidrs.#").Exists(),
+				check.That(data.ResourceName).Key("ipv6_cidrs.#").Exists(),
+			),
+		},
+	})
+}
+
 func (NetworkServiceTagsDataSource) basic() string {
 	return `data "azurerm_network_service_tags" "test" {
   location = "westcentralus"
@@ -84,5 +152,33 @@ func (NetworkServiceTagsDataSource) tagName() string {
   location        = "westus2"
   service         = "Storage"
   location_filter = "westus2"
+}`
+}
+
+func (NetworkServiceTagsDataSource) azureFrontDoor() string {
+	return `data "azurerm_network_service_tags" "test" {
+  location        = "northeurope"
+  service         = "AzureFrontDoor"
+}`
+}
+
+func (NetworkServiceTagsDataSource) azureFrontDoorBackend() string {
+	return `data "azurerm_network_service_tags" "test" {
+  location        = "northeurope"
+  service         = "AzureFrontDoor.Backend"
+}`
+}
+
+func (NetworkServiceTagsDataSource) azureFrontDoorFrontend() string {
+	return `data "azurerm_network_service_tags" "test" {
+  location        = "northeurope"
+  service         = "AzureFrontDoor.Frontend"
+}`
+}
+
+func (NetworkServiceTagsDataSource) azureFrontDoorFirstParty() string {
+	return `data "azurerm_network_service_tags" "test" {
+  location        = "northeurope"
+  service         = "AzureFrontDoor.FirstParty"
 }`
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Added support for `service` with `.` (like `AzureFrontDoor.Frontend`)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
$ make acctests SERVICE='network' TESTARGS='-run=TestAccDataSourceAzureRMServiceTags_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccDataSourceAzureRMServiceTags_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMServiceTags_basic
=== PAUSE TestAccDataSourceAzureRMServiceTags_basic
=== RUN   TestAccDataSourceAzureRMServiceTags_tagName
=== PAUSE TestAccDataSourceAzureRMServiceTags_tagName
=== RUN   TestAccDataSourceAzureRMServiceTags_region
=== PAUSE TestAccDataSourceAzureRMServiceTags_region
=== RUN   TestAccDataSourceAzureRMServiceTags_AzureFrontDoor
=== PAUSE TestAccDataSourceAzureRMServiceTags_AzureFrontDoor
=== RUN   TestAccDataSourceAzureRMServiceTags_AzureFrontDoorBackend
=== PAUSE TestAccDataSourceAzureRMServiceTags_AzureFrontDoorBackend
=== RUN   TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFrontend
=== PAUSE TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFrontend
=== RUN   TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty
=== PAUSE TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty
=== CONT  TestAccDataSourceAzureRMServiceTags_basic
=== CONT  TestAccDataSourceAzureRMServiceTags_AzureFrontDoorBackend
=== CONT  TestAccDataSourceAzureRMServiceTags_region
=== CONT  TestAccDataSourceAzureRMServiceTags_AzureFrontDoor
=== CONT  TestAccDataSourceAzureRMServiceTags_tagName
=== CONT  TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty
=== CONT  TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFrontend
--- PASS: TestAccDataSourceAzureRMServiceTags_basic (27.74s)
--- PASS: TestAccDataSourceAzureRMServiceTags_region (41.33s)
--- PASS: TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFrontend (84.89s)
--- PASS: TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty (93.53s)
--- PASS: TestAccDataSourceAzureRMServiceTags_AzureFrontDoor (102.18s)
--- PASS: TestAccDataSourceAzureRMServiceTags_AzureFrontDoorBackend (111.46s)
--- PASS: TestAccDataSourceAzureRMServiceTags_tagName (148.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       148.566s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_network_service_tags` - `data` support for `AzureFrontDoor.Backend`, `AzureFrontDoor.FirstParty` and `AzureFrontDoor.Frontend` tags

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26428 
