### PR TITLE
`network` - split remaining combined `CreateUpdate` methods

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1548,10 +1548,8 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 func resourceApplicationGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.ApplicationGatewaysClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Application Gateway creation.")
 
 	id := applicationgateways.NewApplicationGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 

--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -218,6 +218,8 @@ func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
+	payload.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
+
 	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}

--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -24,9 +24,9 @@ import (
 
 func resourceLocalNetworkGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceLocalNetworkGatewayCreateUpdate,
+		Create: resourceLocalNetworkGatewayCreate,
 		Read:   resourceLocalNetworkGatewayRead,
-		Update: resourceLocalNetworkGatewayCreateUpdate,
+		Update: resourceLocalNetworkGatewayUpdate,
 		Delete: resourceLocalNetworkGatewayDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := localnetworkgateways.ParseLocalNetworkGatewayID(id)
@@ -101,25 +101,23 @@ func resourceLocalNetworkGateway() *pluginsdk.Resource {
 	}
 }
 
-func resourceLocalNetworkGatewayCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceLocalNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.LocalNetworkGateways
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := localnetworkgateways.NewLocalNetworkGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_local_network_gateway", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_local_network_gateway", id.ID())
 	}
 
 	gateway := localnetworkgateways.LocalNetworkGateway{
@@ -144,29 +142,84 @@ func resourceLocalNetworkGatewayCreateUpdate(d *pluginsdk.ResourceData, meta int
 	pollerType := custompollers.NewLocalNetworkGatewayPoller(client, id)
 	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
 
+	gateway.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
+
+	if _, err := client.CreateOrUpdate(ctx, id, gateway); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	if err := poller.PollUntilDone(ctx); err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
+
+	return resourceLocalNetworkGatewayRead(d, meta)
+}
+
+func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.Client.LocalNetworkGateways
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := localnetworkgateways.ParseLocalNetworkGatewayID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("gateway_address") {
+		payload.Properties.GatewayIPAddress = pointer.To(d.Get("gateway_address").(string))
+	}
+
+	if d.HasChange("gateway_fqdn") {
+		payload.Properties.Fqdn = pointer.To(d.Get("gateway_fqdn").(string))
+	}
+
+	if d.HasChange("bgp_settings") {
+		payload.Properties.BgpSettings = expandLocalNetworkGatewayBGPSettings(d)
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	// This custompoller can be removed once https://github.com/hashicorp/go-azure-sdk/issues/989 has been fixed
+	pollerType := custompollers.NewLocalNetworkGatewayPoller(client, *id)
+	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
 	// There is a bug in the provider where the address space ordering doesn't change as expected.
 	// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
-	if !d.IsNewResource() && d.HasChange("address_space") {
+	if d.HasChange("address_space") {
 		// since the local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, it is by design),
 		// replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
 		if v := d.Get("address_space").([]interface{}); len(v) > 0 {
-			gateway.Properties.LocalNetworkAddressSpace = &localnetworkgateways.AddressSpace{
+			payload.Properties.LocalNetworkAddressSpace = &localnetworkgateways.AddressSpace{
 				AddressPrefixes: &[]string{v[0].(string)},
 			}
 		}
 
 		// This can be switched back over to CreateOrUpdateThenPoll once https://github.com/hashicorp/go-azure-sdk/issues/989 has been fixed
-		if _, err := client.CreateOrUpdate(ctx, id, gateway); err != nil {
+		if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
 			return fmt.Errorf("removing %s: %+v", id, err)
 		}
 		if err := poller.PollUntilDone(ctx); err != nil {
 			return err
 		}
 	}
-	gateway.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 
-	if _, err := client.CreateOrUpdate(ctx, id, gateway); err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
+	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	if err := poller.PollUntilDone(ctx); err != nil {

--- a/internal/services/network/network_ddos_protection_plan_resource.go
+++ b/internal/services/network/network_ddos_protection_plan_resource.go
@@ -27,9 +27,9 @@ const ddosProtectionPlanResourceName = "azurerm_network_ddos_protection_plan"
 
 func resourceNetworkDDoSProtectionPlan() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkDDoSProtectionPlanCreateUpdate,
+		Create: resourceNetworkDDoSProtectionPlanCreate,
 		Read:   resourceNetworkDDoSProtectionPlanRead,
-		Update: resourceNetworkDDoSProtectionPlanCreateUpdate,
+		Update: resourceNetworkDDoSProtectionPlanUpdate,
 		Delete: resourceNetworkDDoSProtectionPlanDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -68,10 +68,10 @@ func resourceNetworkDDoSProtectionPlan() *pluginsdk.Resource {
 	}
 }
 
-func resourceNetworkDDoSProtectionPlanCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkDDoSProtectionPlanCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.DdosProtectionPlans
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	vnetsToLock, err := expandNetworkDDoSProtectionPlanVnetNames(d.Get("virtual_network_ids").([]interface{}))
@@ -86,17 +86,15 @@ func resourceNetworkDDoSProtectionPlanCreateUpdate(d *pluginsdk.ResourceData, me
 	locks.MultipleByName(vnetsToLock, VirtualNetworkResourceName)
 	defer locks.UnlockMultipleByName(vnetsToLock, VirtualNetworkResourceName)
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_ddos_protection_plan", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_ddos_protection_plan", id.ID())
 	}
 
 	payload := ddosprotectionplans.DdosProtectionPlan{
@@ -105,7 +103,54 @@ func resourceNetworkDDoSProtectionPlanCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceNetworkDDoSProtectionPlanRead(d, meta)
+}
+
+func resourceNetworkDDoSProtectionPlanUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.DdosProtectionPlans
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	vnetsToLock, err := expandNetworkDDoSProtectionPlanVnetNames(d.Get("virtual_network_ids").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("extracting names of Virtual Network: %+v", err)
+	}
+
+	id, err := ddosprotectionplans.ParseDdosProtectionPlanID(d.Id())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	locks.ByName(id.DdosProtectionPlanName, ddosProtectionPlanResourceName)
+	defer locks.UnlockByName(id.DdosProtectionPlanName, ddosProtectionPlanResourceName)
+	locks.MultipleByName(vnetsToLock, VirtualNetworkResourceName)
+	defer locks.UnlockMultipleByName(vnetsToLock, VirtualNetworkResourceName)
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -243,7 +243,7 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.NetworkInterfaces
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := commonids.NewNetworkInterfaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))

--- a/internal/services/network/network_profile_resource.go
+++ b/internal/services/network/network_profile_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/networkprofiles"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -29,9 +28,9 @@ const azureNetworkProfileResourceName = "azurerm_network_profile"
 
 func resourceNetworkProfile() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkProfileCreateUpdate,
+		Create: resourceNetworkProfileCreate,
 		Read:   resourceNetworkProfileRead,
-		Update: resourceNetworkProfileCreateUpdate,
+		Update: resourceNetworkProfileUpdate,
 		Delete: resourceNetworkProfileDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := networkprofiles.ParseNetworkProfileID(id)
@@ -103,34 +102,26 @@ func resourceNetworkProfile() *pluginsdk.Resource {
 	}
 }
 
-func resourceNetworkProfileCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkProfileCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.NetworkProfiles
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Profile creation")
-
 	id := networkprofiles.NewNetworkProfileID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id, networkprofiles.DefaultGetOperationOptions())
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id, networkprofiles.DefaultGetOperationOptions())
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_profile", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	t := d.Get("tags").(map[string]interface{})
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_profile", id.ID())
+	}
 
-	containerNetworkInterfacesRaw := d.Get("container_network_interface").([]interface{})
-	containerNetworkInterfaceConfigurations := expandNetworkProfileContainerNetworkInterface(containerNetworkInterfacesRaw)
+	containerNetworkInterfaceConfigurations := expandNetworkProfileContainerNetworkInterface(d.Get("container_network_interface").([]interface{}))
 	subnetsToLock, vnetsToLock, err := expandNetworkProfileVirtualNetworkSubnetNames(containerNetworkInterfaceConfigurations)
 	if err != nil {
 		return fmt.Errorf("extracting names of Subnet and Virtual Network: %+v", err)
@@ -146,15 +137,68 @@ func resourceNetworkProfileCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	defer locks.UnlockMultipleByName(subnetsToLock, SubnetResourceName)
 
 	payload := networkprofiles.NetworkProfile{
-		Location: &location,
-		Tags:     tags.Expand(t),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Properties: &networkprofiles.NetworkProfilePropertiesFormat{
 			ContainerNetworkInterfaceConfigurations: containerNetworkInterfaceConfigurations,
 		},
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, payload); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceNetworkProfileRead(d, meta)
+}
+
+func resourceNetworkProfileUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.NetworkProfiles
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := networkprofiles.ParseNetworkProfileID(d.Id())
+
+	existing, err := client.Get(ctx, *id, networkprofiles.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	containerNetworkInterfaceConfigurations := expandNetworkProfileContainerNetworkInterface(d.Get("container_network_interface").([]interface{}))
+	subnetsToLock, vnetsToLock, err := expandNetworkProfileVirtualNetworkSubnetNames(containerNetworkInterfaceConfigurations)
+	if err != nil {
+		return fmt.Errorf("extracting names of Subnet and Virtual Network: %+v", err)
+	}
+
+	locks.ByName(id.NetworkProfileName, azureNetworkProfileResourceName)
+	defer locks.UnlockByName(id.NetworkProfileName, azureNetworkProfileResourceName)
+
+	locks.MultipleByName(vnetsToLock, VirtualNetworkResourceName)
+	defer locks.UnlockMultipleByName(vnetsToLock, VirtualNetworkResourceName)
+
+	locks.MultipleByName(subnetsToLock, SubnetResourceName)
+	defer locks.UnlockMultipleByName(subnetsToLock, SubnetResourceName)
+
+	if d.HasChange("container_network_interface") {
+		payload.Properties.ContainerNetworkInterfaceConfigurations = containerNetworkInterfaceConfigurations
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/network_profile_resource.go
+++ b/internal/services/network/network_profile_resource.go
@@ -159,6 +159,9 @@ func resourceNetworkProfileUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	defer cancel()
 
 	id, err := networkprofiles.ParseNetworkProfileID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	existing, err := client.Get(ctx, *id, networkprofiles.DefaultGetOperationOptions())
 	if err != nil {

--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -28,9 +28,9 @@ var networkSecurityGroupResourceName = "azurerm_network_security_group"
 
 func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkSecurityGroupCreateUpdate,
+		Create: resourceNetworkSecurityGroupCreate,
 		Read:   resourceNetworkSecurityGroupRead,
-		Update: resourceNetworkSecurityGroupCreateUpdate,
+		Update: resourceNetworkSecurityGroupUpdate,
 		Delete: resourceNetworkSecurityGroupDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -182,25 +182,23 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 	}
 }
 
-func resourceNetworkSecurityGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkSecurityGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.NetworkSecurityGroups
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := networksecuritygroups.NewNetworkSecurityGroupID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id, networksecuritygroups.DefaultGetOperationOptions())
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id, networksecuritygroups.DefaultGetOperationOptions())
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_security_group", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_security_group", id.ID())
 	}
 
 	sgRules, sgErr := expandSecurityRules(d)
@@ -221,7 +219,56 @@ func resourceNetworkSecurityGroupCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, sg); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceNetworkSecurityGroupRead(d, meta)
+}
+
+func resourceNetworkSecurityGroupUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.Client.NetworkSecurityGroups
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := networksecuritygroups.ParseNetworkSecurityGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id, networksecuritygroups.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("security_rule") {
+		sgRules, sgErr := expandSecurityRules(d)
+		if sgErr != nil {
+			return fmt.Errorf("building list of Network Security Group Rules: %+v", sgErr)
+		}
+
+		payload.Properties.SecurityRules = pointer.To(sgRules)
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	locks.ByName(id.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(id.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -17,14 +17,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceNetworkSecurityRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceNetworkSecurityRuleCreateUpdate,
+		Create: resourceNetworkSecurityRuleCreate,
 		Read:   resourceNetworkSecurityRuleRead,
-		Update: resourceNetworkSecurityRuleCreateUpdate,
+		Update: resourceNetworkSecurityRuleUpdate,
 		Delete: resourceNetworkSecurityRuleDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := securityrules.ParseSecurityRuleID(id)
@@ -174,25 +173,23 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 	}
 }
 
-func resourceNetworkSecurityRuleCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceNetworkSecurityRuleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.SecurityRules
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := securityrules.NewSecurityRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("network_security_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_network_security_rule", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_security_rule", id.ID())
 	}
 
 	rule := securityrules.SecurityRule{
@@ -258,7 +255,7 @@ func resourceNetworkSecurityRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 		var sourceApplicationSecurityGroups []securityrules.ApplicationSecurityGroup
 		for _, v := range r.(*pluginsdk.Set).List() {
 			sg := securityrules.ApplicationSecurityGroup{
-				Id: utils.String(v.(string)),
+				Id: pointer.To(v.(string)),
 			}
 			sourceApplicationSecurityGroups = append(sourceApplicationSecurityGroups, sg)
 		}
@@ -269,7 +266,7 @@ func resourceNetworkSecurityRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 		var destinationApplicationSecurityGroups []securityrules.ApplicationSecurityGroup
 		for _, v := range r.(*pluginsdk.Set).List() {
 			sg := securityrules.ApplicationSecurityGroup{
-				Id: utils.String(v.(string)),
+				Id: pointer.To(v.(string)),
 			}
 			destinationApplicationSecurityGroups = append(destinationApplicationSecurityGroups, sg)
 		}
@@ -277,7 +274,138 @@ func resourceNetworkSecurityRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, rule); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceNetworkSecurityRuleRead(d, meta)
+}
+
+func resourceNetworkSecurityRuleUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.SecurityRules
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := securityrules.ParseSecurityRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("description") {
+		payload.Properties.Description = pointer.To(d.Get("description").(string))
+	}
+
+	if d.HasChange("protocol") {
+		payload.Properties.Protocol = securityrules.SecurityRuleProtocol(d.Get("protocol").(string))
+	}
+
+	if d.HasChange("source_port_range") {
+		payload.Properties.SourcePortRange = pointer.To(d.Get("source_port_range").(string))
+	}
+
+	if d.HasChange("source_port_ranges") {
+		var sourcePortRanges []string
+		r := d.Get("destination_port_range").(*pluginsdk.Set).List()
+		for _, v := range r {
+			s := v.(string)
+			sourcePortRanges = append(sourcePortRanges, s)
+		}
+		payload.Properties.DestinationPortRanges = pointer.To(sourcePortRanges)
+	}
+
+	if d.HasChange("destination_port_range") {
+		payload.Properties.DestinationPortRange = pointer.To(d.Get("destination_port_range").(string))
+	}
+
+	if d.HasChange("destination_port_ranges") {
+		var destinationPortRanges []string
+		r := d.Get("destination_port_ranges").(*pluginsdk.Set).List()
+		for _, v := range r {
+			s := v.(string)
+			destinationPortRanges = append(destinationPortRanges, s)
+		}
+		payload.Properties.DestinationPortRanges = pointer.To(destinationPortRanges)
+	}
+
+	if d.HasChange("source_address_prefix") {
+		payload.Properties.SourceAddressPrefix = pointer.To(d.Get("source_address_prefix").(string))
+	}
+
+	if d.HasChange("source_address_prefixes") {
+		var sourceAddressPrefixes []string
+		r := d.Get("source_address_prefixes").(*pluginsdk.Set).List()
+		for _, v := range r {
+			s := v.(string)
+			sourceAddressPrefixes = append(sourceAddressPrefixes, s)
+		}
+		payload.Properties.SourceAddressPrefixes = pointer.To(sourceAddressPrefixes)
+	}
+
+	if d.HasChange("destination_address_prefix") {
+		payload.Properties.DestinationAddressPrefix = pointer.To(d.Get("destination_address_prefix").(string))
+	}
+
+	if d.HasChange("destination_address_prefixes") {
+		var destinationAddressPrefixes []string
+		r := d.Get("destination_address_prefixes").(*pluginsdk.Set).List()
+		for _, v := range r {
+			s := v.(string)
+			destinationAddressPrefixes = append(destinationAddressPrefixes, s)
+		}
+		payload.Properties.DestinationAddressPrefixes = pointer.To(destinationAddressPrefixes)
+	}
+
+	if d.HasChange("source_application_security_group_ids") {
+		var sourceApplicationSecurityGroups []securityrules.ApplicationSecurityGroup
+		for _, v := range d.Get("source_application_security_group_ids").(*pluginsdk.Set).List() {
+			sg := securityrules.ApplicationSecurityGroup{
+				Id: pointer.To(v.(string)),
+			}
+			sourceApplicationSecurityGroups = append(sourceApplicationSecurityGroups, sg)
+		}
+		payload.Properties.SourceApplicationSecurityGroups = pointer.To(sourceApplicationSecurityGroups)
+	}
+
+	if d.HasChange("destination_application_security_group_ids") {
+		var destinationApplicationSecurityGroups []securityrules.ApplicationSecurityGroup
+		for _, v := range d.Get("destination_application_security_group_ids").(*pluginsdk.Set).List() {
+			sg := securityrules.ApplicationSecurityGroup{
+				Id: pointer.To(v.(string)),
+			}
+			destinationApplicationSecurityGroups = append(destinationApplicationSecurityGroups, sg)
+		}
+		payload.Properties.DestinationApplicationSecurityGroups = pointer.To(destinationApplicationSecurityGroups)
+	}
+
+	if d.HasChange("access") {
+		payload.Properties.Access = securityrules.SecurityRuleAccess(d.Get("access").(string))
+	}
+
+	if d.HasChange("priority") {
+		payload.Properties.Priority = int64(d.Get("priority").(int))
+	}
+
+	if d.HasChange("direction") {
+		payload.Properties.Direction = securityrules.SecurityRuleDirection(d.Get("direction").(string))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -301,7 +301,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Client.Subnets
 	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Azure ARM Subnet creation.")

--- a/internal/services/network/virtual_hub_bgp_connection_resource.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource.go
@@ -130,7 +130,7 @@ func resourceVirtualHubBgpConnectionCreate(d *pluginsdk.ResourceData, meta inter
 
 func resourceVirtualHubBgpConnectionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	virtHubId, err := virtualwans.ParseVirtualHubID(d.Get("virtual_hub_id").(string))

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -218,7 +218,7 @@ func resourceVirtualNetworkGatewayNatRuleRead(d *pluginsdk.ResourceData, meta in
 
 func resourceVirtualNetworkGatewayNatRuleUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualNetworkGateways
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := virtualnetworkgateways.ParseVirtualNetworkGatewayNatRuleID(d.Id())

--- a/internal/services/network/virtual_wan_resource.go
+++ b/internal/services/network/virtual_wan_resource.go
@@ -23,9 +23,9 @@ import (
 
 func resourceVirtualWan() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceVirtualWanCreateUpdate,
+		Create: resourceVirtualWanCreate,
 		Read:   resourceVirtualWanRead,
-		Update: resourceVirtualWanCreateUpdate,
+		Update: resourceVirtualWanUpdate,
 		Delete: resourceVirtualWanDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := virtualwans.ParseVirtualWANID(id)
@@ -39,78 +39,70 @@ func resourceVirtualWan() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: resourceVirtualWanSchema(),
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"location": commonschema.Location(),
+
+			"disable_vpn_encryption": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"allow_branch_to_branch_traffic": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"office365_local_breakout_category": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(virtualwans.OfficeTrafficCategoryAll),
+					string(virtualwans.OfficeTrafficCategoryNone),
+					string(virtualwans.OfficeTrafficCategoryOptimize),
+					string(virtualwans.OfficeTrafficCategoryOptimizeAndAllow),
+				}, false),
+				Default: string(virtualwans.OfficeTrafficCategoryNone),
+			},
+
+			"type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  "Standard",
+			},
+
+			"tags": commonschema.Tags(),
+		},
 	}
 }
 
-func resourceVirtualWanSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-
-		"resource_group_name": commonschema.ResourceGroupName(),
-
-		"location": commonschema.Location(),
-
-		"disable_vpn_encryption": {
-			Type:     pluginsdk.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-
-		"allow_branch_to_branch_traffic": {
-			Type:     pluginsdk.TypeBool,
-			Optional: true,
-			Default:  true,
-		},
-
-		"office365_local_breakout_category": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(virtualwans.OfficeTrafficCategoryAll),
-				string(virtualwans.OfficeTrafficCategoryNone),
-				string(virtualwans.OfficeTrafficCategoryOptimize),
-				string(virtualwans.OfficeTrafficCategoryOptimizeAndAllow),
-			}, false),
-			Default: string(virtualwans.OfficeTrafficCategoryNone),
-		},
-
-		"type": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  "Standard",
-		},
-
-		"tags": commonschema.Tags(),
-	}
-}
-
-func resourceVirtualWanCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceVirtualWanCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Virtual WAN creation.")
 
 	id := virtualwans.NewVirtualWANID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.VirtualWansGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.VirtualWansGet(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_virtual_wan", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_virtual_wan", id.ID())
 	}
 
 	wan := virtualwans.VirtualWAN{
@@ -125,7 +117,60 @@ func resourceVirtualWanCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if err := client.VirtualWansCreateOrUpdateThenPoll(ctx, id, wan); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceVirtualWanRead(d, meta)
+}
+
+func resourceVirtualWanUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualwans.ParseVirtualWANID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.VirtualWansGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+
+	payload := existing.Model
+
+	if d.HasChange("disable_vpn_encryption") {
+		payload.Properties.DisableVpnEncryption = pointer.To(d.Get("disable_vpn_encryption").(bool))
+	}
+
+	if d.HasChange("allow_branch_to_branch_traffic") {
+		payload.Properties.AllowBranchToBranchTraffic = pointer.To(d.Get("allow_branch_to_branch_traffic").(bool))
+	}
+
+	if d.HasChange("office365_local_breakout_category") {
+		payload.Properties.Office365LocalBreakoutCategory = pointer.To(virtualwans.OfficeTrafficCategory(d.Get("office365_local_breakout_category").(string)))
+	}
+
+	if d.HasChange("type") {
+		payload.Properties.Type = pointer.To(d.Get("type").(string))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.VirtualWansCreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/virtual_wan_resource.go
+++ b/internal/services/network/virtual_wan_resource.go
@@ -127,7 +127,7 @@ func resourceVirtualWanCreate(d *pluginsdk.ResourceData, meta interface{}) error
 
 func resourceVirtualWanUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := virtualwans.ParseVirtualWANID(d.Id())


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Following remaining resources with combined `CreateUpdate` have been split:

- `azurerm_local_network_gateway`
- `azurerm_network_ddos_protection_plan`
- `azurerm_network_profile`
- `azurerm_network_security_group`
- `azurerm_network_security_rule`
- `azurerm_private_link_service`
- `azurerm_subnet_service_endpoint_storage_policy`
- `azurerm_virtual_hub_ip`
- `azurerm_virtual_wan`


## Testing 

<img width="362" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/37790e8e-bee1-4cd9-ba9f-b0e5bd0251ce">

One test failure was fixed by the last commit in this PR, the others are unrelated.

