### PR TITLE
[TestCase] - add `ignore_changes` for `azurerm_netapp_*`

### DIFF
--- a/internal/services/netapp/netapp_account_encryption_resource_test.go
+++ b/internal/services/netapp/netapp_account_encryption_resource_test.go
@@ -117,6 +117,10 @@ resource "azurerm_key_vault" "test" {
   tenant_id                       = "%[3]s"
 
   sku_name = "standard"
+
+  lifecycle {
+    ignore_changes = ["access_policy"]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "test-currentuser" {
@@ -300,6 +304,10 @@ resource "azurerm_key_vault" "test" {
   tenant_id                       = "%[3]s"
 
   sku_name = "standard"
+
+  lifecycle {
+    ignore_changes = ["access_policy"]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "test-currentuser" {
@@ -413,6 +421,10 @@ resource "azurerm_key_vault" "test" {
   tenant_id                       = "%[3]s"
 
   sku_name = "standard"
+
+  lifecycle {
+    ignore_changes = ["access_policy"]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "test-currentuser" {

--- a/internal/services/netapp/netapp_snapshot_resource_test.go
+++ b/internal/services/netapp/netapp_snapshot_resource_test.go
@@ -145,6 +145,10 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource_test.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource_test.go
@@ -1646,6 +1646,10 @@ resource "azurerm_virtual_network" "test" {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -119,7 +119,6 @@ func expandNetAppVolumeGroupVolumes(input []netAppModels.NetAppVolumeGroupVolume
 		snapshotDirectoryVisible := item.SnapshotDirectoryVisible
 		securityStyle := volumegroups.SecurityStyle(item.SecurityStyle)
 		storageQuotaInGB := item.StorageQuotaInGB * 1073741824
-		proximityPlacementGroupId := utils.NormalizeNilableString(&item.ProximityPlacementGroupId)
 		exportPolicyRule := expandNetAppVolumeGroupVolumeExportPolicyRule(item.ExportPolicy)
 		dataProtectionReplication := expandNetAppVolumeGroupDataProtectionReplication(item.DataProtectionReplication)
 		dataProtectionSnapshotPolicy := expandNetAppVolumeGroupDataProtectionSnapshotPolicy(item.DataProtectionSnapshotPolicy)
@@ -137,7 +136,6 @@ func expandNetAppVolumeGroupVolumes(input []netAppModels.NetAppVolumeGroupVolume
 				ExportPolicy:             exportPolicyRule,
 				SnapshotDirectoryVisible: utils.Bool(snapshotDirectoryVisible),
 				ThroughputMibps:          utils.Float(item.ThroughputInMibps),
-				ProximityPlacementGroup:  &proximityPlacementGroupId,
 				VolumeSpecName:           utils.String(item.VolumeSpecName),
 				DataProtection: &volumegroups.VolumePropertiesDataProtection{
 					Replication: dataProtectionReplication.Replication,
@@ -145,6 +143,10 @@ func expandNetAppVolumeGroupVolumes(input []netAppModels.NetAppVolumeGroupVolume
 				},
 			},
 			Tags: &item.Tags,
+		}
+
+		if item.ProximityPlacementGroupId != "" {
+			volumeProperties.Properties.ProximityPlacementGroup = pointer.To(utils.NormalizeNilableString(pointer.To(item.ProximityPlacementGroupId)))
 		}
 
 		results = append(results, *volumeProperties)

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -145,8 +145,8 @@ func expandNetAppVolumeGroupVolumes(input []netAppModels.NetAppVolumeGroupVolume
 			Tags: &item.Tags,
 		}
 
-		if item.ProximityPlacementGroupId != "" {
-			volumeProperties.Properties.ProximityPlacementGroup = pointer.To(utils.NormalizeNilableString(pointer.To(item.ProximityPlacementGroupId)))
+		if v := item.ProximityPlacementGroupId; v != "" {
+			volumeProperties.Properties.ProximityPlacementGroup = pointer.To(utils.NormalizeNilableString(pointer.To(v)))
 		}
 
 		results = append(results, *volumeProperties)

--- a/internal/services/netapp/netapp_volume_quota_rule_resource_test.go
+++ b/internal/services/netapp/netapp_volume_quota_rule_resource_test.go
@@ -201,6 +201,10 @@ resource "azurerm_virtual_network" "test" {
     "CreatedOnDate"    = "2023-08-17T08:01:00Z",
     "SkipASMAzSecPack" = "true"
   }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -1027,6 +1027,10 @@ resource "azurerm_virtual_network" "updated" {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "updated" {
@@ -1192,6 +1196,10 @@ resource "azurerm_virtual_network" "test" {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1282,6 +1290,10 @@ resource "azurerm_virtual_network" "test" {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1339,6 +1351,10 @@ resource "azurerm_virtual_network" "test" {
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
+  }
+
+  lifecycle {
+    ignore_changes = ["subnet"]
   }
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently test cases related with Netapp RP are failed against v4.x on Teamcity Daily Run. As the Computed of subnet in azurerm_virtual_network and access_policy in azurerm_key_vault are removed by this [PR](https://github.com/hashicorp/terraform-provider-azurerm/commit/709aaeb6341e68d29605f208fe968f3a63e48213#diff-67690aa7a330e07f7a8e10d798fc633ae9e4621046fd9359f8a60f2b84b5e5ef) and that [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/26533), so the corresponding test cases also need to be updated.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Below failed test cases are also failed with same error on Teamcity Daily Run and the error message indicates that it's quota issue. So it's not related with this PR.
![image](https://github.com/user-attachments/assets/d1cf11bf-3d61-44f9-89cc-92a8ce486e53)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] - add `ignore_changes` for `azurerm_netapp_*`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
