### PR TITLE
`azurem_cdn_endpoint` - remove optional + computed 

### DIFF
--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -119,7 +120,7 @@ func resourceCdnEndpoint() *pluginsdk.Resource {
 			"origin_path": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: !features.FourPointOhBeta(),
 			},
 
 			"querystring_caching_behaviour": {
@@ -137,7 +138,7 @@ func resourceCdnEndpoint() *pluginsdk.Resource {
 			"content_types_to_compress": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
-				Computed: true,
+				Computed: !features.FourPointOhBeta(),
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},
@@ -152,7 +153,7 @@ func resourceCdnEndpoint() *pluginsdk.Resource {
 			"probe_path": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: !features.FourPointOhBeta(),
 			},
 
 			"geo_filter": {

--- a/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -165,7 +165,7 @@ func TestAccCdnEndpoint_fullFields(t *testing.T) {
 				check.That(data.ResourceName).Key("origin_host_header").HasValue("www.contoso.com"),
 				check.That(data.ResourceName).Key("optimization_type").HasValue("GeneralWebDelivery"),
 				check.That(data.ResourceName).Key("querystring_caching_behaviour").HasValue("UseQueryString"),
-				check.That(data.ResourceName).Key("content_types_to_compress.#").HasValue("1"),
+				check.That(data.ResourceName).Key("content_types_to_compress.#").HasValue("3"),
 				check.That(data.ResourceName).Key("is_compression_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("geo_filter.#").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
@@ -723,7 +723,7 @@ resource "azurerm_cdn_endpoint" "test" {
   resource_group_name           = azurerm_resource_group.test.name
   is_http_allowed               = true
   is_https_allowed              = true
-  content_types_to_compress     = ["text/html"]
+  content_types_to_compress     = ["text/html", "image/gif", "text/css"]
   is_compression_enabled        = true
   querystring_caching_behaviour = "UseQueryString"
   origin_host_header            = "www.contoso.com"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removing `Computed` from the following properties in `azurem_cdn_endpoint` in 4.0:

- `probe_path` - removing computed in 4.0 as it doesn't appear to return a default
- `content_types_to_compress` - removing computed in 4.0 as it doesn't appear to return a default or have a need to be computed
- `origin_path` - removing computed in 4.0 as it doesn't appear to return a default

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
<img width="412" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/86247157/1314a048-91e9-4005-a147-738aad8b68b2">

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

