### PR TITLE
`resources` - fix tests for 4.0

### DIFF
--- a/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -900,6 +900,10 @@ resource "azurerm_route_table" "test" {
   name                = "acctestrt%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [route]
+  }
 }
 
 resource "azurerm_resource_group_template_deployment" "test" {


### PR DESCRIPTION
```
--- PASS: TestAccResourceGroupTemplateDeployment_childItems (524.71s)
```