### PR TITLE
`testing` - fix step offset bug in adding refresh back to update steps

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -41,21 +41,14 @@ func (td TestData) DataSourceTestInSequence(t *testing.T, steps []TestStep) {
 	td.runAcceptanceSequentialTest(t, testCase)
 }
 
-var refreshStep = TestStep{
-	RefreshState: true,
-}
-
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {
-	newSteps := make([]TestStep, 0)
-	for _, step := range steps {
-		if !step.ImportState {
-			newSteps = append(newSteps, step)
-		} else {
-			newSteps = append(newSteps, refreshStep)
-			newSteps = append(newSteps, step)
+	// Testing framework as of 1.6.0 no longer auto-refreshes state, so adding it back in here for all steps that update
+	// the config rather than having to modify 1000's of tests individually to add a refresh-only step
+	for index, step := range steps {
+		if !step.ImportState && index != 0 {
+			step.RefreshState = true
 		}
 	}
-	steps = newSteps
 
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Correctly addresses the removal of `refresh` from update steps without adding an additional step.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


