### PR TITLE
`azurerm_web_application_firewall_policy`: add support for `js_challenge_cookie_expiration_in_minutes`

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -404,6 +404,13 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 							ValidateFunc: validation.IntAtLeast(0),
 						},
 
+						"js_challenge_cookie_expiration_in_minutes": {
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							Default:      30,
+							ValidateFunc: validation.IntBetween(5, 1440),
+						},
+
 						"log_scrubbing": {
 							Type:     pluginsdk.TypeList,
 							MaxItems: 1,
@@ -717,13 +724,14 @@ func expandWebApplicationFirewallPolicyPolicySettings(input []interface{}) *weba
 	fileUploadLimitInMb := v["file_upload_limit_in_mb"].(int)
 
 	result := webapplicationfirewallpolicies.PolicySettings{
-		State:                       pointer.To(enabled),
-		Mode:                        pointer.To(webapplicationfirewallpolicies.WebApplicationFirewallMode(mode)),
-		RequestBodyCheck:            pointer.To(requestBodyCheck),
-		MaxRequestBodySizeInKb:      pointer.To(int64(maxRequestBodySizeInKb)),
-		FileUploadLimitInMb:         pointer.To(int64(fileUploadLimitInMb)),
-		LogScrubbing:                expandWebApplicationFirewallPolicyLogScrubbing(v["log_scrubbing"].([]interface{})),
-		RequestBodyInspectLimitInKB: pointer.To(int64(v["request_body_inspect_limit_in_kb"].(int))),
+		State:                             pointer.To(enabled),
+		Mode:                              pointer.To(webapplicationfirewallpolicies.WebApplicationFirewallMode(mode)),
+		RequestBodyCheck:                  pointer.To(requestBodyCheck),
+		MaxRequestBodySizeInKb:            pointer.To(int64(maxRequestBodySizeInKb)),
+		FileUploadLimitInMb:               pointer.To(int64(fileUploadLimitInMb)),
+		LogScrubbing:                      expandWebApplicationFirewallPolicyLogScrubbing(v["log_scrubbing"].([]interface{})),
+		RequestBodyInspectLimitInKB:       pointer.To(int64(v["request_body_inspect_limit_in_kb"].(int))),
+		JsChallengeCookieExpirationInMins: pointer.To(int64(v["js_challenge_cookie_expiration_in_minutes"].(int))),
 	}
 
 	return &result
@@ -1075,6 +1083,7 @@ func flattenWebApplicationFirewallPolicyPolicySettings(input *webapplicationfire
 	result["file_upload_limit_in_mb"] = int(pointer.From(input.FileUploadLimitInMb))
 	result["log_scrubbing"] = flattenWebApplicationFirewallPolicyLogScrubbing(input.LogScrubbing)
 	result["request_body_inspect_limit_in_kb"] = pointer.From(input.RequestBodyInspectLimitInKB)
+	result["js_challenge_cookie_expiration_in_minutes"] = pointer.From(input.JsChallengeCookieExpirationInMins)
 
 	return []interface{}{result}
 }

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -633,9 +633,9 @@ resource "azurerm_web_application_firewall_policy" "test" {
   }
 
   policy_settings {
-    enabled                          = true
-    mode                             = "Prevention"
-    request_body_inspect_limit_in_kb = 1000
+    enabled                                   = true
+    mode                                      = "Prevention"
+    request_body_inspect_limit_in_kb          = 1000
     js_challenge_cookie_expiration_in_minutes = 60
   }
 }
@@ -718,9 +718,9 @@ resource "azurerm_web_application_firewall_policy" "test" {
   }
 
   policy_settings {
-    enabled                          = true
-    mode                             = "Prevention"
-    request_body_inspect_limit_in_kb = 1234
+    enabled                                   = true
+    mode                                      = "Prevention"
+    request_body_inspect_limit_in_kb          = 1234
     js_challenge_cookie_expiration_in_minutes = 1440
   }
 }

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -636,6 +636,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
     enabled                          = true
     mode                             = "Prevention"
     request_body_inspect_limit_in_kb = 1000
+    js_challenge_cookie_expiration_in_minutes = 60
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -720,6 +721,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
     enabled                          = true
     mode                             = "Prevention"
     request_body_inspect_limit_in_kb = 1234
+    js_challenge_cookie_expiration_in_minutes = 1440
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -192,6 +192,8 @@ The `policy_settings` block supports the following:
 
 * `request_body_inspect_limit_in_kb` - (Optional) Specifies the maximum request body inspection limit in KB for the Web Application Firewall. Defaults to `128`.
 
+* `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie validity lifetime in minutes. The user is challenged after the lifetime expires. Accepted values are in the range `5` to `1440`. Defaults to `30`.
+
 ---
 
 The `managed_rules` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

add JS challenge support for waf: https://learn.microsoft.com/en-us/azure/web-application-firewall/waf-javascript-challenge#expiration

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
=== RUN   TestAccWebApplicationFirewallPolicy_rateLimit
=== PAUSE TestAccWebApplicationFirewallPolicy_rateLimit
=== CONT  TestAccWebApplicationFirewallPolicy_rateLimit
--- PASS: TestAccWebApplicationFirewallPolicy_rateLimit (403.82s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       403.837s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_web_application_firewall_policy` - support for the `js_challenge_cookie_expiration_in_minutes` property

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26645


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
