### PR TITLE
`mssqlmanagedinstance` - fix tests for 4.0

### DIFF
--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1857,10 +1857,9 @@ resource "azurerm_network_security_rule" "deny_all_outbound_1" {
 }
 
 resource "azurerm_route_table" "test" {
-  name                          = "routetable1-%[1]d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  bgp_route_propagation_enabled = true
+  name                = "routetable1-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   route {
     name           = "subnet-to-vnetlocal"
@@ -2092,10 +2091,9 @@ resource "azurerm_network_security_rule" "deny_all_outbound_2" {
 }
 
 resource "azurerm_route_table" "secondary" {
-  name                          = "routetable2-%[1]d"
-  location                      = azurerm_resource_group.secondary.location
-  resource_group_name           = azurerm_resource_group.secondary.name
-  bgp_route_propagation_enabled = true
+  name                = "routetable2-%[1]d"
+  location            = azurerm_resource_group.secondary.location
+  resource_group_name = azurerm_resource_group.secondary.name
 
   route {
     name           = "subnet-to-vnetlocal"
@@ -2327,10 +2325,9 @@ resource "azurerm_network_security_rule" "deny_all_outbound_3" {
 }
 
 resource "azurerm_route_table" "secondary_2" {
-  name                          = "routetable3-%[1]d"
-  location                      = azurerm_resource_group.secondary_2.location
-  resource_group_name           = azurerm_resource_group.secondary_2.name
-  bgp_route_propagation_enabled = true
+  name                = "routetable3-%[1]d"
+  location            = azurerm_resource_group.secondary_2.location
+  resource_group_name = azurerm_resource_group.secondary_2.name
 
   route {
     name           = "subnet-to-vnetlocal"

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1686,6 +1686,10 @@ resource "azurerm_network_security_group" "test" {
   name                = "mi-security-group1-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    ignore_changes = [security_rule]
+  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_1" {
@@ -1860,7 +1864,7 @@ resource "azurerm_route_table" "test" {
   name                          = "routetable1-%[1]d"
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 
   route {
     name           = "subnet-to-vnetlocal"
@@ -1921,6 +1925,10 @@ resource "azurerm_network_security_group" "secondary" {
   name                = "mi-security-group2-%[1]d"
   location            = azurerm_resource_group.secondary.location
   resource_group_name = azurerm_resource_group.secondary.name
+
+  lifecycle {
+    ignore_changes = [security_rule]
+  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_2" {
@@ -2095,7 +2103,7 @@ resource "azurerm_route_table" "secondary" {
   name                          = "routetable2-%[1]d"
   location                      = azurerm_resource_group.secondary.location
   resource_group_name           = azurerm_resource_group.secondary.name
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 
   route {
     name           = "subnet-to-vnetlocal"
@@ -2156,6 +2164,10 @@ resource "azurerm_network_security_group" "secondary_2" {
   name                = "mi-security-group3-%[1]d"
   location            = azurerm_resource_group.secondary_2.location
   resource_group_name = azurerm_resource_group.secondary_2.name
+
+  lifecycle {
+    ignore_changes = [security_rule]
+  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_3" {
@@ -2330,7 +2342,7 @@ resource "azurerm_route_table" "secondary_2" {
   name                          = "routetable3-%[1]d"
   location                      = azurerm_resource_group.secondary_2.location
   resource_group_name           = azurerm_resource_group.secondary_2.name
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 
   route {
     name           = "subnet-to-vnetlocal"

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1686,10 +1686,6 @@ resource "azurerm_network_security_group" "test" {
   name                = "mi-security-group1-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_1" {
@@ -1925,10 +1921,6 @@ resource "azurerm_network_security_group" "secondary" {
   name                = "mi-security-group2-%[1]d"
   location            = azurerm_resource_group.secondary.location
   resource_group_name = azurerm_resource_group.secondary.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_2" {
@@ -2164,10 +2156,6 @@ resource "azurerm_network_security_group" "secondary_2" {
   name                = "mi-security-group3-%[1]d"
   location            = azurerm_resource_group.secondary_2.location
   resource_group_name = azurerm_resource_group.secondary_2.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_network_security_rule" "allow_management_inbound_3" {


### PR DESCRIPTION
The property `disable_bgp_route_propagation` has been superseded by the property `bgp_route_propagation_enabled` in `azurerm_route_table` and will be removed in v4.0 of the AzureRM Provider.

Fix the following test failure in `mssqlmanagedinstance` RP for 4.0.
![image](https://github.com/user-attachments/assets/8242e75c-df39-4bda-aa6a-ea1cf2a280d2)
