### PR TITLE
Doc Fix: `azurerm_private_service_connection` - add additional note around when `subresource_names` is required. 

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -234,9 +234,11 @@ A `private_service_connection` block supports the following:
 
 * `private_connection_resource_alias` - (Optional) The Service Alias of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. One of `private_connection_resource_id` or `private_connection_resource_alias` must be specified. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Possible values are detailed in the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) in the `Subresources` column. Changing this forces a new resource to be created.
+* `subresource_names` - (Required) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Possible values are detailed in the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) in the `Subresources` column. Changing this forces a new resource to be created. 
 
 -> **NOTE:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
+
+-> **NOTE:** Only for subresource "Private Link service", `subresource_names` can be optional.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The provider allows a maximum request message length of `140` characters, however the request message maximum length is dependent on the service the private endpoint is connected to. Only valid if `is_manual_connection` is set to `true`.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -234,7 +234,7 @@ A `private_service_connection` block supports the following:
 
 * `private_connection_resource_alias` - (Optional) The Service Alias of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. One of `private_connection_resource_id` or `private_connection_resource_alias` must be specified. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Required) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Possible values are detailed in the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) in the `Subresources` column. Changing this forces a new resource to be created. 
+* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Possible values are detailed in the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) in the `Subresources` column. Changing this forces a new resource to be created. 
 
 -> **NOTE:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -238,7 +238,7 @@ A `private_service_connection` block supports the following:
 
 -> **NOTE:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
 
--> **NOTE:** Only for Private-link resource called "Private Link service", `subresource_names` can be optional.
+-> **NOTE:** Only for Private-link resource called "Private Link service", `subresource_names` can be omitted.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The provider allows a maximum request message length of `140` characters, however the request message maximum length is dependent on the service the private endpoint is connected to. Only valid if `is_manual_connection` is set to `true`.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -238,7 +238,7 @@ A `private_service_connection` block supports the following:
 
 -> **NOTE:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
 
--> **NOTE:** Only for Private-link resource called "Private Link service", `subresource_names` can be omitted.
+-> **NOTE:** For most Private Links one or more `subresource_names` will need to be specified, please see the linked documentation for details.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The provider allows a maximum request message length of `140` characters, however the request message maximum length is dependent on the service the private endpoint is connected to. Only valid if `is_manual_connection` is set to `true`.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -238,7 +238,7 @@ A `private_service_connection` block supports the following:
 
 -> **NOTE:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
 
--> **NOTE:** Only for subresource "Private Link service", `subresource_names` can be optional.
+-> **NOTE:** Only for Private-link resource called "Private Link service", `subresource_names` can be optional.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The provider allows a maximum request message length of `140` characters, however the request message maximum length is dependent on the service the private endpoint is connected to. Only valid if `is_manual_connection` is set to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

According to the product documentation:
https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource
subresource name is required. 

Only Private-link resource name "Private Link service" has an empty Sub-resources name so it can be omitted. 
 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).


## Testing 

I've tried to reproduce the issue using the code examples of "azurerm_private_endpoint" resource here:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint#example-usage
 
The first code example (I will call it example 1) of "azurerm_private_endpoint" resource is using the following code and as private_connection_resource_id is using an "azurerm_private_link_service" resource.

``` 
resource "azurerm_private_endpoint" "example" {
  name                = "example-endpoint"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  subnet_id           = azurerm_subnet.endpoint.id

  private_service_connection {
    name                           = "example-privateserviceconnection"
    private_connection_resource_id = azurerm_private_link_service.example.id
    is_manual_connection           = false
  }
}
```
With example 1 I was able to create a private endpoint without using the subresource_names in the code block. For example 1 subresource_names is optional.
 
The second code example that I've used (I will call it example 2), is the code example under the
"Using a Private Endpoint pointing to an owned Azure service, with proper DNS configuration:" text, in the same examples page.
 
In example 2, the resource "azurerm_private_endpoint" is using as private_connection_resource_id an "azurerm_storage_account" resource and also defines a subresource_names value (["blob"])

```
resource "azurerm_private_endpoint" "example" {
  name                = "example-endpoint"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  subnet_id           = azurerm_subnet.example.id
 
  private_service_connection {
    name                           = "example-privateserviceconnection"
    private_connection_resource_id = azurerm_storage_account.example.id
    subresource_names              = ["blob"]
    is_manual_connection           = false
  }
 ```
In my tests with example 2, when subresource_names was omitted or the value was 'null', I was getting the same error as the one you shared.
Here is one of the errors:
```Resource Group Name: "example-resources"
│ Private Endpoint Name: "example-endpoint2"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: MissingParameterOnPrivateLinkServiceConnection: Private link service connection /subscriptions/****************/resourceGroups/example-resources-*****/providers/Microsoft.Network/privateEndpoints/example-endpoint2/privateLinkServiceConnections/example-privateserviceconnection2 is missing required parameter 'group Id'.
│ 
│   with azurerm_private_endpoint.example,
│   on main.tf line 90, in resource "azurerm_private_endpoint" "example":
│   90: resource "azurerm_private_endpoint" "example" {
```


## Change Log

Documentation update

## Related Issue(s)

I couldn't find related issues.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
