### PR TITLE
[Deprecate] Add deprecation message for `Lab Service` RP

### DIFF
--- a/internal/services/labservice/lab_service_lab_resource.go
+++ b/internal/services/labservice/lab_service_lab_resource.go
@@ -107,6 +107,10 @@ func (r LabServiceLabResource) ResourceType() string {
 	return "azurerm_lab_service_lab"
 }
 
+func (r LabServiceLabResource) DeprecationMessage() string {
+	return "The `azurerm_lab_service_lab` resource is deprecated and will be removed in v4.0 of the AzureRM Provider. See more details from https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide"
+}
+
 func (r LabServiceLabResource) ModelObject() interface{} {
 	return &LabServiceLabModel{}
 }

--- a/internal/services/labservice/lab_service_lab_resource_test.go
+++ b/internal/services/labservice/lab_service_lab_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,10 @@ import (
 type LabServiceLabResource struct{}
 
 func TestAccLabServiceLab_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_lab", "test")
 	r := LabServiceLabResource{}
 
@@ -35,6 +40,10 @@ func TestAccLabServiceLab_basic(t *testing.T) {
 }
 
 func TestAccLabServiceLab_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_lab", "test")
 	r := LabServiceLabResource{}
 
@@ -50,6 +59,10 @@ func TestAccLabServiceLab_requiresImport(t *testing.T) {
 }
 
 func TestAccLabServiceLab_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_lab", "test")
 	r := LabServiceLabResource{}
 
@@ -65,6 +78,10 @@ func TestAccLabServiceLab_complete(t *testing.T) {
 }
 
 func TestAccLabServiceLab_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_lab", "test")
 	r := LabServiceLabResource{}
 

--- a/internal/services/labservice/lab_service_plan_resource.go
+++ b/internal/services/labservice/lab_service_plan_resource.go
@@ -63,6 +63,10 @@ func (r LabServicePlanResource) ResourceType() string {
 	return "azurerm_lab_service_plan"
 }
 
+func (r LabServicePlanResource) DeprecationMessage() string {
+	return "The `azurerm_lab_service_plan` resource is deprecated and will be removed in v4.0 of the AzureRM Provider. See more details from https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide"
+}
+
 func (r LabServicePlanResource) ModelObject() interface{} {
 	return &LabServicePlanModel{}
 }

--- a/internal/services/labservice/lab_service_plan_resource_test.go
+++ b/internal/services/labservice/lab_service_plan_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,10 @@ import (
 type LabServicePlanResource struct{}
 
 func TestAccLabServicePlan_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_plan", "test")
 	r := LabServicePlanResource{}
 
@@ -35,6 +40,10 @@ func TestAccLabServicePlan_basic(t *testing.T) {
 }
 
 func TestAccLabServicePlan_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_plan", "test")
 	r := LabServicePlanResource{}
 
@@ -50,6 +59,10 @@ func TestAccLabServicePlan_requiresImport(t *testing.T) {
 }
 
 func TestAccLabServicePlan_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_plan", "test")
 	r := LabServicePlanResource{}
 
@@ -65,6 +78,10 @@ func TestAccLabServicePlan_complete(t *testing.T) {
 }
 
 func TestAccLabServicePlan_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_plan", "test")
 	r := LabServicePlanResource{}
 

--- a/internal/services/labservice/lab_service_schedule_resource.go
+++ b/internal/services/labservice/lab_service_schedule_resource.go
@@ -46,6 +46,10 @@ func (r LabServiceScheduleResource) ResourceType() string {
 	return "azurerm_lab_service_schedule"
 }
 
+func (r LabServiceScheduleResource) DeprecationMessage() string {
+	return "The `azurerm_lab_service_schedule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider. See more details from https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide"
+}
+
 func (r LabServiceScheduleResource) ModelObject() interface{} {
 	return &LabServiceScheduleModel{}
 }

--- a/internal/services/labservice/lab_service_schedule_resource_test.go
+++ b/internal/services/labservice/lab_service_schedule_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -21,6 +22,10 @@ import (
 type LabServiceScheduleResource struct{}
 
 func TestAccLabServiceSchedule_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_schedule", "test")
 	r := LabServiceScheduleResource{}
 	stopTime := time.Now().Add(time.Hour * 1).Format(time.RFC3339)
@@ -37,6 +42,10 @@ func TestAccLabServiceSchedule_basic(t *testing.T) {
 }
 
 func TestAccLabServiceSchedule_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_schedule", "test")
 	r := LabServiceScheduleResource{}
 	stopTime := time.Now().Add(time.Hour * 1).Format(time.RFC3339)
@@ -56,6 +65,10 @@ func TestAccLabServiceSchedule_requiresImport(t *testing.T) {
 }
 
 func TestAccLabServiceSchedule_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_schedule", "test")
 	r := LabServiceScheduleResource{}
 
@@ -75,6 +88,10 @@ func TestAccLabServiceSchedule_complete(t *testing.T) {
 }
 
 func TestAccLabServiceSchedule_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_schedule", "test")
 	r := LabServiceScheduleResource{}
 

--- a/internal/services/labservice/lab_service_user_resource.go
+++ b/internal/services/labservice/lab_service_user_resource.go
@@ -34,6 +34,10 @@ func (r LabServiceUserResource) ResourceType() string {
 	return "azurerm_lab_service_user"
 }
 
+func (r LabServiceUserResource) DeprecationMessage() string {
+	return "The `azurerm_lab_service_user` resource is deprecated and will be removed in v4.0 of the AzureRM Provider. See more details from https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide"
+}
+
 func (r LabServiceUserResource) ModelObject() interface{} {
 	return &LabServiceUserModel{}
 }

--- a/internal/services/labservice/lab_service_user_resource_test.go
+++ b/internal/services/labservice/lab_service_user_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,10 @@ import (
 type LabServiceUserResource struct{}
 
 func TestAccLabServiceUser_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_user", "test")
 	r := LabServiceUserResource{}
 
@@ -35,6 +40,10 @@ func TestAccLabServiceUser_basic(t *testing.T) {
 }
 
 func TestAccLabServiceUser_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_user", "test")
 	r := LabServiceUserResource{}
 
@@ -50,6 +59,10 @@ func TestAccLabServiceUser_requiresImport(t *testing.T) {
 }
 
 func TestAccLabServiceUser_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_user", "test")
 	r := LabServiceUserResource{}
 
@@ -65,6 +78,10 @@ func TestAccLabServiceUser_complete(t *testing.T) {
 }
 
 func TestAccLabServiceUser_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("Resource has been removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lab_service_user", "test")
 	r := LabServiceUserResource{}
 

--- a/website/docs/r/lab_service_lab.html.markdown
+++ b/website/docs/r/lab_service_lab.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Lab Service Lab.
 
+!> **Note:** This resource is being [deprecated by Azure](https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide). This resource will be removed in version 4.0 of the provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/lab_service_plan.html.markdown
+++ b/website/docs/r/lab_service_plan.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Lab Service Plan.
 
+!> **Note:** This resource is being [deprecated by Azure](https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide). This resource will be removed in version 4.0 of the provider.
+
 -> **Note:** Before using this resource, it's required to submit the request of registering the provider with Azure CLI `az provider register --namespace Microsoft.LabServices`.
 
 ## Example Usage

--- a/website/docs/r/lab_service_schedule.html.markdown
+++ b/website/docs/r/lab_service_schedule.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Lab Service Schedule.
 
+!> **Note:** This resource is being [deprecated by Azure](https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide). This resource will be removed in version 4.0 of the provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/lab_service_user.html.markdown
+++ b/website/docs/r/lab_service_user.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Lab Service User.
 
+!> **Note:** This resource is being [deprecated by Azure](https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide). This resource will be removed in version 4.0 of the provider.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently I noticed that test cases related with Lab Service RP are failed on Teamcity Daily Run. Given the Lab resource/Lab Schedule resource/Lab User resource depends on the Lab Plan resource and service API doesn't allow to create Lab Plan for new customers since Lab Service RP has been deprecated by Azure. See more details from https://learn.microsoft.com/en-us/azure/lab-services/retirement-guide. Service team also confirmed that everything under LabServices will be deprecated. 
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. Though existing lab accounts, lab plans, and labs will continue to operate until the service is fully retired on June 28, 2027. But new customers will not be able to sign up for the service from July 15, 2024 onwards. So I think we also can submit PR to deprecate Lab Service for the retirement.

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [Deprecate] Add deprecation message for `Lab Service` RP


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
