### PR TITLE
`azurerm_data_factory_integration_runtime_azure` - remove `Computed` from `cleanup_enabled`

### DIFF
--- a/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
@@ -274,11 +274,10 @@ func expandDataFactoryIntegrationRuntimeAzureComputeProperties(d *pluginsdk.Reso
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	coreCount := int32(d.Get("core_count").(int))
 	timeToLiveMin := int32(d.Get("time_to_live_min").(int))
-	cleanup := true
-	// nolint staticcheck
-	if v, ok := d.GetOkExists("cleanup_enabled"); ok {
-		cleanup = v.(bool)
-	}
+
+	var cleanup bool
+	cleanup = d.Get("cleanup_enabled").(bool)
+
 	return &datafactory.IntegrationRuntimeComputeProperties{
 		Location: &location,
 		DataFlowProperties: &datafactory.IntegrationRuntimeDataFlowProperties{

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
@@ -22,7 +22,7 @@ import (
 )
 
 func resourceDataFactoryIntegrationRuntimeAzure() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDataFactoryIntegrationRuntimeAzureCreateUpdate,
 		Read:   resourceDataFactoryIntegrationRuntimeAzureRead,
 		Update: resourceDataFactoryIntegrationRuntimeAzureCreateUpdate,
@@ -78,7 +78,7 @@ func resourceDataFactoryIntegrationRuntimeAzure() *pluginsdk.Resource {
 			"cleanup_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Computed: true, // Defaults to true
+				Default:  true,
 			},
 
 			"compute_type": {
@@ -114,6 +114,8 @@ func resourceDataFactoryIntegrationRuntimeAzure() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	return resource
 }
 
 func resourceDataFactoryIntegrationRuntimeAzureCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
@@ -284,11 +284,10 @@ func expandDataFactoryIntegrationRuntimeAzureComputeProperties(d *pluginsdk.Reso
 	coreCount := int32(d.Get("core_count").(int))
 	timeToLiveMin := int32(d.Get("time_to_live_min").(int))
 
-	var cleanup bool
+	cleanup := true
 	if features.FourPointOhBeta() {
 		cleanup = d.Get("cleanup_enabled").(bool)
 	} else {
-		cleanup = true
 		// nolint staticcheck
 		if v, ok := d.GetOkExists("cleanup_enabled"); ok {
 			cleanup = v.(bool)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
The `cleanup_enabled` is introduced by this [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/13222/files#diff-a6b52427901543cc50c2f2f87d94ea81ef47ea1581c9507b4b72468888adc9b5). This [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/13222/files#diff-a6b52427901543cc50c2f2f87d94ea81ef47ea1581c9507b4b72468888adc9b5) sets the default value "true" in the create operation and adds Computed to omit the difference. I think it's incorrect and we should set the default value in the property schema.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/5ca20be1-d196-49cc-8efe-41ac81e8cdf9)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_integration_runtime_azure` - remove `Computed` from `cleanup_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
