### PR TITLE
Bug fix - `azurerm_express_route_connection` - Remove `private_link_fast_path_enabled `default vaule

### DIFF
--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -78,7 +78,6 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 			"private_link_fast_path_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"express_route_gateway_bypass_enabled": {
@@ -183,10 +182,6 @@ func resourceExpressRouteConnectionCreate(d *pluginsdk.ResourceData, meta interf
 		return tf.ImportAsExistsError("azurerm_express_route_connection", id.ID())
 	}
 
-	if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
-		return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
-	}
-
 	parameters := expressrouteconnections.ExpressRouteConnection{
 		Name: id.ExpressRouteConnectionName,
 		Properties: &expressrouteconnections.ExpressRouteConnectionProperties{
@@ -197,8 +192,15 @@ func resourceExpressRouteConnectionCreate(d *pluginsdk.ResourceData, meta interf
 			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
 			RoutingWeight:             pointer.To(int64(d.Get("routing_weight").(int))),
 			ExpressRouteGatewayBypass: pointer.To(d.Get("express_route_gateway_bypass_enabled").(bool)),
-			EnablePrivateLinkFastPath: pointer.To(d.Get("private_link_fast_path_enabled").(bool)),
 		},
+	}
+
+	privateLinkFatPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
+	if !privateLinkFatPath.IsNull() {
+		if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
+			return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
+		}
+		parameters.Properties.EnablePrivateLinkFastPath = pointer.To(d.Get("private_link_fast_path_enabled").(bool))
 	}
 
 	if v, ok := d.GetOk("authorization_key"); ok {
@@ -280,9 +282,6 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
-		return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
-	}
 	parameters := expressrouteconnections.ExpressRouteConnection{
 		Name: id.ExpressRouteConnectionName,
 		Properties: &expressrouteconnections.ExpressRouteConnectionProperties{
@@ -293,8 +292,15 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
 			RoutingWeight:             pointer.To(int64(d.Get("routing_weight").(int))),
 			ExpressRouteGatewayBypass: pointer.To(d.Get("express_route_gateway_bypass_enabled").(bool)),
-			EnablePrivateLinkFastPath: pointer.To(d.Get("private_link_fast_path_enabled").(bool)),
 		},
+	}
+
+	privateLinkFatPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
+	if !privateLinkFatPath.IsNull() {
+		if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
+			return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
+		}
+		parameters.Properties.EnablePrivateLinkFastPath = pointer.To(d.Get("private_link_fast_path_enabled").(bool))
 	}
 
 	if v, ok := d.GetOk("authorization_key"); ok {

--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -195,8 +195,8 @@ func resourceExpressRouteConnectionCreate(d *pluginsdk.ResourceData, meta interf
 		},
 	}
 
-	privateLinkFatPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
-	if !privateLinkFatPath.IsNull() {
+	privateLinkFastPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
+	if !privateLinkFastPath.IsNull() {
 		if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
 			return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
 		}
@@ -295,8 +295,8 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 		},
 	}
 
-	privateLinkFatPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
-	if !privateLinkFatPath.IsNull() {
+	privateLinkFastPath := d.GetRawConfig().AsValueMap()["private_link_fast_path_enabled"]
+	if !privateLinkFastPath.IsNull() {
 		if d.Get("private_link_fast_path_enabled").(bool) && !d.Get("express_route_gateway_bypass_enabled").(bool) {
 			return fmt.Errorf("`express_route_gateway_bypass_enabled` must be enabled when `private_link_fast_path_enabled` is set to `true`")
 		}

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -148,7 +148,6 @@ resource "azurerm_express_route_connection" "test" {
   routing_weight                       = 2
   authorization_key                    = "90f8db47-e25b-4b65-a68b-7743ced2a16b"
   enable_internet_security             = true
-  private_link_fast_path_enabled       = true
   express_route_gateway_bypass_enabled = true
 
   routing {
@@ -220,7 +219,6 @@ resource "azurerm_express_route_connection" "test" {
   routing_weight                       = 2
   authorization_key                    = "90f8db47-e25b-4b65-a68b-7743ced2a16b"
   enable_internet_security             = true
-  private_link_fast_path_enabled       = true
   express_route_gateway_bypass_enabled = true
 
   routing {

--- a/internal/services/network/route_map_resource.go
+++ b/internal/services/network/route_map_resource.go
@@ -216,7 +216,7 @@ func (r RouteMapResource) Attributes() map[string]*pluginsdk.Schema {
 
 func (r RouteMapResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			var model RouteMapModel
 			if err := metadata.Decode(&model); err != nil {
@@ -256,7 +256,7 @@ func (r RouteMapResource) Create() sdk.ResourceFunc {
 
 func (r RouteMapResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Network.VirtualWANs
 
@@ -333,7 +333,7 @@ func (r RouteMapResource) Read() sdk.ResourceFunc {
 
 func (r RouteMapResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Network.VirtualWANs
 

--- a/website/docs/r/express_route_connection.html.markdown
+++ b/website/docs/r/express_route_connection.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `express_route_gateway_bypass_enabled` - (Optional) Specified whether Fast Path is enabled for Virtual Wan Firewall Hub. Defaults to `false`.
 
-* `private_link_fast_path_enabled` - (Optional) Bypass the Express Route gateway when accessing private-links. When enabled `express_route_gateway_bypass_enabled` must be set to `true`. Defaults to `false`.
+* `private_link_fast_path_enabled` - (Optional) Bypass the Express Route gateway when accessing private-links. When enabled `express_route_gateway_bypass_enabled` must be set to `true`.
 
 * `routing` - (Optional) A `routing` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->
The `private_link_fast_path_enabled`  should not be added to this resource. Don't know why the API have this property in the API doc. `private_link_fast_path_enabled` is available the Virtual Network Gateway(**ExpressRoute**)  but this resource(`azurerm_express_route_connection`) is for **ExpressRouteGateway**, they are different resources. 

The Virtual Network Gateway(ExpressRoute) can be created through the Virtual Network Gateway,  (Gateway type: `ExpressRoute`). The `ExpressRouteGateway` is  created though the `Virtual Wan -> Hubs`, you can find the ExpressRoute Gateway after the hub is created.
![image](https://github.com/user-attachments/assets/4dabe3e9-588f-4cdc-9e07-939e2e5861c8)




## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26746


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
