### PR TITLE
resourceArmRoleAssignment: Allow `/providers/Micrososoft.Capacity`, `/providers/BillingBenefits` and `/`  as scope value

### DIFF
--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -68,7 +68,7 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Subscription.*"), "Subscription scope is invalid"),
 
 					// This scope is used for the Reservations roles (Reservation Purchaser, Reservation Reader, etc.)
-					validation.StringMatch(regexp.MustCompile("/providers/Micrososoft.Capacity"), "Capacity scope is invalid"),
+					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Capacity"), "Capacity scope is invalid"),
 
 					billingValidate.EnrollmentID,
 					commonids.ValidateManagementGroupID,

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -67,6 +67,9 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 					// It seems only user account is allowed to be elevated access.
 					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Subscription.*"), "Subscription scope is invalid"),
 
+					// This scope is used for the Reservations roles (Reservation Purchaser, Reservation Reader, etc.)
+					validation.StringMatch(regexp.MustCompile("/providers/Micrososoft.Capacity"), "Capacity scope is invalid"),
+
 					billingValidate.EnrollmentID,
 					commonids.ValidateManagementGroupID,
 					commonids.ValidateSubscriptionID,

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -62,13 +62,12 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.Any(
-					// Elevated access for a global admin is needed to assign roles in this scope:
+					// Elevated access (aka User Access Administrator role) is needed to assign roles in the following scopes:
 					// https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin#azure-cli
-					// It seems only user account is allowed to be elevated access.
+					validation.StringMatch(regexp.MustCompile("/"), "Root scope (/) is invalid"),
 					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Subscription.*"), "Subscription scope is invalid"),
-
-					// This scope is used for the Reservations roles (Reservation Purchaser, Reservation Reader, etc.)
 					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Capacity"), "Capacity scope is invalid"),
+					validation.StringMatch(regexp.MustCompile("/providers/Microsoft.BillingBenefits"), "BillingBenefits scope is invalid"),
 
 					billingValidate.EnrollmentID,
 					commonids.ValidateManagementGroupID,

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -263,20 +263,6 @@ func TestAccRoleAssignment_resourceGroupScoped(t *testing.T) {
 	})
 }
 
-func TestAccRoleAssignment_capacityProviderScoped(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
-	r := RoleAssignmentResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.capacityProviderScoped(),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("skip_service_principal_aad_check"),
-	})
-}
-
 func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.RoleAssignmentID(state.ID)
 	if err != nil {
@@ -640,20 +626,4 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = data.azurerm_client_config.test.object_id
 }
 `, data.RandomInteger, data.Locations.Primary)
-}
-
-func (RoleAssignmentResource) capacityProviderScoped() string {
-	return `
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "test" {}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = "/providers/Microsoft.Capacity"
-  role_definition_name = "Reservations Reader"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-`
 }

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -263,6 +263,20 @@ func TestAccRoleAssignment_resourceGroupScoped(t *testing.T) {
 	})
 }
 
+func TestAccRoleAssignment_capacityProviderScoped(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
+	r := RoleAssignmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.capacityProviderScoped(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+	})
+}
+
 func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.RoleAssignmentID(state.ID)
 	if err != nil {
@@ -626,4 +640,20 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = data.azurerm_client_config.test.object_id
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (RoleAssignmentResource) capacityProviderScoped() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = "/providers/Micrososoft.Capacity"
+  role_definition_name = "Reservations Reader"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+`
 }

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -651,7 +651,7 @@ provider "azurerm" {
 data "azurerm_client_config" "test" {}
 
 resource "azurerm_role_assignment" "test" {
-  scope                = "/providers/Micrososoft.Capacity"
+  scope                = "/providers/Microsoft.Capacity"
   role_definition_name = "Reservations Reader"
   principal_id         = data.azurerm_client_config.test.object_id
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

To allow principals to manage `reservation orders`, `savings plans` or global roles at `/` we have to assign the appropriate roles to global provider scopes like `/providers/Micrososoft.Capacity`. 

This PR adds this string als valid scope in the resource `azurerm_role_assignment`.

Example:
```
RoleAssignmentName : 32ff27f5-1b27-46c1-bd2e-16b9f7a23d9e
RoleAssignmentId   : /providers/microsoft.capacity/providers/Microsoft.Authorization/roleAssignments/32ff27f5-1b27-46c1
                     -bd2e-16b9f7a23d9e
Scope              : /providers/microsoft.capacity
DisplayName        : SomeAdmins
SignInName         :
RoleDefinitionName : Reservations Administrator
RoleDefinitionId   : a8889054-8d42-49c9-bc1c-52486c10e7cd
ObjectId           : 00000000-0000-0000-0000-000000000000
ObjectType         : Group
CanDelegate        : False
Description        :
ConditionVersion   :
Condition          :
```

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_assignment` - support for using `/providers/Micrososoft.Capacity` in the scope property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
