### PR TITLE
`azurerm_log_analytics_cluster` - add `100` as valid `size_gb`

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -61,9 +61,9 @@ func (l LogAnalyticsClusterResource) Arguments() map[string]*schema.Schema {
 				if !features.FourPointOh() {
 					return 1000
 				}
-				return 500
+				return 100
 			}(),
-			ValidateFunc: validation.IntInSlice([]int{500, 1000, 2000, 5000}),
+			ValidateFunc: validation.IntInSlice([]int{100, 500, 1000, 2000, 5000}),
 		},
 
 		"tags": tags.Schema(),

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -47,9 +47,9 @@ The following arguments are supported:
 
 * `identity` - (Required) An `identity` block as defined below. Changing this forces a new Log Analytics Cluster to be created.
 
-* `size_gb` - (Optional) The capacity of the Log Analytics Cluster is specified in GB/day. Possible values include `500`, `1000`, `2000` or `5000`. Defaults to `1000`.
+* `size_gb` - (Optional) The capacity of the Log Analytics Cluster is specified in GB/day. Possible values include `100`, `500`, `1000`, `2000` or `5000`. Defaults to `1000`.
 
-~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters). In v3.x the default value is `1000` GB, in v4.0 of the provider this will default to `500` GB.
+~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters). In v3.x the default value is `1000` GB, in v4.0 of the provider this will default to `100` GB.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Cluster.
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `size_gb` - (Optional) The capacity of the Log Analytics Cluster is specified in GB/day. Possible values include `100`, `500`, `1000`, `2000` or `5000`. Defaults to `1000`.
 
-~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters). In v3.x the default value is `1000` GB, in v4.0 of the provider this will default to `100` GB.
+~> **NOTE:** The cluster capacity must start at 100 GB and can be set to 500, 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters). In v3.x the default value is `1000` GB, in v4.0 of the provider this will default to `100` GB.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Cluster.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Also changes the default value for `size_gb` to `100` in 4.0


## Testing

These tests are skipped in TC because of the high cost when deletion goes wrong. The basic test was run locally with `size_gb = 100`.