### PR TITLE
`azurerm_servicebus_*` fix deprecation of `enable_*` properties 

### DIFF
--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -341,21 +341,19 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if !features.FourPointOhBeta() {
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_express"); ok {
-			enableExpress = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_express"]; !v.IsNull() {
+			enableExpress = d.Get("enable_express").(bool)
 		}
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_partitioning"); ok {
-			enablePartitioning = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_partitioning"]; !v.IsNull() {
+			enablePartitioning = d.Get("enable_partitioning").(bool)
 		}
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
-			enableBatchedOperations = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_batched_operations"]; !v.IsNull() {
+			enableBatchedOperations = d.Get("enable_batched_operations").(bool)
 		}
 	}
+
 	userConfig["enableExpress"] = enableExpress
 	userConfig["enablePartitioning"] = enablePartitioning
 	userConfig["enableBatchOps"] = enableBatchedOperations

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -338,7 +338,7 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
 	}
 
-	if features.FourPointOhBeta() {
+	if !features.FourPointOhBeta() {
 
 		if v := d.GetRawConfig().AsValueMap()["enable_express"]; !v.IsNull() {
 			enableExpress = d.Get("enable_express").(bool)

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -136,16 +136,18 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"max_message_size_in_kilobytes": {
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Default:      256,
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues
+			Computed:     true,
 			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
 		},
 
 		"max_size_in_megabytes": {
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Default:      5120,
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues
+			Computed:     true,
 			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
 		},
 
@@ -254,20 +256,6 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 			Computed: true,
 		}
-
-		schema["max_message_size_in_kilobytes"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
-		}
-
-		schema["max_size_in_megabytes"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
-		}
 	}
 
 	return schema
@@ -335,11 +323,22 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	userConfig["autoDeleteOnIdle"] = autoDeleteOnIdle
 	duplicateDetectionHistoryTimeWindow := d.Get("duplicate_detection_history_time_window").(string)
 
-	enableExpress := d.Get("express_enabled").(bool)
-	enablePartitioning := d.Get("partitioning_enabled").(bool)
-	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
+	enableExpress := false
+	enablePartitioning := false
+	enableBatchedOperations := true
+	if v := d.GetRawConfig().AsValueMap()["express_enabled"]; !v.IsNull() {
+		enableExpress = d.Get("express_enabled").(bool)
+	}
 
-	if !features.FourPointOhBeta() {
+	if v := d.GetRawConfig().AsValueMap()["partitioning_enabled"]; !v.IsNull() {
+		enablePartitioning = d.Get("partitioning_enabled").(bool)
+	}
+
+	if v := d.GetRawConfig().AsValueMap()["batched_operations_enabled"]; !v.IsNull() {
+		enableBatchedOperations = d.Get("batched_operations_enabled").(bool)
+	}
+
+	if features.FourPointOhBeta() {
 
 		if v := d.GetRawConfig().AsValueMap()["enable_express"]; !v.IsNull() {
 			enableExpress = d.Get("enable_express").(bool)

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -253,9 +253,8 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
 	if !features.FourPointOhBeta() {
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
-			enableBatchedOperations = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_batched_operations"]; !v.IsNull() {
+			enableBatchedOperations = d.Get("enable_batched_operations").(bool)
 		}
 	}
 

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -163,6 +163,7 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 		schema["enable_batched_operations"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeBool,
 			Optional:      true,
+			Computed:      true,
 			ConflictsWith: []string{"batched_operations_enabled"},
 			Deprecated:    "The property `enable_batched_operations` has been superseded by `batched_operations_enabled` and will be removed in v4.0 of the AzureRM Provider.",
 		}
@@ -170,6 +171,7 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 		schema["enable_express"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeBool,
 			Optional:      true,
+			Computed:      true,
 			ConflictsWith: []string{"express_enabled"},
 			Deprecated:    "The property `enable_express` has been superseded by `express_enabled` and will be removed in v4.0 of the AzureRM Provider.",
 		}
@@ -178,6 +180,7 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 			Type:          pluginsdk.TypeBool,
 			Optional:      true,
 			ForceNew:      true,
+			Computed:      true,
 			ConflictsWith: []string{"partitioning_enabled"},
 			Deprecated:    "The property `enable_partitioning` has been superseded by `partitioning_enabled` and will be removed in v4.0 of the AzureRM Provider.",
 		}
@@ -233,19 +236,16 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	enablePartitioning := d.Get("partitioning_enabled").(bool)
 	if !features.FourPointOh() {
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_batched_operations"); ok {
-			enableBatchedOperations = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_batched_operations"]; !v.IsNull() {
+			enableBatchedOperations = d.Get("enable_batched_operations").(bool)
 		}
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_express"); ok {
-			enableExpress = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_express"]; !v.IsNull() {
+			enableExpress = d.Get("enable_express").(bool)
 		}
 
-		// nolint staticcheck
-		if v, ok := d.GetOkExists("enable_partitioning"); ok {
-			enablePartitioning = v.(bool)
+		if v := d.GetRawConfig().AsValueMap()["enable_partitioning"]; !v.IsNull() {
+			enablePartitioning = d.Get("enable_partitioning").(bool)
 		}
 	}
 

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -113,16 +113,18 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"max_message_size_in_kilobytes": {
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Default:      "256",
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues
+			Computed:     true,
 			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
 		},
 
 		"max_size_in_megabytes": {
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Default:      "5120",
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues
+			Computed:     true,
 			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
 		},
 
@@ -184,20 +186,6 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 			ConflictsWith: []string{"partitioning_enabled"},
 			Deprecated:    "The property `enable_partitioning` has been superseded by `partitioning_enabled` and will be removed in v4.0 of the AzureRM Provider.",
 		}
-
-		schema["max_message_size_in_kilobytes"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azValidate.ServiceBusMaxMessageSizeInKilobytes(),
-		}
-
-		schema["max_size_in_megabytes"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azValidate.ServiceBusMaxSizeInMegabytes(),
-		}
 	}
 
 	return schema
@@ -235,7 +223,6 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	enableExpress := d.Get("express_enabled").(bool)
 	enablePartitioning := d.Get("partitioning_enabled").(bool)
 	if !features.FourPointOh() {
-
 		if v := d.GetRawConfig().AsValueMap()["enable_batched_operations"]; !v.IsNull() {
 			enableBatchedOperations = d.Get("enable_batched_operations").(bool)
 		}

--- a/internal/services/servicebus/servicebus_topic_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_resource_test.go
@@ -125,8 +125,8 @@ func TestAccServiceBusTopic_update(t *testing.T) {
 		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("enable_batched_operations").HasValue("true"),
-				check.That(data.ResourceName).Key("enable_express").HasValue("true"),
+				check.That(data.ResourceName).Key("batched_operations_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("express_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -148,7 +148,7 @@ func TestAccServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 		{
 			Config: r.enablePartitioningStandard(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("enable_partitioning").HasValue("true"),
+				check.That(data.ResourceName).Key("partitioning_enabled").HasValue("true"),
 				// Ensure size is read back in its original value and not the x16 value returned by Azure
 				check.That(data.ResourceName).Key("max_size_in_megabytes").HasValue("5120"),
 			),
@@ -187,7 +187,7 @@ func TestAccServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 		{
 			Config: r.enablePartitioningPremium(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("enable_partitioning").HasValue("false"),
+				check.That(data.ResourceName).Key("partitioning_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("max_size_in_megabytes").HasValue("81920"),
 			),
 		},
@@ -357,10 +357,10 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                      = "acctestservicebustopic-%d"
-  namespace_id              = azurerm_servicebus_namespace.test.id
-  enable_batched_operations = true
-  enable_express            = true
+  name                       = "acctestservicebustopic-%d"
+  namespace_id               = azurerm_servicebus_namespace.test.id
+  batched_operations_enabled = true
+  express_enabled            = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -386,9 +386,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%d"
-  namespace_id        = azurerm_servicebus_namespace.test.id
-  enable_partitioning = false
+  name                 = "acctestservicebustopic-%d"
+  namespace_id         = azurerm_servicebus_namespace.test.id
+  partitioning_enabled = false
 
   max_message_size_in_kilobytes = 102400
 }
@@ -416,7 +416,7 @@ resource "azurerm_servicebus_namespace" "test" {
 resource "azurerm_servicebus_topic" "test" {
   name                  = "acctestservicebustopic-%d"
   namespace_id          = azurerm_servicebus_namespace.test.id
-  enable_partitioning   = true
+  partitioning_enabled  = true
   max_size_in_megabytes = 5120
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -445,7 +445,7 @@ resource "azurerm_servicebus_namespace" "test" {
 resource "azurerm_servicebus_topic" "test" {
   name                  = "acctestservicebustopic-%d"
   namespace_id          = azurerm_servicebus_namespace.test.id
-  enable_partitioning   = false
+  partitioning_enabled  = false
   max_size_in_megabytes = 81920
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`d.GetOkExists` doesn't work as expected for these bools, so changing these to use `d.GetRawConfig()` instead
