### PR TITLE
`batch`: retain ConfigModeAttr functionality for 4.0

### DIFF
--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -167,9 +167,10 @@ func resourceBatchAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 			"encryption": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:       pluginsdk.TypeList,
+				Optional:   true,
+				MaxItems:   1,
+				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"key_vault_key_id": {

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -813,111 +812,6 @@ resource "azurerm_key_vault_key" "test" {
 }
 
 func (BatchAccountResource) removeEncryption(data acceptance.TestData, tenantID string) string {
-	if !features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
-    }
-  }
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-batch-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%[3]s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%[3]s"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_batch_account" "test" {
-  name                                = "testaccbatch%[3]s"
-  resource_group_name                 = azurerm_resource_group.test.name
-  location                            = azurerm_resource_group.test.location
-  pool_allocation_mode                = "BatchService"
-  storage_account_id                  = azurerm_storage_account.test.id
-  storage_account_authentication_mode = "StorageKeys"
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.test.id]
-  }
-  encryption = []
-}
-
-resource "azurerm_key_vault" "test" {
-  name                            = "batchkv%[3]s"
-  location                        = azurerm_resource_group.test.location
-  resource_group_name             = azurerm_resource_group.test.name
-  enabled_for_disk_encryption     = true
-  enabled_for_deployment          = true
-  enabled_for_template_deployment = true
-  purge_protection_enabled        = true
-  tenant_id                       = "%[4]s"
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = "%[4]s"
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "Get",
-      "Create",
-      "Delete",
-      "WrapKey",
-      "UnwrapKey",
-      "GetRotationPolicy",
-      "SetRotationPolicy",
-    ]
-  }
-
-  access_policy {
-    tenant_id = "%[4]s"
-    object_id = azurerm_user_assigned_identity.test.principal_id
-
-    key_permissions = [
-      "Get",
-      "WrapKey",
-      "UnwrapKey"
-    ]
-  }
-}
-
-resource "azurerm_key_vault_key" "test" {
-  name         = "enckey%[1]d"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID)
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -961,6 +855,7 @@ resource "azurerm_batch_account" "test" {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
+  encryption = []
 }
 
 resource "azurerm_key_vault" "test" {

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -168,9 +168,10 @@ func resourceBatchPool() *pluginsdk.Resource {
 							AtLeastOneOf: []string{"container_configuration.0.type", "container_configuration.0.container_image_names", "container_configuration.0.container_registries"},
 						},
 						"container_registries": {
-							Type:     pluginsdk.TypeList,
-							Optional: true,
-							ForceNew: true,
+							Type:       pluginsdk.TypeList,
+							Optional:   true,
+							ForceNew:   true,
+							ConfigMode: pluginsdk.SchemaConfigModeAttr,
 							Elem: &pluginsdk.Resource{
 								Schema: containerRegistry(),
 							},


### PR DESCRIPTION
Test failures largely due to `azurerm_virtual_network` which is addressed in #26791, and some other unrelated failures

<img width="529" alt="Screenshot 2024-07-26 at 09 10 37" src="https://github.com/user-attachments/assets/4c037360-2fd1-4c54-8115-52a96002df28">
<br
<br>

<img width="425" alt="Screenshot 2024-07-26 at 09 10 31" src="https://github.com/user-attachments/assets/7542287e-3cd3-4c8f-87f7-73a81e5ae5f7">
