### PR TITLE
azurerm_app_configuration_feature - fix feature flags are not valid

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -511,7 +511,7 @@ func (k FeatureResource) Update() sdk.ResourceFunc {
 					Parameters: PercentageFilterParameters{Value: model.PercentageFilter},
 				})
 				filterChanged = true
-			} else {
+			} else if percentageFilter.Name != "" {
 				filters = append(filters, percentageFilter)
 			}
 

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -224,6 +224,28 @@ func TestAccAppConfigurationFeature_enabledUpdate(t *testing.T) {
 	})
 }
 
+
+func TestAccAppConfigurationFeature_basicAddTargetingFilter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
+	r := AppConfigurationFeatureResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicNoFilters(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicTargetingFilter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t AppConfigurationFeatureResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	nestedItemId, err := parse.ParseNestedItemID(state.ID)
 	if err != nil {
@@ -479,6 +501,27 @@ resource "azurerm_app_configuration_feature" "test" {
 }
 `, t.template(data), data.RandomInteger)
 }
+
+func (t AppConfigurationFeatureResource) basicTargetingFilter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_configuration_feature" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  description            = "test description"
+  name                   = "acctest-ackey-%[2]d"
+  label                  = "acctest-ackeylabel-%[2]d"
+  enabled                = true
+
+  targeting_filter {
+    users = [
+      "random", "user"
+    ]
+  }
+}
+`, t.template(data), data.RandomInteger)
+}
+
 
 func (t AppConfigurationFeatureResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -224,7 +224,6 @@ func TestAccAppConfigurationFeature_enabledUpdate(t *testing.T) {
 	})
 }
 
-
 func TestAccAppConfigurationFeature_basicAddTargetingFilter(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
 	r := AppConfigurationFeatureResource{}
@@ -522,7 +521,6 @@ resource "azurerm_app_configuration_feature" "test" {
 }
 `, t.template(data), data.RandomInteger)
 }
-
 
 func (t AppConfigurationFeatureResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -514,6 +514,7 @@ resource "azurerm_app_configuration_feature" "test" {
   enabled                = true
 
   targeting_filter {
+    default_rollout_percentage = 39
     users = [
       "random", "user"
     ]


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adding a targeting filter, after first creating a feature flag without one, results in a feature flag that is not valid.

To reproduce. First create a feature flag without targeting filter, e.g.

```hcl
resource "azurerm_app_configuration_feature" "alpha" {
  configuration_store_id = azurerm_app_configuration.example.id
  name                   = "alpha"
  enabled                = true
}
```

Then, re-apply with a targeting filter, e.g.

```hcl
resource "azurerm_app_configuration_feature" "alpha" {
  configuration_store_id = azurerm_app_configuration.example.id
  name                   = "alpha"
  enabled                = true

  targeting_filter {
    default_rollout_percentage = 0

    users = [
      "john.doe@example.com",
    ]
  }
}
```

```
azurerm_app_configuration_feature.alpha: Modifying... [id=https://*******.azconfig.io/kv/.appconfig.featureflag%alpha?label=]
╷
│ Error: while unmarshalling underlying key's value: unknown type ""
│
│   with azurerm_app_configuration_feature.alpha,
│   on main.tf line ***, in resource "azurerm_app_configuration_feature" "alpha":
│  ***: resource "azurerm_app_configuration_feature" "alpha" {
│
│ while unmarshalling underlying key's value: unknown type ""
```

This results in an invalid feature flag as indicated in the feature manager:

```json
{
	"id": "alpha",
	"description": "",
	"enabled": true,
	"conditions": {
		"client_filters": [
			{
				"name": "",
				"parameters": {
					"Value": 0
				}
			},
			{
				"name": "Microsoft.Targeting",
				"parameters": {
					"Audience": {
						"DefaultRolloutPercentage": 0,
						"Users": [
							"john.doe@example.com"
						],
						"Groups": []
					}
				}
			}
		]
	}
}
```

The fix is to easy: to rule out whether the default `percentageFilter := PercentageFeatureFilter{}` is assigned when iterating `fv.Conditions.ClientFilters.Filters`, we change the `else if`-clause to check `percentageFilter.Name != ""`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_app_configuration_feature` - fix feature flags are not valid

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
