### PR TITLE
`azurerm_redis_cache` - review optional and computed

### DIFF
--- a/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource_test.go
@@ -93,14 +93,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = true
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_access_policy_resource_test.go
+++ b/internal/services/redis/redis_cache_access_policy_resource_test.go
@@ -123,14 +123,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = true
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
   }
@@ -159,14 +159,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = true
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
   }

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -157,8 +157,7 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 							Computed:  true,
 							Sensitive: true,
 						},
-						// TODO 4.0: change this from enable_* to *_enabled
-						"enable_authentication": {
+						"authentication_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
@@ -242,8 +241,15 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		resource.Schema["enable_non_ssl_port"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+			Deprecated: "`enable_non_ssl_port` will be removed in favour of the property `non_ssl_port_enabled` in version 4.0 of the AzureRM Provider.",
+		}
+		resource.Schema["redis_configuration"].Elem.(*pluginsdk.Resource).Schema["enable_authentication"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Default:    true,
+			Deprecated: "`enable_authentication` will be removed in favour of the property `authentication_enabled` in version 4.0 of the AzureRM Provider.",
 		}
 	}
 

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/patchschedules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2023-08-01/redis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -67,6 +68,11 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 
 			// TODO 4.0: change this from enable_* to *_enabled
 			"enable_non_ssl_port": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"non_ssl_port_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
@@ -294,7 +300,12 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 		}
 		d.Set("minimum_tls_version", minimumTlsVersion)
 		d.Set("port", props.Port)
-		d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+		d.Set("non_ssl_port_enabled", props.EnableNonSslPort)
+
+		if !features.FourPointOhBeta() {
+			d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+		}
+
 		shardCount := 0
 		if props.ShardCount != nil {
 			shardCount = int(*props.ShardCount)

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -22,7 +22,7 @@ import (
 )
 
 func dataSourceRedisCache() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Read: dataSourceRedisCacheRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -63,12 +63,6 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 
 			"shard_count": {
 				Type:     pluginsdk.TypeInt,
-				Computed: true,
-			},
-
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_non_ssl_port": {
-				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
 
@@ -245,6 +239,15 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["enable_non_ssl_port"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		}
+	}
+
+	return resource
 }
 
 func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/migration"
@@ -43,7 +44,7 @@ var skuWeight = map[string]int8{
 }
 
 func resourceRedisCache() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceRedisCacheCreate,
 		Read:   resourceRedisCacheRead,
 		Update: resourceRedisCacheUpdate,
@@ -84,11 +85,9 @@ func resourceRedisCache() *pluginsdk.Resource {
 			},
 
 			"family": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				// TODO: this should become case-sensitive in v4.0 (true -> false and remove DiffSupressFunc)
-				ValidateFunc:     validation.StringInSlice(redis.PossibleValuesForSkuFamily(), true),
-				DiffSuppressFunc: suppress.CaseDifference,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(redis.PossibleValuesForSkuFamily(), false),
 			},
 
 			"sku_name": {
@@ -117,8 +116,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 				Optional: true,
 			},
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_non_ssl_port": {
+			"non_ssl_port_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Default:  false,
 				Optional: true,
@@ -134,6 +132,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"private_static_ip_address": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				// NOTE O+C: in some cases this gets a default value if omitted. This can remain o+c as it is ForceNew and cannot be updated
 				Computed: true,
 				ForceNew: true,
 			},
@@ -157,12 +156,14 @@ func resourceRedisCache() *pluginsdk.Resource {
 						"maxmemory_delta": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
+							// Note: O+C this gets a variable default based on the cache's total memory. This can remain O+C as it can be updated without issue
 							Computed: true,
 						},
 
 						"maxmemory_reserved": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
+							// Note: O+C this gets a variable default based on the cache's total memory. This can remain O+C as it can be updated without issue
 							Computed: true,
 						},
 
@@ -176,6 +177,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 						"maxfragmentationmemory_reserved": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
+							// Note: O+C this gets a variable default based on the cache's total memory. This can remain O+C as it can be updated without issue
 							Computed: true,
 						},
 
@@ -232,8 +234,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Optional:  true,
 							Sensitive: true,
 						},
-						// TODO 4.0: change this from enable_* to *_enabled
-						"enable_authentication": {
+						"authentication_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  true,
@@ -325,6 +326,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"replicas_per_master": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
+				// NOTE: O+C returns a value when `replicas_per_primary` is set - this can remain as there is no issue updating it
 				Computed: true,
 				// Can't make more than 3 replicas in portal, assuming it's a limitation
 				ValidateFunc: validation.IntBetween(1, 3),
@@ -333,8 +335,9 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"replicas_per_primary": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				// NOTE: O+C returns a value when `replicas_per_master` is set - this can remain as there is no issue updating it
 				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 3),
 			},
@@ -350,7 +353,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"redis_version": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      6,
 				ValidateFunc: validation.StringInSlice([]string{"4", "6"}, false),
 				DiffSuppressFunc: func(_, old, new string, _ *pluginsdk.ResourceData) bool {
 					n := strings.Split(old, ".")
@@ -375,6 +378,83 @@ func resourceRedisCache() *pluginsdk.Resource {
 			}),
 		),
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["family"] = &pluginsdk.Schema{
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validation.StringInSlice(redis.PossibleValuesForSkuFamily(), true),
+			DiffSuppressFunc: suppress.CaseDifference,
+		}
+
+		resource.Schema["enable_non_ssl_port"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Default:       false,
+			Optional:      true,
+			ConflictsWith: []string{"non_ssl_port_enabled"},
+			Deprecated:    "`enable_non_ssl_port` will be removed in favour of the property `non_ssl_port_enabled` in version 4.0 of the AzureRM Provider.",
+		}
+
+		resource.Schema["non_ssl_port_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Computed:      true,
+			Optional:      true,
+			ConflictsWith: []string{"enable_non_ssl_port"},
+		}
+
+		resource.Schema["redis_configuration"].Elem.(*pluginsdk.Resource).Schema["enable_authentication"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Default:       true,
+			ConflictsWith: []string{"redis_configuration.0.authentication_enabled"},
+			Deprecated:    "`enable_authentication` will be removed in favour of the property `authentication_enabled` in version 4.0 of the AzureRM Provider.",
+		}
+
+		resource.Schema["redis_configuration"].Elem.(*pluginsdk.Resource).Schema["authentication_enabled"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"redis_configuration.0.enable_authentication"},
+		}
+
+		resource.Schema["non_ssl_port_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+			Optional: true,
+		}
+
+		resource.Schema["replicas_per_master"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Computed: true,
+			// Can't make more than 3 replicas in portal, assuming it's a limitation
+			ValidateFunc: validation.IntBetween(1, 3),
+		}
+
+		resource.Schema["replicas_per_primary"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(1, 3),
+		}
+
+		resource.Schema["redis_version"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringInSlice([]string{"4", "6"}, false),
+			DiffSuppressFunc: func(_, old, new string, _ *pluginsdk.ResourceData) bool {
+				n := strings.Split(old, ".")
+				if len(n) >= 1 {
+					newMajor := n[0]
+					return new == newMajor
+				}
+				return false
+			},
+		}
+	}
+
+	return resource
 }
 
 func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -411,10 +491,15 @@ func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf(`expanding "identity": %v`, err)
 	}
 
+	enableNonSslPort := d.Get("non_ssl_port_enabled")
+	if v, ok := d.GetOk("enable_non_ssl_port"); ok && !features.FourPointOhBeta() {
+		enableNonSslPort = v
+	}
+
 	parameters := redis.RedisCreateParameters{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: redis.RedisCreateProperties{
-			EnableNonSslPort: pointer.To(d.Get("enable_non_ssl_port").(bool)),
+			EnableNonSslPort: pointer.To(enableNonSslPort.(bool)),
 			Sku: redis.Sku{
 				Capacity: int64(d.Get("capacity").(int)),
 				Family:   redis.SkuFamily(d.Get("family").(string)),
@@ -518,7 +603,10 @@ func resourceRedisCacheUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	enableNonSSLPort := d.Get("enable_non_ssl_port").(bool)
+	enableNonSslPort := d.Get("non_ssl_port_enabled")
+	if v, ok := d.GetOk("enable_non_ssl_port"); ok && !features.FourPointOhBeta() {
+		enableNonSslPort = v
+	}
 
 	t := d.Get("tags").(map[string]interface{})
 	expandedTags := tags.Expand(t)
@@ -526,7 +614,7 @@ func resourceRedisCacheUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	parameters := redis.RedisUpdateParameters{
 		Properties: &redis.RedisUpdateProperties{
 			MinimumTlsVersion: pointer.To(redis.TlsVersion(d.Get("minimum_tls_version").(string))),
-			EnableNonSslPort:  utils.Bool(enableNonSSLPort),
+			EnableNonSslPort:  pointer.To(enableNonSslPort.(bool)),
 			Sku: &redis.Sku{
 				Capacity: int64(d.Get("capacity").(int)),
 				Family:   redis.SkuFamily(d.Get("family").(string)),
@@ -702,7 +790,12 @@ func resourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 		d.Set("minimum_tls_version", minimumTlsVersion)
 		d.Set("port", props.Port)
-		d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+
+		d.Set("non_ssl_port_enabled", props.EnableNonSslPort)
+		if !features.FourPointOhBeta() {
+			d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+		}
+
 		shardCount := 0
 		if props.ShardCount != nil {
 			shardCount = int(*props.ShardCount)
@@ -862,12 +955,12 @@ func expandRedisConfiguration(d *pluginsdk.ResourceData) (*redis.RedisCommonProp
 		if strings.EqualFold(skuName, string(redis.SkuNamePremium)) {
 			if rdbBackupEnabled {
 				if connStr := raw["rdb_storage_connection_string"].(string); connStr == "" {
-					return nil, fmt.Errorf("The rdb_storage_connection_string property must be set when rdb_backup_enabled is true")
+					return nil, fmt.Errorf("the rdb_storage_connection_string property must be set when rdb_backup_enabled is true")
 				}
 			}
 			output.RdbBackupEnabled = utils.String(strconv.FormatBool(rdbBackupEnabled))
 		} else if rdbBackupEnabled && !strings.EqualFold(skuName, string(redis.SkuNamePremium)) {
-			return nil, fmt.Errorf("The `rdb_backup_enabled` property requires a `Premium` sku to be set")
+			return nil, fmt.Errorf("the `rdb_backup_enabled` property requires a `Premium` sku to be set")
 		}
 	}
 
@@ -904,11 +997,16 @@ func expandRedisConfiguration(d *pluginsdk.ResourceData) (*redis.RedisCommonProp
 	if v := raw["aof_storage_connection_string_1"].(string); v != "" {
 		output.AofStorageConnectionString1 = utils.String(v)
 	}
-	authEnabled := raw["enable_authentication"].(bool)
+
+	authEnabled := raw["authentication_enabled"].(bool)
+	if v, ok := raw["enable_authentication"]; ok && !features.FourPointOhBeta() {
+		authEnabled = v.(bool)
+	}
+
 	// Redis authentication can only be disabled if it is launched inside a VNET.
 	if _, isPrivate := d.GetOk("subnet_id"); !isPrivate {
 		if !authEnabled {
-			return nil, fmt.Errorf("Cannot set `enable_authentication` to `false` when `subnet_id` is not set")
+			return nil, fmt.Errorf("cannot set `authentication_enabled` or `enable_authentication` to `false` when `subnet_id` is not set")
 		}
 	} else {
 		value := isAuthNotRequiredAsString(authEnabled)
@@ -1061,9 +1159,17 @@ func flattenRedisConfiguration(input *redis.RedisCommonPropertiesRedisConfigurat
 	}
 
 	// `authnotrequired` is not set for instances launched outside a VNET
-	outputs["enable_authentication"] = true
+	outputs["authentication_enabled"] = true
 	if v := input.Authnotrequired; v != nil {
-		outputs["enable_authentication"] = isAuthRequiredAsBool(*v)
+		outputs["authentication_enabled"] = isAuthRequiredAsBool(*v)
+	}
+
+	if !features.FourPointOhBeta() {
+		// `authnotrequired` is not set for instances launched outside a VNET
+		outputs["enable_authentication"] = true
+		if v := input.Authnotrequired; v != nil {
+			outputs["enable_authentication"] = isAuthRequiredAsBool(*v)
+		}
 	}
 
 	outputs["storage_account_subscription_id"] = pointer.From(input.StorageSubscriptionId)

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -434,7 +434,7 @@ func TestAccRedisCache_WithoutAuth(t *testing.T) {
 			Config: r.withoutAuth(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("redis_configuration.0.enable_authentication").HasValue("false"),
+				check.That(data.ResourceName).Key("redis_configuration.0.authentication_enabled").HasValue("false"),
 			),
 		},
 	})
@@ -1339,7 +1339,7 @@ resource "azurerm_redis_cache" "test" {
   non_ssl_port_enabled = false
   subnet_id            = azurerm_subnet.test.id
   redis_configuration {
-    enable_authentication = false
+    authentication_enabled = false
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -578,11 +577,6 @@ func (t RedisCacheResource) Exists(ctx context.Context, clients *clients.Client,
 
 func (RedisCacheResource) basic(data acceptance.TestData, requireSSL bool) string {
 
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -594,27 +588,22 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  %s                  = %t
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = %t
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl, !requireSSL)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, !requireSSL)
 }
 
 func (RedisCacheResource) managedIdentityAuth(data acceptance.TestData, requireSSL bool) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -626,51 +615,43 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  %s                  = %t
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = %t
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
     data_persistence_authentication_method = "ManagedIdentity"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl, !requireSSL)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, !requireSSL)
 }
 
 func (RedisCacheResource) requiresImport(data acceptance.TestData) string {
 	template := RedisCacheResource{}.basic(data, true)
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_redis_cache" "import" {
-  name                = azurerm_redis_cache.test.name
-  location            = azurerm_redis_cache.test.location
-  resource_group_name = azurerm_redis_cache.test.resource_group_name
-  capacity            = azurerm_redis_cache.test.capacity
-  family              = azurerm_redis_cache.test.family
-  sku_name            = azurerm_redis_cache.test.sku_name
-  %s                  = azurerm_redis_cache.test.%s
+  name                 = azurerm_redis_cache.test.name
+  location             = azurerm_redis_cache.test.location
+  resource_group_name  = azurerm_redis_cache.test.resource_group_name
+  capacity             = azurerm_redis_cache.test.capacity
+  family               = azurerm_redis_cache.test.family
+  sku_name             = azurerm_redis_cache.test.sku_name
+  non_ssl_port_enabled = azurerm_redis_cache.test.non_ssl_port_enabled
 
   redis_configuration {
   }
 }
-`, template, enableNonSsl, enableNonSsl)
+`, template)
 }
 
 func (RedisCacheResource) standard(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -682,13 +663,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Standard"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Standard"
+  non_ssl_port_enabled = false
   redis_configuration {
   }
 
@@ -696,15 +677,10 @@ resource "azurerm_redis_cache" "test" {
     environment = "production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) premium(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -716,13 +692,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     maxmemory_reserved              = 642
@@ -731,14 +707,10 @@ resource "azurerm_redis_cache" "test" {
     maxmemory_policy                = "allkeys-lru"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) premiumSharded(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -750,14 +722,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = true
-  shard_count         = 3
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = true
+  shard_count          = 3
 
   redis_configuration {
     maxmemory_reserved              = 642
@@ -766,15 +738,10 @@ resource "azurerm_redis_cache" "test" {
     maxmemory_policy                = "allkeys-lru"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) premiumShardedScaled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -786,14 +753,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 2
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = true
-  shard_count         = 3
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 2
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = true
+  shard_count          = 3
 
   redis_configuration {
     maxmemory_reserved              = 1328
@@ -802,15 +769,10 @@ resource "azurerm_redis_cache" "test" {
     maxmemory_policy                = "allkeys-lru"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) aadEnabled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -828,21 +790,17 @@ resource "azurerm_redis_cache" "test" {
   capacity                      = 3
   family                        = "P"
   sku_name                      = "Premium"
-  %s                            = false
+  non_ssl_port_enabled          = false
   public_network_access_enabled = false
 
   redis_configuration {
     active_directory_authentication_enabled = true
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) backupDisabled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -890,13 +848,13 @@ resource "azurerm_storage_account" "test3" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     rdb_backup_enabled              = false
@@ -905,15 +863,10 @@ resource "azurerm_redis_cache" "test" {
     aof_storage_connection_string_1 = azurerm_storage_account.test3.primary_connection_string
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (RedisCacheResource) backupEnabled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -937,13 +890,13 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     rdb_backup_enabled              = true
@@ -953,15 +906,10 @@ resource "azurerm_redis_cache" "test" {
     storage_account_subscription_id = "%s"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, enableNonSsl, data.Client().SubscriptionID)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.Client().SubscriptionID)
 }
 
 func (RedisCacheResource) aofBackupDisabled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1009,13 +957,13 @@ resource "azurerm_storage_account" "test3" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     aof_backup_enabled            = false
@@ -1025,15 +973,10 @@ resource "azurerm_redis_cache" "test" {
     rdb_storage_connection_string = azurerm_storage_account.test3.primary_connection_string
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (RedisCacheResource) aofBackupEnabled(data acceptance.TestData) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1069,13 +1012,13 @@ resource "azurerm_storage_account" "test2" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     aof_backup_enabled              = true
@@ -1083,15 +1026,10 @@ resource "azurerm_redis_cache" "test" {
     aof_storage_connection_string_1 = azurerm_storage_account.test2.primary_connection_string
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (RedisCacheResource) ignoreAOFBackupEnableWhenSKUNotPremium(data acceptance.TestData, maxMemoryPolicy string) string {
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1127,13 +1065,13 @@ resource "azurerm_storage_account" "test2" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     aof_backup_enabled = false
@@ -1142,16 +1080,10 @@ resource "azurerm_redis_cache" "test" {
     maxmemory_policy   = "%s"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, enableNonSsl, maxMemoryPolicy)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, maxMemoryPolicy)
 }
 
 func (RedisCacheResource) patchSchedule(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1163,13 +1095,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     maxmemory_reserved = 642
@@ -1183,16 +1115,10 @@ resource "azurerm_redis_cache" "test" {
     maintenance_window = "PT7H"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) publicNetworkAccessDisabled(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1211,19 +1137,13 @@ resource "azurerm_redis_cache" "test" {
   family                        = "C"
   sku_name                      = "Basic"
   minimum_tls_version           = "1.2"
-  %s                            = false
+  non_ssl_port_enabled          = false
   public_network_access_enabled = false
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) subscribeAllEvents(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1247,28 +1167,22 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
 
   redis_configuration {
     notify_keyspace_events = "KAE"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func (RedisCacheResource) internalSubnet(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1294,27 +1208,21 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  subnet_id           = azurerm_subnet.test.id
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
+  subnet_id            = azurerm_subnet.test.id
   redis_configuration {
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (RedisCacheResource) internalSubnetStaticIP(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1346,22 +1254,16 @@ resource "azurerm_redis_cache" "test" {
   capacity                  = 1
   family                    = "P"
   sku_name                  = "Premium"
-  %s                        = false
+  non_ssl_port_enabled      = false
   subnet_id                 = azurerm_subnet.test.id
   private_static_ip_address = "10.0.1.20"
   redis_configuration {
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (RedisCacheResource) internalSubnet_withZone(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1387,28 +1289,22 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  subnet_id           = azurerm_subnet.test.id
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
+  subnet_id            = azurerm_subnet.test.id
   redis_configuration {
   }
   zones = ["1"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (RedisCacheResource) withoutAuth(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1434,58 +1330,22 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  subnet_id           = azurerm_subnet.test.id
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
+  subnet_id            = azurerm_subnet.test.id
   redis_configuration {
     enable_authentication = false
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (RedisCacheResource) replicasPerMaster(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-redis-%d"
-  location = "%s"
-}
-
-resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  replicas_per_master = 3
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
-}
-
-func (RedisCacheResource) replicasPerPrimary(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1503,19 +1363,37 @@ resource "azurerm_redis_cache" "test" {
   capacity             = 3
   family               = "P"
   sku_name             = "Premium"
-  %s                   = false
+  non_ssl_port_enabled = false
+  replicas_per_master  = 3
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RedisCacheResource) replicasPerPrimary(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-redis-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
   replicas_per_primary = 3
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) redisVersion(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1527,25 +1405,19 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  redis_version       = "6"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
+  redis_version        = "6"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) tenantSettings(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1557,27 +1429,21 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 3
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 3
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
   tenant_settings = {
     config = "config"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) redisConfiguration(data acceptance.TestData, maxMemoryPolicy string) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1589,14 +1455,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 2
-  family              = "P"
-  sku_name            = "Premium"
-  %s                  = false
-  minimum_tls_version = "1.2"
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 2
+  family               = "P"
+  sku_name             = "Premium"
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
 
   redis_configuration {
     maxmemory_policy = "%s"
@@ -1608,16 +1474,10 @@ resource "azurerm_redis_cache" "test" {
     maintenance_window = "PT5H"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, maxMemoryPolicy, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, maxMemoryPolicy)
 }
 
 func (RedisCacheResource) systemAssignedIdentity(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1629,13 +1489,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Standard"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Standard"
+  non_ssl_port_enabled = false
   redis_configuration {
   }
 
@@ -1647,16 +1507,10 @@ resource "azurerm_redis_cache" "test" {
     environment = "production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RedisCacheResource) userAssignedIdentity(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1674,13 +1528,13 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Standard"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Standard"
+  non_ssl_port_enabled = false
   redis_configuration {
   }
 
@@ -1693,16 +1547,10 @@ resource "azurerm_redis_cache" "test" {
     environment = "production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func (RedisCacheResource) SkuDowngrade(data acceptance.TestData) string {
-
-	enableNonSsl := "non_ssl_port_enabled"
-	if !features.FourPointOhBeta() {
-		enableNonSsl = "enable_non_ssl_port"
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1714,13 +1562,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_redis_cache" "test" {
-  name                = "acctestRedis-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  capacity            = 1
-  family              = "C"
-  sku_name            = "Basic"
-  %s                  = false
+  name                 = "acctestRedis-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = false
   redis_configuration {
   }
 
@@ -1728,5 +1576,5 @@ resource "azurerm_redis_cache" "test" {
     environment = "production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -1198,6 +1198,10 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [subnet]
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1238,6 +1242,10 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [subnet]
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1279,6 +1287,10 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [subnet]
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1320,6 +1332,10 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [subnet]
+  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -435,7 +435,7 @@ func TestAccRedisCache_WithoutAuth(t *testing.T) {
 			Config: r.withoutAuth(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("redis_configuration.0.authentication_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("redis_configuration.0.enable_authentication").HasValue("false"),
 			),
 		},
 	})
@@ -1443,7 +1443,7 @@ resource "azurerm_redis_cache" "test" {
   %s                  = false
   subnet_id           = azurerm_subnet.test.id
   redis_configuration {
-    authentication_enabled = false
+    enable_authentication = false
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enableNonSsl)

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -600,7 +600,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-  %s = %t
+  %s                  = %t
   minimum_tls_version = "1.2"
 
   redis_configuration {
@@ -632,7 +632,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-  %s = %t
+  %s                  = %t
   minimum_tls_version = "1.2"
 
   redis_configuration {
@@ -658,7 +658,7 @@ resource "azurerm_redis_cache" "import" {
   capacity            = azurerm_redis_cache.test.capacity
   family              = azurerm_redis_cache.test.family
   sku_name            = azurerm_redis_cache.test.sku_name
-  %s = azurerm_redis_cache.test.%s
+  %s                  = azurerm_redis_cache.test.%s
 
   redis_configuration {
   }
@@ -688,7 +688,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Standard"
-  %s = false
+  %s                  = false
   redis_configuration {
   }
 
@@ -722,7 +722,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     maxmemory_reserved              = 642
@@ -756,7 +756,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = true
+  %s                  = true
   shard_count         = 3
 
   redis_configuration {
@@ -792,7 +792,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 2
   family              = "P"
   sku_name            = "Premium"
-  %s = true
+  %s                  = true
   shard_count         = 3
 
   redis_configuration {
@@ -828,7 +828,7 @@ resource "azurerm_redis_cache" "test" {
   capacity                      = 3
   family                        = "P"
   sku_name                      = "Premium"
-  %s           = false
+  %s                            = false
   public_network_access_enabled = false
 
   redis_configuration {
@@ -896,7 +896,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     rdb_backup_enabled              = false
@@ -943,7 +943,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     rdb_backup_enabled              = true
@@ -1015,7 +1015,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     aof_backup_enabled            = false
@@ -1075,7 +1075,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     aof_backup_enabled              = true
@@ -1133,7 +1133,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     aof_backup_enabled = false
@@ -1169,7 +1169,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     maxmemory_reserved = 642
@@ -1211,7 +1211,7 @@ resource "azurerm_redis_cache" "test" {
   family                        = "C"
   sku_name                      = "Basic"
   minimum_tls_version           = "1.2"
-  %s           = false
+  %s                            = false
   public_network_access_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
@@ -1253,7 +1253,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
 
   redis_configuration {
     notify_keyspace_events = "KAE"
@@ -1300,7 +1300,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   subnet_id           = azurerm_subnet.test.id
   redis_configuration {
   }
@@ -1346,7 +1346,7 @@ resource "azurerm_redis_cache" "test" {
   capacity                  = 1
   family                    = "P"
   sku_name                  = "Premium"
-  %s       = false
+  %s                        = false
   subnet_id                 = azurerm_subnet.test.id
   private_static_ip_address = "10.0.1.20"
   redis_configuration {
@@ -1393,7 +1393,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   subnet_id           = azurerm_subnet.test.id
   redis_configuration {
   }
@@ -1440,7 +1440,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   subnet_id           = azurerm_subnet.test.id
   redis_configuration {
     authentication_enabled = false
@@ -1473,7 +1473,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   replicas_per_master = 3
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
@@ -1503,7 +1503,7 @@ resource "azurerm_redis_cache" "test" {
   capacity             = 3
   family               = "P"
   sku_name             = "Premium"
-  %s  = false
+  %s                   = false
   replicas_per_primary = 3
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
@@ -1533,7 +1533,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   redis_version       = "6"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enableNonSsl)
@@ -1563,7 +1563,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 3
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   tenant_settings = {
     config = "config"
   }
@@ -1595,7 +1595,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 2
   family              = "P"
   sku_name            = "Premium"
-  %s = false
+  %s                  = false
   minimum_tls_version = "1.2"
 
   redis_configuration {
@@ -1635,7 +1635,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Standard"
-  %s = false
+  %s                  = false
   redis_configuration {
   }
 
@@ -1680,7 +1680,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Standard"
-  %s = false
+  %s                  = false
   redis_configuration {
   }
 
@@ -1720,7 +1720,7 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-  %s = false
+  %s                  = false
   redis_configuration {
   }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR removes instances of optional + computed in `azurerm_redis_cache` or adds a note explaining the usage. 

It also deprecates `enable_non_ssl_port` in favour of `non_ssl_port_enabled` and deprecates `redis_configuration. enable_authentication` in favour of `redis_configuration. authentication_enabled `

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests running in TC

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->



