### PR TITLE
`azurerm_cognitive_deployment` - replace deprecated `scale` block with `sku` block in version 4.0

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -85,7 +85,7 @@ func TestAccCognitiveDeployment_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("scale.0.capacity").HasValue("1"),
+				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
 				check.That(data.ResourceName).Key("rai_policy_name").HasValue("RAI policy"),
 			),
 		},
@@ -94,7 +94,7 @@ func TestAccCognitiveDeployment_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("scale.0.capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("2"),
 				check.That(data.ResourceName).Key("rai_policy_name").HasValue("Microsoft.Default"),
 			),
 		},
@@ -183,8 +183,8 @@ resource "azurerm_cognitive_deployment" "test" {
     format = "OpenAI"
     name   = "text-embedding-ada-002"
   }
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
   lifecycle {
     ignore_changes = [model.0.version]
@@ -206,8 +206,8 @@ resource "azurerm_cognitive_deployment" "import" {
     name    = "text-embedding-ada-002"
     version = "2"
   }
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 `, config)
@@ -227,8 +227,8 @@ resource "azurerm_cognitive_deployment" "test" {
     name    = "text-embedding-ada-002"
     version = "2"
   }
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
   rai_policy_name        = "RAI policy"
   version_upgrade_option = "OnceNewDefaultVersionAvailable"
@@ -250,8 +250,8 @@ resource "azurerm_cognitive_deployment" "test" {
     name    = "text-embedding-ada-002"
     version = "2"
   }
-  scale {
-    type     = "Standard"
+  sku {
+    name     = "Standard"
     capacity = 2
   }
 }
@@ -272,8 +272,8 @@ resource "azurerm_cognitive_deployment" "test" {
     name    = "text-embedding-ada-002"
     version = "1"
   }
-  scale {
-    type     = "Standard"
+  sku {
+    name     = "Standard"
     capacity = 2
   }
 }
@@ -295,8 +295,8 @@ resource "azurerm_cognitive_deployment" "test" {
     name    = "text-embedding-ada-002"
     version = "1"
   }
-  scale {
-    type     = "Standard"
+  sku {
+    name     = "Standard"
     capacity = 2
   }
 }

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_cognitive_deployment" "example" {
     version = "1"
   }
 
-  scale {
+  sku {
     type = "Standard"
   }
 }
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `model` - (Required) A `model` block as defined below. Changing this forces a new resource to be created.
 
-* `scale` - (Required) A `scale` block as defined below.
+* `sku` - (Required) A `sku` block as defined below.
 
 * `rai_policy_name` - (Optional) The name of RAI policy.
 
@@ -70,17 +70,17 @@ A `model` block supports the following:
 
 ---
 
-A `scale` block supports the following:
+A `sku` block supports the following:
 
-* `type` - (Required) The name of the SKU. Ex - `Standard` or `P3`. It is typically a letter+number code. Changing this forces a new resource to be created.
-
-* `tier` - (Optional) Possible values are `Free`, `Basic`, `Standard`, `Premium`, `Enterprise`. Changing this forces a new resource to be created.
-
-* `size` - (Optional) The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. Changing this forces a new resource to be created.
+* `capacity` - (Optional) Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest).
 
 * `family` - (Optional) If the service has different generations of hardware, for the same SKU, then that can be captured here. Changing this forces a new resource to be created.
 
-* `capacity` - (Optional) Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest).
+* `name` - (Required) The name of the SKU. Ex - `Standard` or `P3`. It is typically a letter+number code. Changing this forces a new resource to be created.
+
+* `size` - (Optional) The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. Changing this forces a new resource to be created.
+
+* `tier` - (Optional) Possible values are `Free`, `Basic`, `Standard`, `Premium`, `Enterprise`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_cognitive_deployment` - replace deprecated `scale` block with `sku` block in version 4.0

The `scale` block has been deprecated for a while now. In the current setup, we support the `scale` block in user templates, but switch to the `sku` block when making REST API calls. This inconsistency might be confusing for our customers. We're planning to address this by standardizing on the `sku` block in version 4.0. 

However, it's important to note that this will be a significant change and will require the adoption of the `sku` block moving forward. If anyone is currently utilizing the `scale` block, it's necessary to rename this block to `sku` and substitute the `type` parameter with `name` within the `sku` block.

> [!NOTE] 
> This is a breaking change to resource `azurerm_cognitive_deployment`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\<alias>\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\<alias>\<pathtogoland>\GoLand\___TestAccCognitiveDeploymentSequential_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\<alias>\<pathtogoland>\GoLand\___TestAccCognitiveDeploymentSequential_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccCognitiveDeploymentSequential\E$ #gosetup
=== RUN   TestAccCognitiveDeploymentSequential
--- PASS: TestAccCognitiveDeploymentSequential (958.13s)
=== RUN   TestAccCognitiveDeploymentSequential/deployment
    --- PASS: TestAccCognitiveDeploymentSequential/deployment (958.13s)
=== RUN   TestAccCognitiveDeploymentSequential/deployment/basic
        --- PASS: TestAccCognitiveDeploymentSequential/deployment/basic (214.56s)
=== RUN   TestAccCognitiveDeploymentSequential/deployment/requiresImport
        --- PASS: TestAccCognitiveDeploymentSequential/deployment/requiresImport (196.19s)
=== RUN   TestAccCognitiveDeploymentSequential/deployment/complete
        --- PASS: TestAccCognitiveDeploymentSequential/deployment/complete (196.20s)
=== RUN   TestAccCognitiveDeploymentSequential/deployment/update
        --- PASS: TestAccCognitiveDeploymentSequential/deployment/update (351.18s)
PASS
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cognitive_deployment` - replace deprecated `scale` block with `sku` block in version 4.0 [GH-26796]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change
