### PR TITLE
`azurerm_virtual_network_gateway_connection` - split create and update function to fix lifecycle - ignore

### DIFF
--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -238,13 +238,13 @@ func resourceLocalNetworkGatewayDelete(d *pluginsdk.ResourceData, meta interface
 	return nil
 }
 
-func resourceGroupAndLocalNetworkGatewayFromId(localNetworkGatewayId string) (string, string, error) {
+func localNetworkGatewayFromId(localNetworkGatewayId string) (string, error) {
 	id, err := localnetworkgateways.ParseLocalNetworkGatewayID(localNetworkGatewayId)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return id.ResourceGroupName, id.LocalNetworkGatewayName, nil
+	return id.LocalNetworkGatewayName, nil
 }
 
 func expandLocalNetworkGatewayBGPSettings(d *pluginsdk.ResourceData) *localnetworkgateways.BgpSettings {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -398,6 +398,10 @@ func resourceVirtualNetworkGatewayConnectionCreate(d *pluginsdk.ResourceData, me
 			return err
 		}
 
+		if resp.Model == nil {
+			return fmt.Errorf("retrieving %s: %+v", gwid, err)
+		}
+
 		virtualNetworkGateway = *resp.Model
 	}
 
@@ -571,7 +575,7 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection update.")
 
 	id, err := virtualnetworkgatewayconnections.ParseConnectionID(d.Id())
 	if err != nil {
@@ -601,6 +605,10 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 		resp, err := vnetGatewayClient.Get(ctx, *gwid)
 		if err != nil {
 			return err
+		}
+
+		if resp.Model == nil {
+			return fmt.Errorf("retrieving %s: %+v", gwid, err)
 		}
 
 		virtualNetworkGateway = *resp.Model
@@ -660,7 +668,7 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 
 	if d.HasChange("custom_bgp_addresses") {
 		if virtualNetworkGateway.Properties.BgpSettings == nil || virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses == nil {
-			return fmt.Errorf("retrieving BGP peering address from `virtual_network_gateway `%s (%s) failed: get nil", *virtualNetworkGateway.Name, *virtualNetworkGateway.Id)
+			return fmt.Errorf("retrieving BGP peering address from `virtual_network_gateway` %s (%s) failed: get nil", *virtualNetworkGateway.Name, *virtualNetworkGateway.Id)
 		}
 
 		gatewayCustomBgpIPAddresses, err := expandGatewayCustomBgpIPAddresses(d, virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses)
@@ -846,7 +854,7 @@ func getVirtualNetworkGatewayConnectionProperties(d *pluginsdk.ResourceData, vir
 	if utils.NormaliseNilableBool(props.EnableBgp) {
 		if _, ok := d.GetOk("custom_bgp_addresses"); ok {
 			if virtualNetworkGateway.Properties.BgpSettings == nil || virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses == nil {
-				return nil, fmt.Errorf("retrieving BGP peering address from `virtual_network_gateway `%s (%s) failed: get nil", *virtualNetworkGateway.Name, *virtualNetworkGateway.Id)
+				return nil, fmt.Errorf("retrieving BGP peering address from `virtual_network_gateway` %s (%s) failed: get nil", *virtualNetworkGateway.Name, *virtualNetworkGateway.Id)
 			}
 
 			gatewayCustomBgpIPAddresses, err := expandGatewayCustomBgpIPAddresses(d, virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses)

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -29,9 +29,9 @@ import (
 
 func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
-		Create: resourceVirtualNetworkGatewayConnectionCreateUpdate,
+		Create: resourceVirtualNetworkGatewayConnectionCreate,
 		Read:   resourceVirtualNetworkGatewayConnectionRead,
-		Update: resourceVirtualNetworkGatewayConnectionCreateUpdate,
+		Update: resourceVirtualNetworkGatewayConnectionUpdate,
 		Delete: resourceVirtualNetworkGatewayConnectionDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -362,28 +362,26 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 	return resource
 }
 
-func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVirtualNetworkGatewayConnectionCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualNetworkGatewayConnections
 	vnetGatewayClient := meta.(*clients.Client).Network.VirtualNetworkGateways
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection creation.")
 
 	id := virtualnetworkgatewayconnections.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_virtual_network_gateway_connection", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_virtual_network_gateway_connection", id.ID())
 	}
 
 	var virtualNetworkGateway virtualnetworkgateways.VirtualNetworkGateway
@@ -416,7 +414,7 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, connection); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if properties.SharedKey != nil && !d.IsNewResource() {
@@ -565,6 +563,150 @@ func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta
 	}
 
 	return nil
+}
+
+func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualNetworkGatewayConnections
+	vnetGatewayClient := meta.(*clients.Client).Network.VirtualNetworkGateways
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection creation.")
+
+	id, err := virtualnetworkgatewayconnections.ParseConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %s", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	payload := existing.Model
+
+	var virtualNetworkGateway virtualnetworkgateways.VirtualNetworkGateway
+	if v, ok := d.GetOk("virtual_network_gateway_id"); ok {
+		virtualNetworkGatewayId := v.(string)
+
+		gwid, err := virtualnetworkgateways.ParseVirtualNetworkGatewayID(virtualNetworkGatewayId)
+		if err != nil {
+			return err
+		}
+
+		resp, err := vnetGatewayClient.Get(ctx, *gwid)
+		if err != nil {
+			return err
+		}
+
+		virtualNetworkGateway = *resp.Model
+	}
+
+	if d.HasChange("authorization_key") {
+		payload.Properties.AuthorizationKey = pointer.To(d.Get("authorization_key").(string))
+	}
+
+	if d.HasChange("egress_nat_rule_ids") {
+		payload.Properties.EgressNatRules = expandVirtualNetworkGatewayConnectionNatRuleIds(d.Get("egress_nat_rule_ids").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("ingress_nat_rule_ids") {
+		payload.Properties.EgressNatRules = expandVirtualNetworkGatewayConnectionNatRuleIds(d.Get("ingress_nat_rule_ids").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("local_network_gateway_id") {
+		localNetworkGatewayId := d.Get("local_network_gateway_id").(string)
+		_, name, err := resourceGroupAndLocalNetworkGatewayFromId(localNetworkGatewayId)
+		if err != nil {
+			return fmt.Errorf("Getting LocalNetworkGateway Name and Group:: %+v", err)
+		}
+
+		payload.Properties.LocalNetworkGateway2 = &virtualnetworkgatewayconnections.LocalNetworkGateway{
+			Id:   &localNetworkGatewayId,
+			Name: &name,
+			Properties: virtualnetworkgatewayconnections.LocalNetworkGatewayPropertiesFormat{
+				LocalNetworkAddressSpace: &virtualnetworkgatewayconnections.AddressSpace{},
+			},
+		}
+	}
+
+	if d.HasChange("enable_bgp") {
+		payload.Properties.EnableBgp = pointer.To(d.Get("enable_bgp").(bool))
+	}
+
+	if d.HasChange("use_policy_based_traffic_selectors") {
+		payload.Properties.UsePolicyBasedTrafficSelectors = pointer.To(d.Get("use_policy_based_traffic_selectors").(bool))
+	}
+
+	if d.HasChange("routing_weight") {
+		payload.Properties.RoutingWeight = pointer.To(int64(d.Get("routing_weight").(int)))
+	}
+
+	if d.HasChange("express_route_gateway_bypass") {
+		payload.Properties.ExpressRouteGatewayBypass = pointer.To(d.Get("express_route_gateway_bypass").(bool))
+	}
+
+	if d.HasChange("private_link_fast_path_enabled") {
+		payload.Properties.EnablePrivateLinkFastPath = pointer.To(d.Get("private_link_fast_path_enabled").(bool))
+	}
+
+	if d.HasChange("traffic_selector_policy") {
+		payload.Properties.TrafficSelectorPolicies = expandVirtualNetworkGatewayConnectionTrafficSelectorPolicies(d.Get("traffic_selector_policy").([]interface{}))
+	}
+
+	if d.HasChange("custom_bgp_addresses") {
+		if virtualNetworkGateway.Properties.BgpSettings == nil || virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses == nil {
+			return fmt.Errorf("retrieving BGP peering address from `virtual_network_gateway `%s (%s) failed: get nil", *virtualNetworkGateway.Name, *virtualNetworkGateway.Id)
+		}
+
+		gatewayCustomBgpIPAddresses, err := expandGatewayCustomBgpIPAddresses(d, virtualNetworkGateway.Properties.BgpSettings.BgpPeeringAddresses)
+		if err != nil {
+			return err
+		}
+
+		payload.Properties.GatewayCustomBgpIPAddresses = gatewayCustomBgpIPAddresses
+	}
+
+	if d.HasChange("ipsec_policy") {
+		payload.Properties.IPsecPolicies = expandVirtualNetworkGatewayConnectionIpsecPolicies(d.Get("ipsec_policy").([]interface{}))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if d.HasChange("shared_key") {
+		if err := client.SetSharedKeyThenPoll(ctx, *id, virtualnetworkgatewayconnections.ConnectionSharedKey{
+			Value: d.Get("shared_key").(string),
+		}); err != nil {
+			return fmt.Errorf("updating Shared Key for %s: %+v", id, err)
+		}
+
+		// Once this issue https://github.com/Azure/azure-rest-api-specs/issues/26660 is fixed, below this part will be removed
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending:    []string{string(virtualnetworkgatewayconnections.ProvisioningStateUpdating)},
+			Target:     []string{string(virtualnetworkgatewayconnections.ProvisioningStateSucceeded)},
+			Refresh:    virtualNetworkGatewayConnectionStateRefreshFunc(ctx, client, *id),
+			MinTimeout: 15 * time.Second,
+			Timeout:    d.Timeout(pluginsdk.TimeoutUpdate),
+		}
+
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for update of %s: %+v", id, err)
+		}
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVirtualNetworkGatewayConnectionRead(d, meta)
 }
 
 func resourceVirtualNetworkGatewayConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -628,7 +628,7 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 
 	if d.HasChange("local_network_gateway_id") {
 		localNetworkGatewayId := d.Get("local_network_gateway_id").(string)
-		_, name, err := resourceGroupAndLocalNetworkGatewayFromId(localNetworkGatewayId)
+		name, err := localNetworkGatewayFromId(localNetworkGatewayId)
 		if err != nil {
 			return fmt.Errorf("Getting LocalNetworkGateway Name and Group:: %+v", err)
 		}
@@ -816,7 +816,7 @@ func getVirtualNetworkGatewayConnectionProperties(d *pluginsdk.ResourceData, vir
 
 	if v, ok := d.GetOk("local_network_gateway_id"); ok {
 		localNetworkGatewayId := v.(string)
-		_, name, err := resourceGroupAndLocalNetworkGatewayFromId(localNetworkGatewayId)
+		name, err := localNetworkGatewayFromId(localNetworkGatewayId)
 		if err != nil {
 			return nil, fmt.Errorf("Getting LocalNetworkGateway Name and Group:: %+v", err)
 		}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR splits the createUpdate function into separate create and update function to fix lifecycle - ignore

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network_gateway_connection` - split create and update function to fix lifecycle - ignore [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
