### PR TITLE
Remove Bourne shell prompt $-character from DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -38,9 +38,9 @@ If you wish to work on the provider, you'll first need [Go](https://go.dev/) ins
 First clone the repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-azurerm`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
-$ git clone git@github.com:hashicorp/terraform-provider-azurerm
-$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-azurerm
+mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+git clone git@github.com:hashicorp/terraform-provider-azurerm
+cd $GOPATH/src/github.com/hashicorp/terraform-provider-azurerm
 ```
 
 Once inside the provider directory, you can run `make tools` to install the dependent tooling required to compile the provider.
@@ -48,10 +48,11 @@ Once inside the provider directory, you can run `make tools` to install the depe
 At this point you can compile the provider by running `make build`, which will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make build
-...
-$ $GOPATH/bin/terraform-provider-azurerm
-...
+make build
+# ... make output omitted ...
+# The provider binary will be output to:
+#   $GOPATH/bin/terraform-provider-azurerm
+# ...
 ```
 
 You can also cross-compile if necessary:
@@ -63,7 +64,7 @@ GOOS=windows GOARCH=amd64 make build
 In order to run the `Unit Tests` for the provider, you can run:
 
 ```sh
-$ make test
+make test
 ```
 
 The majority of tests in the provider are `Acceptance Tests` - which provisions real resources in Azure. It's possible to run the entire acceptance test suite by running `make testacc` - however it's likely you'll want to run a subset, which you can do using a prefix, by running:
@@ -140,11 +141,11 @@ When `make generate` is run, this will then generate the following for this Reso
 You can scaffold the documentation for a Data Source by running:
 
 ```sh
-$ make scaffold-website BRAND_NAME="Resource Group" RESOURCE_NAME="azurerm_resource_group" RESOURCE_TYPE="data"
+make scaffold-website BRAND_NAME="Resource Group" RESOURCE_NAME="azurerm_resource_group" RESOURCE_TYPE="data"
 ```
 
 You can scaffold the documentation for a Resource by running:
 
 ```sh
-$ make scaffold-website BRAND_NAME="Resource Group" RESOURCE_NAME="azurerm_resource_group" RESOURCE_TYPE="resource" RESOURCE_ID="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1"
+make scaffold-website BRAND_NAME="Resource Group" RESOURCE_NAME="azurerm_resource_group" RESOURCE_TYPE="resource" RESOURCE_ID="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1"
 ```


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removes the Bourne shell prompt $-character from the fenced code blocks in the DEVELOPER.md instructions in order to make all code blocks stylistically consistent and enable direct copy-paste of the code blocks into a git bash terminal.

A pedantic nitpick regarding the DEVELOPER.md instructions... but every second counts when bootstrapping to contribute 🚀 🤠 Thank you for the consideration!


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”
