### PR TITLE
`azurerm_servicebus_*` - remove optional and computed in 4.0 and rename `enable_*` to `*_enabled`

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -43,7 +43,7 @@ var (
 )
 
 func resourceServiceBusNamespace() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceServiceBusNamespaceCreateUpdate,
 		Read:   resourceServiceBusNamespaceRead,
 		Update: resourceServiceBusNamespaceCreateUpdate,
@@ -147,7 +147,7 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 			"minimum_tls_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  string(namespaces.TlsVersionOnePointTwo),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(namespaces.TlsVersionOnePointZero),
 					string(namespaces.TlsVersionOnePointOne),
@@ -274,6 +274,20 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 			pluginsdk.CustomizeDiffShim(servicebusTLSVersionDiff),
 		),
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(namespaces.TlsVersionOnePointZero),
+				string(namespaces.TlsVersionOnePointOne),
+				string(namespaces.TlsVersionOnePointTwo),
+			}, false),
+		}
+	}
+	return resource
 }
 
 func resourceServiceBusNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -341,14 +341,17 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if !features.FourPointOhBeta() {
 
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_express"); ok {
 			enableExpress = v.(bool)
 		}
 
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_partitioning"); ok {
 			enablePartitioning = v.(bool)
 		}
 
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
 			enableBatchedOperations = v.(bool)
 		}

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -47,7 +48,7 @@ func resourceServiceBusQueue() *pluginsdk.Resource {
 }
 
 func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -63,11 +64,10 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: namespaces.ValidateNamespaceID,
 		},
 
-		// Optional
 		"auto_delete_on_idle": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "P10675199DT2H48M5.4775807S", // Never
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
@@ -80,33 +80,30 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 		"default_message_ttl": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "P10675199DT2H48M5.4775807S", // Unbounded
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
 		"duplicate_detection_history_time_window": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "PT10M", // 10 minutes
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_batched_operations": {
+		"batched_operations_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_express": {
+		"express_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_partitioning": {
+		"partitioning_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
@@ -128,7 +125,7 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 		"lock_duration": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
+			Default:  "PT1M", // 1 minute
 		},
 
 		"max_delivery_count": {
@@ -141,14 +138,14 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 		"max_message_size_in_kilobytes": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			Computed:     true,
+			Default:      256,
 			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
 		},
 
 		"max_size_in_megabytes": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			Computed:     true,
+			Default:      5120,
 			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
 		},
 
@@ -182,6 +179,98 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 			}, false),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		schema["auto_delete_on_idle"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["default_message_ttl"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["duplicate_detection_history_time_window"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["enable_batched_operations"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Default:       true,
+			ConflictsWith: []string{"batched_operations_enabled"},
+			Deprecated:    "The property `enable_batched_operations` has been superseded by `batched_operations_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["enable_express"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Default:       false,
+			ConflictsWith: []string{"express_enabled"},
+			Deprecated:    "The property `enable_express` has been superseded by `express_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["enable_partitioning"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ForceNew:      true,
+			Default:       false,
+			ConflictsWith: []string{"partitioning_enabled"},
+			Deprecated:    "The property `enable_partitioning` has been superseded by `partitioning_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["batched_operations_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"enable_batched_operations"},
+		}
+
+		schema["express_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"enable_express"},
+		}
+
+		schema["partitioning_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"enable_partitioning"},
+		}
+
+		schema["lock_duration"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		}
+
+		schema["max_message_size_in_kilobytes"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
+		}
+
+		schema["max_size_in_megabytes"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
+		}
+	}
+
+	return schema
 }
 
 func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -231,15 +320,9 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	userConfig["maxDeliveryCount"] = maxDeliveryCount
 	deadLetteringOnMesExp := d.Get("dead_lettering_on_message_expiration").(bool)
 	userConfig["deadLetteringOnMesExp"] = deadLetteringOnMesExp
-	enableExpress := d.Get("enable_express").(bool)
-	userConfig["enableExpress"] = enableExpress
-	enablePartitioning := d.Get("enable_partitioning").(bool)
-	userConfig["enablePartitioning"] = enablePartitioning
 	maxSizeInMB := d.Get("max_size_in_megabytes").(int)
 	requireDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
 	requireSession := d.Get("requires_session").(bool)
-	enableBatchOps := d.Get("enable_batched_operations").(bool)
-	userConfig["enableBatchOps"] = enableBatchOps
 	forwardDeadLetteredMessagesTo := d.Get("forward_dead_lettered_messages_to").(string)
 	userConfig["forwardDeadLetteredMessagesTo"] = forwardDeadLetteredMessagesTo
 	forwardTo := d.Get("forward_to").(string)
@@ -252,11 +335,24 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	userConfig["autoDeleteOnIdle"] = autoDeleteOnIdle
 	duplicateDetectionHistoryTimeWindow := d.Get("duplicate_detection_history_time_window").(string)
 
+	enableExpress := d.Get("express_enabled").(bool)
+	enablePartitioning := d.Get("partitioning_enabled").(bool)
+	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
+
+	if !features.FourPointOhBeta() {
+		enableExpress = d.Get("enable_express").(bool)
+		enablePartitioning = d.Get("enable_partitioning").(bool)
+		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
+	}
+	userConfig["enableExpress"] = enableExpress
+	userConfig["enablePartitioning"] = enablePartitioning
+	userConfig["enableBatchOps"] = enableBatchedOperations
+
 	parameters := queues.SBQueue{
 		Name: utils.String(id.QueueName),
 		Properties: &queues.SBQueueProperties{
 			DeadLetteringOnMessageExpiration: utils.Bool(deadLetteringOnMesExp),
-			EnableBatchedOperations:          utils.Bool(enableBatchOps),
+			EnableBatchedOperations:          utils.Bool(enableBatchedOperations),
 			EnableExpress:                    utils.Bool(enableExpress),
 			EnablePartitioning:               utils.Bool(enablePartitioning),
 			MaxDeliveryCount:                 utils.Int64(int64(maxDeliveryCount)),
@@ -382,9 +478,6 @@ func resourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) er
 			d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
 			d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
 			d.Set("duplicate_detection_history_time_window", props.DuplicateDetectionHistoryTimeWindow)
-			d.Set("enable_batched_operations", props.EnableBatchedOperations)
-			d.Set("enable_express", props.EnableExpress)
-			d.Set("enable_partitioning", props.EnablePartitioning)
 			d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("lock_duration", props.LockDuration)
@@ -393,6 +486,16 @@ func resourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) er
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("status", string(pointer.From(props.Status)))
+
+			if !features.FourPointOhBeta() {
+				d.Set("enable_batched_operations", props.EnableBatchedOperations)
+				d.Set("enable_express", props.EnableExpress)
+				d.Set("enable_partitioning", props.EnablePartitioning)
+			}
+
+			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
+			d.Set("express_enabled", props.EnableExpress)
+			d.Set("partitioning_enabled", props.EnablePartitioning)
 
 			if apiMaxSizeInMegabytes := props.MaxSizeInMegabytes; apiMaxSizeInMegabytes != nil {
 				maxSizeInMegabytes := int(*apiMaxSizeInMegabytes)

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -340,9 +340,18 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
 
 	if !features.FourPointOhBeta() {
-		enableExpress = d.Get("enable_express").(bool)
-		enablePartitioning = d.Get("enable_partitioning").(bool)
-		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
+
+		if v, ok := d.GetOkExists("enable_express"); ok {
+			enableExpress = v.(bool)
+		}
+
+		if v, ok := d.GetOkExists("enable_partitioning"); ok {
+			enablePartitioning = v.(bool)
+		}
+
+		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
+			enableBatchedOperations = v.(bool)
+		}
 	}
 	userConfig["enableExpress"] = enableExpress
 	userConfig["enablePartitioning"] = enablePartitioning

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -51,7 +52,7 @@ func resourceServiceBusSubscription() *pluginsdk.Resource {
 }
 
 func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -70,19 +71,19 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 		"auto_delete_on_idle": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
+			Default:  "P10675199DT2H48M5.4775807S", // Never
 		},
 
 		"default_message_ttl": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
+			Default:  "P10675199DT2H48M5.4775807S", // Unbounded
 		},
 
 		"lock_duration": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
+			Default:  "PT1M", // 1 minute
 		},
 
 		"dead_lettering_on_message_expiration": {
@@ -93,13 +94,19 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 		"dead_lettering_on_filter_evaluation_error": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  true,
+			//	Default:  true,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_batched_operations": {
+		"batched_operations_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
+			Computed: !features.FourPointOhBeta(),
+			ConflictsWith: func() []string {
+				if !features.FourPointOhBeta() {
+					return []string{"enable_batched_operations"}
+				}
+				return []string{}
+			}(),
 		},
 
 		"max_delivery_count": {
@@ -110,7 +117,6 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 		"requires_session": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			// cannot be modified
 			ForceNew: true,
 		},
 
@@ -168,6 +174,37 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+
+		schema["auto_delete_on_idle"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		}
+
+		schema["default_message_ttl"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		}
+
+		schema["lock_duration"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		}
+
+		schema["enable_batched_operations"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"batched_operations_enabled"},
+			Deprecated:    "`enable_batched_operations` will be removed in favour of the property `batched_operations_enabled` in version 4.0 of the AzureRM Provider.",
+		}
+	}
+
+	return schema
 }
 
 func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -213,12 +250,19 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 		}
 	}
 
+	var enableBatchedOperations bool
+	if !features.FourPointOhBeta() {
+		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
+	} else {
+		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
+	}
+
 	status := subscriptions.EntityStatus(d.Get("status").(string))
 	parameters := subscriptions.SBSubscription{
 		Properties: &subscriptions.SBSubscriptionProperties{
 			DeadLetteringOnMessageExpiration:          utils.Bool(d.Get("dead_lettering_on_message_expiration").(bool)),
 			DeadLetteringOnFilterEvaluationExceptions: utils.Bool(d.Get("dead_lettering_on_filter_evaluation_error").(bool)),
-			EnableBatchedOperations:                   utils.Bool(d.Get("enable_batched_operations").(bool)),
+			EnableBatchedOperations:                   utils.Bool(enableBatchedOperations),
 			MaxDeliveryCount:                          utils.Int64(int64(d.Get("max_delivery_count").(int))),
 			RequiresSession:                           utils.Bool(d.Get("requires_session").(bool)),
 			Status:                                    &status,
@@ -292,12 +336,16 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 			d.Set("lock_duration", props.LockDuration)
 			d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
 			d.Set("dead_lettering_on_filter_evaluation_error", props.DeadLetteringOnFilterEvaluationExceptions)
-			d.Set("enable_batched_operations", props.EnableBatchedOperations)
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
 			d.Set("status", utils.String(string(*props.Status)))
 			d.Set("client_scoped_subscription_enabled", props.IsClientAffine)
+
+			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
+			if !features.FourPointOhBeta() {
+				d.Set("enable_batched_operations", props.EnableBatchedOperations)
+			}
 
 			if count := props.MaxDeliveryCount; count != nil {
 				d.Set("max_delivery_count", int(*count))

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -252,6 +252,8 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
 	if !features.FourPointOhBeta() {
+
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
 			enableBatchedOperations = v.(bool)
 		}

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -94,7 +94,7 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 		"dead_lettering_on_filter_evaluation_error": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			//	Default:  true,
+			Default:  true,
 		},
 
 		"batched_operations_enabled": {
@@ -250,11 +250,11 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 		}
 	}
 
-	var enableBatchedOperations bool
+	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
 	if !features.FourPointOhBeta() {
-		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
-	} else {
-		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
+		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
+			enableBatchedOperations = v.(bool)
+		}
 	}
 
 	status := subscriptions.EntityStatus(d.Get("status").(string))

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -45,7 +46,7 @@ func resourceServiceBusTopic() *pluginsdk.Resource {
 }
 
 func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -74,39 +75,39 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 		"auto_delete_on_idle": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "P10675199DT2H48M5.4775807S", // Never
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
 		"default_message_ttl": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "P10675199DT2H48M5.4775807S", // Unbounded
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
 		"duplicate_detection_history_time_window": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			Computed:     true,
+			Default:      "PT10M", // 10 minutes
 			ValidateFunc: validate.ISO8601Duration,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_batched_operations": {
+		"batched_operations_enabled": {
 			Type:     pluginsdk.TypeBool,
+			Computed: !features.FourPointOhBeta(),
 			Optional: true,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_express": {
+		"express_enabled": {
 			Type:     pluginsdk.TypeBool,
+			Computed: !features.FourPointOhBeta(),
 			Optional: true,
 		},
 
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_partitioning": {
+		"partitioning_enabled": {
 			Type:     pluginsdk.TypeBool,
+			Computed: !features.FourPointOhBeta(),
 			Optional: true,
 			ForceNew: true,
 		},
@@ -114,14 +115,14 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 		"max_message_size_in_kilobytes": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			Computed:     true,
+			Default:      "256",
 			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
 		},
 
 		"max_size_in_megabytes": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			Computed:     true,
+			Default:      "5120",
 			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
 		},
 
@@ -136,6 +137,67 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		schema["auto_delete_on_idle"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["default_message_ttl"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["duplicate_detection_history_time_window"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ISO8601Duration,
+		}
+
+		schema["enable_batched_operations"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ConflictsWith: []string{"batched_operations_enabled"},
+			Deprecated:    "The property `enable_batched_operations` has been superseded by `batched_operations_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["enable_express"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ConflictsWith: []string{"express_enabled"},
+			Deprecated:    "The property `enable_express` has been superseded by `express_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["enable_partitioning"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"partitioning_enabled"},
+			Deprecated:    "The property `enable_partitioning` has been superseded by `partitioning_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+
+		schema["max_message_size_in_kilobytes"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
+		}
+
+		schema["max_size_in_megabytes"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
+		}
+	}
+
+	return schema
 }
 
 func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -166,14 +228,25 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	var enableBatchedOperations, enableExpress, enablePartitioning bool
+	if features.FourPointOh() {
+		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
+		enableExpress = d.Get("express_enabled").(bool)
+		enablePartitioning = d.Get("partitioning_enabled").(bool)
+	} else {
+		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
+		enableExpress = d.Get("enable_express").(bool)
+		enablePartitioning = d.Get("enable_partitioning").(bool)
+	}
+
 	status := topics.EntityStatus(d.Get("status").(string))
 	parameters := topics.SBTopic{
 		Name: utils.String(id.TopicName),
 		Properties: &topics.SBTopicProperties{
 			Status:                     &status,
-			EnableBatchedOperations:    utils.Bool(d.Get("enable_batched_operations").(bool)),
-			EnableExpress:              utils.Bool(d.Get("enable_express").(bool)),
-			EnablePartitioning:         utils.Bool(d.Get("enable_partitioning").(bool)),
+			EnableBatchedOperations:    utils.Bool(enableBatchedOperations),
+			EnableExpress:              utils.Bool(enableExpress),
+			EnablePartitioning:         utils.Bool(enablePartitioning),
 			MaxSizeInMegabytes:         utils.Int64(int64(d.Get("max_size_in_megabytes").(int))),
 			RequiresDuplicateDetection: utils.Bool(d.Get("requires_duplicate_detection").(bool)),
 			SupportOrdering:            utils.Bool(d.Get("support_ordering").(bool)),
@@ -254,9 +327,16 @@ func resourceServiceBusTopicRead(d *pluginsdk.ResourceData, meta interface{}) er
 				d.Set("duplicate_detection_history_time_window", window)
 			}
 
-			d.Set("enable_batched_operations", props.EnableBatchedOperations)
-			d.Set("enable_express", props.EnableExpress)
-			d.Set("enable_partitioning", props.EnablePartitioning)
+			if !features.FourPointOhBeta() {
+				d.Set("enable_batched_operations", props.EnableBatchedOperations)
+				d.Set("enable_express", props.EnableExpress)
+				d.Set("enable_partitioning", props.EnablePartitioning)
+			}
+
+			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
+			d.Set("express_enabled", props.EnableExpress)
+			d.Set("partitioning_enabled", props.EnablePartitioning)
+
 			d.Set("max_message_size_in_kilobytes", props.MaxMessageSizeInKilobytes)
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("support_ordering", props.SupportOrdering)

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -232,12 +232,18 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	enableExpress := d.Get("express_enabled").(bool)
 	enablePartitioning := d.Get("partitioning_enabled").(bool)
 	if !features.FourPointOh() {
+
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
 			enableBatchedOperations = v.(bool)
 		}
+
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_express"); ok {
 			enableExpress = v.(bool)
 		}
+
+		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_partitioning"); ok {
 			enablePartitioning = v.(bool)
 		}

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -228,15 +228,19 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	var enableBatchedOperations, enableExpress, enablePartitioning bool
-	if features.FourPointOh() {
-		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
-		enableExpress = d.Get("express_enabled").(bool)
-		enablePartitioning = d.Get("partitioning_enabled").(bool)
-	} else {
-		enableBatchedOperations = d.Get("enable_batched_operations").(bool)
-		enableExpress = d.Get("enable_express").(bool)
-		enablePartitioning = d.Get("enable_partitioning").(bool)
+	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
+	enableExpress := d.Get("express_enabled").(bool)
+	enablePartitioning := d.Get("partitioning_enabled").(bool)
+	if !features.FourPointOh() {
+		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
+			enableBatchedOperations = v.(bool)
+		}
+		if v, ok := d.GetOkExists("enable_express"); ok {
+			enableExpress = v.(bool)
+		}
+		if v, ok := d.GetOkExists("enable_partitioning"); ok {
+			enablePartitioning = v.(bool)
+		}
 	}
 
 	status := topics.EntityStatus(d.Get("status").(string))


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR removes optional and computed properties in servicebus and renames `enable_*` to `*_enabled` in `azurem_servicebus_namespace`, `azurem_servicebus_queue`, `azurem_servicebus_topic` and `azurem_servicebus_subscription`.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->



## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests passing aside from tests currently failing in main

<img width="392" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/86247157/7334a857-8a63-4efc-95aa-67a3a59c2534">


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
