### PR TITLE
`azurerm_kubernetes_cluster` - remove "AvailabilitySet" option from `default_node_pool`'s `type` property in version 4.0

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -121,6 +121,9 @@ func TestAccKubernetesClusterNodePool_capacityReservationGroup(t *testing.T) {
 }
 
 func TestAccKubernetesClusterNodePool_errorForAvailabilitySet(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("AvailabilitySet not supported as an option for default_node_pool in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
 

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -22,6 +22,9 @@ import (
 )
 
 func TestAccKubernetesCluster_basicAvailabilitySet(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skip("AvailabilitySet not supported as an option for default_node_pool in 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1579,40 +1579,6 @@ resource "azurerm_kubernetes_cluster" "import" {
 }
 
 func (KubernetesClusterResource) criticalAddonsTaintConfig(data acceptance.TestData) string {
-	if features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
-}
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
-
-  default_node_pool {
-    name                         = "default"
-    node_count                   = 1
-    vm_size                      = "Standard_DS2_v2"
-    only_critical_addons_enabled = true
-    upgrade_settings {
-      max_surge = "10%%"
-    }
-  }
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-	}
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -60,7 +60,6 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ForceNew: true,
 						Default:  string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
 						ValidateFunc: validation.StringInSlice([]string{
-							string(managedclusters.AgentPoolTypeAvailabilitySet),
 							string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
 						}, false),
 					},
@@ -292,6 +291,11 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				}
 
 				if !features.FourPointOhBeta() {
+					s["type"].ValidateFunc = validation.StringInSlice([]string{
+						string(managedclusters.AgentPoolTypeAvailabilitySet),
+						string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+					}, false)
+
 					s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
 						string(agentpools.OSSKUAzureLinux),
 						string(agentpools.OSSKUCBLMariner),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -56,12 +56,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 					"type": {
 						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						Default:  string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
-						}, false),
+						Computed: true,
 					},
 
 					"vm_size": {
@@ -291,10 +286,15 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				}
 
 				if !features.FourPointOhBeta() {
-					s["type"].ValidateFunc = validation.StringInSlice([]string{
-						string(managedclusters.AgentPoolTypeAvailabilitySet),
-						string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
-					}, false)
+					s["type"] = &pluginsdk.Schema{
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+						ValidateFunc: validation.StringInSlice([]string{
+							string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+						}, false),
+					}
 
 					s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
 						string(agentpools.OSSKUAzureLinux),
@@ -1266,7 +1266,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		NodeLabels:             nodeLabels,
 		NodeTaints:             nodeTaints,
 		Tags:                   tags.Expand(t),
-		Type:                   pointer.To(managedclusters.AgentPoolType(raw["type"].(string))),
+		Type:                   pointer.To(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
 		VMSize:                 utils.String(raw["vm_size"].(string)),
 
 		// at this time the default node pool has to be Linux or the AKS cluster fails to provision with:

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -56,7 +56,12 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 					"type": {
 						Type:     pluginsdk.TypeString,
-						Computed: true,
+						Optional: true,
+						ForceNew: true,
+						Default:  string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+						ValidateFunc: validation.StringInSlice([]string{
+							string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+						}, false),
 					},
 
 					"vm_size": {
@@ -286,15 +291,10 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				}
 
 				if !features.FourPointOhBeta() {
-					s["type"] = &pluginsdk.Schema{
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						Default:  string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
-						}, false),
-					}
+					s["type"].ValidateFunc = validation.StringInSlice([]string{
+						string(managedclusters.AgentPoolTypeAvailabilitySet),
+						string(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+					}, false)
 
 					s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
 						string(agentpools.OSSKUAzureLinux),
@@ -1266,7 +1266,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		NodeLabels:             nodeLabels,
 		NodeTaints:             nodeTaints,
 		Tags:                   tags.Expand(t),
-		Type:                   pointer.To(managedclusters.AgentPoolTypeVirtualMachineScaleSets),
+		Type:                   pointer.To(managedclusters.AgentPoolType(raw["type"].(string))),
 		VMSize:                 utils.String(raw["vm_size"].(string)),
 
 		// at this time the default node pool has to be Linux or the AKS cluster fails to provision with:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

To address issue https://github.com/hashicorp/terraform-provider-azurerm/pull/26576#issuecomment-2244682620, for resource `azurerm_kubernetes_cluster`, if the `default_node_pool`'s `type` property is set to "AvailabilitySet" and `node_os_channel_upgrade` is set to "NodeImage", the script will fail as node image upgrade is not supported on AvailabilitySet agent pools.

Checked with the service team, and the reply was "we recommend cx moving away from AvailabilitySet agent pools".

So this pr will remove the support for setting the type to AvailabilitySet in the `default_node_pool` setting.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster` - remove "AvailabilitySet" option from `default_node_pool`'s `type` property in version 4.0


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
