### PR TITLE
`azurerm_virtual_network` - replace `address_prefix` with `address_prefixes` in 4.0

### DIFF
--- a/internal/services/network/virtual_network_data_source_test.go
+++ b/internal/services/network/virtual_network_data_source_test.go
@@ -75,8 +75,8 @@ resource "azurerm_virtual_network" "test" {
   dns_servers         = ["10.0.0.4"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 

--- a/internal/services/network/virtual_network_dns_servers_resource_test.go
+++ b/internal/services/network/virtual_network_dns_servers_resource_test.go
@@ -107,8 +107,8 @@ resource "azurerm_virtual_network" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 
@@ -137,8 +137,8 @@ resource "azurerm_virtual_network" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -706,8 +706,6 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 				subnetObj.Properties.AddressPrefix = nil
 			}
 
-			subnetObj.Properties.AddressPrefixes = pointer.To(addressPrefixes)
-
 			privateEndpointNetworkPolicies := virtualnetworks.VirtualNetworkPrivateEndpointNetworkPolicies(subnet["private_endpoint_network_policies"].(string))
 			privateLinkServiceNetworkPolicies := virtualnetworks.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled
 			if subnet["private_link_service_network_policies_enabled"].(bool) {

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -372,7 +372,8 @@ func (r VirtualNetworkResource) Destroy(ctx context.Context, client *clients.Cli
 }
 
 func (VirtualNetworkResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -397,6 +398,32 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (r VirtualNetworkResource) tagCount(data acceptance.TestData) string {
@@ -405,7 +432,8 @@ func (r VirtualNetworkResource) tagCount(data acceptance.TestData) string {
 		tags += fmt.Sprintf("t%d = \"v%d\"\n", i, i)
 	}
 
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -430,10 +458,38 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, tags)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+  tags = {
+                                    %s
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, tags)
 }
 
 func (VirtualNetworkResource) complete(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -465,10 +521,44 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16", "10.10.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_servers         = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
+
+  encryption {
+    enforcement = "AllowUnencrypted"
+  }
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+
+  subnet {
+    name             = "subnet2"
+    address_prefixes = ["10.10.1.0/24"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (r VirtualNetworkResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_virtual_network" "import" {
@@ -483,10 +573,27 @@ resource "azurerm_virtual_network" "import" {
   }
 }
 `, r.basic(data))
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network" "import" {
+  name                = azurerm_virtual_network.test.name
+  location            = azurerm_virtual_network.test.location
+  resource_group_name = azurerm_virtual_network.test.resource_group_name
+  address_space       = ["10.0.0.0/16"]
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+}
+`, r.basic(data))
 }
 
 func (VirtualNetworkResource) ddosProtectionPlan(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -522,10 +629,48 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_network_ddos_protection_plan" "test" {
+  name                = "acctestddospplan-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ddos_protection_plan {
+    id     = azurerm_network_ddos_protection_plan.test.id
+    enable = true
+  }
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (VirtualNetworkResource) withTags(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -552,10 +697,40 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (VirtualNetworkResource) withTagsUpdated(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -574,6 +749,33 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 
   tags = {
@@ -630,7 +832,8 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) bgpCommunity(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -649,6 +852,31 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+
+  bgp_community = "12076:20000"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 
   bgp_community = "12076:20000"
@@ -724,13 +952,13 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 
 resource "azurerm_virtual_network" "test" {
   name                = "acctestvirtnet%[1]d"
-  address_space       = ["10.0.0.0/16"]
+  address_space       = ["10.0.0.0/16", "ace:cab:deca::/48"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
   subnet {
     name                                          = "subnet1"
-    address_prefix                                = "10.0.1.0/24"
+    address_prefixes                              = ["10.0.1.0/24", "ace:cab:deca::/64"]
     private_link_service_network_policies_enabled = false
     private_endpoint_network_policies             = "Enabled"
     service_endpoints                             = ["Microsoft.Sql", "Microsoft.Storage"]
@@ -749,7 +977,7 @@ resource "azurerm_virtual_network" "test" {
 
   subnet {
     name                                          = "subnet2"
-    address_prefix                                = "10.0.2.0/24"
+    address_prefixes                              = ["10.0.2.0/24"]
     private_link_service_network_policies_enabled = false
     service_endpoints                             = ["Microsoft.Storage"]
     service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
@@ -797,7 +1025,7 @@ resource "azurerm_virtual_network" "test" {
 
   subnet {
     name                                          = "subnet1"
-    address_prefix                                = "10.0.1.0/24"
+    address_prefixes                              = ["10.0.1.0/24"]
     default_outbound_access_enabled               = false
     private_link_service_network_policies_enabled = true
     private_endpoint_network_policies             = "Enabled"
@@ -823,7 +1051,8 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) subnetRouteTable(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -863,10 +1092,52 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  route {
+    name                   = "first"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+    route_table_id   = azurerm_route_table.test.id
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (VirtualNetworkResource) subnetRouteTableRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -898,6 +1169,46 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  route {
+    name                   = "first"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 
   tags = {

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
@@ -137,8 +137,8 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 
@@ -174,8 +174,8 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 
@@ -225,8 +225,8 @@ resource "azurerm_virtual_network" "test_alt" {
   address_space       = ["10.0.0.0/16"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 
@@ -280,8 +280,8 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 
@@ -322,8 +322,8 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
 
   subnet {
-    name           = "subnet1"
-    address_prefix = "10.0.1.0/24"
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
   }
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Related to #3917

## Testing 

Tests in 4.0:
```
--- PASS: TestAccVirtualNetwork_basic (75.65s)
--- PASS: TestAccVirtualNetwork_complete (88.93s)
--- PASS: TestAccVirtualNetwork_disappears (114.28s)
--- PASS: TestAccVirtualNetwork_basicUpdated (120.78s)
--- PASS: TestAccVirtualNetwork_requiresImport (122.83s)
--- PASS: TestAccVirtualNetwork_ddosProtectionPlan (128.28s)
--- PASS: TestAccVirtualNetwork_deleteSubnet (138.33s)
--- PASS: TestAccVirtualNetwork_subnetRouteTable (169.76s)
--- PASS: TestAccVirtualNetwork_withTags (172.84s)
--- PASS: TestAccVirtualNetwork_bgpCommunity (190.74s)
--- PASS: TestAccVirtualNetwork_edgeZone (244.48s)
--- PASS: TestAccVirtualNetwork_subnet (247.60s)
--- PASS: TestAccVirtualNetwork_updateFlowTimeoutInMinutes (257.57s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       260.613s

```

Tests in 3.0:
```
--- PASS: TestAccVirtualNetwork_disappears (81.34s)
--- PASS: TestAccVirtualNetwork_requiresImport (105.60s)
--- PASS: TestAccVirtualNetwork_withTags (119.88s)
--- PASS: TestAccVirtualNetwork_basic (128.33s)
--- PASS: TestAccVirtualNetwork_complete (133.41s)
--- PASS: TestAccVirtualNetwork_ddosProtectionPlan (145.43s)
--- PASS: TestAccVirtualNetwork_basicUpdated (151.87s)
--- PASS: TestAccVirtualNetwork_edgeZone (181.18s)
--- PASS: TestAccVirtualNetwork_deleteSubnet (182.49s)
--- PASS: TestAccVirtualNetwork_updateFlowTimeoutInMinutes (204.86s)
--- PASS: TestAccVirtualNetwork_bgpCommunity (206.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       209.177s

```

Manual upgrade from v3.114.0 to 4.0:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azurerm_virtual_network.test will be updated in-place
  ~ resource "azurerm_virtual_network" "test" {
        id                      = "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/bcctest-sw/providers/Microsoft.Network/virtualNetworks/acctestvirtnetsw"
        name                    = "acctestvirtnetsw"
        tags                    = {}
        # (6 unchanged attributes hidden)

      - subnet {
          - address_prefixes                              = [
              - "10.0.1.0/24",
            ] -> null
          - default_outbound_access_enabled               = false -> null
          - id                                            = "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/bcctest-sw/providers/Microsoft.Network/virtualNetworks/acctestvirtnetsw/subnets/subnet1" -> null
          - name                                          = "subnet1" -> null
          - private_endpoint_network_policies             = "Disabled" -> null
          - private_link_service_network_policies_enabled = true -> null
          - service_endpoint_policy_ids                   = [] -> null
          - service_endpoints                             = [] -> null
        }
      - subnet {
          - address_prefixes                              = [
              - "10.10.1.0/24",
            ] -> null
          - default_outbound_access_enabled               = false -> null
          - id                                            = "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/bcctest-sw/providers/Microsoft.Network/virtualNetworks/acctestvirtnetsw/subnets/subnet2" -> null
          - name                                          = "subnet2" -> null
          - private_endpoint_network_policies             = "Disabled" -> null
          - private_link_service_network_policies_enabled = true -> null
          - service_endpoint_policy_ids                   = [] -> null
          - service_endpoints                             = [] -> null
        }
      + subnet {
          + address_prefixes                              = [
              + "10.0.1.0/24",
            ]
          + default_outbound_access_enabled               = true
          + id                                            = (known after apply)
          + name                                          = "subnet1"
          + private_endpoint_network_policies             = "Disabled"
          + private_link_service_network_policies_enabled = true
          + service_endpoint_policy_ids                   = []
          + service_endpoints                             = []
        }
      + subnet {
          + address_prefixes                              = [
              + "10.10.1.0/24",
            ]
          + default_outbound_access_enabled               = true
          + id                                            = (known after apply)
          + name                                          = "subnet2"
          + private_endpoint_network_policies             = "Disabled"
          + private_link_service_network_policies_enabled = true
          + service_endpoint_policy_ids                   = []
          + service_endpoints                             = []
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
