### PR TITLE
`azurerm_palo_alto_local_rulestack_rule` - correctly populate `protocol` property

### DIFF
--- a/internal/services/paloalto/local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource.go
@@ -160,10 +160,13 @@ func (r LocalRuleStackRule) Arguments() map[string]*pluginsdk.Schema {
 
 	if !features.FourPointOhBeta() {
 		schema["protocol"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			Default:       protocolApplicationDefault,
-			ValidateFunc:  validate.ProtocolWithPort,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  protocolApplicationDefault,
+			ValidateFunc: validation.Any(
+				validate.ProtocolWithPort,
+				validation.StringInSlice([]string{protocolApplicationDefault}, false),
+			),
 			ConflictsWith: []string{"protocol_ports"},
 			// if `protocol_ports` is set, the default value should not be used
 			DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {

--- a/internal/services/paloalto/local_rulestack_rule_resource_test.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -182,6 +183,34 @@ func (r LocalRuleResource) Exists(ctx context.Context, client *clients.Client, s
 }
 
 func (r LocalRuleResource) basic(data acceptance.TestData) string {
+	if features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_palo_alto_local_rulestack_rule" "test" {
+  name         = "testacc-palr-%[2]d"
+  rulestack_id = azurerm_palo_alto_local_rulestack.test.id
+  priority     = 100
+  action       = "Allow"
+  protocol     = "application-default"
+
+  applications = ["any"]
+
+  destination {
+    cidrs = ["any"]
+  }
+
+  source {
+    cidrs = ["any"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -267,9 +296,30 @@ resource "azurerm_palo_alto_local_rulestack_rule" "test" {
 }
 
 func (r LocalRuleResource) requiresImport(data acceptance.TestData) string {
+	if features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_palo_alto_local_rulestack_rule" "import" {
+  name         = azurerm_palo_alto_local_rulestack_rule.test.name
+  rulestack_id = azurerm_palo_alto_local_rulestack_rule.test.rulestack_id
+  priority     = azurerm_palo_alto_local_rulestack_rule.test.priority
+  action       = "Allow"
+  applications = azurerm_palo_alto_local_rulestack_rule.test.applications
+  protocol     = azurerm_palo_alto_local_rulestack_rule.test.protocol
+
+  destination {
+    cidrs = azurerm_palo_alto_local_rulestack_rule.test.destination.0.cidrs
+  }
+
+  source {
+    cidrs = azurerm_palo_alto_local_rulestack_rule.test.source.0.cidrs
+  }
+}
+`, r.basic(data), data.RandomInteger)
+	}
+
 	return fmt.Sprintf(`
-
-
 %[1]s
 
 resource "azurerm_palo_alto_local_rulestack_rule" "import" {
@@ -291,6 +341,34 @@ resource "azurerm_palo_alto_local_rulestack_rule" "import" {
 }
 
 func (r LocalRuleResource) withDestination(data acceptance.TestData) string {
+	if features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_palo_alto_local_rulestack_rule" "test" {
+  name         = "testacc-palr-%[2]d"
+  rulestack_id = azurerm_palo_alto_local_rulestack.test.id
+  priority     = 100
+  action       = "Allow"
+  protocol     = "application-default"
+
+  applications = ["any"]
+
+  destination {
+    countries = ["US", "GB"]
+  }
+
+  source {
+    countries = ["US", "GB"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/paloalto/local_rulestack_rule_resource_test.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource_test.go
@@ -93,7 +93,6 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -101,7 +100,6 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -109,7 +107,6 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").IsEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -117,7 +114,6 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -134,7 +130,6 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -142,7 +137,6 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocol(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -150,7 +144,6 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocolPorts(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").IsEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -158,7 +151,6 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocol(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -166,7 +158,6 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/paloalto/local_rulestack_rule_resource_test.go
+++ b/internal/services/paloalto/local_rulestack_rule_resource_test.go
@@ -93,6 +93,7 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -100,6 +101,7 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -107,6 +109,7 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").IsEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -114,6 +117,7 @@ func TestAccPaloAltoLocalRule_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -130,6 +134,7 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),
@@ -137,6 +142,7 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocol(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -144,6 +150,7 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocolPorts(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").IsEmpty(),
 			),
 		},
 		data.ImportStep(),
@@ -151,6 +158,7 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basicProtocol(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("TCP:8080"),
 			),
 		},
 		data.ImportStep(),
@@ -158,6 +166,7 @@ func TestAccPaloAltoLocalRule_updateProtocol(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("protocol").HasValue("application-default"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
+++ b/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
@@ -29,6 +29,7 @@ resource "azurerm_palo_alto_local_rulestack_rule" "example" {
   rulestack_id = azurerm_palo_alto_local_rulestack.example.id
   priority     = 1000
   action       = "Allow"
+  protocol     = "application-default"
 
   applications = ["any"]
 
@@ -85,6 +86,8 @@ The following arguments are supported:
 
 * `protocol` - (Optional) The Protocol and port to use in the form `[protocol]:[port_number]` e.g. `TCP:8080` or `UDP:53`. Conflicts with `protocol_ports`. Defaults to `application-default`.
 
+~> **NOTE**: In 4.0 or later versions of the provider, the default of `protocol` will no longer be set by provider, exactly one of `protocol` and `protocol_ports` must be specified. You need to explicitly specify `protocol="application-default"` to keep the the current default of the `protocol`.
+ 
 * `protocol_ports` - (Optional) Specifies a list of Protocol:Port entries. E.g. `[ "TCP:80", "UDP:5431" ]`. Conflicts with `protocol`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Palo Alto Local Rulestack Rule.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fix the issue when `protocol_ports` is set, the `protocol` property in Terraform state (populated with `application-default`) is inconsistent with API response (empty).

Terraform state (both `protocol` and `protocol_ports` are set):
```hcl
resource "azurerm_palo_alto_local_rulestack_rule" "example" {
    action                    = "Allow"
    applications              = [
        "any",
    ]
    audit_comment             = null
    decryption_rule_type      = "None"
    description               = null
    enabled                   = true
    id                        = "/subscriptions/XXXX/resourceGroups/lrs-test-tf3/providers/PaloAltoNetworks.Cloudngfw/localRulestacks/lrs-test-1/localRules/1000"
    inspection_certificate_id = null
    logging_enabled           = false
    name                      = "lr-test-1"
    negate_destination        = false
    negate_source             = false
    priority                  = 1000
    protocol                  = "application-default"
    protocol_ports            = [
        "TCP:8080",
        "UDP:5431",
    ]
    rulestack_id              = "/subscriptions/XXXX/resourceGroups/lrs-test-tf3/providers/PaloAltoNetworks.Cloudngfw/localRulestacks/lrs-test-1"
    tags                      = {}

    destination {
        cidrs                           = [
            "192.168.16.0/24",
        ]
        countries                       = []
        feeds                           = []
        local_rulestack_fqdn_list_ids   = []
        local_rulestack_prefix_list_ids = []
    }

    source {
        cidrs                           = [
            "10.0.0.0/8",
        ]
        countries                       = []
        feeds                           = []
        local_rulestack_prefix_list_ids = []
    }
}
```

true API response (only protocol ports is set):
```json
{
    "id": "/subscriptions/XXXX/resourceGroups/lrs-test-tf3/providers/PaloAltoNetworks.Cloudngfw/localRulestacks/lrs-test-1/localRules/1000",
    "name": "1000",
    "type": "localRulestacks/localRules",
    "properties": {
        "ruleName": "lr-test-1",
        "priority": 1000,
        "ruleState": "ENABLED",
        "source": {
            "cidrs": [
                "10.0.0.0/8"
            ],
            "countries": [],
            "feeds": [],
            "prefixLists": []
        },
        "negateSource": "FALSE",
        "destination": {
            "cidrs": [
                "192.168.16.0/24"
            ],
            "countries": [],
            "feeds": [],
            "prefixLists": [],
            "fqdnLists": []
        },
        "negateDestination": "FALSE",
        "applications": [
            "any"
        ],
        "protocolPortList": [
            "TCP:8080",
            "UDP:5431"
        ],
        "actionType": "Allow",
        "enableLogging": "DISABLED",
        "decryptionRuleType": "None",
        "tags": [],
        "etag": "010d4f2a-350c-11ef-8703-96b8677701c7"
    }
}
```
But to deal with the API behaviour that `protocol` default value does not work if `protocol_ports` is set, a DiffSuppressFunc is added to below schema.
```go
		"protocol": {
			Type:          pluginsdk.TypeString,
			Optional:      true,
			Default:       protocolApplicationDefault,
			ValidateFunc:  validate.ProtocolWithPort,
			ConflictsWith: []string{"protocol_ports"},
                }
````
## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
TF_ACC=1 go test -v ./internal/services/paloalto -parallel 6 -run TestAccPaloAltoLocalRule_ -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPaloAltoLocalRule_basic
=== PAUSE TestAccPaloAltoLocalRule_basic
=== RUN   TestAccPaloAltoLocalRule_requiresImport
=== PAUSE TestAccPaloAltoLocalRule_requiresImport
=== RUN   TestAccPaloAltoLocalRule_withDestination
=== PAUSE TestAccPaloAltoLocalRule_withDestination
=== RUN   TestAccPaloAltoLocalRule_complete
=== PAUSE TestAccPaloAltoLocalRule_complete
=== RUN   TestAccPaloAltoLocalRule_update
=== PAUSE TestAccPaloAltoLocalRule_update
=== RUN   TestAccPaloAltoLocalRule_updateProtocol
=== PAUSE TestAccPaloAltoLocalRule_updateProtocol
=== CONT  TestAccPaloAltoLocalRule_basic
=== CONT  TestAccPaloAltoLocalRule_complete
=== CONT  TestAccPaloAltoLocalRule_updateProtocol
=== CONT  TestAccPaloAltoLocalRule_withDestination
=== CONT  TestAccPaloAltoLocalRule_requiresImport
=== CONT  TestAccPaloAltoLocalRule_update
--- PASS: TestAccPaloAltoLocalRule_basic (986.57s)
--- PASS: TestAccPaloAltoLocalRule_withDestination (1035.82s)
--- PASS: TestAccPaloAltoLocalRule_requiresImport (1069.00s)
--- PASS: TestAccPaloAltoLocalRule_updateProtocol (1301.80s)
--- PASS: TestAccPaloAltoLocalRule_complete (1367.64s)
--- PASS: TestAccPaloAltoLocalRule_update (1679.92s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto      1679.978s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_palo_alto_local_rulestack_rule` - correctly populate `protocol` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
