### PR TITLE
`azurerm_palo_alto_local_rulestack_rule` - fix `protocol` update

### DIFF
--- a/internal/services/paloalto/local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource.go
@@ -341,8 +341,8 @@ func (r LocalRuleStackRule) Read() sdk.ResourceFunc {
 				}
 				state.NegateDestination = boolEnumAsBoolRule(props.NegateDestination)
 				state.NegateSource = boolEnumAsBoolRule(props.NegateSource)
-				if v := pointer.From(props.Protocol); !strings.EqualFold(v, protocolApplicationDefault) {
-					state.Protocol = pointer.From(props.Protocol)
+				if v := pointer.From(props.Protocol); v != "" && !strings.EqualFold(v, protocolApplicationDefault) {
+					state.Protocol = v
 				} else {
 					state.Protocol = protocolApplicationDefault
 				}
@@ -470,11 +470,19 @@ func (r LocalRuleStackRule) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("protocol") {
-				ruleEntry.Properties.Protocol = pointer.To(model.Protocol)
+				if model.Protocol != "" && !strings.EqualFold(model.Protocol, protocolApplicationDefault) && len(model.ProtocolPorts) == 0 {
+					ruleEntry.Properties.Protocol = pointer.To(model.Protocol)
+				} else {
+					ruleEntry.Properties.Protocol = nil
+				}
 			}
 
 			if metadata.ResourceData.HasChange("protocol_ports") {
-				ruleEntry.Properties.ProtocolPortList = pointer.To(model.ProtocolPorts)
+				if len(model.ProtocolPorts) != 0 {
+					ruleEntry.Properties.ProtocolPortList = pointer.To(model.ProtocolPorts)
+				} else {
+					ruleEntry.Properties.ProtocolPortList = nil
+				}
 			}
 
 			if metadata.ResourceData.HasChange("enabled") {

--- a/internal/services/paloalto/local_rulestack_rule_resource_test.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource_test.go
@@ -212,14 +212,6 @@ resource "azurerm_palo_alto_local_rulestack_rule" "test" {
     countries = ["US", "GB"]
   }
 }
-
-
-
-
-
-
-
-
 `, r.template(data), data.RandomInteger)
 }
 
@@ -316,7 +308,7 @@ resource "azurerm_palo_alto_local_rulestack_rule" "test" {
   negate_destination = false
   negate_source      = false
 
-  protocol = "TCP:8080"
+  protocol_ports = ["TCP:8080", "TCP:8081"]
 
   enabled = true
 

--- a/internal/services/paloalto/local_rulestack_rule_resource_test.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource_test.go
@@ -120,6 +120,50 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 	})
 }
 
+func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_palo_alto_local_rulestack_rule", "test")
+
+	r := LocalRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicProtocol(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicProtocolPorts(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicProtocol(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LocalRuleResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := localrules.ParseLocalRuleID(state.ID)
 	if err != nil {
@@ -152,6 +196,64 @@ resource "azurerm_palo_alto_local_rulestack_rule" "test" {
   action       = "Allow"
 
   applications = ["any"]
+
+  destination {
+    cidrs = ["any"]
+  }
+
+  source {
+    cidrs = ["any"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LocalRuleResource) basicProtocol(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_palo_alto_local_rulestack_rule" "test" {
+  name         = "testacc-palr-%[2]d"
+  rulestack_id = azurerm_palo_alto_local_rulestack.test.id
+  priority     = 100
+  action       = "Allow"
+
+  applications = ["any"]
+
+  protocol = "TCP:8080"
+
+  destination {
+    cidrs = ["any"]
+  }
+
+  source {
+    cidrs = ["any"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LocalRuleResource) basicProtocolPorts(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_palo_alto_local_rulestack_rule" "test" {
+  name         = "testacc-palr-%[2]d"
+  rulestack_id = azurerm_palo_alto_local_rulestack.test.id
+  priority     = 100
+  action       = "Allow"
+
+  applications = ["any"]
+
+  protocol_ports = ["TCP:8080", "TCP:8081"]
 
   destination {
     cidrs = ["any"]


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

fix update from `protocol = "TCP:8080"` to `protocol_ports = ["TCP:8080", "TCP:8081"]`, these two properties are mutually exclusive(ConflictsWith in schema), so we need to set nil in update to avoid API error `Both Protocol and ProtPortList cannot be specified`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
make acctests SERVICE="paloalto" TESTARGS="-parallel 5 -run TestAccPaloAltoLocalRule_" TESTTIMEOUT='2h'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/paloalto -parallel 5 -run TestAccPaloAltoLocalRule_ -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPaloAltoLocalRule_basic
=== PAUSE TestAccPaloAltoLocalRule_basic
=== RUN   TestAccPaloAltoLocalRule_requiresImport
=== PAUSE TestAccPaloAltoLocalRule_requiresImport
=== RUN   TestAccPaloAltoLocalRule_withDestination
=== PAUSE TestAccPaloAltoLocalRule_withDestination
=== RUN   TestAccPaloAltoLocalRule_complete
=== PAUSE TestAccPaloAltoLocalRule_complete
=== RUN   TestAccPaloAltoLocalRule_update
=== PAUSE TestAccPaloAltoLocalRule_update
=== CONT  TestAccPaloAltoLocalRule_basic
=== CONT  TestAccPaloAltoLocalRule_update
=== CONT  TestAccPaloAltoLocalRule_complete
=== CONT  TestAccPaloAltoLocalRule_requiresImport
=== CONT  TestAccPaloAltoLocalRule_withDestination
--- PASS: TestAccPaloAltoLocalRule_requiresImport (1046.40s)
--- PASS: TestAccPaloAltoLocalRule_basic (1055.87s)
--- PASS: TestAccPaloAltoLocalRule_withDestination (1074.80s)
--- PASS: TestAccPaloAltoLocalRule_complete (1305.17s)
--- PASS: TestAccPaloAltoLocalRule_update (1611.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto      1611.776s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_palo_alto_local_rulestack_rule` - fix `protocol` update [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
