### PR TITLE
`azurerm_public_ip` - fix panic when updating `idle_timeout_in_minutes`

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -344,7 +344,7 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("idle_timeout_in_minutes") {
-		payload.Properties.IdleTimeoutInMinutes = utils.Int64(d.Get("idle_timeout_in_minutes").(int64))
+		payload.Properties.IdleTimeoutInMinutes = utils.Int64(int64(d.Get("idle_timeout_in_minutes").(int)))
 	}
 
 	if d.HasChange("domain_name_label") {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -740,12 +740,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                = "acctestpublicip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Basic"
-  domain_name_label   = "acctest-%d"
+  name                    = "acctestpublicip-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  allocation_method       = "Static"
+  sku                     = "Basic"
+  domain_name_label       = "acctest-%d"
+  idle_timeout_in_minutes = 30
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -238,10 +238,16 @@ func TestAccPublicIpStatic_idleTimeout(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.idleTimeout(data),
+			Config: r.idleTimeout(data, 30),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("idle_timeout_in_minutes").HasValue("30"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.idleTimeout(data, 15),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -751,7 +757,7 @@ resource "azurerm_public_ip" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (PublicIPResource) idleTimeout(data acceptance.TestData) string {
+func (PublicIPResource) idleTimeout(data acceptance.TestData, idleTimeout int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -768,9 +774,9 @@ resource "azurerm_public_ip" "test" {
   resource_group_name     = azurerm_resource_group.test.name
   allocation_method       = "Static"
   sku                     = "Basic"
-  idle_timeout_in_minutes = 30
+  idle_timeout_in_minutes = %d
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, idleTimeout)
 }
 
 func (PublicIPResource) dynamic_basic(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

We had no tests updating `idle_timeout_in_minutes` which is why this wasn't caught. Added the property to the `update` config to ensure no regressions going forward.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_public_ip` - prevent panic when updating `idle_timeout_in_minutes` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26887


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
