### PR TITLE
`media` - fix tests for 4.0

### DIFF
--- a/internal/services/media/media_asset_filter_resource_test.go
+++ b/internal/services/media/media_asset_filter_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type AssetFilterResource struct{}
 
 func TestAccAssetFilter_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset_filter", "test")
 	r := AssetFilterResource{}
 
@@ -34,6 +38,9 @@ func TestAccAssetFilter_basic(t *testing.T) {
 }
 
 func TestAccAssetFilter_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset_filter", "test")
 	r := AssetFilterResource{}
 
@@ -49,6 +56,9 @@ func TestAccAssetFilter_requiresImport(t *testing.T) {
 }
 
 func TestAccAssetFilter_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset_filter", "test")
 	r := AssetFilterResource{}
 
@@ -64,6 +74,9 @@ func TestAccAssetFilter_complete(t *testing.T) {
 }
 
 func TestAccAssetFilter_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset_filter", "test")
 	r := AssetFilterResource{}
 

--- a/internal/services/media/media_asset_resource_test.go
+++ b/internal/services/media/media_asset_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MediaAssetResource struct{}
 
 func TestAccMediaAsset_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset", "test")
 	r := MediaAssetResource{}
 
@@ -34,6 +38,9 @@ func TestAccMediaAsset_basic(t *testing.T) {
 }
 
 func TestAccMediaAsset_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset", "test")
 	r := MediaAssetResource{}
 
@@ -49,6 +56,9 @@ func TestAccMediaAsset_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaAsset_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset", "test")
 	r := MediaAssetResource{}
 
@@ -67,6 +77,9 @@ func TestAccMediaAsset_complete(t *testing.T) {
 }
 
 func TestAccMediaAsset_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_asset` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_asset", "test")
 	r := MediaAssetResource{}
 

--- a/internal/services/media/media_content_key_policy_resource_test.go
+++ b/internal/services/media/media_content_key_policy_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MediaContentKeyPolicyResource struct{}
 
 func TestAccMediaContentKeyPolicy_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_content_key_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
 	r := MediaContentKeyPolicyResource{}
 
@@ -35,6 +39,9 @@ func TestAccMediaContentKeyPolicy_basic(t *testing.T) {
 }
 
 func TestAccMediaContentKeyPolicy_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_content_key_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
 	r := MediaContentKeyPolicyResource{}
 
@@ -64,6 +71,9 @@ func TestAccMediaContentKeyPolicy_update(t *testing.T) {
 }
 
 func TestAccMediaContentKeyPolicy_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_content_key_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
 	r := MediaContentKeyPolicyResource{}
 
@@ -80,6 +90,9 @@ func TestAccMediaContentKeyPolicy_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaContentKeyPolicy_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_content_key_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
 	r := MediaContentKeyPolicyResource{}
 

--- a/internal/services/media/media_job_resource_test.go
+++ b/internal/services/media/media_job_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MediaJobResource struct{}
 
 func TestAccMediaJob_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_job` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_job", "test")
 	r := MediaJobResource{}
 
@@ -36,6 +40,9 @@ func TestAccMediaJob_basic(t *testing.T) {
 }
 
 func TestAccMediaJob_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_job` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_job", "test")
 	r := MediaJobResource{}
 
@@ -53,6 +60,9 @@ func TestAccMediaJob_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaJob_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_job` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_job", "test")
 	r := MediaJobResource{}
 
@@ -71,6 +81,9 @@ func TestAccMediaJob_complete(t *testing.T) {
 }
 
 func TestAccMediaJob_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_job` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_job", "test")
 	r := MediaJobResource{}
 

--- a/internal/services/media/media_live_output_resource_test.go
+++ b/internal/services/media/media_live_output_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type LiveOutputResource struct{}
 
 func TestAccLiveOutput_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event_output` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event_output", "test")
 	r := LiveOutputResource{}
 
@@ -34,6 +38,9 @@ func TestAccLiveOutput_basic(t *testing.T) {
 }
 
 func TestAccLiveOutput_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event_output` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event_output", "test")
 	r := LiveOutputResource{}
 
@@ -49,6 +56,9 @@ func TestAccLiveOutput_requiresImport(t *testing.T) {
 }
 
 func TestAccLiveOutput_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event_output` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event_output", "test")
 	r := LiveOutputResource{}
 
@@ -65,6 +75,9 @@ func TestAccLiveOutput_complete(t *testing.T) {
 }
 
 func TestAccLiveOutput_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event_output` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event_output", "test")
 	r := LiveOutputResource{}
 

--- a/internal/services/media/media_service_account_filter_resource_test.go
+++ b/internal/services/media/media_service_account_filter_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type AccountFilterResource struct{}
 
 func TestAccMediaServicesAccountFilter_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
 	r := AccountFilterResource{}
 
@@ -34,6 +38,9 @@ func TestAccMediaServicesAccountFilter_basic(t *testing.T) {
 }
 
 func TestAccMediaServicesAccountFilter_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
 	r := AccountFilterResource{}
 
@@ -49,6 +56,9 @@ func TestAccMediaServicesAccountFilter_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaServicesAccountFilter_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
 	r := AccountFilterResource{}
 
@@ -64,6 +74,9 @@ func TestAccMediaServicesAccountFilter_complete(t *testing.T) {
 }
 
 func TestAccMediaServicesAccountFilter_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account_filter` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
 	r := AccountFilterResource{}
 

--- a/internal/services/media/media_services_account_resource_test.go
+++ b/internal/services/media/media_services_account_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type MediaServicesAccountResource struct{}
 
 func TestAccMediaServicesAccount_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -35,6 +39,9 @@ func TestAccMediaServicesAccount_basic(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -50,6 +57,9 @@ func TestAccMediaServicesAccount_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_multipleAccounts(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -71,6 +81,9 @@ func TestAccMediaServicesAccount_multipleAccounts(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_storageAuthWithManagedIdentity(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -86,6 +99,9 @@ func TestAccMediaServicesAccount_storageAuthWithManagedIdentity(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_multiplePrimaries(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -98,6 +114,9 @@ func TestAccMediaServicesAccount_multiplePrimaries(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_publicNetwork(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -127,6 +146,9 @@ func TestAccMediaServicesAccount_publicNetwork(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_identity(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -156,6 +178,9 @@ func TestAccMediaServicesAccount_identity(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_encryptionCustomerKey(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -171,6 +196,9 @@ func TestAccMediaServicesAccount_encryptionCustomerKey(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_encryptionUpdated(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 
@@ -200,6 +228,9 @@ func TestAccMediaServicesAccount_encryptionUpdated(t *testing.T) {
 }
 
 func TestAccMediaServicesAccount_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_services_account` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_services_account", "test")
 	r := MediaServicesAccountResource{}
 

--- a/internal/services/media/media_streaming_endpoint_resource_test.go
+++ b/internal/services/media/media_streaming_endpoint_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type MediaStreamingEndpointResource struct{}
 
 func TestAccMediaStreamingEndpoint_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 
@@ -36,6 +40,9 @@ func TestAccMediaStreamingEndpoint_basic(t *testing.T) {
 }
 
 func TestAccMediaStreamingEndpoint_CDN(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 
@@ -52,6 +59,9 @@ func TestAccMediaStreamingEndpoint_CDN(t *testing.T) {
 }
 
 func TestAccMediaStreamingEndpoint_MaxCacheAge(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 
@@ -67,6 +77,9 @@ func TestAccMediaStreamingEndpoint_MaxCacheAge(t *testing.T) {
 }
 
 func TestAccMediaStreamingEndpoint_shouldStopWhenStarted(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 
@@ -84,6 +97,9 @@ func TestAccMediaStreamingEndpoint_shouldStopWhenStarted(t *testing.T) {
 }
 
 func TestAccMediaStreamingEndpoint_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 
@@ -106,6 +122,9 @@ func TestAccMediaStreamingEndpoint_update(t *testing.T) {
 }
 
 func TestAccMediaStreamingEndpoint_standard(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_endpoint` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
 	r := MediaStreamingEndpointResource{}
 

--- a/internal/services/media/media_streaming_live_event_resource_test.go
+++ b/internal/services/media/media_streaming_live_event_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type LiveEventResource struct{}
 
 func TestAccLiveEvent_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
 	r := LiveEventResource{}
 
@@ -34,6 +38,9 @@ func TestAccLiveEvent_basic(t *testing.T) {
 }
 
 func TestAccLiveEvent_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
 	r := LiveEventResource{}
 
@@ -49,6 +56,9 @@ func TestAccLiveEvent_requiresImport(t *testing.T) {
 }
 
 func TestAccLiveEvent_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
 	r := LiveEventResource{}
 
@@ -70,6 +80,9 @@ func TestAccLiveEvent_update(t *testing.T) {
 }
 
 func TestAccLiveEvent_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_live_event` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
 	r := LiveEventResource{}
 

--- a/internal/services/media/media_streaming_locator_resource_test.go
+++ b/internal/services/media/media_streaming_locator_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type StreamingLocatorResource struct{}
 
 func TestAccStreamingLocator_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_locator` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_locator", "test")
 	r := StreamingLocatorResource{}
 
@@ -35,6 +39,9 @@ func TestAccStreamingLocator_basic(t *testing.T) {
 }
 
 func TestAccStreamingLocator_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_locator` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_locator", "test")
 	r := StreamingLocatorResource{}
 
@@ -51,6 +58,9 @@ func TestAccStreamingLocator_requiresImport(t *testing.T) {
 }
 
 func TestAccStreamingLocator_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_locator` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_locator", "test")
 	r := StreamingLocatorResource{}
 
@@ -67,6 +77,9 @@ func TestAccStreamingLocator_complete(t *testing.T) {
 }
 
 func TestAccStreamingLocator_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_locator` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_locator", "test")
 	r := StreamingLocatorResource{}
 

--- a/internal/services/media/media_streaming_policy_resource_test.go
+++ b/internal/services/media/media_streaming_policy_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type StreamingPolicyResource struct{}
 
 func TestAccStreamingPolicy_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_policy", "test")
 	r := StreamingPolicyResource{}
 
@@ -34,6 +38,9 @@ func TestAccStreamingPolicy_basic(t *testing.T) {
 }
 
 func TestAccStreamingPolicy_clearKeyEncryption(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_policy", "test")
 	r := StreamingPolicyResource{}
 
@@ -49,6 +56,9 @@ func TestAccStreamingPolicy_clearKeyEncryption(t *testing.T) {
 }
 
 func TestAccStreamingPolicy_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_policy", "test")
 	r := StreamingPolicyResource{}
 
@@ -64,6 +74,9 @@ func TestAccStreamingPolicy_requiresImport(t *testing.T) {
 }
 
 func TestAccStreamingPolicy_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_policy", "test")
 	r := StreamingPolicyResource{}
 
@@ -80,6 +93,9 @@ func TestAccStreamingPolicy_complete(t *testing.T) {
 }
 
 func TestAccStreamingPolicy_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_streaming_policy` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_streaming_policy", "test")
 	r := StreamingPolicyResource{}
 

--- a/internal/services/media/media_transform_resource_test.go
+++ b/internal/services/media/media_transform_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,6 +20,9 @@ import (
 type MediaTransformResource struct{}
 
 func TestAccMediaTransform_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_transform` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_transform", "test")
 	r := MediaTransformResource{}
 
@@ -35,6 +39,9 @@ func TestAccMediaTransform_basic(t *testing.T) {
 }
 
 func TestAccMediaTransform_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_transform` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_transform", "test")
 	r := MediaTransformResource{}
 
@@ -51,6 +58,9 @@ func TestAccMediaTransform_requiresImport(t *testing.T) {
 }
 
 func TestAccMediaTransform_complete(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_transform` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_transform", "test")
 	r := MediaTransformResource{}
 
@@ -68,6 +78,9 @@ func TestAccMediaTransform_complete(t *testing.T) {
 }
 
 func TestAccMediaTransform_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("The `azurerm_media_transform` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_media_transform", "test")
 	r := MediaTransformResource{}
 


### PR DESCRIPTION
Skipping tests as all resources in `media` are deprecated and will be removed in v4.0 of the AzureRM Provider.

Test results:
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MEDIA/204198?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true