### PR TITLE
storage: remove deprecated properties for v4.0

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -64,7 +64,7 @@ var (
 )
 
 func resourceStorageAccount() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceStorageAccountCreate,
 		Read:   resourceStorageAccountRead,
 		Update: resourceStorageAccountUpdate,
@@ -259,8 +259,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
-			// TODO 4.0: change this from enable_* to *_enabled
-			"enable_https_traffic_only": {
+			"https_traffic_only_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -1260,6 +1259,20 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			}),
 		),
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["https_traffic_only_enabled"].Computed = true
+
+		resource.Schema["enable_https_traffic_only"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"https_traffic_only_enabled"},
+			Deprecated:    "The property `enable_https_traffic_only` has been superseded by `https_traffic_only_enabled` and will be removed in v4.0 of the AzureRM Provider.",
+		}
+	}
+
+	return resource
 }
 
 func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -1298,6 +1311,14 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
 
+	httpsTrafficOnlyEnabled := d.Get("https_traffic_only_enabled").(bool)
+	if !features.FourPointOhBeta() {
+		// nolint staticcheck
+		if v, ok := d.GetOkExists("enable_https_traffic_only"); ok {
+			httpsTrafficOnlyEnabled = v.(bool)
+		}
+	}
+
 	dnsEndpointType := d.Get("dns_endpoint_type").(string)
 	isHnsEnabled := d.Get("is_hns_enabled").(bool)
 	nfsV3Enabled := d.Get("nfsv3_enabled").(bool)
@@ -1312,7 +1333,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			AllowSharedKeyAccess:         pointer.To(d.Get("shared_access_key_enabled").(bool)),
 			DnsEndpointType:              pointer.To(storageaccounts.DnsEndpointType(dnsEndpointType)),
 			DefaultToOAuthAuthentication: pointer.To(d.Get("default_to_oauth_authentication").(bool)),
-			SupportsHTTPSTrafficOnly:     pointer.To(d.Get("enable_https_traffic_only").(bool)),
+			SupportsHTTPSTrafficOnly:     pointer.To(httpsTrafficOnlyEnabled),
 			IsNfsV3Enabled:               pointer.To(nfsV3Enabled),
 			IsHnsEnabled:                 pointer.To(isHnsEnabled),
 			IsLocalUserEnabled:           pointer.To(d.Get("local_user_enabled").(bool)),
@@ -1712,9 +1733,16 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChange("default_to_oauth_authentication") {
 		props.DefaultToOAuthAuthentication = pointer.To(d.Get("default_to_oauth_authentication").(bool))
 	}
-	if d.HasChange("enable_https_traffic_only") {
-		props.SupportsHTTPSTrafficOnly = pointer.To(d.Get("enable_https_traffic_only").(bool))
+
+	if d.HasChange("https_traffic_only_enabled") {
+		props.SupportsHTTPSTrafficOnly = pointer.To(d.Get("https_traffic_only_enabled").(bool))
 	}
+	if !features.FourPointOhBeta() {
+		if d.HasChange("enable_https_traffic_only") {
+			props.SupportsHTTPSTrafficOnly = pointer.To(d.Get("enable_https_traffic_only").(bool))
+		}
+	}
+
 	if d.HasChange("large_file_share_enabled") {
 		// largeFileSharesState can only be set to `Enabled` and not `Disabled`, even if it is currently `Disabled`
 		if oldValue, newValue := d.GetChange("large_file_share_enabled"); oldValue.(bool) && !newValue.(bool) {
@@ -2033,7 +2061,10 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 				return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
 			}
 			d.Set("cross_tenant_replication_enabled", pointer.From(props.AllowCrossTenantReplication))
-			d.Set("enable_https_traffic_only", pointer.From(props.SupportsHTTPSTrafficOnly))
+			d.Set("https_traffic_only_enabled", pointer.From(props.SupportsHTTPSTrafficOnly))
+			if !features.FourPointOhBeta() {
+				d.Set("enable_https_traffic_only", pointer.From(props.SupportsHTTPSTrafficOnly))
+			}
 			d.Set("is_hns_enabled", pointer.From(props.IsHnsEnabled))
 			d.Set("nfsv3_enabled", pointer.From(props.IsNfsV3Enabled))
 			d.Set("primary_location", pointer.From(props.PrimaryLocation))

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1262,6 +1262,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		resource.Schema["https_traffic_only_enabled"].Computed = true
+		resource.Schema["https_traffic_only_enabled"].Default = nil
 
 		resource.Schema["enable_https_traffic_only"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeBool,
@@ -1311,8 +1312,11 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
 
-	httpsTrafficOnlyEnabled := d.Get("https_traffic_only_enabled").(bool)
-	if !features.FourPointOhBeta() {
+	httpsTrafficOnlyEnabled := true
+	// nolint staticcheck
+	if v, ok := d.GetOkExists("https_traffic_only_enabled"); ok {
+		httpsTrafficOnlyEnabled = v.(bool)
+	} else if !features.FourPointOhBeta() {
 		// nolint staticcheck
 		if v, ok := d.GetOkExists("enable_https_traffic_only"); ok {
 			httpsTrafficOnlyEnabled = v.(bool)

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -226,7 +226,7 @@ func TestAccStorageAccount_enableHttpsTrafficOnly(t *testing.T) {
 			Config: r.enableHttpsTrafficOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enable_https_traffic_only").HasValue("true"),
+				check.That(data.ResourceName).Key("https_traffic_only_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -234,7 +234,7 @@ func TestAccStorageAccount_enableHttpsTrafficOnly(t *testing.T) {
 			Config: r.enableHttpsTrafficOnlyDisabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enable_https_traffic_only").HasValue("false"),
+				check.That(data.ResourceName).Key("https_traffic_only_enabled").HasValue("false"),
 			),
 		},
 	})
@@ -2049,10 +2049,10 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                  = azurerm_resource_group.test.location
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  enable_https_traffic_only = true
+  location                   = azurerm_resource_group.test.location
+  account_tier               = "Standard"
+  account_replication_type   = "LRS"
+  https_traffic_only_enabled = true
 
   tags = {
     environment = "production"
@@ -2076,10 +2076,10 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                  = azurerm_resource_group.test.location
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  enable_https_traffic_only = false
+  location                   = azurerm_resource_group.test.location
+  account_tier               = "Standard"
+  account_replication_type   = "LRS"
+  https_traffic_only_enabled = false
 
   tags = {
     environment = "production"
@@ -2198,13 +2198,13 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                  = azurerm_resource_group.test.location
-  account_tier              = "Premium"
-  account_kind              = "BlockBlobStorage"
-  account_replication_type  = "LRS"
-  is_hns_enabled            = true
-  nfsv3_enabled             = true
-  enable_https_traffic_only = false
+  location                   = azurerm_resource_group.test.location
+  account_tier               = "Premium"
+  account_kind               = "BlockBlobStorage"
+  account_replication_type   = "LRS"
+  is_hns_enabled             = true
+  nfsv3_enabled              = true
+  https_traffic_only_enabled = false
   network_rules {
     default_action             = "Deny"
     virtual_network_subnet_ids = [azurerm_subnet.test.id]
@@ -3009,7 +3009,7 @@ resource "azurerm_storage_account" "test" {
   location                        = azurerm_resource_group.test.location
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
-  enable_https_traffic_only       = true
+  https_traffic_only_enabled      = true
   allow_nested_items_to_be_public = true
 
   blob_properties {
@@ -3444,15 +3444,15 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 resource "azurerm_storage_account" "test" {
-  name                      = "acctestsa%s"
-  resource_group_name       = azurerm_resource_group.test.name
-  location                  = azurerm_resource_group.test.location
-  account_kind              = "BlockBlobStorage"
-  account_tier              = "Premium"
-  account_replication_type  = "LRS"
-  is_hns_enabled            = true
-  min_tls_version           = "TLS1_2"
-  enable_https_traffic_only = true
+  name                       = "acctestsa%s"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  account_kind               = "BlockBlobStorage"
+  account_tier               = "Premium"
+  account_replication_type   = "LRS"
+  is_hns_enabled             = true
+  min_tls_version            = "TLS1_2"
+  https_traffic_only_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/storage/storage_share_directory_resource_test.go
+++ b/internal/services/storage/storage_share_directory_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/file/directories"
@@ -51,6 +52,10 @@ func TestAccStorageShareDirectory_basicAzureADAuth(t *testing.T) {
 
 func TestAccStorageShareDirectory_basicDeprecated(t *testing.T) {
 	// TODO: remove test in v4.0
+	if features.FourPointOhBeta() {
+		t.Skip("test not applicable in v4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
 	r := StorageShareDirectoryResource{}
 
@@ -67,6 +72,10 @@ func TestAccStorageShareDirectory_basicDeprecated(t *testing.T) {
 
 func TestAccStorageShareDirectory_migrateStorageShareId(t *testing.T) {
 	// TODO: remove test in v4.0
+	if features.FourPointOhBeta() {
+		t.Skip("test not applicable in v4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
 	r := StorageShareDirectoryResource{}
 
@@ -269,6 +278,7 @@ resource "azurerm_storage_share_directory" "test" {
 }
 
 func (r StorageShareDirectoryResource) basicDeprecated(data acceptance.TestData) string {
+	// TODO: remove in v4.0
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -77,6 +77,7 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 	}
 
 	if !features.FourPointOhBeta() {
+		resource.Schema["storage_table_id"].Required = false
 		resource.Schema["storage_table_id"].Optional = true
 		resource.Schema["storage_table_id"].Computed = true
 		resource.Schema["storage_table_id"].ConflictsWith = []string{"table_name", "storage_account_name"}

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -26,7 +27,7 @@ import (
 )
 
 func resourceStorageTableEntity() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceStorageTableEntityCreate,
 		Read:   resourceStorageTableEntityRead,
 		Update: resourceStorageTableEntityUpdate,
@@ -46,31 +47,9 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"storage_table_id": {
-				Type:          pluginsdk.TypeString,
-				Optional:      true, // TODO: make required and forcenew in v4.0
-				Computed:      true, // TODO: remove computed in v4.0
-				ConflictsWith: []string{"table_name", "storage_account_name"},
-				ValidateFunc:  storageValidate.StorageTableDataPlaneID,
-			},
-
-			"table_name": {
-				Type:          pluginsdk.TypeString,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
-				ConflictsWith: []string{"storage_table_id"},
-				RequiredWith:  []string{"storage_account_name"},
-				ValidateFunc:  validate.StorageTableName,
-			},
-
-			"storage_account_name": {
-				Type:          pluginsdk.TypeString,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
-				ConflictsWith: []string{"storage_table_id"},
-				RequiredWith:  []string{"table_name"},
-				ValidateFunc:  validate.StorageAccountName,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: storageValidate.StorageTableDataPlaneID,
 			},
 
 			"partition_key": {
@@ -96,6 +75,34 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["storage_table_id"].Optional = true
+		resource.Schema["storage_table_id"].Computed = true
+		resource.Schema["storage_table_id"].ConflictsWith = []string{"table_name", "storage_account_name"}
+
+		resource.Schema["table_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
+			ConflictsWith: []string{"storage_table_id"},
+			RequiredWith:  []string{"storage_account_name"},
+			ValidateFunc:  validate.StorageTableName,
+		}
+
+		resource.Schema["storage_account_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
+			ConflictsWith: []string{"storage_table_id"},
+			RequiredWith:  []string{"table_name"},
+			ValidateFunc:  validate.StorageAccountName,
+		}
+	}
+
+	return resource
 }
 
 func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -114,7 +121,7 @@ func resourceStorageTableEntityCreate(d *pluginsdk.ResourceData, meta interface{
 		if err != nil {
 			return err
 		}
-	} else {
+	} else if !features.FourPointOhBeta() {
 		// TODO: this is needed until `table_name` / `storage_account_name` are removed in favor of `storage_table_id` in v4.0
 		// we will retrieve the storage account twice but this will make it easier to refactor later
 		storageAccountName := d.Get("storage_account_name").(string)
@@ -280,10 +287,13 @@ func resourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	d.Set("storage_table_id", storageTableId.ID())
-	d.Set("storage_account_name", id.AccountId.AccountName)
-	d.Set("table_name", id.TableName)
 	d.Set("partition_key", id.PartitionKey)
 	d.Set("row_key", id.RowKey)
+
+	if !features.FourPointOhBeta() {
+		d.Set("storage_account_name", id.AccountId.AccountName)
+		d.Set("table_name", id.TableName)
+	}
 
 	if err = d.Set("entity", flattenEntity(result.Entity)); err != nil {
 		return fmt.Errorf("setting `entity` for %s: %v", id, err)

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/entities"
@@ -51,6 +52,10 @@ func TestAccTableEntity_basicAzureADAuth(t *testing.T) {
 
 func TestAccTableEntity_basicDeprecated(t *testing.T) {
 	// TODO: remove test in v4.0
+	if features.FourPointOhBeta() {
+		t.Skip("test not applicable in v4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_table_entity", "test")
 	r := StorageTableEntityResource{}
 
@@ -67,6 +72,10 @@ func TestAccTableEntity_basicDeprecated(t *testing.T) {
 
 func TestAccTableEntity_migrateStorageTableId(t *testing.T) {
 	// TODO: remove test in v4.0
+	if features.FourPointOhBeta() {
+		t.Skip("test not applicable in v4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_table_entity", "test")
 	r := StorageTableEntityResource{}
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -47,7 +47,7 @@ output "storage_account_tier" {
 
 * `dns_endpoint_type` - Which DNS endpoint type is used - either `Standard` or `AzureDnsZone`.
 
-* `enable_https_traffic_only` - Is traffic only allowed via HTTPS? See [here](https://docs.microsoft.com/azure/storage/storage-require-secure-transfer/)
+* `https_traffic_only_enabled` - Is traffic only allowed via HTTPS? See [here](https://docs.microsoft.com/azure/storage/storage-require-secure-transfer/)
     for more information.
 
 * `min_tls_version` - The minimum supported TLS version for this storage account.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Storage Account should exist. Changing this forces a new Storage Account to be created.
 
-* `enable_https_traffic_only` - (Optional) Boolean flag which forces HTTPS if enabled, see [here](https://docs.microsoft.com/azure/storage/storage-require-secure-transfer/) for more information. Defaults to `true`.
+* `https_traffic_only_enabled` - (Optional) Boolean flag which forces HTTPS if enabled, see [here](https://docs.microsoft.com/azure/storage/storage-require-secure-transfer/) for more information. Defaults to `true`.
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the storage account. Possible values are `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_2` for new storage accounts.
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -129,7 +129,6 @@ The following arguments are supported:
 
 ~> Note: When the principal running Terraform has access to the subscription containing the Key Vault, it's recommended to use the `key_vault_id` property for maximum compatibility, rather than the `key_vault_uri` property.
 
-
 * `key_vault_uri` - (Optional) URI pointing at the Key Vault. Required when using `federated_identity_client_id`. Exactly one of `managed_hsm_key_id`, `key_vault_id`, or `key_vault_uri` must be specified.
 
 * `managed_hsm_key_id` - (Optional) Key ID of a key in a managed HSM.  Exactly one of `managed_hsm_key_id`, `key_vault_id`, or `key_vault_uri` must be specified.


### PR DESCRIPTION
Remove deprecated properties for v4.0

**Changelog**

* `data.azurerm_storage_account` - the `enable_https_traffic_only` property has been superseded by `https_traffic_only_enabled`
* `azurerm_storage_account` - the `enable_https_traffic_only` property has been superseded by `https_traffic_only_enabled`

(other properties were already deprecated)