### PR TITLE
`azurerm_log_analytics_saved_search` - update validation for `azurerm_log_analytics_saved_search`

### DIFF
--- a/internal/services/loganalytics/log_analytics_saved_search_resource.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource.go
@@ -91,8 +91,9 @@ func resourceLogAnalyticsSavedSearch() *pluginsdk.Resource {
 				ForceNew: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
+					// https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/functions/user-defined-functions
 					ValidateFunc: validation.StringMatch(
-						regexp.MustCompile(`^[a-zA-Z0-9!-_]*:[a-zA-Z0-9!_-]+=[a-zA-Z0-9!_-]+|^[a-zA-Z0-9!-_]*:[a-zA-Z0-9!_-]+`),
+						regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9-_]*:([a-z]+(=[^,\n]+)?|\(\*\)|(\([a-zA-Z_][a-zA-Z0-9-_]*:[a-z]+(,[a-zA-Z_][a-zA-Z0-9-_]*:([a-z]+))*\)))(,\s*[a-zA-Z_][a-zA-Z0-9-_]*:([a-z]+(=[^,\n]+)?|\(\*\)|(\([a-zA-Z_][a-zA-Z0-9-_]*:[a-z]+(,\s*[a-zA-Z_][a-zA-Z0-9-_]*:([a-z]+))*\))))*$`),
 						"Log Analytics Saved Search Function Parameters must be in the following format: param-name1:type1=default_value1 OR param-name1:type1 OR param-name1:string='string goes here'",
 					),
 				},

--- a/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
@@ -149,7 +149,7 @@ resource "azurerm_log_analytics_saved_search" "test" {
 
   category     = "Saved Search Test Category"
   display_name = "Create or Update Saved Search Test"
-  query        = "Heartbeat | summarize Count() by Computer | take a"
+  query        = "Heartbeat | summarize Count() by Computer | take 1"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -193,7 +193,7 @@ resource "azurerm_log_analytics_saved_search" "test" {
 
   category     = "Saved Search Test Category"
   display_name = "Create or Update Saved Search Test"
-  query        = "Heartbeat | summarize Count() by Computer | take a"
+  query        = "Heartbeat | summarize Count() by Computer | take 1"
 
   function_alias      = "heartbeat_func"
   function_parameters = ["a:int=1", "b:int=2", "c:int=3"]
@@ -225,7 +225,7 @@ resource "azurerm_log_analytics_saved_search" "test" {
 
   category     = "Saved Search Test Category"
   display_name = "Create or Update Saved Search Test"
-  query        = "Heartbeat | summarize Count() by Computer | take a"
+  query        = "Heartbeat | summarize Count() by Computer | take 1"
 
   function_alias      = "heartbeat_func"
   function_parameters = ["%s"]
@@ -257,7 +257,7 @@ resource "azurerm_log_analytics_saved_search" "test" {
 
   category     = "Saved Search Test Category"
   display_name = "Create or Update Saved Search Test"
-  query        = "Heartbeat | summarize Count() by Computer | take a"
+  query        = "Heartbeat | summarize Count() by Computer | take 1"
 
   tags = {
     "Environment" = "Test"

--- a/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
@@ -64,6 +64,35 @@ func TestAccLogAnalyticsSavedSearch_withTag(t *testing.T) {
 	})
 }
 
+func TestAccLogAnalyticsSavedSearch_functionParameter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_saved_search", "test")
+	r := LogAnalyticsSavedSearchResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.function_parameter(data, "foo:(*)"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.function_parameter(data, "foo:int=1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.function_parameter(data, "foo:(bar:long)"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogAnalyticsSavedSearch_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_saved_search", "test")
 	r := LogAnalyticsSavedSearchResource{}
@@ -170,6 +199,38 @@ resource "azurerm_log_analytics_saved_search" "test" {
   function_parameters = ["a:int=1", "b:int=2", "c:int=3"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LogAnalyticsSavedSearchResource) function_parameter(data acceptance.TestData, para string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_saved_search" "test" {
+  name                       = "acctestLASS-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  category     = "Saved Search Test Category"
+  display_name = "Create or Update Saved Search Test"
+  query        = "Heartbeat | summarize Count() by Computer | take a"
+
+  function_alias      = "heartbeat_func"
+  function_parameters = ["%s"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, para)
 }
 
 func (LogAnalyticsSavedSearchResource) withTag(data acceptance.TestData) string {

--- a/website/docs/r/log_analytics_saved_search.html.markdown
+++ b/website/docs/r/log_analytics_saved_search.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `function_alias` - (Optional) The function alias if the query serves as a function. Changing this forces a new resource to be created.
 
-* `function_parameters` - (Optional) The function parameters if the query serves as a function. Changing this forces a new resource to be created.
+* `function_parameters` - (Optional) The function parameters if the query serves as a function. Changing this forces a new resource to be created. For more examples and proper syntax please refer to [this document](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/functions/user-defined-functions)
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Logs Analytics Saved Search. Changing this forces a new resource to be created.
 

--- a/website/docs/r/log_analytics_saved_search.html.markdown
+++ b/website/docs/r/log_analytics_saved_search.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `function_alias` - (Optional) The function alias if the query serves as a function. Changing this forces a new resource to be created.
 
-* `function_parameters` - (Optional) The function parameters if the query serves as a function. Changing this forces a new resource to be created. For more examples and proper syntax please refer to [this document](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/functions/user-defined-functions)
+* `function_parameters` - (Optional) The function parameters if the query serves as a function. Changing this forces a new resource to be created. For more examples and proper syntax please refer to [this document](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/functions/user-defined-functions).
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Logs Analytics Saved Search. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
These validation regxp might be out of date, can not validate some format of parameters.  The expression was provided on https://github.com/hashicorp/terraform-provider-azurerm/issues/26685, Thanks to @Folling
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
❯❯ tftest loganalytics TestAccLogAnalyticsSavedSearch
=== RUN   TestAccLogAnalyticsSavedSearch_basic
=== PAUSE TestAccLogAnalyticsSavedSearch_basic
=== RUN   TestAccLogAnalyticsSavedSearch_complete
=== PAUSE TestAccLogAnalyticsSavedSearch_complete
=== RUN   TestAccLogAnalyticsSavedSearch_withTag
=== PAUSE TestAccLogAnalyticsSavedSearch_withTag
=== RUN   TestAccLogAnalyticsSavedSearch_requiresImport
=== PAUSE TestAccLogAnalyticsSavedSearch_requiresImport
=== CONT  TestAccLogAnalyticsSavedSearch_basic
=== CONT  TestAccLogAnalyticsSavedSearch_withTag
=== CONT  TestAccLogAnalyticsSavedSearch_complete
=== CONT  TestAccLogAnalyticsSavedSearch_requiresImport
--- PASS: TestAccLogAnalyticsSavedSearch_withTag (191.96s)
--- PASS: TestAccLogAnalyticsSavedSearch_requiresImport (202.24s)
--- PASS: TestAccLogAnalyticsSavedSearch_complete (208.41s)
--- PASS: TestAccLogAnalyticsSavedSearch_basic (218.12s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  220.329s
```
```
❯❯ tftest loganalytics TestAccLogAnalyticsSavedSearch_functionParameter
=== RUN   TestAccLogAnalyticsSavedSearch_functionParameter
=== PAUSE TestAccLogAnalyticsSavedSearch_functionParameter
=== CONT  TestAccLogAnalyticsSavedSearch_functionParameter
--- PASS: TestAccLogAnalyticsSavedSearch_functionParameter (281.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  283.494s
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_saved_search` - pdate validation for `azurerm_log_analytics_saved_search` [GH-26701]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26685

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
