### PR TITLE
`azurerm_kusto_cluster` -  replace `language_extensions` property with `language_extensions` block in 4.0

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
@@ -32,7 +31,7 @@ import (
 )
 
 func resourceKustoCluster() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceKustoClusterCreate,
 		Read:   resourceKustoClusterRead,
 		Update: resourceKustoClusterUpdate,
@@ -228,49 +227,31 @@ func resourceKustoCluster() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"language_extensions": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForLanguageExtensionName(), false),
+						},
+						"image": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForLanguageExtensionImageName(), false),
+						},
+					},
+				},
+			},
+
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),
 
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	if features.FourPointOhBeta() {
-		resource.Schema["language_extensions"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"name": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForLanguageExtensionName(), false),
-					},
-					"image": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForLanguageExtensionImageName(), false),
-					},
-				},
-			},
-		}
-	} else {
-		resource.Schema["language_extensions"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"R", "PYTHON", "PYTHON_3.10.8"}, false),
-			},
-		}
-		resource.Schema["engine"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Deprecated:   "This property has been deprecated as it will no longer be supported by the API. It will be removed in v4.0 of the AzureRM Provider.",
-			ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForEngineType(), false),
-		}
-	}
-
-	return resource
 }
 
 func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -357,13 +338,9 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 	clusterProperties.RestrictOutboundNetworkAccess = &restrictOutboundNetworkAccess
 
-	if features.FourPointOhBeta() {
-		if v, ok := d.GetOk("language_extensions"); ok {
-			extList := v.([]interface{})
-			clusterProperties.LanguageExtensions = expandKustoClusterLanguageExtensionList(extList)
-		}
-	} else {
-		clusterProperties.LanguageExtensions = expandKustoClusterLanguageExtensions(d)
+	if v, ok := d.GetOk("language_extensions"); ok {
+		extList := v.([]interface{})
+		clusterProperties.LanguageExtensions = expandKustoClusterLanguageExtensionList(extList)
 	}
 
 	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
@@ -489,12 +466,8 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("language_extensions") {
-		if features.FourPointOhBeta() {
-			if v, ok := d.GetOk("language_extensions"); ok {
-				props.LanguageExtensions = expandKustoClusterLanguageExtensionList(v.([]interface{}))
-			}
-		} else {
-			props.LanguageExtensions = expandKustoClusterLanguageExtensions(d)
+		if v, ok := d.GetOk("language_extensions"); ok {
+			props.LanguageExtensions = expandKustoClusterLanguageExtensionList(v.([]interface{}))
 		}
 	}
 
@@ -629,13 +602,7 @@ func resourceKustoClusterRead(d *pluginsdk.ResourceData, meta interface{}) error
 			d.Set("uri", props.Uri)
 			d.Set("data_ingestion_uri", props.DataIngestionUri)
 			d.Set("public_ip_type", string(pointer.From(props.PublicIPType)))
-
-			if features.FourPointOhBeta() {
-				d.Set("language_extensions", flattenKustoClusterLanguageExtensionList(props.LanguageExtensions))
-			} else {
-				d.Set("language_extensions", flattenKustoClusterLanguageExtensions(props.LanguageExtensions))
-			}
-
+			d.Set("language_extensions", flattenKustoClusterLanguageExtensionList(props.LanguageExtensions))
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
@@ -749,43 +716,6 @@ func expandKustoClusterVNET(input []interface{}) *clusters.VirtualNetworkConfigu
 		DataManagementPublicIPId: dataManagementPublicIPID,
 		State:                    pointer.To(clusters.VnetStateEnabled),
 	}
-}
-
-func expandKustoClusterLanguageExtensions(d *pluginsdk.ResourceData) *clusters.LanguageExtensionsList {
-	if v, ok := d.GetOk("language_extensions"); ok {
-		extList := v.(*pluginsdk.Set).List()
-		if len(extList) > 0 {
-			extensions := make([]clusters.LanguageExtension, 0)
-			for _, language := range extList {
-				name := language.(string)
-				lanExt := clusters.LanguageExtension{}
-				switch name {
-				case "R":
-					n := clusters.LanguageExtensionNameR
-					lanExt.LanguageExtensionName = &n
-					imageName := clusters.LanguageExtensionImageNameR
-					lanExt.LanguageExtensionImageName = &imageName
-				case "PYTHON":
-					n := clusters.LanguageExtensionNamePYTHON
-					lanExt.LanguageExtensionName = &n
-					imageName := clusters.LanguageExtensionImageNamePythonThreeSixFive
-					lanExt.LanguageExtensionImageName = &imageName
-				case "PYTHON_3.10.8":
-					n := clusters.LanguageExtensionNamePYTHON
-					lanExt.LanguageExtensionName = &n
-					imageName := clusters.LanguageExtensionImageNamePythonThreeOneZeroEight
-					lanExt.LanguageExtensionImageName = &imageName
-				default:
-					continue
-				}
-				extensions = append(extensions, lanExt)
-			}
-			return &clusters.LanguageExtensionsList{
-				Value: &extensions,
-			}
-		}
-	}
-	return nil
 }
 
 func expandKustoClusterLanguageExtensionList(input []interface{}) *clusters.LanguageExtensionsList {

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -228,9 +228,8 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			},
 
 			"language_extensions": {
-				Type:     pluginsdk.TypeList,
+				Type:     pluginsdk.TypeSet,
 				Optional: true,
-				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
@@ -339,7 +338,7 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	clusterProperties.RestrictOutboundNetworkAccess = &restrictOutboundNetworkAccess
 
 	if v, ok := d.GetOk("language_extensions"); ok {
-		extList := v.([]interface{})
+		extList := v.(*pluginsdk.Set).List()
 		clusterProperties.LanguageExtensions = expandKustoClusterLanguageExtensionList(extList)
 	}
 
@@ -467,7 +466,7 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if d.HasChange("language_extensions") {
 		if v, ok := d.GetOk("language_extensions"); ok {
-			props.LanguageExtensions = expandKustoClusterLanguageExtensionList(v.([]interface{}))
+			props.LanguageExtensions = expandKustoClusterLanguageExtensionList(v.(*pluginsdk.Set).List())
 		}
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -768,30 +768,6 @@ func flattenKustoClusterVNET(vnet *clusters.VirtualNetworkConfiguration) []inter
 	return []interface{}{output}
 }
 
-func flattenKustoClusterLanguageExtensions(extensions *clusters.LanguageExtensionsList) []interface{} {
-	if extensions == nil {
-		return []interface{}{}
-	}
-
-	output := make([]interface{}, 0)
-	if extensions.Value != nil {
-		for _, v := range *extensions.Value {
-			if v.LanguageExtensionImageName != nil {
-				switch *v.LanguageExtensionImageName {
-				case clusters.LanguageExtensionImageNameR:
-					output = append(output, "R")
-				case clusters.LanguageExtensionImageNamePythonThreeSixFive:
-					output = append(output, "PYTHON")
-				case clusters.LanguageExtensionImageNamePythonThreeOneZeroEight:
-					output = append(output, "PYTHON_3.10.8")
-				}
-			}
-		}
-	}
-
-	return output
-}
-
 func flattenKustoClusterLanguageExtensionList(extensions *clusters.LanguageExtensionsList) []interface{} {
 	if extensions == nil {
 		return []interface{}{}

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -277,6 +277,10 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
+				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("PYTHON"),
+				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("Python3_6_5"),
+				check.That(data.ResourceName).Key("language_extensions.1.name").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.1.image").HasValue("R"),
 			),
 		},
 		data.ImportStep(),
@@ -285,7 +289,10 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
-				check.That(data.ResourceName).Key("language_extensions.1").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("PYTHON"),
+				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("Python3_10_8"),
+				check.That(data.ResourceName).Key("language_extensions.1.name").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.1.image").HasValue("R"),
 			),
 		},
 		{
@@ -293,7 +300,8 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("1"),
-				check.That(data.ResourceName).Key("language_extensions.0").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("R"),
 			),
 		},
 		data.ImportStep(),
@@ -830,7 +838,15 @@ resource "azurerm_kusto_cluster" "test" {
     capacity = 2
   }
 
-  language_extensions = ["PYTHON", "R"]
+  language_extensions {
+    name  = "PYTHON"
+    image = "Python3_6_5"
+  }
+
+  language_extensions {
+    name  = "R"
+	image = "R"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -856,7 +872,15 @@ resource "azurerm_kusto_cluster" "test" {
     capacity = 2
   }
 
-  language_extensions = ["PYTHON_3.10.8", "R"]
+  language_extensions {
+    name  = "PYTHON"
+    image = "Python3_10_8"
+  }
+
+  language_extensions {
+    name  = "R"
+	image = "R"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -882,7 +906,10 @@ resource "azurerm_kusto_cluster" "test" {
     capacity = 2
   }
 
-  language_extensions = ["R"]
+  language_extensions {
+    name  = "R"
+	image = "R"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -265,9 +264,6 @@ func TestAccKustoCluster_vnet(t *testing.T) {
 }
 
 func TestAccKustoCluster_languageExtensions(t *testing.T) {
-	if features.FourPointOhBeta() {
-		t.Skip("Property has been removed in 4.0")
-	}
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
 	r := KustoClusterResource{}
 
@@ -277,10 +273,6 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
-				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("PYTHON"),
-				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("Python3_6_5"),
-				check.That(data.ResourceName).Key("language_extensions.1.name").HasValue("R"),
-				check.That(data.ResourceName).Key("language_extensions.1.image").HasValue("R"),
 			),
 		},
 		data.ImportStep(),
@@ -289,10 +281,6 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
-				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("PYTHON"),
-				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("Python3_10_8"),
-				check.That(data.ResourceName).Key("language_extensions.1.name").HasValue("R"),
-				check.That(data.ResourceName).Key("language_extensions.1.image").HasValue("R"),
 			),
 		},
 		{
@@ -300,8 +288,6 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("1"),
-				check.That(data.ResourceName).Key("language_extensions.0.name").HasValue("R"),
-				check.That(data.ResourceName).Key("language_extensions.0.image").HasValue("R"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
+++ b/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
@@ -151,10 +151,19 @@ func (s KustoAttachedClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"language_extensions": {
-			Type:     pluginsdk.TypeList,
+			Type:     pluginsdk.TypeSet,
 			Optional: true,
-			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"image": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
 			},
 		},
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -72,9 +72,7 @@ The following arguments are supported:
 
 ~> **NOTE:** Currently removing `virtual_network_configuration` sets the `virtual_network_configuration` to `Disabled` state. But any changes to `virtual_network_configuration` in `Disabled` state forces a new resource to be created.
 
-* `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON`, `PYTHON_3.10.8` and `R`. `PYTHON` is used to specify Python 3.6.5 image and `PYTHON_3.10.8` is used to specify Python 3.10.8 image. Note that `PYTHON_3.10.8` is only available in skus which support nested virtualization.
-
-~> **NOTE:** In `v4.0.0` and later version of the AzureRM Provider, `language_extensions` will be changed to a list of `language_extension` block. In each block, `name` and `image` are required. `name` is the name of the language extension, possible values are `PYTHON`, `R`. `image` is the image of the language extension, possible values are `Python3_6_5`, `Python3_10_8` and `R`.
+* `language_extensions` - (Optional) A `language_extensions` block defined as defined below.
 
 * `optimized_auto_scale` - (Optional) An `optimized_auto_scale` block as defined below.
 
@@ -123,6 +121,14 @@ A `optimized_auto_scale` block supports the following:
 * `minimum_instances` - (Required) The minimum number of allowed instances. Must between `0` and `1000`.
 
 * `maximum_instances` - (Required) The maximum number of allowed instances. Must between `0` and `1000`.
+
+---
+
+A `language_extensions` block supports the following:
+
+* `name` - (Required) The name of the language extension, possible values are `PYTHON`, `R`.
+
+* `image` - (Required) The image of the language extension, possible values are `Python3_6_5`, `Python3_10_8`, `Python3_10_8_DL`, `PythonCustomImage` and `R`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

For resource `azurerm_kusto_cluster` 
- replace `language_extensions` property with `language_extensions` block in 4.0 as planned
- change type from List to Set because the GET API returns each language extension in random order
- change document and state migration logic accordingly

> [!NOTE] 
> This is a breaking change for resource `azurerm_kusto_cluster` 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\<alias>\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\<alias>\<path>\___TestAccKustoCluster_languageExtensions_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\<alias>\<path>\___TestAccKustoCluster_languageExtensions_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccKustoCluster_languageExtensions\E$ #gosetup
=== RUN   TestAccKustoCluster_languageExtensions
=== PAUSE TestAccKustoCluster_languageExtensions
=== CONT  TestAccKustoCluster_languageExtensions
--- PASS: TestAccKustoCluster_languageExtensions (4671.17s)
PASS


Process finished with the exit code 0
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kusto_cluster` -  replace `language_extensions` property with `language_extensions` block in 4.0 [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change
