### PR TITLE
`appservice` - deprecate `azurerm_app_service_environment` resource and data source

### DIFF
--- a/internal/services/web/app_service_environment_data_source.go
+++ b/internal/services/web/app_service_environment_data_source.go
@@ -19,8 +19,8 @@ import (
 
 func dataSourceAppServiceEnvironment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Read: dataSourceAppServiceEnvironmentRead,
-
+		Read:               dataSourceAppServiceEnvironmentRead,
+		DeprecationMessage: "This data source is deprecated due to the [retirement of v1 and v2 App Service Environments](https://azure.microsoft.com/en-gb/updates/app-service-environment-v1-and-v2-retirement-announcement/) and will be removed inv4.0 of the provider. Please use `azurerm_app_service_environment_v3` instead.",
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},

--- a/internal/services/web/app_service_environment_data_source_test.go
+++ b/internal/services/web/app_service_environment_data_source_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type AppServiceEnvironmentDataSource struct{}
 
 func TestAccDataSourceAppServiceEnvironment_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_environment", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/web/app_service_environment_resource.go
+++ b/internal/services/web/app_service_environment_resource.go
@@ -35,10 +35,11 @@ const (
 
 func resourceAppServiceEnvironment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceAppServiceEnvironmentCreate,
-		Read:   resourceAppServiceEnvironmentRead,
-		Update: resourceAppServiceEnvironmentUpdate,
-		Delete: resourceAppServiceEnvironmentDelete,
+		DeprecationMessage: "This resource is deprecated due to the [retirement of v1 and v2 App Service Environments](https://azure.microsoft.com/en-gb/updates/app-service-environment-v1-and-v2-retirement-announcement/) and will be removed inv4.0 of the provider. Please use `azurerm_app_service_environment_v3` instead.",
+		Create:             resourceAppServiceEnvironmentCreate,
+		Read:               resourceAppServiceEnvironmentRead,
+		Update:             resourceAppServiceEnvironmentUpdate,
+		Delete:             resourceAppServiceEnvironmentDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.AppServiceEnvironmentID(id)
 			return err

--- a/internal/services/web/app_service_environment_resource_test.go
+++ b/internal/services/web/app_service_environment_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -19,6 +20,9 @@ import (
 type AppServiceEnvironmentResource struct{}
 
 func TestAccAppServiceEnvironment_basic(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -36,6 +40,9 @@ func TestAccAppServiceEnvironment_basic(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_requiresImport(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -51,6 +58,9 @@ func TestAccAppServiceEnvironment_requiresImport(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_update(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -76,6 +86,9 @@ func TestAccAppServiceEnvironment_update(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_tierAndScaleFactor(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -93,6 +106,9 @@ func TestAccAppServiceEnvironment_tierAndScaleFactor(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_withAppServicePlan(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	aspData := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServiceEnvironmentResource{}
@@ -112,6 +128,9 @@ func TestAccAppServiceEnvironment_withAppServicePlan(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_dedicatedResourceGroup(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -127,6 +146,9 @@ func TestAccAppServiceEnvironment_dedicatedResourceGroup(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_withCertificatePfx(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -142,6 +164,9 @@ func TestAccAppServiceEnvironment_withCertificatePfx(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_internalLoadBalancer(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 
@@ -158,6 +183,9 @@ func TestAccAppServiceEnvironment_internalLoadBalancer(t *testing.T) {
 }
 
 func TestAccAppServiceEnvironment_clusterSettings(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("skipping as removed in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
 	r := AppServiceEnvironmentResource{}
 

--- a/internal/services/web/registration.go
+++ b/internal/services/web/registration.go
@@ -4,6 +4,7 @@
 package web
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -24,26 +25,28 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	datasources := map[string]*pluginsdk.Resource{
 		"azurerm_app_service":                   dataSourceAppService(),
 		"azurerm_app_service_certificate_order": dataSourceAppServiceCertificateOrder(),
-		"azurerm_app_service_environment":       dataSourceAppServiceEnvironment(),
 		"azurerm_app_service_certificate":       dataSourceAppServiceCertificate(),
 		"azurerm_app_service_plan":              dataSourceAppServicePlan(),
 		"azurerm_function_app":                  dataSourceFunctionApp(),
 		"azurerm_function_app_host_keys":        dataSourceFunctionAppHostKeys(),
 	}
+	if !features.FourPointOhBeta() {
+		datasources["azurerm_app_service_environment"] = dataSourceAppServiceEnvironment()
+	}
+	return datasources
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	resources := map[string]*pluginsdk.Resource{
 		"azurerm_app_service_active_slot":                           resourceAppServiceActiveSlot(),
 		"azurerm_app_service_certificate":                           resourceAppServiceCertificate(),
 		"azurerm_app_service_certificate_order":                     resourceAppServiceCertificateOrder(),
 		"azurerm_app_service_custom_hostname_binding":               resourceAppServiceCustomHostnameBinding(),
 		"azurerm_app_service_certificate_binding":                   resourceAppServiceCertificateBinding(),
-		"azurerm_app_service_environment":                           resourceAppServiceEnvironment(),
 		"azurerm_app_service_hybrid_connection":                     resourceAppServiceHybridConnection(),
 		"azurerm_app_service_managed_certificate":                   resourceAppServiceManagedCertificate(),
 		"azurerm_app_service_plan":                                  resourceAppServicePlan(),
@@ -59,6 +62,12 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_static_site":                                       resourceStaticSite(),
 		"azurerm_static_site_custom_domain":                         resourceStaticSiteCustomDomain(),
 	}
+
+	if !features.FourPointOhBeta() {
+		resources["azurerm_app_service_environment"] = resourceAppServiceEnvironment()
+	}
+
+	return resources
 }
 
 func (r Registration) DataSources() []sdk.DataSource {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

deprecates `azurerm_app_service_environment` resource and data source due to retirement as of 2024-08-31

conditionally removes `azurerm_app_service_environment` resource and data source for 4.0 as it's no longer possible to create or manage these and existing instances will be terminated.

See [this announcement](https://azure.microsoft.com/en-gb/updates/app-service-environment-v1-and-v2-retirement-announcement/) for details.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

* `azurerm_app_service_environment` - This resource has been deprecated
* Data Source: `azurerm_app_service_environment` - This data source has been deprecated


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
