### PR TITLE
`mariadb` - fix tests for 4.0

### DIFF
--- a/internal/services/mariadb/mariadb_configuration_resource_test.go
+++ b/internal/services/mariadb/mariadb_configuration_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type MariaDbConfigurationResource struct{}
 
 func TestAccMariaDbConfiguration_characterSetServer(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_configuration` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	srv := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_configuration", "test")
 	r := MariaDbConfigurationResource{}
@@ -43,6 +47,9 @@ func TestAccMariaDbConfiguration_characterSetServer(t *testing.T) {
 }
 
 func TestAccMariaDbConfiguration_interactiveTimeout(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_configuration` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	srv := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_configuration", "test")
 	r := MariaDbConfigurationResource{}
@@ -66,6 +73,9 @@ func TestAccMariaDbConfiguration_interactiveTimeout(t *testing.T) {
 }
 
 func TestAccMariaDbConfiguration_logSlowAdminStatements(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_configuration` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	srv := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_configuration", "test")
 	r := MariaDbConfigurationResource{}

--- a/internal/services/mariadb/mariadb_database_resource_test.go
+++ b/internal/services/mariadb/mariadb_database_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MariaDbDatabaseResource struct{}
 
 func TestAccMariaDbDatabase_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_database` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_database", "test")
 	r := MariaDbDatabaseResource{}
 
@@ -36,6 +40,9 @@ func TestAccMariaDbDatabase_basic(t *testing.T) {
 }
 
 func TestAccMariaDbDatabase_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_database` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_database", "test")
 	r := MariaDbDatabaseResource{}
 

--- a/internal/services/mariadb/mariadb_firewall_rule_resource_test.go
+++ b/internal/services/mariadb/mariadb_firewall_rule_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MariaDbFirewallRuleResource struct{}
 
 func TestAccMariaDbFirewallRule_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_firewall_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_firewall_rule", "test")
 	r := MariaDbFirewallRuleResource{}
 
@@ -34,6 +38,9 @@ func TestAccMariaDbFirewallRule_basic(t *testing.T) {
 }
 
 func TestAccMariaDbFirewallRule_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_firewall_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_firewall_rule", "test")
 	r := MariaDbFirewallRuleResource{}
 

--- a/internal/services/mariadb/mariadb_server_data_source_test.go
+++ b/internal/services/mariadb/mariadb_server_data_source_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type MariaDbServerDataSource struct{}
 
 func TestAccMariaDbServerDataSource_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `data.azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_mariadb_server", "test")
 	r := MariaDbServerDataSource{}
 

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type MariaDbServerResource struct{}
 
 func TestAccMariaDbServer_basicTenTwo(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	version := "10.2"
@@ -37,6 +41,9 @@ func TestAccMariaDbServer_basicTenTwo(t *testing.T) {
 }
 
 func TestAccMariaDbServer_basicTenThree(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	version := "10.3"
@@ -54,6 +61,9 @@ func TestAccMariaDbServer_basicTenThree(t *testing.T) {
 }
 
 func TestAccMariaDbServer_autogrowOnly(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	version := "10.3"
@@ -70,6 +80,9 @@ func TestAccMariaDbServer_autogrowOnly(t *testing.T) {
 }
 
 func TestAccMariaDbServer_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 
@@ -85,6 +98,9 @@ func TestAccMariaDbServer_requiresImport(t *testing.T) {
 }
 
 func TestAccMariaDbServer_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 
@@ -100,6 +116,9 @@ func TestAccMariaDbServer_complete(t *testing.T) {
 }
 
 func TestAccMariaDbServer_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	version := "10.3"
@@ -130,6 +149,9 @@ func TestAccMariaDbServer_update(t *testing.T) {
 }
 
 func TestAccMariaDbServer_updateSKU(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 
@@ -152,6 +174,9 @@ func TestAccMariaDbServer_updateSKU(t *testing.T) {
 }
 
 func TestAccMariaDbServer_createReplica(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	version := "10.3"
@@ -176,6 +201,9 @@ func TestAccMariaDbServer_createReplica(t *testing.T) {
 }
 
 func TestAccMariaDbServer_createPointInTimeRestore(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_server` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
 	r := MariaDbServerResource{}
 	restoreTime := time.Now().Add(11 * time.Minute)

--- a/internal/services/mariadb/mariadb_virtual_network_rule_resource_test.go
+++ b/internal/services/mariadb/mariadb_virtual_network_rule_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type MariaDbVirtualNetworkRuleResource struct{}
 
 func TestAccMariaDbVirtualNetworkRule_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_virtual_network_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_virtual_network_rule", "test")
 	r := MariaDbVirtualNetworkRuleResource{}
 
@@ -34,6 +38,9 @@ func TestAccMariaDbVirtualNetworkRule_basic(t *testing.T) {
 }
 
 func TestAccMariaDbVirtualNetworkRule_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_virtual_network_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_virtual_network_rule", "test")
 	r := MariaDbVirtualNetworkRuleResource{}
 
@@ -52,6 +59,9 @@ func TestAccMariaDbVirtualNetworkRule_requiresImport(t *testing.T) {
 }
 
 func TestAccMariaDbVirtualNetworkRule_switchSubnets(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_virtual_network_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_virtual_network_rule", "test")
 	r := MariaDbVirtualNetworkRuleResource{}
 
@@ -78,6 +88,9 @@ func TestAccMariaDbVirtualNetworkRule_switchSubnets(t *testing.T) {
 }
 
 func TestAccMariaDbVirtualNetworkRule_multipleSubnets(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_mariadb_virtual_network_rule` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_mariadb_virtual_network_rule", "rule1")
 	r := MariaDbVirtualNetworkRuleResource{}
 


### PR DESCRIPTION
Skipping tests as all resources in `mariadb` are deprecated and will be removed in v4.0 of the AzureRM Provider.

Test results:
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MARIADB/204194?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true