### PR TITLE
`sentinel` - fix tests for 4.0

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -167,6 +167,10 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
+
+  event_grouping {
+    aggregation_method = "SingleAlert"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -231,6 +235,9 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
     OperatingSystemType = "OSType"
   }
 
+  event_grouping {
+    aggregation_method = "SingleAlert"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -250,6 +257,9 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
     OperatingSystemType = "OSType"
   }
 
+  event_grouping {
+    aggregation_method = "SingleAlert"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -264,6 +274,10 @@ resource "azurerm_sentinel_alert_rule_nrt" "import" {
   display_name               = azurerm_sentinel_alert_rule_nrt.test.display_name
   severity                   = azurerm_sentinel_alert_rule_nrt.test.severity
   query                      = azurerm_sentinel_alert_rule_nrt.test.query
+
+  event_grouping {
+    aggregation_method = "azurerm_sentinel_alert_rule_nrt.test.event_grouping.0.aggregation_method"
+  }
 }
 `, r.basic(data))
 }
@@ -284,6 +298,10 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
   severity                   = "Low"
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   query                      = "Heartbeat"
+
+  event_grouping {
+    aggregation_method = "SingleAlert"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
@@ -166,14 +166,14 @@ func dataSourceSentinelAlertRuleTemplateRead(d *pluginsdk.ResourceData, meta int
 		nameToLog = name
 		resp, err = getAlertRuleTemplateByName(ctx, client, workspaceID, name)
 		if err != nil {
-			return fmt.Errorf("an Alert Rule Template named %q was not found", name)
+			return fmt.Errorf("finding Alert Rule Template named %q: %+v", name, err)
 		}
 	} else {
 		nameToLog = displayName
 		var realName *string
 		resp, realName, err = getAlertRuleTemplateByDisplayName(ctx, client, workspaceID, displayName)
 		if err != nil {
-			return fmt.Errorf("an Alert Rule Template with the Display Name %q was not found", displayName)
+			return fmt.Errorf("finding Alert Rule Template with the Display Name %q: %+v", displayName, err)
 		}
 		name = *realName
 	}

--- a/internal/services/sentinel/sentinel_automation_rule_resource.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource.go
@@ -280,7 +280,6 @@ func resourceSentinelAutomationRuleCreateOrUpdate(d *pluginsdk.ResourceData, met
 				IsEnabled:    d.Get("enabled").(bool),
 				TriggersOn:   automationrules.TriggersOn(d.Get("triggers_on").(string)),
 				TriggersWhen: automationrules.TriggersWhen(d.Get("triggers_when").(string)),
-				Conditions:   expandAutomationRuleConditions(d.Get("condition").([]interface{})),
 			},
 			Actions: actions,
 		},

--- a/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource_test.go
+++ b/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource_test.go
@@ -164,8 +164,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
```
data "azurerm_sentinel_alert_rule_template" "test" {
  display_name               = "Advanced Multistage Attack Detection"
  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
}
```

is enabled by Default so we'll disable it when pulling it into the provider to get tests passing again

We're also removing [Conditions:   expandAutomationRuleConditions(d.Get("condition").([]interface{})),](https://github.com/hashicorp/terraform-provider-azurerm/compare/t-sentinel-4-1?expand=1#diff-920b0eb015eb80951f4e71afe4492216de54cdf2421c431c0d3d1c0e09da7786L283) as we do the 4.0 check down below and this is causing a panic