### PR TITLE
`azurerm_redis_cache_access_policy` - remove `ForceNew` from `permissions`

### DIFF
--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -132,7 +132,7 @@ func (r RedisCacheAccessPolicyResource) Update() sdk.ResourceFunc {
 			}
 
 			if existing.Model == nil {
-				return fmt.Errorf("retrieving %s: model was nil", *id)
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
 			}
 
 			if existing.Model.Properties == nil {

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -15,10 +15,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type RedisCacheAccessPolicyResource struct {
-}
+type RedisCacheAccessPolicyResource struct{}
 
-var _ sdk.Resource = RedisCacheAccessPolicyResource{}
+var _ sdk.ResourceWithUpdate = RedisCacheAccessPolicyResource{}
 
 type RedisCacheAccessPolicyResourceModel struct {
 	Name         string `tfschema:"name"`
@@ -42,7 +41,6 @@ func (r RedisCacheAccessPolicyResource) Arguments() map[string]*pluginsdk.Schema
 		"permissions": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 	}
 }
@@ -107,6 +105,52 @@ func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r RedisCacheAccessPolicyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Redis.Redis
+
+			var state RedisCacheAccessPolicyResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			id, err := redis.ParseAccessPolicyID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.AccessPolicyGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			if existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+
+			model := *existing.Model
+			if metadata.ResourceData.HasChange("permissions") {
+				model.Properties.Permissions = state.Permissions
+			}
+
+			locks.ByID(state.RedisCacheID)
+			defer locks.UnlockByID(state.RedisCacheID)
+
+			if err := client.AccessPolicyCreateUpdateThenPoll(ctx, *id, model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
 			return nil
 		},
 	}

--- a/website/docs/r/redis_cache_access_policy.html.markdown
+++ b/website/docs/r/redis_cache_access_policy.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new Redis Cache Access Policy to be created.
 
-* `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy. Changing this forces a new Redis Cache Access Policy to be created.
+* `permissions` - (Required) Permissions that are going to be assigned to this Redis Cache Access Policy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

After validating the behavior of the API, the `permissions` is allowed to be updated. Submit this PR to remove the `ForceNew` for `permissions` to fix #26390 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

`PASS: TestAccRedisCacheAccessPolicy_update (2489.80s)
`
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_redis_cache_access_policy` -  remove `ForceNew` from `permissions` [GH-26390]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26390


