### PR TITLE
azurerm_express_route_gateway - prevent panic

### DIFF
--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -280,36 +280,61 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 				AuthorizationKey:          props.AuthorizationKey,
 				EnableInternetSecurity:    props.EnableInternetSecurity,
 				EnablePrivateLinkFastPath: props.EnablePrivateLinkFastPath,
-				ExpressRouteCircuitPeering: expressroutegateways.ExpressRouteCircuitPeeringId{
-					Id: props.ExpressRouteCircuitPeering.Id,
-				},
 				ExpressRouteGatewayBypass: props.ExpressRouteGatewayBypass,
 				ProvisioningState:         (*expressroutegateways.ProvisioningState)(props.ProvisioningState),
-				RoutingConfiguration: &expressroutegateways.RoutingConfiguration{
-					AssociatedRouteTable: &expressroutegateways.SubResource{
-						Id: props.RoutingConfiguration.AssociatedRouteTable.Id,
-					},
-					InboundRouteMap: &expressroutegateways.SubResource{
-						Id: props.RoutingConfiguration.InboundRouteMap.Id,
-					},
-					OutboundRouteMap: &expressroutegateways.SubResource{
-						Id: props.RoutingConfiguration.OutboundRouteMap.Id,
-					},
+			}
+
+			if props.ExpressRouteCircuitPeering != nil {
+				o.Properties.ExpressRouteCircuitPeering = expressroutegateways.ExpressRouteCircuitPeeringId{
+					Id: props.ExpressRouteCircuitPeering.Id,
+				}
+			}
+
+			if props.RoutingConfiguration != nil {
+				o.Properties.RoutingConfiguration = &expressroutegateways.RoutingConfiguration{
+					AssociatedRouteTable: &expressroutegateways.SubResource{},
+					InboundRouteMap:      &expressroutegateways.SubResource{},
+					OutboundRouteMap:     &expressroutegateways.SubResource{},
 					PropagatedRouteTables: &expressroutegateways.PropagatedRouteTable{
-						Ids:    convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.PropagatedRouteTables.Ids),
+						Ids:    make([]expressroutegateways.SubResource, 0),
 						Labels: props.RoutingConfiguration.PropagatedRouteTables.Labels,
 					},
 					VnetRoutes: &expressroutegateways.VnetRoute{
-						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.VnetRoutes.BgpConnections),
-						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(props.RoutingConfiguration.VnetRoutes.StaticRoutes),
-						StaticRoutesConfig: &expressroutegateways.StaticRoutesConfig{
-							PropagateStaticRoutes:          i.Properties.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.PropagateStaticRoutes,
-							VnetLocalRouteOverrideCriteria: (*expressroutegateways.VnetLocalRouteOverrideCriteria)(i.Properties.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria),
-						},
+						BgpConnections: make([]expressroutegateways.SubResource, 0),
+						StaticRoutes:   make([]expressroutegateways.StaticRoute, 0),
 					},
-				},
-				RoutingWeight: props.RoutingWeight,
+				}
+
+				if props.RoutingConfiguration.AssociatedRouteTable != nil {
+					o.Properties.RoutingConfiguration.AssociatedRouteTable.Id = props.RoutingConfiguration.AssociatedRouteTable.Id
+				}
+
+				if props.RoutingConfiguration.InboundRouteMap != nil {
+					o.Properties.RoutingConfiguration.InboundRouteMap.Id = props.RoutingConfiguration.InboundRouteMap.Id
+				}
+
+				if props.RoutingConfiguration.OutboundRouteMap != nil {
+					o.Properties.RoutingConfiguration.OutboundRouteMap.Id = props.RoutingConfiguration.OutboundRouteMap.Id
+				}
+
+				if props.RoutingConfiguration.PropagatedRouteTables != nil {
+					o.Properties.RoutingConfiguration.PropagatedRouteTables.Ids = convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.PropagatedRouteTables.Ids)
+				}
+
+				if props.RoutingConfiguration.VnetRoutes != nil {
+					o.Properties.RoutingConfiguration.VnetRoutes.BgpConnections = convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.VnetRoutes.BgpConnections)
+					o.Properties.RoutingConfiguration.VnetRoutes.StaticRoutes = convertConnectionsStaticRouteToGatewayStaticRoute(props.RoutingConfiguration.VnetRoutes.StaticRoutes)
+
+					if props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig != nil {
+						o.Properties.RoutingConfiguration.VnetRoutes.StaticRoutesConfig = &expressroutegateways.StaticRoutesConfig{
+							PropagateStaticRoutes:          props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.PropagateStaticRoutes,
+							VnetLocalRouteOverrideCriteria: (*expressroutegateways.VnetLocalRouteOverrideCriteria)(props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria),
+						}
+					}
+				}
 			}
+
+			o.Properties.RoutingWeight = props.RoutingWeight
 		}
 		output = append(output, o)
 	}

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -280,61 +280,59 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 				AuthorizationKey:          props.AuthorizationKey,
 				EnableInternetSecurity:    props.EnableInternetSecurity,
 				EnablePrivateLinkFastPath: props.EnablePrivateLinkFastPath,
+				ExpressRouteCircuitPeering: expressroutegateways.ExpressRouteCircuitPeeringId{
+					Id: props.ExpressRouteCircuitPeering.Id,
+				},
 				ExpressRouteGatewayBypass: props.ExpressRouteGatewayBypass,
 				ProvisioningState:         (*expressroutegateways.ProvisioningState)(props.ProvisioningState),
+				RoutingWeight:             props.RoutingWeight,
 			}
 
-			if props.ExpressRouteCircuitPeering != nil {
-				o.Properties.ExpressRouteCircuitPeering = expressroutegateways.ExpressRouteCircuitPeeringId{
-					Id: props.ExpressRouteCircuitPeering.Id,
-				}
-			}
+			if routingConfiguration := props.RoutingConfiguration; routingConfiguration != nil {
+				rc := &expressroutegateways.RoutingConfiguration{}
 
-			if props.RoutingConfiguration != nil {
-				o.Properties.RoutingConfiguration = &expressroutegateways.RoutingConfiguration{
-					AssociatedRouteTable: &expressroutegateways.SubResource{},
-					InboundRouteMap:      &expressroutegateways.SubResource{},
-					OutboundRouteMap:     &expressroutegateways.SubResource{},
-					PropagatedRouteTables: &expressroutegateways.PropagatedRouteTable{
-						Ids:    make([]expressroutegateways.SubResource, 0),
-						Labels: props.RoutingConfiguration.PropagatedRouteTables.Labels,
-					},
-					VnetRoutes: &expressroutegateways.VnetRoute{
-						BgpConnections: make([]expressroutegateways.SubResource, 0),
-						StaticRoutes:   make([]expressroutegateways.StaticRoute, 0),
-					},
+				if routingConfiguration.AssociatedRouteTable != nil {
+					rc.AssociatedRouteTable = &expressroutegateways.SubResource{
+						Id: routingConfiguration.AssociatedRouteTable.Id,
+					}
 				}
 
-				if props.RoutingConfiguration.AssociatedRouteTable != nil {
-					o.Properties.RoutingConfiguration.AssociatedRouteTable.Id = props.RoutingConfiguration.AssociatedRouteTable.Id
+				if routingConfiguration.InboundRouteMap != nil {
+					rc.InboundRouteMap = &expressroutegateways.SubResource{
+						Id: routingConfiguration.InboundRouteMap.Id,
+					}
 				}
 
-				if props.RoutingConfiguration.InboundRouteMap != nil {
-					o.Properties.RoutingConfiguration.InboundRouteMap.Id = props.RoutingConfiguration.InboundRouteMap.Id
+				if routingConfiguration.OutboundRouteMap != nil {
+					rc.OutboundRouteMap = &expressroutegateways.SubResource{
+						Id: routingConfiguration.OutboundRouteMap.Id,
+					}
 				}
 
-				if props.RoutingConfiguration.OutboundRouteMap != nil {
-					o.Properties.RoutingConfiguration.OutboundRouteMap.Id = props.RoutingConfiguration.OutboundRouteMap.Id
+				if routingConfiguration.PropagatedRouteTables != nil {
+					rc.PropagatedRouteTables = &expressroutegateways.PropagatedRouteTable{
+						Ids:    convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.PropagatedRouteTables.Ids),
+						Labels: routingConfiguration.PropagatedRouteTables.Labels,
+					}
 				}
 
-				if props.RoutingConfiguration.PropagatedRouteTables != nil {
-					o.Properties.RoutingConfiguration.PropagatedRouteTables.Ids = convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.PropagatedRouteTables.Ids)
-				}
+				if vnewt := routingConfiguration.VnetRoutes; vnewt != nil {
+					rc.VnetRoutes = &expressroutegateways.VnetRoute{
+						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(vnewt.BgpConnections),
+						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnewt.StaticRoutes),
+					}
 
-				if props.RoutingConfiguration.VnetRoutes != nil {
-					o.Properties.RoutingConfiguration.VnetRoutes.BgpConnections = convertConnectionsSubresourceToGatewaySubResource(props.RoutingConfiguration.VnetRoutes.BgpConnections)
-					o.Properties.RoutingConfiguration.VnetRoutes.StaticRoutes = convertConnectionsStaticRouteToGatewayStaticRoute(props.RoutingConfiguration.VnetRoutes.StaticRoutes)
-
-					if props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig != nil {
-						o.Properties.RoutingConfiguration.VnetRoutes.StaticRoutesConfig = &expressroutegateways.StaticRoutesConfig{
-							PropagateStaticRoutes:          props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.PropagateStaticRoutes,
-							VnetLocalRouteOverrideCriteria: (*expressroutegateways.VnetLocalRouteOverrideCriteria)(props.RoutingConfiguration.VnetRoutes.StaticRoutesConfig.VnetLocalRouteOverrideCriteria),
+					if src := vnewt.StaticRoutesConfig; src != nil {
+						rc.VnetRoutes.StaticRoutesConfig = &expressroutegateways.StaticRoutesConfig{
+							PropagateStaticRoutes:          src.PropagateStaticRoutes,
+							VnetLocalRouteOverrideCriteria: (*expressroutegateways.VnetLocalRouteOverrideCriteria)(src.VnetLocalRouteOverrideCriteria),
 						}
 					}
 				}
+
+				o.Properties.RoutingConfiguration = rc
 			}
 
-			o.Properties.RoutingWeight = props.RoutingWeight
 		}
 		output = append(output, o)
 	}

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -316,7 +316,7 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 					}
 				}
 
-				if vnewt := routingConfiguration.VnetRoutes; vnewt != nil {
+				if vnet := routingConfiguration.VnetRoutes; vnet != nil {
 					rc.VnetRoutes = &expressroutegateways.VnetRoute{
 						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(vnewt.BgpConnections),
 						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnewt.StaticRoutes),

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -322,7 +322,7 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnet.StaticRoutes),
 					}
 
-					if src := vnewt.StaticRoutesConfig; src != nil {
+					if src := vnet.StaticRoutesConfig; src != nil {
 						rc.VnetRoutes.StaticRoutesConfig = &expressroutegateways.StaticRoutesConfig{
 							PropagateStaticRoutes:          src.PropagateStaticRoutes,
 							VnetLocalRouteOverrideCriteria: (*expressroutegateways.VnetLocalRouteOverrideCriteria)(src.VnetLocalRouteOverrideCriteria),

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -318,7 +318,7 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 
 				if vnet := routingConfiguration.VnetRoutes; vnet != nil {
 					rc.VnetRoutes = &expressroutegateways.VnetRoute{
-						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(vnewt.BgpConnections),
+						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(vnet.BgpConnections),
 						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnewt.StaticRoutes),
 					}
 

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -319,7 +319,7 @@ func convertConnectionsToGatewayConnections(input *[]expressrouteconnections.Exp
 				if vnet := routingConfiguration.VnetRoutes; vnet != nil {
 					rc.VnetRoutes = &expressroutegateways.VnetRoute{
 						BgpConnections: convertConnectionsSubresourceToGatewaySubResource(vnet.BgpConnections),
-						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnewt.StaticRoutes),
+						StaticRoutes:   convertConnectionsStaticRouteToGatewayStaticRoute(vnet.StaticRoutes),
 					}
 
 					if src := vnewt.StaticRoutesConfig; src != nil {


### PR DESCRIPTION
fix:

Stack trace from the terraform-provider-azurerm_v3.108.0_x5 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x535f69f]

goroutine 120 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/network.convertConnectionsToGatewayConnections(0xc004c827b0)
github.com/hashicorp/terraform-provider-azurerm/internal/services/network/express_route_gateway_resource.go:303 +0x13f
github.com/hashicorp/terraform-provider-azurerm/internal/services/network.resourceExpressRouteGatewayUpdate(0xc004b19880, {0x719fc60?, 0xc002ebed80})
github.com/hashicorp/terraform-provider-azurerm/internal/services/network/express_route_gateway_resource.go:178 +0x571
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(Resource).update(0x894c2d0?, {0x894c2d0?, 0xc004b296e0?}, 0xd?, {0x719fc60?, 0xc002ebed80?}) github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:800 +0x163 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(Resource).Apply(0xc001a5ca80, {0x894c2d0, 0xc004b296e0}, 0xc0030a32b0, 0xc004b19700, {0x719fc60, 0xc002ebed80})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:919 +0x83a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(GRPCProviderServer).ApplyResourceChange(0xc000ade870, {0x894c2d0?, 0xc004b295f0?}, 0xc0000400f0) github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/grpc_provider.go:1060 +0xdbc github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(server).ApplyResourceChange(0xc001c95a40, {0x894c2d0?, 0xc004b28c00?}, 0xc002b23110)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/tf5server/server.go:859 +0x56b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x7ddf4a0?, 0xc001c95a40}, {0x894c2d0, 0xc004b28c00}, 0xc002b230a0, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:467 +0x169
google.golang.org/grpc.(Server).processUnaryRPC(0xc0004ce000, {0x8976a00, 0xc0019281a0}, 0xc004b26c60, 0xc001a94180, 0xdecd338, 0x0) google.golang.org/grpc@v1.58.3/server.go:1374 +0xde7 google.golang.org/grpc.(Server).handleStream(0xc0004ce000, {0x8976a00, 0xc0019281a0}, 0xc004b26c60, 0x0)
google.golang.org/grpc@v1.58.3/server.go:1751 +0x9e7
google.golang.org/grpc.(Server).serveStreams.func1.1() google.golang.org/grpc@v1.58.3/server.go:986 +0xbb created by google.golang.org/grpc.(Server).serveStreams.func1 in goroutine 38
google.golang.org/grpc@v1.58.3/server.go:997 +0x145