### PR TITLE
`azurerm_storage_account_network_rules` - split create update and remove ConfigModeAttr / O+C

### DIFF
--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -122,7 +122,7 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 func resourceStorageAccountNetworkRulesCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	tenantId := meta.(*clients.Client).Account.TenantId
 	client := meta.(*clients.Client).Storage.ResourceManager.StorageAccounts
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
@@ -178,7 +178,7 @@ func resourceStorageAccountNetworkRulesCreate(d *pluginsdk.ResourceData, meta in
 		},
 	}
 	if _, err = client.Update(ctx, *id, payload); err != nil {
-		return fmt.Errorf("updating Network Rules for %s: %+v", *id, err)
+		return fmt.Errorf("creating Network Rules for %s: %+v", *id, err)
 	}
 
 	d.SetId(id.ID())
@@ -189,7 +189,7 @@ func resourceStorageAccountNetworkRulesCreate(d *pluginsdk.ResourceData, meta in
 func resourceStorageAccountNetworkRulesUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	tenantId := meta.(*clients.Client).Account.TenantId
 	client := meta.(*clients.Client).Storage.ResourceManager.StorageAccounts
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))

--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -24,9 +24,9 @@ import (
 
 func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceStorageAccountNetworkRulesCreateUpdate,
+		Create: resourceStorageAccountNetworkRulesCreate,
 		Read:   resourceStorageAccountNetworkRulesRead,
-		Update: resourceStorageAccountNetworkRulesCreateUpdate,
+		Update: resourceStorageAccountNetworkRulesUpdate,
 		Delete: resourceStorageAccountNetworkRulesDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -51,10 +51,9 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 			},
 
 			"bypass": {
-				Type:       pluginsdk.TypeSet,
-				Optional:   true,
-				Computed:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Computed: true, // Defaults to storageaccounts.BypassAzureServices in the API, but schema does not support defaults for lists/sets.
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -68,10 +67,8 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 			},
 
 			"ip_rules": {
-				Type:       pluginsdk.TypeSet,
-				Optional:   true,
-				Computed:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validate.StorageAccountIpRule,
@@ -80,10 +77,8 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 			},
 
 			"virtual_network_subnet_ids": {
-				Type:       pluginsdk.TypeSet,
-				Optional:   true,
-				Computed:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: azure.ValidateResourceID,
@@ -124,7 +119,7 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 	}
 }
 
-func resourceStorageAccountNetworkRulesCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceStorageAccountNetworkRulesCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	tenantId := meta.(*clients.Client).Account.TenantId
 	client := meta.(*clients.Client).Storage.ResourceManager.StorageAccounts
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
@@ -152,20 +147,18 @@ func resourceStorageAccountNetworkRulesCreateUpdate(d *pluginsdk.ResourceData, m
 	if resp.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `model.Properties` was nil", *id)
 	}
-	if d.IsNewResource() {
-		usesNonDefaultStorageAccountRules := false
-		if acls := resp.Model.Properties.NetworkAcls; acls != nil {
-			// The default action "Allow" is set in the creation of the storage account resource as default value.
-			hasIPRules := acls.IPRules != nil && len(*acls.IPRules) > 0
-			defaultActionConfigured := acls.DefaultAction != storageaccounts.DefaultActionAllow
-			hasVirtualNetworkRules := acls.VirtualNetworkRules != nil && len(*acls.VirtualNetworkRules) > 0
-			if hasIPRules || defaultActionConfigured || hasVirtualNetworkRules {
-				usesNonDefaultStorageAccountRules = true
-			}
+	usesNonDefaultStorageAccountRules := false
+	if acls := resp.Model.Properties.NetworkAcls; acls != nil {
+		// The default action "Allow" is set in the creation of the storage account resource as default value.
+		hasIPRules := acls.IPRules != nil && len(*acls.IPRules) > 0
+		defaultActionConfigured := acls.DefaultAction != storageaccounts.DefaultActionAllow
+		hasVirtualNetworkRules := acls.VirtualNetworkRules != nil && len(*acls.VirtualNetworkRules) > 0
+		if hasIPRules || defaultActionConfigured || hasVirtualNetworkRules {
+			usesNonDefaultStorageAccountRules = true
 		}
-		if usesNonDefaultStorageAccountRules {
-			return tf.ImportAsExistsError("azurerm_storage_account_network_rule", id.ID())
-		}
+	}
+	if usesNonDefaultStorageAccountRules {
+		return tf.ImportAsExistsError("azurerm_storage_account_network_rule", id.ID())
 	}
 
 	acls := resp.Model.Properties.NetworkAcls
@@ -184,12 +177,74 @@ func resourceStorageAccountNetworkRulesCreateUpdate(d *pluginsdk.ResourceData, m
 			NetworkAcls: acls,
 		},
 	}
-	if _, err := client.Update(ctx, *id, payload); err != nil {
+	if _, err = client.Update(ctx, *id, payload); err != nil {
 		return fmt.Errorf("updating Network Rules for %s: %+v", *id, err)
 	}
 
-	if d.IsNewResource() {
-		d.SetId(id.ID())
+	d.SetId(id.ID())
+
+	return resourceStorageAccountNetworkRulesRead(d, meta)
+}
+
+func resourceStorageAccountNetworkRulesUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	tenantId := meta.(*clients.Client).Account.TenantId
+	client := meta.(*clients.Client).Storage.ResourceManager.StorageAccounts
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.StorageAccountName, storageAccountResourceName)
+	defer locks.UnlockByName(id.StorageAccountName, storageAccountResourceName)
+
+	resp, err := client.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+	if resp.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `model.Properties` was nil", *id)
+	}
+
+	acls := resp.Model.Properties.NetworkAcls
+	if acls == nil {
+		acls = &storageaccounts.NetworkRuleSet{}
+	}
+
+	if d.HasChange("default_action") {
+		acls.DefaultAction = storageaccounts.DefaultAction(d.Get("default_action").(string))
+	}
+	if d.HasChange("bypass") {
+		acls.Bypass = expandAccountNetworkRuleBypass(d.Get("bypass").(*pluginsdk.Set).List())
+	}
+	if d.HasChange("ip_rules") {
+		acls.IPRules = expandAccountNetworkRuleIPRules(d.Get("ip_rules").(*pluginsdk.Set).List())
+	}
+	if d.HasChange("virtual_network_subnet_ids") {
+		acls.VirtualNetworkRules = expandAccountNetworkRuleVirtualNetworkRules(d.Get("virtual_network_subnet_ids").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("private_link_access") {
+		acls.ResourceAccessRules = expandAccountNetworkRulePrivateLinkAccess(d.Get("private_link_access").([]interface{}), tenantId)
+	}
+
+	payload := storageaccounts.StorageAccountUpdateParameters{
+		Properties: &storageaccounts.StorageAccountPropertiesUpdateParameters{
+			NetworkAcls: acls,
+		},
+	}
+
+	if _, err := client.Update(ctx, *id, payload); err != nil {
+		return fmt.Errorf("updating Network Rules for %s: %+v", *id, err)
 	}
 
 	return resourceStorageAccountNetworkRulesRead(d, meta)

--- a/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -405,10 +405,8 @@ resource "azurerm_storage_account" "test" {
 resource "azurerm_storage_account_network_rules" "test" {
   storage_account_id = azurerm_storage_account.test.id
 
-  default_action             = "Deny"
-  bypass                     = ["None"]
-  ip_rules                   = []
-  virtual_network_subnet_ids = []
+  default_action = "Deny"
+  bypass         = ["None"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 
-* `bypass` - (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
+* `bypass` - (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of `Logging`, `Metrics`, `AzureServices`, or `None`. Defaults to `["AzureServices"]`.
 
 -> **NOTE** User has to explicitly set `bypass` to empty slice (`[]`) to remove it.
 


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

split create/update
remove O+C where possible
remove redundant ConfigModeAttr schema settings

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account_network_rules` - split create update and remove ConfigModeAttr / O+C
