### PR TITLE
`azurerm_security_center_storage_defender`: add `scan_results_event_grid_topic_id` property

### DIFF
--- a/internal/services/securitycenter/security_center_storage_defender_resource.go
+++ b/internal/services/securitycenter/security_center_storage_defender_resource.go
@@ -6,6 +6,7 @@ package securitycenter
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -82,9 +83,9 @@ func (s StorageDefenderResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"scan_results_event_grid_topic_id": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  false,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: azure.ValidateResourceID,
 		},
 	}
 }

--- a/internal/services/securitycenter/security_center_storage_defender_resource.go
+++ b/internal/services/securitycenter/security_center_storage_defender_resource.go
@@ -6,8 +6,9 @@ package securitycenter
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"

--- a/internal/services/securitycenter/security_center_storage_defender_resource.go
+++ b/internal/services/securitycenter/security_center_storage_defender_resource.go
@@ -27,6 +27,7 @@ type StorageDefenderModel struct {
 	MalwareScanningOnUploadEnabled   bool   `tfschema:"malware_scanning_on_upload_enabled"`
 	MalwareScanningOnUploadCapPerMon int64  `tfschema:"malware_scanning_on_upload_cap_gb_per_month"`
 	SensitiveDataDiscoveryEnabled    bool   `tfschema:"sensitive_data_discovery_enabled"`
+	ScanResultsEventGridTopicId      string `tfschema:"scan_results_event_grid_topic_id"`
 }
 
 var _ sdk.ResourceWithUpdate = StorageDefenderResource{}
@@ -79,6 +80,12 @@ func (s StorageDefenderResource) Arguments() map[string]*schema.Schema {
 			Optional: true,
 			Default:  false,
 		},
+
+		"scan_results_event_grid_topic_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  false,
+		},
 	}
 }
 
@@ -120,6 +127,7 @@ func (s StorageDefenderResource) Create() sdk.ResourceFunc {
 							IsEnabled:     pointer.To(plan.MalwareScanningOnUploadEnabled),
 							CapGBPerMonth: pointer.To(plan.MalwareScanningOnUploadCapPerMon),
 						},
+						ScanResultsEventGridTopicResourceId: pointer.To(plan.ScanResultsEventGridTopicId),
 					},
 					SensitiveDataDiscovery: &defenderforstorage.SensitiveDataDiscoveryProperties{
 						IsEnabled: pointer.To(plan.SensitiveDataDiscoveryEnabled),
@@ -189,6 +197,10 @@ func (s StorageDefenderResource) Update() sdk.ResourceFunc {
 				prop.MalwareScanning.OnUpload.CapGBPerMonth = pointer.To(plan.MalwareScanningOnUploadCapPerMon)
 			}
 
+			if metadata.ResourceData.HasChange("scan_results_event_grid_topic_id") {
+				prop.MalwareScanning.ScanResultsEventGridTopicResourceId = pointer.To(plan.ScanResultsEventGridTopicId)
+			}
+
 			if prop.SensitiveDataDiscovery == nil {
 				prop.SensitiveDataDiscovery = &defenderforstorage.SensitiveDataDiscoveryProperties{}
 			}
@@ -251,6 +263,7 @@ func (s StorageDefenderResource) Read() sdk.ResourceFunc {
 							state.MalwareScanningOnUploadEnabled = pointer.From(onUpload.IsEnabled)
 							state.MalwareScanningOnUploadCapPerMon = pointer.From(onUpload.CapGBPerMonth)
 						}
+						state.ScanResultsEventGridTopicId = pointer.From(ms.ScanResultsEventGridTopicResourceId)
 					}
 
 					if sdd := prop.SensitiveDataDiscovery; sdd != nil {

--- a/internal/services/securitycenter/security_center_storage_defender_resource.go
+++ b/internal/services/securitycenter/security_center_storage_defender_resource.go
@@ -126,12 +126,19 @@ func (s StorageDefenderResource) Create() sdk.ResourceFunc {
 							IsEnabled:     pointer.To(plan.MalwareScanningOnUploadEnabled),
 							CapGBPerMonth: pointer.To(plan.MalwareScanningOnUploadCapPerMon),
 						},
-						ScanResultsEventGridTopicResourceId: pointer.To(plan.ScanResultsEventGridTopicId),
 					},
 					SensitiveDataDiscovery: &defenderforstorage.SensitiveDataDiscoveryProperties{
 						IsEnabled: pointer.To(plan.SensitiveDataDiscoveryEnabled),
 					},
 				},
+			}
+
+			if plan.ScanResultsEventGridTopicId != "" {
+				topicId, err := topics.ParseTopicID(plan.ScanResultsEventGridTopicId)
+				if err != nil {
+					return err
+				}
+				input.Properties.MalwareScanning.ScanResultsEventGridTopicResourceId = pointer.To(topicId.ID())
 			}
 
 			_, err = client.Create(ctx, id, input)

--- a/website/docs/r/security_center_storage_defender.html.markdown
+++ b/website/docs/r/security_center_storage_defender.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `malware_scanning_on_upload_cap_gb_per_month` - (Optional) The max GB to be scanned per Month. Must be `-1` or above `0`. Omit this property or set to `-1` if no capping is needed. Defaults to `-1`.
 
+* `scan_results_event_grid_topic_id` - (Optional) Event Grid Topic where every scan result will be sent. When you set an Event Grid custom topic, you should set `override_subscription_settings_enabled` to `true` make sure it overrides the subscription-level settings.
+
 * `sensitive_data_discovery_enabled` - (Optional) Whether Sensitive Data Discovery should be enabled. Defaults to `false`.
  
 ## Attributes Reference


### PR DESCRIPTION
Add  `scan_results_event_grid_topic_id` property to `azurerm_security_center_storage_defender` resource.

Closes: #23607

(The Github issue has an additional comment asking for the `scan_results_log_analytics_workspace_id` property as well. This is not included in this PR, because the current API-Version does not support that. It would involve an API-Version upgrade, which can be done separated from this change.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_security_center_storage_defender`: add `scan_results_event_grid_topic_id` property [GH-23607]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23607


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
