### PR TITLE
`storage` - fix tests for 4.0

### DIFF
--- a/internal/services/storage/storage_table_entities_data_source.go
+++ b/internal/services/storage/storage_table_entities_data_source.go
@@ -6,8 +6,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
-	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/entities"
 	"log"
 	"strings"
 	"time"
@@ -16,11 +14,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/accounts"
+	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/entities"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/tables"
 )
 

--- a/internal/services/storage/storage_table_entities_data_source.go
+++ b/internal/services/storage/storage_table_entities_data_source.go
@@ -6,16 +6,22 @@ package storage
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/entities"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
+	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/entities"
+	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/blob/accounts"
+	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/table/tables"
 )
 
 type storageTableEntitiesDataSource struct{}
@@ -23,8 +29,9 @@ type storageTableEntitiesDataSource struct{}
 var _ sdk.DataSource = storageTableEntitiesDataSource{}
 
 type TableEntitiesDataSourceModel struct {
-	TableName          string                       `tfschema:"table_name"`
-	StorageAccountName string                       `tfschema:"storage_account_name"`
+	StorageTableId     string                       `tfschema:"storage_table_id"`
+	TableName          string                       `tfschema:"table_name,removedInNextMajorVersion"`
+	StorageAccountName string                       `tfschema:"storage_account_name,removedInNextMajorVersion"`
 	Filter             string                       `tfschema:"filter"`
 	Select             []string                     `tfschema:"select"`
 	Items              []TableEntityDataSourceModel `tfschema:"items"`
@@ -37,17 +44,11 @@ type TableEntityDataSourceModel struct {
 }
 
 func (k storageTableEntitiesDataSource) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-		"table_name": {
+	s := map[string]*pluginsdk.Schema{
+		"storage_table_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
-			ValidateFunc: validate.StorageTableName,
-		},
-
-		"storage_account_name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.StorageAccountName,
+			ValidateFunc: storageValidate.StorageTableDataPlaneID,
 		},
 
 		"filter": {
@@ -64,6 +65,35 @@ func (k storageTableEntitiesDataSource) Arguments() map[string]*pluginsdk.Schema
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		s["storage_table_id"].Required = false
+		s["storage_table_id"].Optional = true
+		s["storage_table_id"].Computed = true
+		s["storage_table_id"].ConflictsWith = []string{"table_name", "storage_account_name"}
+
+		s["table_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
+			ConflictsWith: []string{"storage_table_id"},
+			RequiredWith:  []string{"storage_account_name"},
+			ValidateFunc:  validate.StorageTableName,
+		}
+
+		s["storage_account_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			Deprecated:    "the `table_name` and `storage_account_name` properties have been superseded by the `storage_table_id` property and will be removed in version 4.0 of the AzureRM provider",
+			ConflictsWith: []string{"storage_table_id"},
+			RequiredWith:  []string{"table_name"},
+			ValidateFunc:  validate.StorageAccountName,
+		}
+	}
+
+	return s
 }
 
 func (k storageTableEntitiesDataSource) Attributes() map[string]*pluginsdk.Schema {
@@ -114,13 +144,53 @@ func (k storageTableEntitiesDataSource) Read() sdk.ResourceFunc {
 			}
 
 			storageClient := metadata.Client.Storage
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			account, err := storageClient.FindAccount(ctx, metadata.Client.Account.SubscriptionId, model.StorageAccountName)
+			var storageTableId *tables.TableId
+			var err error
+			if model.StorageTableId != "" {
+				storageTableId, err = tables.ParseTableID(model.StorageTableId, storageClient.StorageDomainSuffix)
+				if err != nil {
+					return err
+				}
+			} else if !features.FourPointOhBeta() {
+				// TODO: this is needed until `table_name` / `storage_account_name` are removed in favor of `storage_table_id` in v4.0
+				// we will retrieve the storage account twice but this will make it easier to refactor later
+				storageAccountName := model.StorageAccountName
+
+				account, err := storageClient.FindAccount(ctx, subscriptionId, storageAccountName)
+				if err != nil {
+					return fmt.Errorf("retrieving Account %q: %v", storageAccountName, err)
+				}
+				if account == nil {
+					return fmt.Errorf("locating Storage Account %q", storageAccountName)
+				}
+
+				// Determine the table endpoint, so we can build a data plane ID
+				endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeTable)
+				if err != nil {
+					return fmt.Errorf("determining Table endpoint: %v", err)
+				}
+
+				// Parse the table endpoint as a data plane account ID
+				accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
+				if err != nil {
+					return fmt.Errorf("parsing Account ID: %v", err)
+				}
+
+				storageTableId = pointer.To(tables.NewTableID(*accountId, model.TableName))
+			}
+
+			if storageTableId == nil {
+				return fmt.Errorf("determining storage table ID")
+			}
+
+			account, err := storageClient.FindAccount(ctx, subscriptionId, storageTableId.AccountId.AccountName)
 			if err != nil {
-				return fmt.Errorf("retrieving Account %q for Table %q: %s", model.StorageAccountName, model.TableName, err)
+				return fmt.Errorf("retrieving Account %q for Table %q: %v", storageTableId.AccountId.AccountName, storageTableId.TableName, err)
 			}
 			if account == nil {
-				return fmt.Errorf("the parent Storage Account %s was not found", model.StorageAccountName)
+				return fmt.Errorf("the parent Storage Account %s was not found", storageTableId.AccountId.AccountName)
 			}
 
 			client, err := storageClient.TableEntityDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
@@ -138,11 +208,11 @@ func (k storageTableEntitiesDataSource) Read() sdk.ResourceFunc {
 				input.PropertyNamesToSelect = &model.Select
 			}
 
-			id := parse.NewStorageTableEntitiesId(model.StorageAccountName, storageClient.StorageDomainSuffix, model.TableName, model.Filter)
+			id := parse.NewStorageTableEntitiesId(storageTableId.AccountId.AccountName, storageClient.StorageDomainSuffix, storageTableId.TableName, model.Filter)
 
-			result, err := client.Query(ctx, model.TableName, input)
+			result, err := client.Query(ctx, storageTableId.TableName, input)
 			if err != nil {
-				return fmt.Errorf("retrieving Entities (Filter %q) (Table %q in %s): %+v", model.Filter, model.TableName, account.StorageAccountId, err)
+				return fmt.Errorf("retrieving Entities (Filter %q) (Table %q in %s): %+v", model.Filter, storageTableId.TableName, account.StorageAccountId, err)
 			}
 
 			var flattenedEntities []TableEntityDataSourceModel

--- a/internal/services/storage/storage_table_entities_data_source_test.go
+++ b/internal/services/storage/storage_table_entities_data_source_test.go
@@ -68,8 +68,7 @@ resource "azurerm_storage_table" "test" {
 }
 
 resource "azurerm_storage_table_entity" "test" {
-  storage_account_name = azurerm_storage_account.test.name
-  table_name           = azurerm_storage_table.test.name
+  storage_table_id = azurerm_storage_table.test.id
 
   partition_key = "testpartition"
   row_key       = "testrow"
@@ -81,8 +80,7 @@ resource "azurerm_storage_table_entity" "test" {
 }
 
 resource "azurerm_storage_table_entity" "test2" {
-  storage_account_name = azurerm_storage_account.test.name
-  table_name           = azurerm_storage_table.test.name
+  storage_table_id = azurerm_storage_table.test.id
 
   partition_key = "testpartition"
   row_key       = "testrow2"
@@ -94,8 +92,7 @@ resource "azurerm_storage_table_entity" "test2" {
 }
 
 resource "azurerm_storage_table_entity" "testselector" {
-  storage_account_name = azurerm_storage_account.test.name
-  table_name           = azurerm_storage_table.test.name
+  storage_table_id = azurerm_storage_table.test.id
 
   partition_key = "testselectorpartition"
   row_key       = "testrow"

--- a/internal/services/storage/storage_table_entities_data_source_test.go
+++ b/internal/services/storage/storage_table_entities_data_source_test.go
@@ -112,9 +112,8 @@ func (d StorageTableEntitiesDataSource) basicWithDataSource(data acceptance.Test
 %s
 
 data "azurerm_storage_table_entities" "test" {
-  table_name           = azurerm_storage_table_entity.test.table_name
-  storage_account_name = azurerm_storage_table_entity.test.storage_account_name
-  filter               = "PartitionKey eq 'testpartition'"
+  storage_table_id = azurerm_storage_table.test.id
+  filter           = "PartitionKey eq 'testpartition'"
 
   depends_on = [
     azurerm_storage_table_entity.test,
@@ -130,10 +129,9 @@ func (d StorageTableEntitiesDataSource) basicWithDataSourceAndSelector(data acce
 %s
 
 data "azurerm_storage_table_entities" "test" {
-  table_name           = azurerm_storage_table_entity.test.table_name
-  storage_account_name = azurerm_storage_table_entity.test.storage_account_name
-  filter               = "PartitionKey eq 'testselectorpartition'"
-  select               = ["testselector"]
+  storage_table_id = azurerm_storage_table.test.id
+  filter           = "PartitionKey eq 'testselectorpartition'"
+  select           = ["testselector"]
 
   depends_on = [
     azurerm_storage_table_entity.test,

--- a/internal/services/storage/storage_table_entity_data_source_test.go
+++ b/internal/services/storage/storage_table_entity_data_source_test.go
@@ -53,8 +53,7 @@ resource "azurerm_storage_table" "test" {
 }
 
 resource "azurerm_storage_table_entity" "test" {
-  storage_account_name = azurerm_storage_account.test.name
-  table_name           = azurerm_storage_table.test.name
+  storage_table_id = azurerm_storage_table.test.id
 
   partition_key = "testpartition"
   row_key       = "testrow"
@@ -72,10 +71,9 @@ func (d StorageTableEntityDataSource) basicWithDataSource(data acceptance.TestDa
 %s
 
 data "azurerm_storage_table_entity" "test" {
-  table_name           = azurerm_storage_table_entity.test.table_name
-  storage_account_name = azurerm_storage_table_entity.test.storage_account_name
-  partition_key        = azurerm_storage_table_entity.test.partition_key
-  row_key              = azurerm_storage_table_entity.test.row_key
+  storage_table_id = azurerm_storage_table.test.id
+  partition_key    = azurerm_storage_table_entity.test.partition_key
+  row_key          = azurerm_storage_table_entity.test.row_key
 }
 `, config)
 }

--- a/website/docs/d/storage_table_entities.html.markdown
+++ b/website/docs/d/storage_table_entities.html.markdown
@@ -24,9 +24,7 @@ data "azurerm_storage_table_entities" "example" {
 
 The following arguments are supported:
 
-* `table_name` - The name of the Table.
-
-* `storage_account_name` - The name of the Storage Account where the Table exists.
+* `storage_table_id` - The Storage Table ID where the entities exist.
 
 * `filter` - The filter used to retrieve the entities.
 

--- a/website/docs/d/storage_table_entity.html.markdown
+++ b/website/docs/d/storage_table_entity.html.markdown
@@ -25,9 +25,7 @@ data "azurerm_storage_table_entity" "example" {
 
 The following arguments are supported:
 
-* `table_name` - The name of the Table.
-
-* `storage_account_name` - The name of the Storage Account where the Table exists.
+* `storage_table_id` - (Required) The Storage Table ID where the entity exists.
 
 * `partition_key` - The key for the partition where the entity will be retrieved.
 

--- a/website/docs/guides/4.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/4.0-upgrade-guide.html.markdown
@@ -1173,6 +1173,10 @@ The deprecated data source has been superseded by `azurerm_mssql_server` and has
 
 * The deprecated properties `storage_account_name` and `table_name` have been removed in favour of the `storage_table_id` property.
 
+### `azurerm_storage_table_entities`
+
+* The deprecated properties `storage_account_name` and `table_name` have been removed in favour of the `storage_table_id` property.
+
 ### `azurerm_subnet`
 
 * The deprecated property `private_endpoint_network_policies_enabled` has been removed in favour of the `private_endpoint_network_policies` property.


### PR DESCRIPTION
This test fixes up some more tests for storage and adds `storage_table_id` to the `azurerm_storage_table_entity` data source