### PR TITLE
`4.0` - adding the beta flag

### DIFF
--- a/internal/features/five_point_oh.go
+++ b/internal/features/five_point_oh.go
@@ -1,0 +1,37 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package features
+
+// nolint gocritic
+// DeprecatedInFivePointOh returns the deprecation message if the provider
+// is running in 4.0 mode - otherwise is returns an empty string (such that
+// this deprecation should be ignored).
+// This can be used for the following scenarios:
+//   - Signify resources which will be Deprecated in 5.0, but not Removed (which will happen in a later release).
+//   - For properties undergoing a rename, where the renamed property will only be introduced in the next release
+func DeprecatedInFivePointOh(deprecationMessage string) string {
+	if !FivePointOhBeta() {
+		return ""
+	}
+
+	return deprecationMessage
+}
+
+// FourPointOh returns whether this provider is running in 5.0 mode
+// that is to say - the final 5.0 release
+//
+// This exists to allow breaking changes to be piped through the provider
+// during the development of 4.x until 5.0 is ready.
+func FivePointOh() bool {
+	return false
+}
+
+// FivePointOhBeta returns whether this provider is running in 5.0 mode
+// which is an opt-in Beta of the changes coming in 5.0.
+//
+// This exists to allow breaking changes to be piped through the provider
+// during the development of 4.x until 5.0 is ready.
+func FivePointOhBeta() bool {
+	return FivePointOh() || false
+}

--- a/internal/features/four_point_oh.go
+++ b/internal/features/four_point_oh.go
@@ -3,7 +3,10 @@
 
 package features
 
-// import "os"
+import (
+	"os"
+	"strings"
+)
 
 // nolint gocritic
 // DeprecatedInFourPointOh returns the deprecation message if the provider
@@ -30,13 +33,17 @@ func FourPointOh() bool {
 }
 
 // FourPointOhBeta returns whether this provider is running in 4.0 mode
-// which is an opt-in Beta of the (non-breaking changes) coming in 4.0.
-//
-// Any features behind this flag should be backwards-compatible to allow
-// users to try out 4.0 functionality.
+// which is an opt-in Beta of the changes coming in 4.0.
 //
 // This exists to allow breaking changes to be piped through the provider
 // during the development of 3.x until 4.0 is ready.
+//
+// The environment variable `ARM_FOURPOINTZERO_BETA` has been added
+// to facilitate testing. But it should be noted that
+// `ARM_FOURPOINTZERO_BETA` is ** NOT READY FOR PUBLIC USE ** and
+// ** SHOULD NOT BE SET IN PRODUCTION ENVIRONMENTS **
+// Setting `ARM_FOURPOINTZERO_BETA` will cause irreversible changes
+// to your state.
 func FourPointOhBeta() bool {
-	return FourPointOh() || false
+	return FourPointOh() || strings.EqualFold(os.Getenv("ARM_FOURPOINTZERO_BETA"), "true")
 }


### PR DESCRIPTION
<!--  All Submissions -->


Hooking up the `FourPointOhBeta` flag to an environment variable to facilitate testing in preparation of the beta release. 

⚠️ This flag is not ready for public use and should not be set in any environments - setting this environment variable will cause irreversible state changes ⚠️ 