### PR TITLE
`hybridcompute`, `iothub`, `keyvault`, `kusto`, `logic` - reverting `ignore_changes`

### DIFF
--- a/internal/services/hybridcompute/arc_machine_data_source_test.go
+++ b/internal/services/hybridcompute/arc_machine_data_source_test.go
@@ -82,10 +82,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/hybridcompute/arc_machine_extension_resource_test.go
+++ b/internal/services/hybridcompute/arc_machine_extension_resource_test.go
@@ -221,10 +221,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/internal/services/iothub/iothub_device_update_instance_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource_test.go
@@ -169,10 +169,6 @@ resource "azurerm_iothub" "test" {
     name     = "S1"
     capacity = "1"
   }
-
-  lifecycle {
-    ignore_changes = [route]
-  }
 }
 
 resource "azurerm_iothub_device_update_account" "test" {

--- a/internal/services/iothub/iothub_enrichment_resource_test.go
+++ b/internal/services/iothub/iothub_enrichment_resource_test.go
@@ -143,10 +143,6 @@ resource "azurerm_iothub" "test" {
   tags = {
     purpose = "testing"
   }
-
-  lifecycle {
-    ignore_changes = [endpoint, enrichment]
-  }
 }
 
 resource "azurerm_iothub_endpoint_storage_container" "test" {
@@ -226,10 +222,6 @@ resource "azurerm_iothub" "test" {
 
   tags = {
     purpose = "testing"
-  }
-
-  lifecycle {
-    ignore_changes = [endpoint, enrichment]
   }
 }
 

--- a/internal/services/iothub/iothub_route_resource_test.go
+++ b/internal/services/iothub/iothub_route_resource_test.go
@@ -152,10 +152,6 @@ resource "azurerm_iothub" "test" {
   tags = {
     purpose = "testing"
   }
-
-  lifecycle {
-    ignore_changes = [endpoint, route]
-  }
 }
 
 resource "azurerm_iothub_endpoint_storage_container" "test" {
@@ -221,10 +217,6 @@ resource "azurerm_iothub" "test" {
 
   tags = {
     purpose = "testing"
-  }
-
-  lifecycle {
-    ignore_changes = [endpoint, route]
   }
 }
 

--- a/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
@@ -265,7 +265,7 @@ resource "azurerm_key_vault" "test" {
   soft_delete_retention_days = 7
 
   lifecycle {
-    ignore_changes = [contact, access_policy]
+    ignore_changes = [contact]
   }
 }
 

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -1345,10 +1345,6 @@ resource "azurerm_key_vault" "test" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -1447,10 +1443,6 @@ resource "azurerm_key_vault" "test" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test" {

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -774,10 +774,6 @@ resource "azurerm_key_vault" "test" {
   tags = {
     environment = "accTest"
   }
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -842,10 +838,6 @@ resource "azurerm_key_vault" "test" {
 
   tags = {
     environment = "accTest"
-  }
-
-  lifecycle {
-    ignore_changes = [access_policy]
   }
 }
 

--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -589,10 +589,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test_a" {

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -445,10 +445,6 @@ resource "azurerm_key_vault" "test" {
   tags = {
     environment = "Production"
   }
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -501,10 +497,6 @@ resource "azurerm_key_vault" "test" {
 
   tags = {
     environment = "Production"
-  }
-
-  lifecycle {
-    ignore_changes = [access_policy]
   }
 }
 

--- a/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -265,10 +265,6 @@ resource "azurerm_key_vault" "test" {
   tenant_id                = data.azurerm_client_config.current.tenant_id
   sku_name                 = "standard"
   purge_protection_enabled = true
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "cluster" {
@@ -342,10 +338,6 @@ resource "azurerm_key_vault" "test" {
   tenant_id                = data.azurerm_client_config.current.tenant_id
   sku_name                 = "standard"
   purge_protection_enabled = true
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "cluster" {

--- a/internal/services/logic/integration_service_environment_resource_test.go
+++ b/internal/services/logic/integration_service_environment_resource_test.go
@@ -226,10 +226,6 @@ resource "azurerm_virtual_network" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/22"]
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "isesubnet1" {

--- a/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
@@ -125,10 +125,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test1" {
@@ -283,10 +279,6 @@ resource "azurerm_key_vault" "test2" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
-
-  lifecycle {
-    ignore_changes = [access_policy]
-  }
 }
 
 resource "azurerm_key_vault_access_policy" "test3" {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1620,10 +1620,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -2061,10 +2057,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test1" {
@@ -2146,10 +2138,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test1" {
@@ -2232,10 +2220,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  lifecycle {
-    ignore_changes = [subnet]
-  }
 }
 
 resource "azurerm_subnet" "test1" {


### PR DESCRIPTION
Deprecated functionality linter can be ignored