### PR TITLE
New Resource: `azurerm_static_web_app_link_backend`

### DIFF
--- a/internal/services/appservice/registration.go
+++ b/internal/services/appservice/registration.go
@@ -53,6 +53,7 @@ func (r Registration) Resources() []sdk.Resource {
 		StaticWebAppResource{},
 		StaticWebAppCustomDomainResource{},
 		StaticWebAppFunctionAppRegistrationResource{},
+		StaticWebAppLinkBackendResource{},
 		WebAppActiveSlotResource{},
 		WebAppHybridConnectionResource{},
 		WindowsFunctionAppResource{},

--- a/internal/services/appservice/static_web_app_link_backend.go
+++ b/internal/services/appservice/static_web_app_link_backend.go
@@ -1,0 +1,241 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package appservice
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/apimanagementservice"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/containerapps"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/staticsites"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type StaticWebAppLinkBackendResource struct{}
+
+var _ sdk.Resource = StaticWebAppLinkBackendResource{}
+
+type StaticWebAppLinkBackendModel struct {
+	StaticWebAppID    string `tfschema:"static_web_app_id"`
+	BackendResourceId string `tfschema:"backend_resource_id"`
+}
+
+type linkedBackend struct {
+	id   string
+	name string
+}
+
+func (r StaticWebAppLinkBackendResource) ResourceType() string {
+	return "azurerm_static_web_app_link_backend"
+}
+
+func (r StaticWebAppLinkBackendResource) ModelObject() interface{} {
+	return &StaticWebAppLinkBackendModel{}
+}
+
+func (r StaticWebAppLinkBackendResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return staticsites.ValidateLinkedBackendID
+}
+
+func (r StaticWebAppLinkBackendResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"static_web_app_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: staticsites.ValidateStaticSiteID,
+		},
+
+		"backend_resource_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.Any(
+				apimanagementservice.ValidateServiceID,
+				commonids.ValidateAppServiceID,
+				containerapps.ValidateContainerAppID,
+			),
+		},
+	}
+}
+
+func (r StaticWebAppLinkBackendResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r StaticWebAppLinkBackendResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+			model := StaticWebAppLinkBackendModel{}
+
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			staticAppId, err := staticsites.ParseStaticSiteID(model.StaticWebAppID)
+			if err != nil {
+				return err
+			}
+
+			loc := ""
+			linkedBackend := linkedBackend{}
+
+			if apiManagementId, err := apimanagementservice.ParseServiceID(model.BackendResourceId); err == nil {
+				linkedBackend.id = apiManagementId.ID()
+				linkedBackend.name = apiManagementId.ServiceName
+
+				backendClient := metadata.Client.ApiManagement.ServiceClient
+
+				apiManagement, err := backendClient.Get(ctx, *apiManagementId)
+				if err != nil {
+					return fmt.Errorf("reading specified %s: %+v", *apiManagementId, err)
+				}
+
+				if appModel := apiManagement.Model; appModel != nil {
+					loc = location.Normalize(appModel.Location)
+				}
+
+			} else if appServiceId, err := commonids.ParseAppServiceID(model.BackendResourceId); err == nil {
+				linkedBackend.id = appServiceId.ID()
+				linkedBackend.name = appServiceId.SiteName
+
+				backendClient := metadata.Client.AppService.WebAppsClient
+
+				appService, err := backendClient.Get(ctx, *appServiceId)
+				if err != nil {
+					return fmt.Errorf("reading specified %s: %+v", *appServiceId, err)
+				}
+
+				if appModel := appService.Model; appModel != nil {
+					loc = location.Normalize(appModel.Location)
+				}
+
+			} else if containerAppId, err := containerapps.ParseContainerAppID(model.BackendResourceId); err == nil {
+				linkedBackend.id = containerAppId.ID()
+				linkedBackend.name = containerAppId.ContainerAppName
+
+				backendClient := metadata.Client.ContainerApps.ContainerAppClient
+
+				containerApp, err := backendClient.Get(ctx, *containerAppId)
+				if err != nil {
+					return fmt.Errorf("reading specified %s: %+v", *containerAppId, err)
+				}
+
+				if appModel := containerApp.Model; appModel != nil {
+					loc = location.Normalize(appModel.Location)
+				}
+
+			} else {
+				return fmt.Errorf("unsupported backend resource type")
+			}
+
+			id := staticsites.NewLinkedBackendID(staticAppId.SubscriptionId, staticAppId.ResourceGroupName, staticAppId.StaticSiteName, linkedBackend.name)
+
+			existing, err := client.GetLinkedBackend(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			backends, err := client.GetLinkedBackends(ctx, *staticAppId)
+			if err != nil {
+				return fmt.Errorf("checking for existing Static Site backends for %s: %+v", id, err)
+			}
+
+			if backendList := backends.Model; backendList != nil {
+				if len(*backendList) != 0 {
+					return fmt.Errorf("%s already has a backend and cannot have another", id)
+				}
+			}
+
+			payload := staticsites.StaticSiteLinkedBackendARMResource{
+				Properties: &staticsites.StaticSiteLinkedBackendARMResourceProperties{
+					Region:            pointer.To(loc),
+					BackendResourceId: pointer.To(linkedBackend.id),
+				},
+			}
+
+			if err = client.LinkBackendThenPoll(ctx, id, payload); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r StaticWebAppLinkBackendResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+			state := StaticWebAppLinkBackendModel{}
+
+			id, err := staticsites.ParseLinkedBackendID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			state.StaticWebAppID = staticsites.NewStaticSiteID(id.SubscriptionId, id.ResourceGroupName, id.StaticSiteName).ID()
+
+			result, err := client.GetLinkedBackend(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return metadata.MarkAsGone(*id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if model := result.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.BackendResourceId = pointer.From(props.BackendResourceId)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r StaticWebAppLinkBackendResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+
+			id, err := staticsites.ParseLinkedBackendID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			option := staticsites.UnlinkBackendOperationOptions{}
+			if _, err := client.UnlinkBackend(ctx, *id, option); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/appservice/static_web_app_link_backend_test.go
+++ b/internal/services/appservice/static_web_app_link_backend_test.go
@@ -1,0 +1,327 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package appservice_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/staticsites"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StaticWebAppLinkBackendResource struct{}
+
+func TestStaticWebAppLinkBackendResource_basicApiManagement(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_link_backend", "test")
+	r := StaticWebAppLinkBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicApiManagement(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestStaticWebAppLinkBackendResource_basicAppService(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_link_backend", "test")
+	r := StaticWebAppLinkBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAppService(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestStaticWebAppLinkBackendResource_basicContainerApp(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_link_backend", "test")
+	r := StaticWebAppLinkBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicContainerApp(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestStaticWebAppLinkBackendResource_multipleExpectError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_link_backend", "test")
+	r := StaticWebAppLinkBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicApiManagement(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:      r.multipleApiManagement(data),
+			ExpectError: regexp.MustCompile("already has a backend and cannot have another"),
+		},
+	})
+}
+
+func TestStaticWebAppLinkBackendResource_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_link_backend", "test")
+	r := StaticWebAppLinkBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicApiManagement(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (s StaticWebAppLinkBackendResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := staticsites.ParseLinkedBackendID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.AppService.StaticSitesClient.GetLinkedBackend(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r StaticWebAppLinkBackendResource) basicApiManagement(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_static_web_app_link_backend" "test" {
+  static_web_app_id   = azurerm_static_web_app.test.id
+  backend_resource_id = azurerm_api_management.test.id
+}
+`, r.apiManagement(data))
+}
+
+func (r StaticWebAppLinkBackendResource) basicAppService(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_static_web_app_link_backend" "test" {
+  static_web_app_id   = azurerm_static_web_app.test.id
+  backend_resource_id = azurerm_linux_web_app.test.id
+}
+`, r.appService(data))
+}
+
+func (r StaticWebAppLinkBackendResource) basicContainerApp(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_static_web_app_link_backend" "test" {
+  static_web_app_id   = azurerm_static_web_app.test.id
+  backend_resource_id = azurerm_container_app.test.id
+}
+`, r.containerApps(data))
+}
+
+func (r StaticWebAppLinkBackendResource) multipleApiManagement(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAPIM-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Consumption_0"
+}
+
+resource "azurerm_api_management" "test2" {
+  name                = "acctestAPIM-%[2]d-2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Consumption_0"
+}
+
+resource "azurerm_static_web_app_link_backend" "test" {
+  static_web_app_id   = azurerm_static_web_app.test.id
+  backend_resource_id = azurerm_api_management.test.id
+}
+
+resource "azurerm_static_web_app_link_backend" "test2" {
+  static_web_app_id   = azurerm_static_web_app.test.id
+  backend_resource_id = azurerm_api_management.test2.id
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r StaticWebAppLinkBackendResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_static_web_app_link_backend" "import" {
+  static_web_app_id   = azurerm_static_web_app_link_backend.test.static_web_app_id
+  backend_resource_id = azurerm_static_web_app_link_backend.test.backend_resource_id
+}
+`, r.basicApiManagement(data))
+}
+
+func (r StaticWebAppLinkBackendResource) apiManagement(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAPIM-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Consumption_0"
+}
+
+`, r.template(data), data.RandomInteger)
+}
+
+func (r StaticWebAppLinkBackendResource) appService(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  sku_name            = "F1"
+}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestWP-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_service_plan.test.location
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    always_on = false
+  }
+
+  lifecycle {
+    ignore_changes = [auth_settings_v2]
+  }
+}
+
+`, r.template(data), data.RandomInteger)
+}
+
+func (r StaticWebAppLinkBackendResource) containerApps(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_container_app_environment" "test" {
+  name                = "acctestCAEnv-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+    maximum_count         = 0
+    minimum_count         = 0
+  }
+}
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  resource_group_name          = azurerm_resource_group.test.name
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  template {
+    container {
+      name   = "examplecontainerapp"
+      image  = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  ingress {
+    allow_insecure_connections = false
+    external_enabled           = false
+    target_port                = 443
+    transport                  = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+}
+	`, r.template(data), data.RandomInteger)
+}
+
+func (r StaticWebAppLinkBackendResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_static_web_app" "test" {
+  name                = "acctestSWA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_size            = "Standard"
+  sku_tier            = "Standard"
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/docs/r/static_web_app_link_backend.html.markdown
+++ b/website/docs/r/static_web_app_link_backend.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "App Service (Web Apps)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_static_web_app_link_backend"
+description: |-
+  Manages a Static Web App Link Backend.
+---
+
+# azurerm_static_web_app_link_backend
+
+Manages an App Service Static Web App Link Backend.
+
+~> **NOTE:** This resource registers the specified API Management, App Service, or Container App to the `Production` build of the Static Web App.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "westus"
+}
+
+resource "azurerm_static_web_app" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_tier            = "Standard"
+  sku_size            = "Standard"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-api-management"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Consumption_0"
+}
+
+resource "azurerm_static_web_app_link_backend" "example" {
+  static_web_app_id   = azurerm_static_web_app.example.id
+  backend_resource_id = azurerm_api_management.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `static_web_app_id` - (Required) The ID of the Static Web App to register the API Management, App Service, or Container App to as a backend. Changing this forces a new Static Web App Link Backend to be created.
+
+* `backend_resource_id` - (Required) The ID of an API Management, App Service, or Container App to connect to the Static Web App as a Backend. Changing this forces a new Static Web App Link Backend to be created.
+
+~> **NOTE:** Only one Backend resource can be connected to a Static Web App. Multiple resources are not currently supported.
+
+~> **NOTE:** Connecting an App Service resource to a Static Web App resource updates the App Service to use AuthV2 and configures the `azure_static_web_app_v2` which may need to be accounted for by the use of `ignore_changes` depending on the existing `auth_settings_v2` configuration of the target App Service.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Static Web App Link Backend.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Static Web App Link Backend.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Static Web App Link Backend.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Static Web App Link Backend.
+
+## Import
+
+Static Web App Link Backend can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_static_web_app_link_backend.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Web/staticSites/swa1/linkedBackends/linkedbackend1
+```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for linking Static Web App to API Management, App Service, or Container App.
Only API Management ID, App Service ID, or Container App ID can be specified in the `backend_resource_id` argument as backend resources to be linked with Static Web Apps.

- https://learn.microsoft.com/en-us/azure/static-web-apps/apis-overview
- https://learn.microsoft.com/en-us/rest/api/appservice/static-sites/link-backend?view=rest-appservice-2023-01-01&tabs=HTTP#staticsitelinkedbackendarmresource

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```console
$ make acctests SERVICE='appservice' TESTARGS='-run=TestStaticWebAppLinkBackendResource_' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestStaticWebAppLinkBackendResource_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestStaticWebAppLinkBackendResource_basicApiManagement
=== PAUSE TestStaticWebAppLinkBackendResource_basicApiManagement
=== RUN   TestStaticWebAppLinkBackendResource_basicAppService
=== PAUSE TestStaticWebAppLinkBackendResource_basicAppService
=== RUN   TestStaticWebAppLinkBackendResource_basicContainerApp
=== PAUSE TestStaticWebAppLinkBackendResource_basicContainerApp
=== RUN   TestStaticWebAppLinkBackendResource_multipleExpectError
=== PAUSE TestStaticWebAppLinkBackendResource_multipleExpectError
=== RUN   TestStaticWebAppLinkBackendResource_requiresImport
=== PAUSE TestStaticWebAppLinkBackendResource_requiresImport
=== CONT  TestStaticWebAppLinkBackendResource_basicApiManagement
=== CONT  TestStaticWebAppLinkBackendResource_multipleExpectError
=== CONT  TestStaticWebAppLinkBackendResource_requiresImport
=== CONT  TestStaticWebAppLinkBackendResource_basicContainerApp
=== CONT  TestStaticWebAppLinkBackendResource_basicAppService
--- PASS: TestStaticWebAppLinkBackendResource_basicApiManagement (232.01s)
--- PASS: TestStaticWebAppLinkBackendResource_basicAppService (296.44s)
--- PASS: TestStaticWebAppLinkBackendResource_requiresImport (300.86s)
--- PASS: TestStaticWebAppLinkBackendResource_multipleExpectError (399.11s)
--- PASS: TestStaticWebAppLinkBackendResource_basicContainerApp (1174.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    1176.671s
```



<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Resource: `azurerm_static_web_app_link_backend` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26350


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
