### PR TITLE
`azurerm_communication_service` `data.azurerm_communication_service` - Mark credentials as `sensitive`

### DIFF
--- a/internal/services/communication/communication_service_data_source.go
+++ b/internal/services/communication/communication_service_data_source.go
@@ -53,23 +53,27 @@ func (CommunicationServiceDataSource) Attributes() map[string]*pluginsdk.Schema 
 		},
 
 		"primary_connection_string": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"primary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"secondary_connection_string": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"secondary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"tags": commonschema.TagsDataSource(),

--- a/internal/services/communication/communication_service_resource.go
+++ b/internal/services/communication/communication_service_resource.go
@@ -90,23 +90,27 @@ func (CommunicationServiceResource) Arguments() map[string]*pluginsdk.Schema {
 func (CommunicationServiceResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"primary_connection_string": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"secondary_connection_string": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"primary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"secondary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
As #26548 addressed both of resource and data source `azurerm_communication_service` exported credentials including key and connection string as plain text, which could jeopardize security.

This patch marked these credentials as sensitive.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
=== RUN   TestAccCommunicationService_basic
=== PAUSE TestAccCommunicationService_basic
=== CONT  TestAccCommunicationService_basic
--- PASS: TestAccCommunicationService_basic (330.79s)
=== RUN   TestAccCommunicationService_requiresImport
=== PAUSE TestAccCommunicationService_requiresImport
=== CONT  TestAccCommunicationService_requiresImport
--- PASS: TestAccCommunicationService_requiresImport (328.39s)
=== RUN   TestAccCommunicationService_complete
=== PAUSE TestAccCommunicationService_complete
=== CONT  TestAccCommunicationService_complete
--- PASS: TestAccCommunicationService_complete (331.93s)
=== RUN   TestAccCommunicationService_update
=== PAUSE TestAccCommunicationService_update
=== CONT  TestAccCommunicationService_update
--- PASS: TestAccCommunicationService_update (459.19s)
=== RUN   TestAccCommunicationServiceDataSource_basic
=== PAUSE TestAccCommunicationServiceDataSource_basic
=== CONT  TestAccCommunicationServiceDataSource_basic
--- PASS: TestAccCommunicationServiceDataSource_basic (322.90s)
=== RUN   TestAccCommunicationServiceDataSource_complete
=== PAUSE TestAccCommunicationServiceDataSource_complete
=== CONT  TestAccCommunicationServiceDataSource_complete
--- PASS: TestAccCommunicationServiceDataSource_complete (319.25s)
PASS


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26548 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
