### PR TITLE
`azurerm_web_application_firewall_policy` - update tests using `managed_rules.managed_rule_set.version` `3.1` -> `3.2`

### DIFF
--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -1433,7 +1433,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
   policy_settings {
@@ -2923,7 +2923,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 }
@@ -3024,7 +3024,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 }
@@ -3042,7 +3042,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp_listener" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 }
@@ -3146,7 +3146,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 }
@@ -3164,7 +3164,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp_path_rule" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 }

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -437,7 +437,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
     }
   }
 
@@ -883,7 +883,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
   managed_rules {
     managed_rule_set {
       type    = "OWASP"
-      version = "3.1"
+      version = "3.2"
 
       rule_group_override {
         disabled_rules = [


### PR DESCRIPTION
This PR fixes tests using `managed_rules.managed_rule_set.version` `3.1` which does not support `request_body_inspect_limit_in_kb` causing issues like

```
              ~ policy_settings {
                  ~ request_body_inspect_limit_in_kb = 0 -> 128
                    # (5 unchanged attributes hidden)
                }
```

This PR updates all tests using `3.1` to `3.2`
