### PR TITLE
`azurerm_virtual_network` - extend `subnet` block

### DIFF
--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -685,13 +685,14 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 			subnetObj.Properties = &virtualnetworks.SubnetPropertiesFormat{}
 		}
 
+		subnetObj.Properties.AddressPrefix = pointer.To(subnet["address_prefix"].(string))
+
 		if features.FourPointOhBeta() {
 			privateEndpointNetworkPolicies := virtualnetworks.VirtualNetworkPrivateEndpointNetworkPolicies(subnet["private_endpoint_network_policies"].(string))
 			privateLinkServiceNetworkPolicies := virtualnetworks.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled
 			if subnet["private_link_service_network_policies_enabled"].(bool) {
 				privateLinkServiceNetworkPolicies = virtualnetworks.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled
 			}
-			subnetObj.Properties.AddressPrefix = pointer.To(subnet["address_prefix"].(string))
 			subnetObj.Properties.DefaultOutboundAccess = pointer.To(subnet["default_outbound_access_enabled"].(bool))
 			subnetObj.Properties.Delegations = expandVirtualNetworkSubnetDelegation(subnet["delegation"].([]interface{}))
 			subnetObj.Properties.PrivateEndpointNetworkPolicies = pointer.To(privateEndpointNetworkPolicies)

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -263,7 +263,6 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 					},
 				},
 			},
-			Set: resourceAzureSubnetHash,
 		},
 
 		"tags": commonschema.Tags(),
@@ -953,45 +952,6 @@ func resourceAzureSubnetHash(v interface{}) int {
 		}
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))
-		}
-
-		if features.FourPointOhBeta() {
-			if v, ok := m["default_outbound_access_enabled"]; ok {
-				buf.WriteString(fmt.Sprintf("%t", v.(bool)))
-			}
-			if delegations, ok := m["delegation"].([]interface{}); ok {
-				for _, delegation := range delegations {
-					d := delegation.(map[string]interface{})
-					if name, ok := d["name"]; ok {
-						buf.WriteString(name.(string))
-					}
-					if serviceDelegations, ok := d["service_delegation"].([]interface{}); ok {
-						if sd, ok := serviceDelegations[0].(map[string]interface{}); ok {
-							if name, ok := sd["name"]; ok {
-								buf.WriteString(name.(string))
-							}
-							if actions, ok := sd["actions"]; ok {
-								buf.WriteString(fmt.Sprintf("%s", actions))
-							}
-						}
-					}
-				}
-			}
-			if v, ok := m["private_endpoint_network_policies"]; ok {
-				buf.WriteString(v.(string))
-			}
-			if v, ok := m["private_link_service_network_policies_enabled"]; ok {
-				buf.WriteString(fmt.Sprintf("%t", v.(bool)))
-			}
-			if v, ok := m["route_table_id"]; ok {
-				buf.WriteString(v.(string))
-			}
-			if v, ok := m["service_endpoints"]; ok {
-				buf.WriteString(fmt.Sprintf("%s", v))
-			}
-			if v, ok := m["service_endpoint_policy_ids"]; ok {
-				buf.WriteString(fmt.Sprintf("%s", v))
-			}
 		}
 	}
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -1047,15 +1047,17 @@ func expandResourcesForLocking(d *pluginsdk.ResourceData) ([]string, []string, e
 				}
 			}
 
-			routeTableId := subnet["route_table_id"].(string)
-			if routeTableId != "" {
-				parsedRouteTableID, err := routetables.ParseRouteTableID(routeTableId)
-				if err != nil {
-					return nil, nil, err
-				}
-				routeTableName := parsedRouteTableID.RouteTableName
-				if !utils.SliceContainsValue(routeTableNames, routeTableName) {
-					routeTableNames = append(routeTableNames, routeTableName)
+			if features.FourPointOhBeta() {
+				routeTableId := subnet["route_table_id"].(string)
+				if routeTableId != "" {
+					parsedRouteTableID, err := routetables.ParseRouteTableID(routeTableId)
+					if err != nil {
+						return nil, nil, err
+					}
+					routeTableName := parsedRouteTableID.RouteTableName
+					if !utils.SliceContainsValue(routeTableNames, routeTableName) {
+						routeTableNames = append(routeTableNames, routeTableName)
+					}
 				}
 			}
 		}

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -270,6 +271,10 @@ func TestAccVirtualNetwork_edgeZone(t *testing.T) {
 }
 
 func TestAccVirtualNetwork_subnet(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		t.Skip("Skipping since this test is only applicable in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
 
@@ -283,6 +288,39 @@ func TestAccVirtualNetwork_subnet(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.subnetUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.noSubnet(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetwork_subnetRouteTable(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		t.Skip("Skipping since this test is only applicable in 4.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subnetRouteTable(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.subnetRouteTableRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -546,22 +584,47 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) noSubnet(data acceptance.TestData) string {
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  subnet              = []
+}
+`, data.RandomInteger, data.Locations.Primary)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
+  name                = "acctestSEP-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
+  name                = "acctestvirtnet%[1]d"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  subnet              = []
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -674,13 +737,29 @@ resource "azurerm_virtual_network" "test" {
     service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
-      name = "first"
-
+      name = "nginx"
       service_delegation {
         name = "NGINX.NGINXPLUS/nginxDeployments"
-
         actions = [
           "Microsoft.Network/virtualNetworks/subnets/join/action",
+        ]
+      }
+    }
+  }
+
+  subnet {
+    name                                          = "subnet2"
+    address_prefix                                = "10.0.2.0/24"
+    private_link_service_network_policies_enabled = false
+    service_endpoints                             = ["Microsoft.Storage"]
+    service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
+
+    delegation {
+      name = "containers"
+      service_delegation {
+        name = "Microsoft.ContainerInstance/containerGroups"
+        actions = [
+          "Microsoft.Network/virtualNetworks/subnets/action",
         ]
       }
     }
@@ -719,6 +798,7 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name                                          = "subnet1"
     address_prefix                                = "10.0.1.0/24"
+    default_outbound_access_enabled               = false
     private_link_service_network_policies_enabled = true
     private_endpoint_network_policies             = "Enabled"
     service_endpoints                             = ["Microsoft.Storage"]
@@ -727,12 +807,97 @@ resource "azurerm_virtual_network" "test" {
     delegation {
       name = "first"
       service_delegation {
-        name = "PaloAltoNetworks.Cloudngfw/firewalls"
+        name = "Microsoft.ContainerInstance/containerGroups"
         actions = [
-          "Microsoft.Network/virtualNetworks/subnets/join/action",
+          "Microsoft.Network/virtualNetworks/subnets/action",
         ]
       }
     }
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkResource) subnetRouteTable(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  route {
+    name                   = "first"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.0.1.0/24"
+    route_table_id = azurerm_route_table.test.id
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkResource) subnetRouteTableRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  route {
+    name                   = "first"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.0.1.0/24"
   }
 
   tags = {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR removes `Computed` and `ConfigModeAttr` on the `subnet` block in 4.0 and also adds the following properties to it:

- `default_outbound_access_enabled`
- `delegation`
- `private_endpoint_network_policies`
- `private_link_service_network_policies_enabled`
- `route_table_id`
- `service_endpoints`
- `service_endpoint_policy_ids`

## Testing 

<img width="365" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/25562180/e5864e96-9627-4e99-87f4-7613b2d894ad">


Test results in 4.0 mode:
```
--- PASS: TestAccVirtualNetwork_disappears (83.24s)
--- PASS: TestAccVirtualNetwork_requiresImport (93.90s)
--- PASS: TestAccVirtualNetwork_subnet (137.31s)
--- PASS: TestAccVirtualNetwork_deleteSubnet (145.86s)
--- PASS: TestAccVirtualNetwork_bgpCommunity (160.34s)
--- PASS: TestAccVirtualNetwork_complete (162.25s)
--- PASS: TestAccVirtualNetwork_ddosProtectionPlan (162.62s)
--- PASS: TestAccVirtualNetwork_basicUpdated (169.71s)
--- PASS: TestAccVirtualNetwork_basic (172.02s)
--- PASS: TestAccVirtualNetwork_withTags (174.45s)
--- PASS: TestAccVirtualNetwork_subnetRouteTable (181.92s)
--- PASS: TestAccVirtualNetwork_edgeZone (186.37s)
--- PASS: TestAccVirtualNetwork_updateFlowTimeoutInMinutes (210.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       213.306s

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)
Closes #3917
Closes #6382
Closes #18107
Supersedes #24972

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
