### PR TITLE
`azurerm_databricks_workspace` - update default value for `no_public_ip` to `true` in v4.0 of the provider

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -36,7 +36,7 @@ import (
 )
 
 func resourceDatabricksWorkspace() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDatabricksWorkspaceCreateUpdate,
 		Read:   resourceDatabricksWorkspaceRead,
 		Update: resourceDatabricksWorkspaceCreateUpdate,
@@ -159,110 +159,6 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 				ValidateFunc: loadbalancers.ValidateLoadBalancerBackendAddressPoolID,
 			},
 
-			"custom_parameters": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
-				Computed: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"machine_learning_workspace_id": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							ValidateFunc: mlworkspace.ValidateWorkspaceID,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"nat_gateway_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"no_public_ip": {
-							Type:         pluginsdk.TypeBool,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"public_ip_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"public_subnet_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"public_subnet_network_security_group_association_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: azure.ValidateResourceID,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"private_subnet_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"private_subnet_network_security_group_association_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: azure.ValidateResourceID,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"virtual_network_id": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							ValidateFunc: commonids.ValidateVirtualNetworkID,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"storage_account_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: storageValidate.StorageAccountName,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						// Per Service Team: This field is actually changeable so the ForceNew is no longer required, however we agreed to not change the current behavior for consistency purposes
-						"storage_account_sku_name": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-
-						"vnet_address_prefix": {
-							Type:         pluginsdk.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: workspaceCustomParametersString(),
-						},
-					},
-				},
-			},
-
 			"managed_resource_group_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -381,6 +277,221 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 			return nil
 		}),
 	}
+
+	if features.FourPointOhBeta() {
+		resource.Schema["custom_parameters"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"machine_learning_workspace_id": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						ValidateFunc: mlworkspace.ValidateWorkspaceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"nat_gateway_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					// Per Service Team: 'no_public_ip' should now default to 'true'
+					"no_public_ip": {
+						Type:         pluginsdk.TypeBool,
+						Optional:     true,
+						Default:      true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_ip_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_subnet_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_subnet_network_security_group_association_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: azure.ValidateResourceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"private_subnet_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"private_subnet_network_security_group_association_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: azure.ValidateResourceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"virtual_network_id": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						ValidateFunc: commonids.ValidateVirtualNetworkID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"storage_account_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: storageValidate.StorageAccountName,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					// Per Service Team: This field is actually changeable, removing the ForceNew for v4.0
+					"storage_account_sku_name": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"vnet_address_prefix": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+				},
+			},
+		}
+	} else {
+		resource.Schema["custom_parameters"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"machine_learning_workspace_id": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						ValidateFunc: mlworkspace.ValidateWorkspaceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"nat_gateway_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					// NOTE: Adding default 'false' to keep the v3.x behavior consistent
+					// in version 2024-05-01 of the API the default value for the 'no_public_ip'
+					// changed from 'false' to 'true'.
+					"no_public_ip": {
+						Type:         pluginsdk.TypeBool,
+						Optional:     true,
+						Default:      false,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_ip_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_subnet_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"public_subnet_network_security_group_association_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: azure.ValidateResourceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"private_subnet_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"private_subnet_network_security_group_association_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: azure.ValidateResourceID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"virtual_network_id": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						ValidateFunc: commonids.ValidateVirtualNetworkID,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"storage_account_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: storageValidate.StorageAccountName,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					// Per Service Team: This field is actually changeable so the ForceNew is no longer required, however we agreed to not change the current behavior for consistency purposes
+					"storage_account_sku_name": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+
+					"vnet_address_prefix": {
+						Type:         pluginsdk.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Computed:     true,
+						AtLeastOneOf: workspaceCustomParametersString(),
+					},
+				},
+			},
+		}
+	}
+
+	return resource
 }
 
 func resourceDatabricksWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -159,6 +159,108 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 				ValidateFunc: loadbalancers.ValidateLoadBalancerBackendAddressPoolID,
 			},
 
+			"custom_parameters": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
+				Computed: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"machine_learning_workspace_id": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: mlworkspace.ValidateWorkspaceID,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"nat_gateway_name": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"no_public_ip": {
+							Type:         pluginsdk.TypeBool,
+							Optional:     true,
+							Default:      true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"public_ip_name": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"public_subnet_name": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"public_subnet_network_security_group_association_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: azure.ValidateResourceID,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"private_subnet_name": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"private_subnet_network_security_group_association_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: azure.ValidateResourceID,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"virtual_network_id": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: commonids.ValidateVirtualNetworkID,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"storage_account_name": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: storageValidate.StorageAccountName,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"storage_account_sku_name": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+
+						"vnet_address_prefix": {
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: workspaceCustomParametersString(),
+						},
+					},
+				},
+			},
+
 			"managed_resource_group_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -278,215 +380,14 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 		}),
 	}
 
-	if features.FourPointOhBeta() {
-		resource.Schema["custom_parameters"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
-			Computed: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"machine_learning_workspace_id": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						ValidateFunc: mlworkspace.ValidateWorkspaceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"nat_gateway_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					// Per Service Team: 'no_public_ip' should now default to 'true'
-					"no_public_ip": {
-						Type:         pluginsdk.TypeBool,
-						Optional:     true,
-						Default:      true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_ip_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_subnet_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_subnet_network_security_group_association_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: azure.ValidateResourceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"private_subnet_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"private_subnet_network_security_group_association_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: azure.ValidateResourceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"virtual_network_id": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						ValidateFunc: commonids.ValidateVirtualNetworkID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"storage_account_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						ValidateFunc: storageValidate.StorageAccountName,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					// Per Service Team: This field is actually changeable, removing the ForceNew for v4.0
-					"storage_account_sku_name": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"vnet_address_prefix": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-				},
-			},
-		}
-	} else {
-		resource.Schema["custom_parameters"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			// NOTE: O+C The API populates these and since many are ForceNew there doesn't appear to be a need to remove this once set to use the defaults
-			Computed: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"machine_learning_workspace_id": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						ValidateFunc: mlworkspace.ValidateWorkspaceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"nat_gateway_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					// NOTE: Leaving this as O+C as the 2024-05-01 API breaking change was accidentally introduced in PR #25919
-					// and released in v3.104.0 of the provider...
-					"no_public_ip": {
-						Type:         pluginsdk.TypeBool,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_ip_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_subnet_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"public_subnet_network_security_group_association_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: azure.ValidateResourceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"private_subnet_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"private_subnet_network_security_group_association_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: azure.ValidateResourceID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"virtual_network_id": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						ValidateFunc: commonids.ValidateVirtualNetworkID,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"storage_account_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						ValidateFunc: storageValidate.StorageAccountName,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					// Per Service Team: This field is actually changeable so the ForceNew is no longer required, however we agreed to not change the current behavior for consistency purposes
-					"storage_account_sku_name": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-
-					"vnet_address_prefix": {
-						Type:         pluginsdk.TypeString,
-						ForceNew:     true,
-						Optional:     true,
-						Computed:     true,
-						AtLeastOneOf: workspaceCustomParametersString(),
-					},
-				},
-			},
+	if !features.FourPointOhBeta() {
+		// NOTE: Leaving this as O+C as the 2024-05-01 API breaking change was accidentally introduced in PR #25919
+		// and released in v3.104.0 of the provider...
+		resource.Schema["custom_parameters"].Elem.(*pluginsdk.Resource).Schema["no_public_ip"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeBool,
+			Optional:     true,
+			Computed:     true,
+			AtLeastOneOf: workspaceCustomParametersString(),
 		}
 	}
 

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -407,13 +407,12 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 						AtLeastOneOf: workspaceCustomParametersString(),
 					},
 
-					// NOTE: Adding default 'false' to keep the v3.x behavior consistent
-					// in version 2024-05-01 of the API the default value for the 'no_public_ip'
-					// changed from 'false' to 'true'.
+					// NOTE: Leaving this as O+C as the 2024-05-01 API breaking change was accidentally introduced in PR #25919
+					// and released in v3.104.0 of the provider...
 					"no_public_ip": {
 						Type:         pluginsdk.TypeBool,
 						Optional:     true,
-						Default:      false,
+						Computed:     true,
 						AtLeastOneOf: workspaceCustomParametersString(),
 					},
 

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -1196,6 +1196,7 @@ resource "azurerm_databricks_workspace" "test" {
   sku                 = "%[3]s"
 
   custom_parameters {
+    no_public_ip                  = false
     machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   }
 }

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -102,6 +102,8 @@ A `custom_parameters` block supports the following:
 
 ~> **Note:** Updating `no_public_ip` parameter is only allowed if the value is changing from `false` to `true` and and only for VNet-injected workspaces.
 
+~> **Note:** In v4.0 of the provider the `no_public_ip` parameter will default to `true` instead of `false`.
+
 * `public_subnet_name` - (Optional) The name of the Public Subnet within the Virtual Network. Required if `virtual_network_id` is set. Changing this forces a new resource to be created.
 
 * `public_subnet_network_security_group_association_id` - (Optional) The resource ID of the `azurerm_subnet_network_security_group_association` resource which is referred to by the `public_subnet_name` field. This is the same as the ID of the subnet referred to by the `public_subnet_name` field. Required if `virtual_network_id` is set.
@@ -113,6 +115,8 @@ A `custom_parameters` block supports the following:
 * `storage_account_name` - (Optional) Default Databricks File Storage account name. Defaults to a randomized name(e.g. `dbstoragel6mfeghoe5kxu`). Changing this forces a new resource to be created.
 
 * `storage_account_sku_name` - (Optional) Storage account SKU name. Possible values include `Standard_LRS`, `Standard_GRS`, `Standard_RAGRS`, `Standard_GZRS`, `Standard_RAGZRS`, `Standard_ZRS`, `Premium_LRS` or `Premium_ZRS`. Defaults to `Standard_GRS`. Changing this forces a new resource to be created.
+
+~> **Note:** In v4.0 of the provider changing the `storage_account_sku_name` parameter will no longer cause a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of a Virtual Network where this Databricks Cluster should be created. Changing this forces a new resource to be created.
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -102,7 +102,7 @@ A `custom_parameters` block supports the following:
 
 ~> **Note:** Updating `no_public_ip` parameter is only allowed if the value is changing from `false` to `true` and and only for VNet-injected workspaces.
 
-~> **Note:** In v4.0 of the provider the `no_public_ip` parameter will default to `true` instead of `false`.
+~> **Note:** In `v3.104.0` and higher of the provider the `no_public_ip` parameter will now default to `true` instead of `false`.
 
 * `public_subnet_name` - (Optional) The name of the Public Subnet within the Virtual Network. Required if `virtual_network_id` is set. Changing this forces a new resource to be created.
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -100,7 +100,7 @@ A `custom_parameters` block supports the following:
 
 * `no_public_ip` - (Optional) Are public IP Addresses not allowed? Possible values are `true` or `false`. Defaults to `false`.
 
-~> **Note:** Updating `no_public_ip` parameter is only allowed if the value is changing from `false` to `true` and and only for VNet-injected workspaces.
+~> **Note:** Updating `no_public_ip` parameter is only allowed if the value is changing from `false` to `true` and only for VNet-injected workspaces.
 
 ~> **Note:** In `v3.104.0` and higher of the provider the `no_public_ip` parameter will now default to `true` instead of `false`.
 
@@ -114,9 +114,7 @@ A `custom_parameters` block supports the following:
 
 * `storage_account_name` - (Optional) Default Databricks File Storage account name. Defaults to a randomized name(e.g. `dbstoragel6mfeghoe5kxu`). Changing this forces a new resource to be created.
 
-* `storage_account_sku_name` - (Optional) Storage account SKU name. Possible values include `Standard_LRS`, `Standard_GRS`, `Standard_RAGRS`, `Standard_GZRS`, `Standard_RAGZRS`, `Standard_ZRS`, `Premium_LRS` or `Premium_ZRS`. Defaults to `Standard_GRS`. Changing this forces a new resource to be created.
-
-~> **Note:** In v4.0 of the provider changing the `storage_account_sku_name` parameter will no longer cause a new resource to be created.
+* `storage_account_sku_name` - (Optional) Storage account SKU name. Possible values include `Standard_LRS`, `Standard_GRS`, `Standard_RAGRS`, `Standard_GZRS`, `Standard_RAGZRS`, `Standard_ZRS`, `Premium_LRS` or `Premium_ZRS`. Defaults to `Standard_GRS`.
 
 * `virtual_network_id` - (Optional) The ID of a Virtual Network where this Databricks Cluster should be created. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The Microsoft Terraform provider team received a request from the databricks service team to onboard their new API version `2024-05-01` which includes a **breaking change** which was approved by Microsoft's Breaking Change review board (see [API Spec PR](https://github.com/Azure/azure-rest-api-specs/pull/28156) for details) in v4.0 of the provider (e.g., As part of new API version `2024-05-01`, creation of databrick workspaces by default will have `"enableNoPublicIp": { "type": "Bool", "value": true }`). That said this [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/25919) was opened on May 11, 2024, which upgraded the databricks API to the `2024-05-01` to expose the `default_storage_firewall_enabled` property that was requested in issue #25899 and released in `v3.104.0` of the provider. In doing so, that [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/25919) accidentally pulled in the **breaking change** to the `azurerm_databricks_workspace` resource where the `no_public_ip` property switches it's `default` value from `false` to `true`. In the current provider, the `no_public_ip` property is defined as an `optional` + `computed` field in the schema, which complicates this further because now the Terraform documentation is incorrect depending on what version of the provider you are using.

| Provider Version | `no_public_ip` value |
| ------------------ | --------------------- |
|  < `v3.104.0`       |  `false`                      |
| >= `v3.104.0`      | `true`                       |
| `v4.x`                   | `true`                       |

This can be very confusing for our customers and I am not sure of the correct way out of this situation. This PR is attempting to preserve the < `v3.104.0` provider behavior for consistency, but if the end user is using a  >= `v3.104.0` provider this would result in a diff.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or data source changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="377" alt="image" src="https://github.com/user-attachments/assets/c7b57cb6-4500-4ae0-a7c8-ae4623bf314f">


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_databricks_workspace` - update default value for `no_public_ip` to `true` in v4.0 of the provider 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (e.g., adding a service, resource, or data source)
- [X] Enhancement
- [X] Breaking Change


## Related Issue(s)
N/A


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
