### PR TITLE
new datasource `azurerm_elastic_san_volume_snapshot`

### DIFF
--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source.go
@@ -107,7 +107,7 @@ func (r ElasticSANVolumeSnapshotDataSource) Read() sdk.ResourceFunc {
 				// only ElasticSAN Volumes are supported for now
 				volumeId, err := volumes.ParseVolumeIDInsensitively(model.Properties.CreationData.SourceId)
 				if err != nil {
-					return fmt.Errorf("parsing source ID as ElasticSAN Volume ID: %+v", err)
+					return err
 				}
 
 				state.SourceId = volumeId.ID()

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source.go
@@ -1,0 +1,147 @@
+package elasticsan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/snapshots"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/volumes"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ElasticSANVolumeSnapshotDataSource struct{}
+
+var _ sdk.DataSource = ElasticSANVolumeSnapshotDataSource{}
+
+type ElasticSANVolumeSnapshotDataSourceModel struct {
+	Name                string                                 `tfschema:"name"`
+	SourceVolumeSizeGiB int64                                  `tfschema:"source_volume_size_gib"`
+	CreateSource        []ElasticSANVolumeSnapshotCreateSource `tfschema:"creation_source"`
+	VolumeGroupId       string                                 `tfschema:"volume_group_id"`
+	VolumeName          string                                 `tfschema:"volume_name"`
+}
+
+type ElasticSANVolumeSnapshotCreateSource struct {
+	SourceId string `tfschema:"source_id"`
+}
+
+func (r ElasticSANVolumeSnapshotDataSource) ResourceType() string {
+	return "azurerm_elastic_san_volume_snapshot"
+}
+
+func (r ElasticSANVolumeSnapshotDataSource) ModelObject() interface{} {
+	return &ElasticSANVolumeSnapshotDataSourceModel{}
+}
+
+func (r ElasticSANVolumeSnapshotDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.ElasticSanSnapshotName,
+		},
+
+		"volume_group_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+	}
+}
+
+func (r ElasticSANVolumeSnapshotDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"creation_source": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"source_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"source_volume_size_gib": {
+			Computed: true,
+			Type:     pluginsdk.TypeInt,
+		},
+		"volume_name": {
+			Computed: true,
+			Type:     pluginsdk.TypeString,
+		},
+	}
+}
+
+func (r ElasticSANVolumeSnapshotDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ElasticSan.Snapshots
+
+			var state ElasticSANVolumeSnapshotDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			volumeGroupId, err := snapshots.ParseVolumeGroupID(state.VolumeGroupId)
+			if err != nil {
+				return err
+			}
+
+			id := snapshots.NewSnapshotID(volumeGroupId.SubscriptionId, volumeGroupId.ResourceGroupName, volumeGroupId.ElasticSanName, volumeGroupId.VolumeGroupName, state.Name)
+
+			resp, err := client.VolumeSnapshotsGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s does not exist", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state.VolumeGroupId = volumeGroupId.ID()
+			state.Name = id.SnapshotName
+			if model := resp.Model; model != nil {
+				// these properties are not pointer so we don't need to check for nil
+				state.SourceVolumeSizeGiB = pointer.From(model.Properties.SourceVolumeSizeGiB)
+				state.VolumeName = pointer.From(model.Properties.VolumeName)
+
+				createSource, err := FlattenElasticSANVolumeSnapshotCreateSource(model.Properties.CreationData)
+				if err != nil {
+					return err
+				}
+				state.CreateSource = *createSource
+			}
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func FlattenElasticSANVolumeSnapshotCreateSource(input snapshots.SnapshotCreationData) (*[]ElasticSANVolumeSnapshotCreateSource, error) {
+	if input.SourceId == "" {
+		return &[]ElasticSANVolumeSnapshotCreateSource{}, nil
+	}
+
+	// for now source ID can only be ElasticSAN Volume ID
+	var sourceId string
+	parsedSourceId, err := volumes.ParseVolumeIDInsensitively(input.SourceId)
+	if err != nil {
+		return nil, fmt.Errorf("parsing source ID as ElasticSAN Volume ID: %+v", err)
+	}
+	sourceId = parsedSourceId.ID()
+
+	return &[]ElasticSANVolumeSnapshotCreateSource{
+		{
+			SourceId: sourceId,
+		},
+	}, nil
+}

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
@@ -1,0 +1,114 @@
+package elasticsan_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ElasticSANVolumeSnapshotDataSource struct{}
+
+// https://github.com/hashicorp/terraform-provider-azurerm/pull/25372#issuecomment-2022105240
+// Elastic SAN Volume Snapshot is context-based and should not be regarded as the infrastructure managed by Terraform
+// so we only onboard this as a data source instead of a resource. The acctest relys on Azure CLI to create/delete the snapshot.
+func TestAccElasticSANVolumeSnapshotDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_elastic_san_volume_snapshot", "test")
+	d := ElasticSANVolumeSnapshotDataSource{}
+
+	const SnapshotTestRunEnv = "ARM_TEST_ELASTIC_SAN_VOLUME_SNAPSHOT_RUN"
+
+	if os.Getenv(SnapshotTestRunEnv) == "" {
+		t.Skipf("skip the test as one or more of below environment variables are not specified: %q", SnapshotTestRunEnv)
+	}
+
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("creation_source.#").HasValue("1"),
+				check.That(data.ResourceName).Key("creation_source.0.source_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("source_volume_size_gib").IsNotEmpty(),
+				check.That(data.ResourceName).Key("volume_name").IsNotEmpty(),
+			),
+		},
+	})
+}
+
+func (d ElasticSANVolumeSnapshotDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+variable "primary_location" {
+  default = %q
+}
+variable "random_integer" {
+  default = %d
+}
+variable "random_string" {
+  default = %q
+}
+
+provider "azurerm" {
+  features{}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-esvg-${var.random_integer}"
+  location = var.primary_location
+}
+
+resource "azurerm_elastic_san" "test" {
+  name                = "acctestes-${var.random_string}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  base_size_in_tib    = 1
+  sku {
+    name = "Premium_LRS"
+  }
+}
+
+resource "azurerm_elastic_san_volume_group" "test" {
+  name           = "acctestesvg-${var.random_string}"
+  elastic_san_id = azurerm_elastic_san.test.id
+}
+
+resource "azurerm_elastic_san_volume" "test" {
+  name            = "acctestesv-${var.random_string}"
+  volume_group_id = azurerm_elastic_san_volume_group.test.id
+  size_in_gib     = 1
+}
+
+locals {
+  snapshot_name = "acctest-ess-${var.random_string}"
+}
+
+resource "terraform_data" "test" {
+  input = {
+    resource_group_name = azurerm_resource_group.test.name
+    elastic_san_name = azurerm_elastic_san.test.name
+    volume_group_name = azurerm_elastic_san_volume_group.test.name
+    snapshot_name = local.snapshot_name
+  }
+
+  provisioner "local-exec" {
+    command = <<COMMAND
+      az elastic-san volume snapshot create -g ${self.input.resource_group_name} -e ${self.input.elastic_san_name} -v ${self.input.volume_group_name} -n ${self.input.snapshot_name} --creation-data '{source-id:${azurerm_elastic_san_volume.test.id}}'
+    COMMAND
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<COMMAND
+      az elastic-san volume snapshot delete -g ${self.input.resource_group_name} -e ${self.input.elastic_san_name} -v ${self.input.volume_group_name} -n ${self.input.snapshot_name} -y
+    COMMAND
+  }
+}
+
+data "azurerm_elastic_san_volume_snapshot" "test" {
+  name            = local.snapshot_name
+  volume_group_id = azurerm_elastic_san_volume_group.test.id
+  depends_on = [terraform_data.test]
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
@@ -18,7 +18,7 @@ type ElasticSANVolumeSnapshotDataSource struct{}
 
 // https://github.com/hashicorp/terraform-provider-azurerm/pull/25372#issuecomment-2022105240
 // Elastic SAN Volume Snapshot is context-based and should not be regarded as the infrastructure managed by Terraform
-// so we only onboard this as a data source instead of a resource. The acctest create the snapshot as a test step
+// so we only onboard this as a data source instead of a resource. The acctest creates the snapshot as a test step
 func TestAccElasticSANVolumeSnapshotDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_elastic_san_volume_snapshot", "test")
 	d := ElasticSANVolumeSnapshotDataSource{}

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
@@ -1,43 +1,145 @@
 package elasticsan_test
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/snapshots"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/volumes"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 )
 
 type ElasticSANVolumeSnapshotDataSource struct{}
 
 // https://github.com/hashicorp/terraform-provider-azurerm/pull/25372#issuecomment-2022105240
 // Elastic SAN Volume Snapshot is context-based and should not be regarded as the infrastructure managed by Terraform
-// so we only onboard this as a data source instead of a resource. The acctest relys on Azure CLI to create/delete the snapshot.
+// so we only onboard this as a data source instead of a resource. The acctest create the snapshot as a test step
 func TestAccElasticSANVolumeSnapshotDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_elastic_san_volume_snapshot", "test")
 	d := ElasticSANVolumeSnapshotDataSource{}
 
-	const SnapshotTestRunEnv = "ARM_TEST_ELASTIC_SAN_VOLUME_SNAPSHOT_RUN"
-
-	if os.Getenv(SnapshotTestRunEnv) == "" {
-		t.Skipf("skip the test as one or more of below environment variables are not specified: %q", SnapshotTestRunEnv)
-	}
-
 	data.DataSourceTestInSequence(t, []acceptance.TestStep{
 		{
-			Config: d.basic(data),
+			Config: d.snapshotSource(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("creation_source.#").HasValue("1"),
-				check.That(data.ResourceName).Key("creation_source.0.source_id").IsNotEmpty(),
-				check.That(data.ResourceName).Key("source_volume_size_gib").IsNotEmpty(),
+				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+					if _, ok := ctx.Deadline(); !ok {
+						var cancel context.CancelFunc
+						ctx, cancel = context.WithTimeout(ctx, 30*time.Minute)
+						defer cancel()
+					}
+
+					volumeId, err := volumes.ParseVolumeID(state.ID)
+					if err != nil {
+						return err
+					}
+
+					id := snapshots.NewSnapshotID(volumeId.SubscriptionId, volumeId.ResourceGroupName, volumeId.ElasticSanName, volumeId.VolumeGroupName, data.RandomString)
+
+					snapshot := snapshots.Snapshot{
+						Properties: snapshots.SnapshotProperties{
+							CreationData: snapshots.SnapshotCreationData{
+								SourceId: volumeId.ID(),
+							},
+						},
+					}
+
+					client := clients.ElasticSan.Snapshots
+					if err = client.VolumeSnapshotsCreateThenPoll(ctx, id, snapshot); err != nil {
+						return fmt.Errorf("creating %s: %+v", id, err)
+					}
+
+					return nil
+				}, "azurerm_elastic_san_volume.test"),
+			),
+		},
+		{
+			Config: d.snapshotRestore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("source_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("source_volume_size_in_gib").IsNotEmpty(),
 				check.That(data.ResourceName).Key("volume_name").IsNotEmpty(),
+			),
+		},
+		{
+			Config: d.snapshotSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+					if _, ok := ctx.Deadline(); !ok {
+						var cancel context.CancelFunc
+						ctx, cancel = context.WithTimeout(ctx, 30*time.Minute)
+						defer cancel()
+					}
+
+					volumeId, err := volumes.ParseVolumeID(state.ID)
+					if err != nil {
+						return err
+					}
+
+					id := snapshots.NewSnapshotID(volumeId.SubscriptionId, volumeId.ResourceGroupName, volumeId.ElasticSanName, volumeId.VolumeGroupName, data.RandomString)
+
+					client := clients.ElasticSan.Snapshots
+					if err = client.VolumeSnapshotsDeleteThenPoll(ctx, id); err != nil {
+						return fmt.Errorf("creating %s: %+v", id, err)
+					}
+
+					return nil
+				}, "azurerm_elastic_san_volume.test"),
 			),
 		},
 	})
 }
 
-func (d ElasticSANVolumeSnapshotDataSource) basic(data acceptance.TestData) string {
+func (d ElasticSANVolumeSnapshotDataSource) snapshotSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+variable "primary_location" {
+  default = %q
+}
+variable "random_integer" {
+  default = %d
+}
+variable "random_string" {
+  default = %q
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-esvg-${var.random_integer}"
+  location = var.primary_location
+}
+
+resource "azurerm_elastic_san" "test" {
+  name                = "acctestes-${var.random_string}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  base_size_in_tib    = 1
+  sku {
+    name = "Premium_LRS"
+  }
+}
+
+resource "azurerm_elastic_san_volume_group" "test" {
+  name           = "acctestesvg-${var.random_string}"
+  elastic_san_id = azurerm_elastic_san.test.id
+}
+
+resource "azurerm_elastic_san_volume" "test" {
+  name            = "acctestesv-${var.random_string}"
+  volume_group_id = azurerm_elastic_san_volume_group.test.id
+  size_in_gib     = 1
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (d ElasticSANVolumeSnapshotDataSource) snapshotRestore(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 variable "primary_location" {
   default = %q
@@ -79,36 +181,9 @@ resource "azurerm_elastic_san_volume" "test" {
   size_in_gib     = 1
 }
 
-locals {
-  snapshot_name = "acctest-ess-${var.random_string}"
-}
-
-resource "terraform_data" "test" {
-  input = {
-    resource_group_name = azurerm_resource_group.test.name
-    elastic_san_name    = azurerm_elastic_san.test.name
-    volume_group_name   = azurerm_elastic_san_volume_group.test.name
-    snapshot_name       = local.snapshot_name
-  }
-
-  provisioner "local-exec" {
-    command = <<COMMAND
-      az elastic-san volume snapshot create -g ${self.input.resource_group_name} -e ${self.input.elastic_san_name} -v ${self.input.volume_group_name} -n ${self.input.snapshot_name} --creation-data '{source-id:${azurerm_elastic_san_volume.test.id}}'
-    COMMAND
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<COMMAND
-      az elastic-san volume snapshot delete -g ${self.input.resource_group_name} -e ${self.input.elastic_san_name} -v ${self.input.volume_group_name} -n ${self.input.snapshot_name} -y
-    COMMAND
-  }
-}
-
 data "azurerm_elastic_san_volume_snapshot" "test" {
-  name            = local.snapshot_name
+  name            = var.random_string
   volume_group_id = azurerm_elastic_san_volume_group.test.id
-  depends_on      = [terraform_data.test]
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
@@ -97,27 +97,17 @@ func TestAccElasticSANVolumeSnapshotDataSource_basic(t *testing.T) {
 
 func (d ElasticSANVolumeSnapshotDataSource) snapshotSource(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-variable "primary_location" {
-  default = %q
-}
-variable "random_integer" {
-  default = %d
-}
-variable "random_string" {
-  default = %q
-}
-
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-esvg-${var.random_integer}"
-  location = var.primary_location
+  name     = "acctestrg-esvg-%[2]d"
+  location = "%[1]s"
 }
 
 resource "azurerm_elastic_san" "test" {
-  name                = "acctestes-${var.random_string}"
+  name                = "acctestes-%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   base_size_in_tib    = 1
@@ -127,12 +117,12 @@ resource "azurerm_elastic_san" "test" {
 }
 
 resource "azurerm_elastic_san_volume_group" "test" {
-  name           = "acctestesvg-${var.random_string}"
+  name           = "acctestesvg-%[3]s"
   elastic_san_id = azurerm_elastic_san.test.id
 }
 
 resource "azurerm_elastic_san_volume" "test" {
-  name            = "acctestesv-${var.random_string}"
+  name            = "acctestesv-%[3]s"
   volume_group_id = azurerm_elastic_san_volume_group.test.id
   size_in_gib     = 1
 }
@@ -141,27 +131,17 @@ resource "azurerm_elastic_san_volume" "test" {
 
 func (d ElasticSANVolumeSnapshotDataSource) snapshotRestore(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-variable "primary_location" {
-  default = %q
-}
-variable "random_integer" {
-  default = %d
-}
-variable "random_string" {
-  default = %q
-}
-
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-esvg-${var.random_integer}"
-  location = var.primary_location
+  name     = "acctestrg-esvg-%[2]d"
+  location = "%[1]s"
 }
 
 resource "azurerm_elastic_san" "test" {
-  name                = "acctestes-${var.random_string}"
+  name                = "acctestes-%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   base_size_in_tib    = 1
@@ -171,18 +151,18 @@ resource "azurerm_elastic_san" "test" {
 }
 
 resource "azurerm_elastic_san_volume_group" "test" {
-  name           = "acctestesvg-${var.random_string}"
+  name           = "acctestesvg-%[3]s"
   elastic_san_id = azurerm_elastic_san.test.id
 }
 
 resource "azurerm_elastic_san_volume" "test" {
-  name            = "acctestesv-${var.random_string}"
+  name            = "acctestesv-%[3]s"
   volume_group_id = azurerm_elastic_san_volume_group.test.id
   size_in_gib     = 1
 }
 
 data "azurerm_elastic_san_volume_snapshot" "test" {
-  name            = var.random_string
+  name            = "%[3]s"
   volume_group_id = azurerm_elastic_san_volume_group.test.id
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)

--- a/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_snapshot_data_source_test.go
@@ -50,7 +50,7 @@ variable "random_string" {
 }
 
 provider "azurerm" {
-  features{}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -86,9 +86,9 @@ locals {
 resource "terraform_data" "test" {
   input = {
     resource_group_name = azurerm_resource_group.test.name
-    elastic_san_name = azurerm_elastic_san.test.name
-    volume_group_name = azurerm_elastic_san_volume_group.test.name
-    snapshot_name = local.snapshot_name
+    elastic_san_name    = azurerm_elastic_san.test.name
+    volume_group_name   = azurerm_elastic_san_volume_group.test.name
+    snapshot_name       = local.snapshot_name
   }
 
   provisioner "local-exec" {
@@ -108,7 +108,7 @@ resource "terraform_data" "test" {
 data "azurerm_elastic_san_volume_snapshot" "test" {
   name            = local.snapshot_name
   volume_group_id = azurerm_elastic_san_volume_group.test.id
-  depends_on = [terraform_data.test]
+  depends_on      = [terraform_data.test]
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/elasticsan/registration.go
+++ b/internal/services/elasticsan/registration.go
@@ -21,6 +21,7 @@ func (Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		ElasticSANDataSource{},
 		ElasticSANVolumeGroupDataSource{},
+		ElasticSANVolumeSnapshotDataSource{},
 	}
 }
 

--- a/internal/services/elasticsan/validate/elastic_san_snapshot_name.go
+++ b/internal/services/elasticsan/validate/elastic_san_snapshot_name.go
@@ -1,0 +1,24 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func ElasticSanSnapshotName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	if matched := regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{1,61}[a-z0-9]$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q must be between 3 and 63 characters. It can contain only lowercase letters, numbers, underscores (_) and hyphens (-). It must start and end with a lowercase letter or number", k))
+	}
+
+	if matched := regexp.MustCompile(`[_-][_-]`).Match([]byte(v)); matched {
+		errors = append(errors, fmt.Errorf("%q must have hyphens and underscores be surrounded by alphanumeric character", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/elasticsan/validate/elastic_san_snapshot_name_test.go
+++ b/internal/services/elasticsan/validate/elastic_san_snapshot_name_test.go
@@ -1,0 +1,104 @@
+package validate
+
+import "testing"
+
+func TestElasticSanSnapshotName(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// basic example
+			input:    "hello",
+			expected: true,
+		},
+		{
+			// 2 chars
+			input:    "ab",
+			expected: false,
+		},
+		{
+			// 3 chars
+			input:    "abc",
+			expected: true,
+		},
+		{
+			// 63 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk",
+			expected: true,
+		},
+		{
+			// 64 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl",
+			expected: false,
+		},
+		{
+			// may contain alphanumerics, dashes and underscores
+			input:    "hello_world7-goodbye",
+			expected: true,
+		},
+		{
+			// must begin with an alphanumeric
+			input:    "_hello",
+			expected: false,
+		},
+		{
+			// can't end with a dash
+			input:    "hello-",
+			expected: false,
+		},
+		{
+			// cannot end with an underscore
+			input:    "hello_",
+			expected: false,
+		},
+		{
+			// cannot have consecutive underscore
+			input:    "hello__world",
+			expected: false,
+		},
+		{
+			// cannot have consecutive dash
+			input:    "hello--world",
+			expected: false,
+		},
+		{
+			// cannot have consecutive underscore or dash
+			input:    "hello-_world",
+			expected: false,
+		},
+		{
+			// can't contain an exclamation mark
+			input:    "hello!",
+			expected: false,
+		},
+		{
+			// start with a number
+			input:    "0abc",
+			expected: true,
+		},
+		{
+			// contain only numbers
+			input:    "12345",
+			expected: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := ElasticSanSnapshotName(v.input, "name")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			if len(errors) > 0 {
+				t.Logf("[DEBUG] Errors: %v", errors)
+			}
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/website/docs/d/elastic_san_volume_snapshot.html.markdown
+++ b/website/docs/d/elastic_san_volume_snapshot.html.markdown
@@ -25,11 +25,11 @@ data "azurerm_elastic_san_volume_group" "example" {
 
 data "azurerm_elastic_san_volume_snapshot" "example" {
   name            = "existing"
-  volume_group_id = data.azurerm_elastic_san.example.id
+  volume_group_id = data.azurerm_elastic_san_volume_group.example.id
 }
 
 output "id" {
-  value = data.azurerm_elastic_san_volume_group.example.id
+  value = data.azurerm_elastic_san_volume_snapshot.example.id
 }
 ```
 
@@ -47,13 +47,11 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Elastic SAN.
 
-* `creation_source` - A `creation_source` block as defined below.
-
----
-
-A `creation_source` block exports the following arguments:
-
 * `source_id` - The Resource ID from which the Snapshot is created.
+
+* `source_volume_size_gib` - Size of Source Volume.
+
+* `volume_name` - Source Volume Name of the Snapshot.
 
 ## Timeouts
 

--- a/website/docs/d/elastic_san_volume_snapshot.html.markdown
+++ b/website/docs/d/elastic_san_volume_snapshot.html.markdown
@@ -54,6 +54,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 A `creation_source` block exports the following arguments:
 
 * `source_id` - The Resource ID from which the Snapshot is created.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/d/elastic_san_volume_snapshot.html.markdown
+++ b/website/docs/d/elastic_san_volume_snapshot.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Elastic SAN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_elastic_san_volume_snapshot"
+description: |-
+  Gets information about an existing Elastic SAN Volume Snapshot.
+---
+
+# Data Source: azurerm_elastic_san_volume_snapshot
+
+Use this data source to access information about an existing Elastic SAN Volume Snapshot.
+
+## Example Usage
+
+```hcl
+data "azurerm_elastic_san" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+data "azurerm_elastic_san_volume_group" "example" {
+  name           = "existing"
+  elastic_san_id = data.azurerm_elastic_san.example.id
+}
+
+data "azurerm_elastic_san_volume_snapshot" "example" {
+  name            = "existing"
+  volume_group_id = data.azurerm_elastic_san.example.id
+}
+
+output "id" {
+  value = data.azurerm_elastic_san_volume_group.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - The name of the Elastic SAN Volume Snapshot.
+
+* `volume_group_id` - The Elastic SAN Volume Group ID within which the Elastic SAN Volume Snapshot exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Elastic SAN.
+
+* `creation_source` - A `creation_source` block as defined below.
+
+---
+
+A `creation_source` block exports the following arguments:
+
+* `source_id` - The Resource ID from which the Snapshot is created.
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Elastic SAN Volume Snapshot.

--- a/website/docs/d/elastic_san_volume_snapshot.html.markdown
+++ b/website/docs/d/elastic_san_volume_snapshot.html.markdown
@@ -45,13 +45,13 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Elastic SAN.
+* `id` - The ID of the Elastic SAN Volume Snapshot.
 
-* `source_id` - The Resource ID from which the Snapshot is created.
+* `source_id` - The resource ID from which the Snapshot is created.
 
-* `source_volume_size_gib` - Size of Source Volume.
+* `source_volume_size_in_gib` - The size of source volume.
 
-* `volume_name` - Source Volume Name of the Snapshot.
+* `volume_name` - The source volume name of the Snapshot.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

As discussed in https://github.com/hashicorp/terraform-provider-azurerm/pull/25372#issuecomment-2022105240, the Elastic SAN Volume Snapshot should be onboarded as a data source instead of a resource. The acctest relys on Azure CLI to create/delete the snapshot, and an envrionment variable `ARM_TEST_ELASTIC_SAN_VOLUME_SNAPSHOT_RUN` is used to control whether to run the test.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
% ARM_TEST_ELASTIC_SAN_VOLUME_SNAPSHOT_RUN=1 make acctests SERVICE="elasticsan" TESTARGS="-parallel 5 -run TestAccElasticSANVolumeSnapshotData" TESTTIMEOUT='2h'                                                                                         ==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/elasticsan -parallel 5 -run TestAccElasticSANVolumeSnapshotData -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccElasticSANVolumeSnapshotDataSource_basic
--- PASS: TestAccElasticSANVolumeSnapshotDataSource_basic (336.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/elasticsan    336.633s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* new datasource `azurerm_elastic_san_volume_snapshot` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
