### PR TITLE
provider: support the `resource_provider_registrations` and `resource_providers_to_register` provider properties (v4.0 only)

### DIFF
--- a/internal/acceptance/required_test.go
+++ b/internal/acceptance/required_test.go
@@ -25,13 +25,11 @@ func TestAccEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 
 	builder := clients.ClientBuilder{
 		AuthConfig:                  config,
-		TerraformVersion:            "0.0.0",
-		PartnerID:                   "",
 		DisableCorrelationRequestID: true,
 		DisableTerraformPartnerID:   false,
-		// this test intentionally checks all the RP's are registered - so this is intentional
-		SkipProviderRegistration: true,
-		SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
+		PartnerID:                   "",
+		SubscriptionID:              os.Getenv("ARM_SUBSCRIPTION_ID"),
+		TerraformVersion:            "0.0.0",
 	}
 	armClient, err := clients.Build(context.Background(), builder)
 	if err != nil {
@@ -41,7 +39,7 @@ func TestAccEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	client := armClient.Resource.ResourceProvidersClient
 	ctx := armClient.StopContext
 
-	requiredResourceProviders := resourceproviders.Required()
+	requiredResourceProviders := resourceproviders.Legacy()
 	subscriptionId := commonids.NewSubscriptionID(armClient.Account.SubscriptionId)
 
 	if err = resourceproviders.EnsureRegistered(ctx, client, subscriptionId, requiredResourceProviders); err != nil {

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -65,12 +65,11 @@ func Build() (*clients.Client, error) {
 		}
 
 		clientBuilder := clients.ClientBuilder{
-			AuthConfig:               &authConfig,
-			SkipProviderRegistration: true,
-			TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
-			Features:                 features.Default(),
-			StorageUseAzureAD:        false,
-			SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
+			AuthConfig:        &authConfig,
+			TerraformVersion:  os.Getenv("TERRAFORM_CORE_VERSION"),
+			Features:          features.Default(),
+			StorageUseAzureAD: false,
+			SubscriptionID:    os.Getenv("ARM_SUBSCRIPTION_ID"),
 		}
 
 		client, err := clients.Build(ctx, clientBuilder)

--- a/internal/clients/auth.go
+++ b/internal/clients/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/claims"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients/graph"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceproviders"
 )
 
 type ResourceManagerAccount struct {
@@ -25,10 +26,10 @@ type ResourceManagerAccount struct {
 	TenantId       string
 
 	AuthenticatedAsAServicePrincipal bool
-	SkipResourceProviderRegistration bool
+	RegisteredResourceProviders      resourceproviders.ResourceProviders
 }
 
-func NewResourceManagerAccount(ctx context.Context, config auth.Credentials, subscriptionId string, skipResourceProviderRegistration bool) (*ResourceManagerAccount, error) {
+func NewResourceManagerAccount(ctx context.Context, config auth.Credentials, subscriptionId string, registeredResourceProviders resourceproviders.ResourceProviders) (*ResourceManagerAccount, error) {
 	authorizer, err := auth.NewAuthorizerFromCredentials(ctx, config, config.Environment.MicrosoftGraph)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build authorizer for Microsoft Graph API: %+v", err)
@@ -131,7 +132,7 @@ func NewResourceManagerAccount(ctx context.Context, config auth.Credentials, sub
 		TenantId:       tenantId,
 
 		AuthenticatedAsAServicePrincipal: authenticatedAsServicePrincipal,
-		SkipResourceProviderRegistration: skipResourceProviderRegistration,
+		RegisteredResourceProviders:      registeredResourceProviders,
 	}
 
 	return &account, nil

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -23,16 +23,15 @@ type ClientBuilder struct {
 	AuthConfig *auth.Credentials
 	Features   features.UserFeatures
 
+	CustomCorrelationRequestID  string
 	DisableCorrelationRequestID bool
 	DisableTerraformPartnerID   bool
-	SkipProviderRegistration    bool
+	MetadataHost                string
+	PartnerID                   string
+	RegisteredResourceProviders resourceproviders.ResourceProviders
 	StorageUseAzureAD           bool
-
-	CustomCorrelationRequestID string
-	MetadataHost               string
-	PartnerID                  string
-	SubscriptionID             string
-	TerraformVersion           string
+	SubscriptionID              string
+	TerraformVersion            string
 }
 
 const azureStackEnvironmentError = `
@@ -97,7 +96,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return authorizer, nil
 	})
 
-	account, err := NewResourceManagerAccount(ctx, *builder.AuthConfig, builder.SubscriptionID, builder.SkipProviderRegistration)
+	account, err := NewResourceManagerAccount(ctx, *builder.AuthConfig, builder.SubscriptionID, builder.RegisteredResourceProviders)
 	if err != nil {
 		return nil, fmt.Errorf("building account: %+v", err)
 	}
@@ -150,7 +149,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		CustomCorrelationRequestID:  builder.CustomCorrelationRequestID,
 		DisableCorrelationRequestID: builder.DisableCorrelationRequestID,
 		DisableTerraformPartnerID:   builder.DisableTerraformPartnerID,
-		SkipProviderReg:             builder.SkipProviderRegistration,
+		SkipProviderReg:             builder.RegisteredResourceProviders == nil,
 		StorageUseAzureAD:           builder.StorageUseAzureAD,
 
 		ResourceManagerEndpoint: *resourceManagerEndpoint,

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -47,7 +47,6 @@ type ClientOptions struct {
 	DisableCorrelationRequestID bool
 
 	DisableTerraformPartnerID bool
-	SkipProviderReg           bool
 	StorageUseAzureAD         bool
 
 	ResourceManagerEndpoint string
@@ -58,6 +57,9 @@ type ClientOptions struct {
 	ManagedHSMAuthorizer      autorest.Authorizer
 	ResourceManagerAuthorizer autorest.Authorizer
 	SynapseAuthorizer         autorest.Authorizer
+
+	// TODO: Remove when all go-autorest clients are gone
+	SkipProviderReg bool
 }
 
 // Configure set up a resourcemanager.Client using an auth.Authorizer from hashicorp/go-azure-sdk

--- a/internal/features/enhanced_validation.go
+++ b/internal/features/enhanced_validation.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 )
 
-// EnhancedValidationEnabled returns whether or not the feature for Enhanced Validation is
-// enabled.
+// EnhancedValidationEnabled returns whether the feature for Enhanced Validation is enabled.
 //
 // This functionality calls out to the Azure MetaData Service to cache the list of supported
 // Azure Locations for the specified Endpoint - and then uses that to provide enhanced validation

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -481,7 +481,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 // buildClient is used to configure behavioral aspects of the provider. To configure the
 // cloud environment and authentication-related settings, use the providerConfigure function.
 func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData, authConfig *auth.Credentials) (*clients.Client, diag.Diagnostics) {
-	// TODO: Remove this hardcoded default in v4.0
+	// TODO: This hardcoded default is for v3.x, where `resource_provider_registrations` is not defined. Remove this hardcoded default in v4.0
 	providerRegistrations := "legacy"
 	if features.FourPointOhBeta() {
 		providerRegistrations = d.Get("resource_provider_registrations").(string)
@@ -490,7 +490,7 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	// TODO: Remove in v5.0
 	if d.Get("skip_provider_registration").(bool) {
 		if providerRegistrations != "legacy" {
-			return nil, diag.Errorf("provider property `%[2]s` cannot be set at the same time as `%[1]s`, please remove `%[2]s` from your configuration or unset the `%[3]s` environment variable", "resource_provider_registrations", "skip_provider_registration", "ARM_SKIP_PROVIDER_REGISTRATION")
+			return nil, diag.Errorf("provider property `skip_provider_registration` cannot be set at the same time as `resource_provider_registrations`, please remove `skip_provider_registration` from your configuration or unset the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable")
 		}
 		providerRegistrations = "none"
 	}
@@ -508,7 +508,7 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	case "legacy":
 		requiredResourceProviders = resourceproviders.Legacy()
 	default:
-		return nil, diag.Errorf("unsupported value %q for provider property `%s`", providerRegistrations, "resource_provider_registrations")
+		return nil, diag.Errorf("unsupported value %q for provider property `resource_provider_registrations`", providerRegistrations)
 	}
 
 	if features.FourPointOhBeta() {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -555,34 +555,8 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	defer cancel()
 
 	if err = resourceproviders.EnsureRegistered(ctx2, client.Resource.ResourceProvidersClient, subscriptionId, requiredResourceProviders); err != nil {
-		return nil, diag.Errorf(resourceProviderRegistrationErrorFmt, err)
+		return nil, diag.FromErr(err)
 	}
 
 	return client, nil
 }
-
-const resourceProviderRegistrationErrorFmt = `Encountered an error whilst ensuring Resource Providers are registered.
-
-Terraform automatically attempts to register the Azure Resource Providers it supports, to
-ensure it is able to provision resources.
-
-If you don't have permission to register Resource Providers you may wish to disable this
-functionality by adding the following to the Provider block:
-
-provider "azurerm" {
-  "resource_provider_registrations = "none"
-}
-
-Please note that if you opt out of Resource Provider Registration and Terraform tries
-to provision a resource from a Resource Provider which is unregistered, then the errors
-may appear misleading - for example:
-
-> API version 2019-XX-XX was not found for Microsoft.Foo
-
-Could suggest that the Resource Provider "Microsoft.Foo" requires registration, but
-this could also indicate that this Azure Region doesn't support this API version.
-
-More information on the "resource_provider_registrations" property can be found here:
-https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#resource_provider_registrations
-
-Original Error: %s`

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -126,6 +126,10 @@ func TestProvider_counts(t *testing.T) {
 }
 
 func TestAccProvider_resourceProviders_legacy(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -147,6 +151,10 @@ func TestAccProvider_resourceProviders_legacy(t *testing.T) {
 
 // TODO: Remove this test in v5.0
 func TestAccProvider_resourceProviders_deprecatedSkip(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -172,6 +180,10 @@ func TestAccProvider_resourceProviders_deprecatedSkip(t *testing.T) {
 func TestAccProvider_resourceProviders_legacyWithAdditional(t *testing.T) {
 	if !features.FourPointOhBeta() {
 		t.Skip("skipping 4.0 specific test")
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -209,6 +221,10 @@ func TestAccProvider_resourceProviders_core(t *testing.T) {
 		t.Skip("skipping 4.0 specific test")
 	}
 
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -234,6 +250,10 @@ func TestAccProvider_resourceProviders_core(t *testing.T) {
 func TestAccProvider_resourceProviders_coreWithAdditional(t *testing.T) {
 	if !features.FourPointOhBeta() {
 		t.Skip("skipping 4.0 specific test")
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -268,6 +288,10 @@ func TestAccProvider_resourceProviders_coreWithAdditional(t *testing.T) {
 func TestAccProvider_resourceProviders_explicit(t *testing.T) {
 	if !features.FourPointOhBeta() {
 		t.Skip("skipping 4.0 specific test")
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -118,6 +118,7 @@ func TestProvider_impl(t *testing.T) {
 func TestProvider_counts(t *testing.T) {
 	// @tombuildsstuff: this is less a unit test and more a useful placeholder tbh
 	provider := TestAzureProvider()
+
 	log.Printf("Data Sources: %d", len(provider.DataSourcesMap))
 	log.Printf("Resources:    %d", len(provider.ResourcesMap))
 	log.Printf("-----------------")
@@ -131,7 +132,10 @@ func TestAccProvider_resourceProviders_legacy(t *testing.T) {
 	logging.SetOutput(t)
 
 	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
+
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := resourceproviders.Legacy()
 	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
@@ -148,12 +152,14 @@ func TestAccProvider_resourceProviders_deprecatedSkip(t *testing.T) {
 
 	logging.SetOutput(t)
 
+	provider := TestAzureProvider()
 	config := map[string]interface{}{
 		"skip_provider_registration": "true",
 	}
 
-	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(config))
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := make(resourceproviders.ResourceProviders)
 	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
@@ -173,15 +179,19 @@ func TestAccProvider_resourceProviders_legacyWithAdditional(t *testing.T) {
 
 	logging.SetOutput(t)
 
+	provider := TestAzureProvider()
 	config := map[string]interface{}{
 		"resource_providers_to_register": []interface{}{
 			"Microsoft.ApiManagement",
+			"Microsoft.ContainerService",
 			"Microsoft.KeyVault",
+			"Microsoft.Kubernetes",
 		},
 	}
 
-	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(config))
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := resourceproviders.Legacy().Merge(resourceproviders.ResourceProviders{
 		"Microsoft.ApiManagement": {},
@@ -204,12 +214,14 @@ func TestAccProvider_resourceProviders_core(t *testing.T) {
 
 	logging.SetOutput(t)
 
+	provider := TestAzureProvider()
 	config := map[string]interface{}{
 		"resource_provider_registrations": "core",
 	}
 
-	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(config))
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := resourceproviders.Core()
 	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
@@ -229,6 +241,7 @@ func TestAccProvider_resourceProviders_coreWithAdditional(t *testing.T) {
 
 	logging.SetOutput(t)
 
+	provider := TestAzureProvider()
 	config := map[string]interface{}{
 		"resource_provider_registrations": "core",
 		"resource_providers_to_register": []interface{}{
@@ -237,8 +250,9 @@ func TestAccProvider_resourceProviders_coreWithAdditional(t *testing.T) {
 		},
 	}
 
-	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(config))
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := resourceproviders.Core().Merge(resourceproviders.ResourceProviders{
 		"Microsoft.ApiManagement": {},
@@ -261,6 +275,7 @@ func TestAccProvider_resourceProviders_explicit(t *testing.T) {
 
 	logging.SetOutput(t)
 
+	provider := TestAzureProvider()
 	config := map[string]interface{}{
 		"resource_provider_registrations": "none",
 		"resource_providers_to_register": []interface{}{
@@ -270,8 +285,9 @@ func TestAccProvider_resourceProviders_explicit(t *testing.T) {
 		},
 	}
 
-	provider := TestAzureProvider()
-	provider.Configure(ctx, terraform.NewResourceConfigRaw(config))
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
 
 	expectedResourceProviders := resourceproviders.ResourceProviders{
 		"Microsoft.Compute": {},

--- a/internal/resourceproviders/cache.go
+++ b/internal/resourceproviders/cache.go
@@ -15,8 +15,8 @@ import (
 
 // cachedResourceProviders can be (validly) nil - as such this shouldn't be relied on
 var cachedResourceProviders *[]string
-var registeredResourceProviders *map[string]struct{}
-var unregisteredResourceProviders *map[string]struct{}
+var registeredResourceProviders map[string]struct{}
+var unregisteredResourceProviders map[string]struct{}
 
 var cacheLock = &sync.Mutex{}
 
@@ -53,8 +53,8 @@ func populateCache(ctx context.Context, client *providers.ProvidersClient, subsc
 	}
 
 	providerNames := make([]string, 0)
-	registeredProviders := make(map[string]struct{}, 0)
-	unregisteredProviders := make(map[string]struct{}, 0)
+	registeredResourceProviders = make(map[string]struct{})
+	unregisteredResourceProviders = make(map[string]struct{})
 	for _, provider := range providers.Items {
 		if provider.Namespace == nil {
 			continue
@@ -63,14 +63,12 @@ func populateCache(ctx context.Context, client *providers.ProvidersClient, subsc
 		providerNames = append(providerNames, *provider.Namespace)
 		registered := provider.RegistrationState != nil && strings.EqualFold(*provider.RegistrationState, "registered")
 		if registered {
-			registeredProviders[*provider.Namespace] = struct{}{}
+			registeredResourceProviders[*provider.Namespace] = struct{}{}
 		} else {
-			unregisteredProviders[*provider.Namespace] = struct{}{}
+			unregisteredResourceProviders[*provider.Namespace] = struct{}{}
 		}
 	}
 
 	cachedResourceProviders = &providerNames
-	registeredResourceProviders = &registeredProviders
-	unregisteredResourceProviders = &unregisteredProviders
 	return nil
 }

--- a/internal/resourceproviders/errors.go
+++ b/internal/resourceproviders/errors.go
@@ -1,0 +1,78 @@
+package resourceproviders
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var ErrNoAuthorization = errors.New("authorization failed")
+
+const registrationErrorFmt = `%s.
+
+Terraform automatically attempts to register the Azure Resource Providers it supports, to
+ensure it is able to provision resources.
+
+If you don't have permission to register Resource Providers you may wish to disable this
+functionality by adding the following to the Provider block:
+
+provider "azurerm" {
+  "resource_provider_registrations = "none"
+}
+
+Please note that if you opt out of Resource Provider Registration and Terraform tries
+to provision a resource from a Resource Provider which is unregistered, then the errors
+may appear misleading - for example:
+
+> API version 2019-XX-XX was not found for Microsoft.Foo
+
+Could suggest that the Resource Provider "Microsoft.Foo" requires registration, but
+this could also indicate that this Azure Region doesn't support this API version.
+
+More information on the "resource_provider_registrations" property can be found here:
+https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#resource_provider_registrations
+
+Encountered the following errors:
+
+%v`
+
+// userError exposes custom messaging depending on the type of error(s) received when attempting to register
+// resource providers.
+func userError(err error) error {
+	if errors.Is(err, ErrNoAuthorization) {
+		return fmt.Errorf(registrationErrorFmt, "Terraform does not have the necessary permissions to register Resource Providers", err)
+	}
+	return fmt.Errorf(registrationErrorFmt, "Encountered an error whilst ensuring Resource Providers are registered", err)
+}
+
+// registrationErrors is a container for errors encountered when attempting to register resource providers. It makes
+// use of unwrap support in `errors.Is()` to detect whether any of the contained errors match a target error, which
+// allows us to expose different user-facing messages depending on the types of errors encountered. A mutex is
+// necessary, as we populate this from goroutines.
+type registrationErrors struct {
+	errs []error
+	lock sync.Mutex
+}
+
+func (e *registrationErrors) Error() (out string) {
+	return errors.Join(e.errs...).Error()
+}
+
+func (e *registrationErrors) Unwrap() []error {
+	return e.errs
+}
+
+func (e *registrationErrors) append(err error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if e.errs == nil {
+		e.errs = make([]error, 0)
+	}
+
+	e.errs = append(e.errs, err)
+}
+
+func (e *registrationErrors) hasErr() bool {
+	return len(e.errs) > 0
+}

--- a/internal/resourceproviders/registration.go
+++ b/internal/resourceproviders/registration.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceproviders/custompollers"
 )
 
-func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, subscriptionId commonids.SubscriptionId, requiredRPs map[string]struct{}) error {
+func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, subscriptionId commonids.SubscriptionId, requiredRPs ResourceProviders) error {
 	if cachedResourceProviders == nil || registeredResourceProviders == nil || unregisteredResourceProviders == nil {
 		if err := populateCache(ctx, client, subscriptionId); err != nil {
 			return fmt.Errorf("populating Resource Provider cache: %+v", err)
@@ -27,7 +27,7 @@ func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, su
 	log.Printf("[DEBUG] Determining which Resource Providers require Registration")
 	providersToRegister, err := DetermineWhichRequiredResourceProvidersRequireRegistration(requiredRPs)
 	if err != nil {
-		return fmt.Errorf("determining which Required Resource Providers require registration: %+v", err)
+		return fmt.Errorf("determining which Resource Providers require registration: %+v", err)
 	}
 
 	if len(*providersToRegister) > 0 {
@@ -67,7 +67,7 @@ func registerForSubscription(ctx context.Context, client *providers.ProvidersCli
 	wg.Wait()
 
 	if len(failedProviders) > 0 {
-		err = fmt.Errorf("Cannot register providers: %s. Errors were: %s", strings.Join(failedProviders, ", "), err)
+		err = fmt.Errorf("cannot register providers: %s. Errors were: %s", strings.Join(failedProviders, ", "), err)
 	}
 	return err
 }
@@ -76,7 +76,7 @@ func registerWithSubscription(ctx context.Context, client *providers.ProvidersCl
 	providerId := providers.NewSubscriptionProviderID(subscriptionId.SubscriptionId, providerName)
 	log.Printf("[DEBUG] Registering %s..", providerId)
 	if _, err := client.Register(ctx, providerId, providers.ProviderRegistrationRequest{}); err != nil {
-		return fmt.Errorf("Cannot register provider %s with Azure Resource Manager: %s.", providerName, err)
+		return fmt.Errorf("cannot register provider %s with Azure Resource Manager: %s", providerName, err)
 	}
 
 	log.Printf("[DEBUG] Waiting for %s to finish registering..", providerId)

--- a/internal/resourceproviders/registration.go
+++ b/internal/resourceproviders/registration.go
@@ -5,18 +5,22 @@ package resourceproviders
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceproviders/custompollers"
 )
 
+// EnsureRegistered tries to determine whether all requiredRPs are registered in the subscription, and attempts to
+// register them if it appears they are not. Note that this may fail if a resource provider is not available in the
+// current cloud environment (a warning message will be logged to indicate when a resource provider is not listed).
 func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, subscriptionId commonids.SubscriptionId, requiredRPs ResourceProviders) error {
 	if cachedResourceProviders == nil || registeredResourceProviders == nil || unregisteredResourceProviders == nil {
 		if err := populateCache(ctx, client, subscriptionId); err != nil {
@@ -30,13 +34,14 @@ func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, su
 		return fmt.Errorf("determining which Resource Providers require registration: %+v", err)
 	}
 
-	if len(*providersToRegister) > 0 {
-		log.Printf("[DEBUG] Registering %d Resource Providers", len(*providersToRegister))
-		if err := registerForSubscription(ctx, client, subscriptionId, *providersToRegister); err != nil {
-			return err
-		}
-	} else {
+	if len(*providersToRegister) == 0 {
 		log.Printf("[DEBUG] All required Resource Providers are registered")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Registering %d Resource Providers", len(*providersToRegister))
+	if err = registerForSubscription(ctx, client, subscriptionId, *providersToRegister); err != nil {
+		return userError(err)
 	}
 
 	return nil
@@ -44,8 +49,7 @@ func EnsureRegistered(ctx context.Context, client *providers.ProvidersClient, su
 
 // registerForSubscription registers the specified Resource Providers in the current Subscription
 func registerForSubscription(ctx context.Context, client *providers.ProvidersClient, subscriptionId commonids.SubscriptionId, providersToRegister []string) error {
-	var err error
-	var failedProviders []string
+	errs := &registrationErrors{}
 	var wg sync.WaitGroup
 	wg.Add(len(providersToRegister))
 
@@ -53,30 +57,33 @@ func registerForSubscription(ctx context.Context, client *providers.ProvidersCli
 		go func(p string) {
 			defer wg.Done()
 			log.Printf("[DEBUG] Registering Resource Provider %q with namespace", p)
-			if innerErr := registerWithSubscription(ctx, client, subscriptionId, p); innerErr != nil {
-				failedProviders = append(failedProviders, p)
-				if err == nil {
-					err = innerErr
-				} else {
-					err = fmt.Errorf("%s\n%s", err, innerErr)
-				}
+			if err := registerWithSubscription(ctx, client, subscriptionId, p); err != nil {
+				errs.append(err)
 			}
 		}(providerName)
 	}
 
 	wg.Wait()
 
-	if len(failedProviders) > 0 {
-		err = fmt.Errorf("cannot register providers: %s. Errors were: %s", strings.Join(failedProviders, ", "), err)
+	if errs.hasErr() {
+		return errs
 	}
-	return err
+
+	return nil
 }
 
 func registerWithSubscription(ctx context.Context, client *providers.ProvidersClient, subscriptionId commonids.SubscriptionId, providerName string) error {
 	providerId := providers.NewSubscriptionProviderID(subscriptionId.SubscriptionId, providerName)
 	log.Printf("[DEBUG] Registering %s..", providerId)
-	if _, err := client.Register(ctx, providerId, providers.ProviderRegistrationRequest{}); err != nil {
-		return fmt.Errorf("cannot register provider %s with Azure Resource Manager: %s", providerName, err)
+	if resp, err := client.Register(ctx, providerId, providers.ProviderRegistrationRequest{}); err != nil {
+		msg := fmt.Sprintf("registering resource provider %q: %s", providerName, err)
+
+		if response.WasForbidden(resp.HttpResponse) {
+			// a 403 response was received, so wrap ErrNoAuthorization in order to expose messaging for this
+			return fmt.Errorf("%w: %s", ErrNoAuthorization, msg)
+		}
+
+		return errors.New(msg)
 	}
 
 	log.Printf("[DEBUG] Waiting for %s to finish registering..", providerId)

--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -3,22 +3,131 @@
 
 package resourceproviders
 
-// Required returns core Resource Providers used by the AzureRM Provider
-// Terraform auto-registers core Resource Providers, since those RP’s should be enabled by default
-// but that list is something we come up with based on experience.
-// whilst all may not be used by every user - the intention is that we determine which should be
-// registered such that we can avoid obscure errors where Resource Providers aren't registered.
-// new core Resource Providers should be added to this list as they're used in the Provider
-// (this is the approach used by Microsoft in their tooling)
-func Required() map[string]struct{} {
-	// NOTE: Resource Providers in this list are case sensitive
-	return map[string]struct{}{
-		"Microsoft.AppConfiguration":        {},
+// This file contains sets of resource providers which the provider should automatically register, depending on
+// configuration by the user. Historically, we have ordained the same set of RPs for all users, and users could
+// enable or disable automatic registration of the RPs in that set.
+//
+// Users may now choose a set of RPs that best meets their needs, via the provider block, or they can provide their
+// own set. They can also choose to not register any RPs, and manage these out-of-band, if they wish.
+//
+// Note that resource providers are case-sensitive.
+//
+// Official Docs: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-services-resource-providers
+
+type ResourceProviders map[string]struct{}
+
+func (r ResourceProviders) Add(providers ...string) {
+	for _, p := range providers {
+		r[p] = struct{}{}
+	}
+}
+
+func (r ResourceProviders) Merge(a ResourceProviders) ResourceProviders {
+	for k, v := range a {
+		r[k] = v
+	}
+	return r
+}
+
+// Core is a minimal set of RPs, and will be the default set in a future major version of the provider.
+func Core() ResourceProviders {
+	return ResourceProviders{
+		"Microsoft.Authorization":       {},
+		"Microsoft.Compute":             {},
+		"Microsoft.CostManagement":      {},
+		"Microsoft.ManagedIdentity":     {},
+		"Microsoft.MarketplaceOrdering": {},
+		"Microsoft.Network":             {},
+		"Microsoft.Resources":           {},
+		"Microsoft.Storage":             {},
+	}
+}
+
+// Extended is an expanded set of resource providers, as suggested by the community.
+func Extended() ResourceProviders {
+	return Core().Merge(ResourceProviders{
+		"Microsoft.ApiManagement":        {},
+		"Microsoft.AppConfiguration":     {},
+		"Microsoft.AppPlatform":          {},
+		"Microsoft.Automation":           {},
+		"Microsoft.Cache":                {},
+		"Microsoft.Cdn":                  {},
+		"Microsoft.ContainerInstance":    {},
+		"Microsoft.ContainerRegistry":    {},
+		"Microsoft.ContainerService":     {},
+		"Microsoft.DBforMariaDB":         {},
+		"Microsoft.DBforMySQL":           {},
+		"Microsoft.DBforPostgreSQL":      {},
+		"Microsoft.DataFactory":          {},
+		"Microsoft.DataLakeAnalytics":    {},
+		"Microsoft.DataLakeStore":        {},
+		"Microsoft.DataMigration":        {},
+		"Microsoft.DataProtection":       {},
+		"Microsoft.Databricks":           {},
+		"Microsoft.DevTestLab":           {},
+		"Microsoft.Devices":              {},
+		"Microsoft.DocumentDB":           {},
+		"Microsoft.EventGrid":            {},
+		"Microsoft.EventHub":             {},
+		"Microsoft.HDInsight":            {},
+		"microsoft.insights":             {},
+		"Microsoft.KeyVault":             {},
+		"Microsoft.Kusto":                {},
+		"Microsoft.Logic":                {},
+		"Microsoft.Maintenance":          {},
+		"Microsoft.Management":           {},
+		"Microsoft.NotificationHubs":     {},
+		"Microsoft.OperationalInsights":  {},
+		"Microsoft.OperationsManagement": {},
+		"Microsoft.PowerBIDedicated":     {},
+		"Microsoft.Relay":                {},
+		"Microsoft.Security":             {},
+		"Microsoft.SecurityInsights":     {},
+		"Microsoft.ServiceBus":           {},
+		"Microsoft.ServiceFabric":        {},
+		"Microsoft.SignalRService":       {},
+		"Microsoft.Sql":                  {},
+		"Microsoft.StreamAnalytics":      {},
+		"Microsoft.TimeSeriesInsights":   {},
+		"Microsoft.Web":                  {},
+	})
+}
+
+// All is intended to be a complete set of RPs that might be needed to utilize any functionality in the provider.
+func All() ResourceProviders {
+	return Extended().Merge(ResourceProviders{
+		"Github.Network":                    {},
+		"Microsoft.AVS":                     {},
+		"Microsoft.AlertsManagement":        {},
+		"Microsoft.Blueprint":               {},
+		"Microsoft.BotService":              {},
+		"Microsoft.CognitiveServices":       {},
+		"Microsoft.CustomProviders":         {},
+		"Microsoft.DesktopVirtualization":   {},
+		"Microsoft.GuestConfiguration":      {},
+		"Microsoft.HealthcareApis":          {},
+		"Microsoft.IoTCentral":              {},
+		"Microsoft.MachineLearningServices": {},
+		"Microsoft.ManagedServices":         {},
+		"Microsoft.Maps":                    {},
+		"Microsoft.Media":                   {},
+		"Microsoft.MixedReality":            {},
+		"Microsoft.PolicyInsights":          {},
+		"Microsoft.RecoveryServices":        {},
+		"Microsoft.Search":                  {},
+	})
+}
+
+// Legacy is the set of automatically registered RPs from earlier versions of the provider, and is provided for
+// forwards compatibility. This set should not be changed going forward, and will be removed in a future major release.
+func Legacy() ResourceProviders {
+	return ResourceProviders{
+		"Microsoft.AVS":                     {},
 		"Microsoft.ApiManagement":           {},
+		"Microsoft.AppConfiguration":        {},
 		"Microsoft.AppPlatform":             {},
 		"Microsoft.Authorization":           {},
 		"Microsoft.Automation":              {},
-		"Microsoft.AVS":                     {},
 		"Microsoft.Blueprint":               {},
 		"Microsoft.BotService":              {},
 		"Microsoft.Cache":                   {},
@@ -30,27 +139,26 @@ func Required() map[string]struct{} {
 		"Microsoft.ContainerService":        {},
 		"Microsoft.CostManagement":          {},
 		"Microsoft.CustomProviders":         {},
-		"Microsoft.Databricks":              {},
+		"Microsoft.DBforMariaDB":            {},
+		"Microsoft.DBforMySQL":              {},
+		"Microsoft.DBforPostgreSQL":         {},
 		"Microsoft.DataFactory":             {},
 		"Microsoft.DataLakeAnalytics":       {},
 		"Microsoft.DataLakeStore":           {},
 		"Microsoft.DataMigration":           {},
 		"Microsoft.DataProtection":          {},
-		"Microsoft.DBforMariaDB":            {},
-		"Microsoft.DBforMySQL":              {},
-		"Microsoft.DBforPostgreSQL":         {},
+		"Microsoft.Databricks":              {},
 		"Microsoft.DesktopVirtualization":   {},
-		"Microsoft.Devices":                 {},
 		"Microsoft.DevTestLab":              {},
+		"Microsoft.Devices":                 {},
 		"Microsoft.DocumentDB":              {},
 		"Microsoft.EventGrid":               {},
 		"Microsoft.EventHub":                {},
+		"Microsoft.GuestConfiguration":      {},
 		"Microsoft.HDInsight":               {},
 		"Microsoft.HealthcareApis":          {},
-		"Microsoft.GuestConfiguration":      {},
 		"Microsoft.KeyVault":                {},
 		"Microsoft.Kusto":                   {},
-		"microsoft.insights":                {},
 		"Microsoft.Logic":                   {},
 		"Microsoft.MachineLearningServices": {},
 		"Microsoft.Maintenance":             {},
@@ -67,19 +175,20 @@ func Required() map[string]struct{} {
 		"Microsoft.OperationsManagement":    {},
 		"Microsoft.PolicyInsights":          {},
 		"Microsoft.PowerBIDedicated":        {},
-		"Microsoft.Relay":                   {},
 		"Microsoft.RecoveryServices":        {},
+		"Microsoft.Relay":                   {},
 		"Microsoft.Resources":               {},
-		"Microsoft.SignalRService":          {},
 		"Microsoft.Search":                  {},
 		"Microsoft.Security":                {},
 		"Microsoft.SecurityInsights":        {},
 		"Microsoft.ServiceBus":              {},
 		"Microsoft.ServiceFabric":           {},
+		"Microsoft.SignalRService":          {},
 		"Microsoft.Sql":                     {},
 		"Microsoft.Storage":                 {},
 		"Microsoft.StreamAnalytics":         {},
 		"Microsoft.TimeSeriesInsights":      {},
 		"Microsoft.Web":                     {},
+		"microsoft.insights":                {},
 	}
 }

--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -55,7 +55,6 @@ func Extended() ResourceProviders {
 		"Microsoft.ContainerInstance":    {},
 		"Microsoft.ContainerRegistry":    {},
 		"Microsoft.ContainerService":     {},
-		"Microsoft.DBforMariaDB":         {},
 		"Microsoft.DBforMySQL":           {},
 		"Microsoft.DBforPostgreSQL":      {},
 		"Microsoft.DataFactory":          {},
@@ -88,7 +87,6 @@ func Extended() ResourceProviders {
 		"Microsoft.SignalRService":       {},
 		"Microsoft.Sql":                  {},
 		"Microsoft.StreamAnalytics":      {},
-		"Microsoft.TimeSeriesInsights":   {},
 		"Microsoft.Web":                  {},
 	})
 }
@@ -110,7 +108,6 @@ func All() ResourceProviders {
 		"Microsoft.MachineLearningServices": {},
 		"Microsoft.ManagedServices":         {},
 		"Microsoft.Maps":                    {},
-		"Microsoft.Media":                   {},
 		"Microsoft.MixedReality":            {},
 		"Microsoft.PolicyInsights":          {},
 		"Microsoft.RecoveryServices":        {},

--- a/internal/resourceproviders/requiring_registration.go
+++ b/internal/resourceproviders/requiring_registration.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DetermineWhichRequiredResourceProvidersRequireRegistration determines which Resource Providers require registration to be able to be used
-func DetermineWhichRequiredResourceProvidersRequireRegistration(requiredResourceProviders map[string]struct{}) (*[]string, error) {
+func DetermineWhichRequiredResourceProvidersRequireRegistration(requiredResourceProviders ResourceProviders) (*[]string, error) {
 	if registeredResourceProviders == nil || unregisteredResourceProviders == nil {
 		return nil, fmt.Errorf("internal-error: the registered/unregistered Resource Provider cache isn't populated")
 	}

--- a/internal/resourceproviders/requiring_registration.go
+++ b/internal/resourceproviders/requiring_registration.go
@@ -16,11 +16,11 @@ func DetermineWhichRequiredResourceProvidersRequireRegistration(requiredResource
 
 	requiringRegistration := make([]string, 0)
 	for providerName := range requiredResourceProviders {
-		if _, isRegistered := (*registeredResourceProviders)[providerName]; isRegistered {
+		if _, isRegistered := registeredResourceProviders[providerName]; isRegistered {
 			continue
 		}
 
-		if _, isUnregistered := (*unregisteredResourceProviders)[providerName]; !isUnregistered {
+		if _, isUnregistered := unregisteredResourceProviders[providerName]; !isUnregistered {
 			// some RPs may not exist in some non-public clouds, so we'll log a warning here instead of raising an error
 			log.Printf("[WARN] The required Resource Provider %q wasn't returned from the Azure API", providerName)
 			continue

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -24,9 +24,8 @@ import (
 )
 
 var (
-	_ sdk.ResourceWithUpdate                      = ResourceProviderRegistrationResource{}
-	_ sdk.ResourceWithCustomImporter              = ResourceProviderRegistrationResource{}
-	_ sdk.ResourceWithDeprecationAndNoReplacement = ResourceProviderRegistrationResource{}
+	_ sdk.ResourceWithUpdate         = ResourceProviderRegistrationResource{}
+	_ sdk.ResourceWithCustomImporter = ResourceProviderRegistrationResource{}
 )
 
 type ResourceProviderRegistrationResource struct{}
@@ -49,11 +48,6 @@ const (
 	NotRegistered = "NotRegistered"
 	Unregistered  = "Unregistered"
 )
-
-func (r ResourceProviderRegistrationResource) DeprecationMessage() string {
-	// TODO: Remove this resource in v4.0
-	return "The `azurerm_resource_provider_registration` resource has been deprecated and will be removed in v4.0 of the provider. Please instead use the `resource_providers_to_register` provider property to register additional Resource Providers, or use the `azurerm_preview_feature` resource to register Preview Features."
-}
 
 func (r ResourceProviderRegistrationResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Improved handling of resource provider registrations in v4.0

1. Support implicit registration of different sets of resource providers (RPs) and allow users to select a set that best suits their needs, specified in the provider block.
   | Set Name | Description |
   | --- | --- |
   | `core` | A minimal set required for the provider to function and also includes some registered-by-default RPs, will be the default in v5.0 |
   | `extended` | All in core, plus the most commonly used RPs in the provider |
   | `all` | Everything you might possibly want for the entire provider |
   | `none` | An empty set, i.e. do not implicitly register any RPs (same as current `skip_provider_registration = true`) |
   | `legacy` | The current automatically-registered set for compatibility with v3.x, will be the default for v4.x releases and removed in v5.0 |

   Example configuration:

   ```terraform
   provider "azurerm" {
       resource_provider_registrations = "extended"
   }
   ```

2. Support explicit registration of a set of user-provided RPs, specified in the provider block. These would be in addition to the implicit set, whether that is `none` or one of the populated sets. Duplicates are tolerated for user convenience.

   Example configuration:

   ```terraform
   provider "azurerm" {
       resource_provider_registrations = "none"
   
       resource_providers_to_register = [
           "Microsoft.ApiManagement",
           "Microsoft.Compute",
           "Microsoft.KeyVault",
           "Microsoft.Network",
           "Microsoft.Storage",
       ]
   }
   ```

3. Improve user messaging around RP registration, so we can inform when different error conditions occur. Specifically we now explain when a 403 response is received, that the user doesn't have permission(s) to register one or more RPs. The overall user messaging around this should now be more flexible and extendable.


## Test results

(in v3.x and v4.0 mode, respectively)

<img width="687" alt="Screenshot 2024-07-09 at 00 45 45" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/251987/53289c8e-9da9-4fc5-9d6e-9461300d4dce">

## Example messaging for failures

<img width="944" alt="Screenshot 2024-07-10 at 03 00 06" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/251987/9bc806ad-c3ce-4f14-bfc2-68c063d35a24">


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* **provider:** - support the `resource_provider_registrations` and `resource_providers_to_register` provider properties

