### PR TITLE
`databasemigration`, `databricks`, `datafactory`, `devtestlabs` - reverting changes 

### DIFF
--- a/internal/services/databasemigration/database_migration_service_resource_test.go
+++ b/internal/services/databasemigration/database_migration_service_resource_test.go
@@ -125,10 +125,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
@@ -257,10 +257,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -335,10 +331,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -117,10 +117,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {

--- a/internal/services/databricks/databricks_workspace_private_endpoint_connection_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_private_endpoint_connection_data_source_test.go
@@ -54,10 +54,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -115,10 +111,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -480,10 +480,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -532,10 +528,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -597,10 +589,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -649,10 +637,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -750,10 +734,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -802,10 +782,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -859,10 +835,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -911,10 +883,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -970,10 +938,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -1022,10 +986,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -1082,10 +1042,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -1134,10 +1090,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-private-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -1209,10 +1161,6 @@ resource "azurerm_key_vault" "test" {
 
   purge_protection_enabled   = true
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -1238,10 +1186,6 @@ resource "azurerm_machine_learning_workspace" "test" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [managed_network]
   }
 }
 
@@ -1275,10 +1219,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -1336,10 +1276,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -1425,10 +1361,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -1477,10 +1409,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -1536,10 +1464,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -1588,10 +1512,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -1735,10 +1655,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -1844,10 +1760,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -1961,10 +1873,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -2060,10 +1968,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "public" {
@@ -2121,10 +2025,6 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "acctest-nsg-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [security_rule]
-  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "public" {
@@ -2182,10 +2082,6 @@ resource "azurerm_key_vault" "test" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -2354,10 +2250,6 @@ resource "azurerm_key_vault" "keyVault" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "services" {
@@ -2508,10 +2400,6 @@ resource "azurerm_key_vault" "keyVault" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 # Create this in a different subscription...
@@ -2525,10 +2413,6 @@ resource "azurerm_key_vault" "keyVaultAlt" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "servicesAlt" {
@@ -2712,10 +2596,6 @@ resource "azurerm_key_vault" "keyVault" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "services" {
@@ -2842,10 +2722,6 @@ resource "azurerm_key_vault" "keyVault" {
   sku_name            = "premium"
 
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_key" "disk" {

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
@@ -281,10 +281,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -481,10 +477,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -554,10 +546,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -827,10 +815,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource_test.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource_test.go
@@ -158,10 +158,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/datafactory/data_factory_managed_private_endpoint_resource_test.go
+++ b/internal/services/datafactory/data_factory_managed_private_endpoint_resource_test.go
@@ -131,10 +131,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/devtestlabs/dev_test_global_vm_shutdown_schedule_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_global_vm_shutdown_schedule_resource_test.go
@@ -136,10 +136,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
