### PR TITLE
provider: make `subscription_id` an Optional attribute in provider schema, implement own function to validate it for v4.0

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -143,3 +143,14 @@ func getTenantId(d *pluginsdk.ResourceData) (*string, error) {
 
 	return &tenantId, nil
 }
+
+func getSubscriptionId(d *pluginsdk.ResourceData) (*string, error) {
+	if v := d.Get("subscription_id"); v.(string) != "" {
+		ret := v.(string)
+		return &ret, nil
+	}
+	if v := os.Getenv("ARM_SUBSCRIPTION_ID"); v != "" {
+		return &v, nil
+	}
+	return nil, fmt.Errorf("`subscription_id` is a required provider property")
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,11 +6,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -206,8 +206,10 @@ func TestAccProvider_resourceProviders_legacyWithAdditional(t *testing.T) {
 	}
 
 	expectedResourceProviders := resourceproviders.Legacy().Merge(resourceproviders.ResourceProviders{
-		"Microsoft.ApiManagement": {},
-		"Microsoft.KeyVault":      {},
+		"Microsoft.ApiManagement":    {},
+		"Microsoft.ContainerService": {},
+		"Microsoft.KeyVault":         {},
+		"Microsoft.Kubernetes":       {},
 	})
 	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
 


### PR DESCRIPTION
This should mitigate the schema difference issue with terraform-plugin-mux