### PR TITLE
`testing ` - Fix ImportStateVerify Issue by Adding a RefreshStep

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -48,6 +48,8 @@ var refreshStep = TestStep{
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {
 	newSteps := make([]TestStep, 0)
 	for index, step := range steps {
+		// Testing framework as of 1.6.0 no longer auto-refreshes state, so adding it back in here for all steps that update
+		// the config rather than having to modify 1000's of tests individually to add a refresh-only step
 		if !step.ImportState && step.Config == "" && step.ConfigDirectory == nil && step.ConfigFile == nil && index != 0 {
 			step.RefreshState = true
 		}

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -41,14 +41,24 @@ func (td TestData) DataSourceTestInSequence(t *testing.T, steps []TestStep) {
 	td.runAcceptanceSequentialTest(t, testCase)
 }
 
+var refreshStep = TestStep{
+	RefreshState: true,
+}
+
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {
-	// Testing framework as of 1.6.0 no longer auto-refreshes state, so adding it back in here for all steps that update
-	// the config rather than having to modify 1000's of tests individually to add a refresh-only step
+	newSteps := make([]TestStep, 0)
 	for index, step := range steps {
-		if !step.ImportState && index != 0 {
+		if !step.ImportState && step.Config == "" && step.ConfigDirectory == nil && step.ConfigFile == nil && index != 0 {
 			step.RefreshState = true
 		}
+
+		if step.ImportState {
+			newSteps = append(newSteps, refreshStep)
+		}
+
+		newSteps = append(newSteps, step)
 	}
+	steps = newSteps
 
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Many tests are broken when checking Computed Values and return something like

```
  testcase.go:121: Step 2/6 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        +   "access_rule.0.anonymous_gid":           "0",
        +   "access_rule.0.anonymous_uid":           "0",
        +   "access_rule.0.root_squash_enabled":     "false",
        +   "access_rule.0.submount_access_enabled": "false",
        +   "access_rule.0.suid_enabled":            "false",
          }
```

The additional refresh step was taken out with #26845 so this PR adds it back in while keeping the #26845 functionality. We're also making the check to add the Refresh tag a little more specific as it can only be added under specific circumstances. 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->
