### PR TITLE
#26797: disable_access_keys_authentication property for Redis Cache

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -235,6 +235,11 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
+			"access_keys_authentication_disabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -343,6 +348,8 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 		enableSslPort := !*props.EnableNonSslPort
 		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.Model.PrimaryKey, enableSslPort))
 		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.Model.SecondaryKey, enableSslPort))
+
+		d.Set("access_keys_authentication_disabled", *props.DisableAccessKeyAuthentication)
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return fmt.Errorf("setting `tags`: %+v", err)

--- a/internal/services/redis/redis_cache_data_source_test.go
+++ b/internal/services/redis/redis_cache_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccRedisCacheDataSource_standard(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.environment").HasValue("production"),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("access_keys_authentication_disabled").Exists(),
 			),
 		},
 	})

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -381,6 +381,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 				}
 				return false
 			}),
+			// add validation for https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication
 		),
 	}
 

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -148,6 +148,10 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 						},
+						"disable_access_keys_authentication": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
 						"maxclients": {
 							Type:     pluginsdk.TypeInt,
 							Computed: true,

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -381,7 +381,12 @@ func resourceRedisCache() *pluginsdk.Resource {
 				}
 				return false
 			}),
-			// add validation for https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+				return validate.ValidateAccessKeysAuth(
+					diff.Get("access_keys_authentication_disabled").(bool),
+					diff.Get("redis_configuration.0.active_directory_authentication_enabled").(bool),
+				)
+			}),
 		),
 	}
 

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -148,10 +148,6 @@ func resourceRedisCache() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 						},
-						"disable_access_keys_authentication": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
 						"maxclients": {
 							Type:     pluginsdk.TypeInt,
 							Computed: true,
@@ -367,6 +363,11 @@ func resourceRedisCache() *pluginsdk.Resource {
 					}
 					return false
 				},
+			},
+
+			"disable_access_keys_authentication": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -368,7 +368,6 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"access_keys_authentication_disabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -1650,6 +1650,7 @@ resource "azurerm_redis_cache" "test" {
   access_keys_authentication_disabled = %t
 
   redis_configuration {
+    active_directory_authentication_enabled = true
   }
 }`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
 }

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -567,26 +567,23 @@ func TestAccRedisCache_AccessKeysAuthenticationEnabledDisabled(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.accessKeysAuthentication(data, false),
+			Config: r.accessKeysAuthentication(data, false, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.accessKeysAuthentication(data, true),
+			Config: r.accessKeysAuthentication(data, true, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.accessKeysAuthentication(data, false),
+			Config: r.accessKeysAuthentication(data, false, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -1627,7 +1624,7 @@ resource "azurerm_redis_cache" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (RedisCacheResource) accessKeysAuthentication(data acceptance.TestData, enabled bool) string {
+func (RedisCacheResource) accessKeysAuthentication(data acceptance.TestData, accessKeysAuthenticationDisabled bool, activeDirectoryAuthenticationEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1650,7 +1647,7 @@ resource "azurerm_redis_cache" "test" {
   access_keys_authentication_disabled = %t
 
   redis_configuration {
-    active_directory_authentication_enabled = true
+    active_directory_authentication_enabled = %t
   }
-}`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
+}`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, accessKeysAuthenticationDisabled, accessKeysAuthenticationDisabled)
 }

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -572,24 +572,24 @@ func TestAccRedisCache_AccessKeysAuthenticationEnabledDisabled(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("false"),
 			),
-			ExpectNonEmptyPlan: true,
 		},
+		data.ImportStep(),
 		{
 			Config: r.accessKeysAuthentication(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("true"),
 			),
-			ExpectNonEmptyPlan: true,
 		},
+		data.ImportStep(),
 		{
 			Config: r.accessKeysAuthentication(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("access_keys_authentication_disabled").HasValue("false"),
 			),
-			ExpectNonEmptyPlan: true,
 		},
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/redis/validate/access_keys_auth.go
+++ b/internal/services/redis/validate/access_keys_auth.go
@@ -1,0 +1,18 @@
+package validate
+
+import (
+	"fmt"
+	"log"
+)
+
+// Entra (AD) auth has to be set to disable access keys auth
+// https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication
+func ValidateAccessKeysAuth(accessKeysAuthenticationDisabled bool, activeDirectoryAuthenticationEnabled bool) error {
+	log.Printf("[DEBUG] ValidateAccessKeysAuth: accessKeysAuthenticationDisabled: %v, activeDirectoryAuthenticationEnabled: %v", accessKeysAuthenticationDisabled, activeDirectoryAuthenticationEnabled)
+
+	if accessKeysAuthenticationDisabled && !activeDirectoryAuthenticationEnabled {
+		return fmt.Errorf("microsoft entra authorization (active_directory_authentication_enabled) must be enabled in order to disable access key authentication (access_keys_authentication_disabled): https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication#disable-access-key-authentication-on-your-cache")
+	}
+
+	return nil
+}

--- a/internal/services/redis/validate/access_keys_auth_test.go
+++ b/internal/services/redis/validate/access_keys_auth_test.go
@@ -1,0 +1,17 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestValidateAccessKeysAuth_valid(t *testing.T) {
+	if err := ValidateAccessKeysAuth(true, true); err != nil {
+		t.Fatalf("Should be valid if accessKeysAuthenticationDisabled: true and activeDirectoryAuthenticationEnabled: true but got error: %v", err)
+	}
+}
+
+func TestValidateAccessKeysAuth_invalid(t *testing.T) {
+	if err := ValidateAccessKeysAuth(true, false); err == nil {
+		t.Fatalf("Should return error if accessKeysAuthenticationDisabled: true and activeDirectoryAuthenticationEnabled: false")
+	}
+}

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -68,6 +68,8 @@ output "hostname" {
 
 * `secondary_connection_string` - The secondary connection string of the Redis Instance.
 
+* `access_keys_authentication_disabled` - Whether access key authentication is disabled.
+
 * `redis_configuration` - A `redis_configuration` block as defined below.
 
 * `zones` - A list of Availability Zones in which this Redis Cache is located.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 ---
 
+* `access_keys_authentication_disabled` - (Optional) Disable access key authentication. Microsoft Entra (AAD) authentication (`active_directory_authentication_enabled`) must be enabled to disable this. Defaults to `false`.
+
 * `enable_non_ssl_port` - (Optional) Enable the non-SSL port (6379) - disabled by default.
 
 * `identity` - (Optional) An `identity` block as defined below.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
