### PR TITLE
Docs:  Fix wrong description of 'format'

### DIFF
--- a/website/docs/r/api_management_policy_fragment.html.markdown
+++ b/website/docs/r/api_management_policy_fragment.html.markdown
@@ -44,13 +44,13 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Api Management Policy Fragment. Changing this forces a new Api Management Policy Fragment to be created.
 
-* `format` - (Required) The format of the Policy Fragment. Possible values are `xml` or `rawxml`.
-
-~> **NOTE:** The `value` property will be updated to reflect the corresponding format when `format` is updated.
-
 * `value` - (Required) The value of the Policy Fragment.
 
 ~> **NOTE:** Be aware of the two format possibilities. If the `value` is not applied and continues to cause a diff the format could be wrong.
+
+* `format` - (Optional) The format of the Policy Fragment. Possible values are `xml` or `rawxml`. Default is `xml`.
+
+~> **NOTE:** The `value` property will be updated to reflect the corresponding format when `format` is updated.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Per the [code](https://github.com/hashicorp/terraform-provider-azurerm/blob/550f464571172856aba60c8a251c19edac1f935e/internal/services/apimanagement/api_management_policy_fragment_resource.go#L70), `format` should be `optional` and default to `xml`. Updated documentation to fix this issue found in #26959.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26959


