### PR TITLE
azurerm_storage_account: make `large_file_share_enabled` optional+computed again

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -823,18 +823,11 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"large_file_share_enabled": func() *pluginsdk.Schema {
-				s := &pluginsdk.Schema{
-					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  false, // @tombuildsstuff: this now defaults to `true` when `account_kind` is set to `FileStorage`
-				}
-				if !features.FourPointOhBeta() {
-					s.Computed = true
-					s.Default = nil
-				}
-				return s
-			}(),
+			"large_file_share_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 
 			"local_user_enabled": {
 				Type:     pluginsdk.TypeBool,
@@ -1380,13 +1373,13 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	// BlobStorage does not support ZRS
 	if accountKind == storageaccounts.KindBlobStorage && string(payload.Sku.Name) == string(storageaccounts.SkuNameStandardZRS) {
-		return fmt.Errorf("a `account_replication_type` of `ZRS` isn't supported for Blob Storage accounts")
+		return fmt.Errorf("`account_replication_type` of `ZRS` isn't supported for Blob Storage accounts")
 	}
 
 	accessTier, accessTierSetInConfig := d.GetOk("access_tier")
 	_, skuTierSupported := storageKindsSupportsSkuTier[accountKind]
 	if !skuTierSupported && accessTierSetInConfig {
-		keys := sortedKeysFromSlice(storageKindsSupportHns)
+		keys := sortedKeysFromSlice(storageKindsSupportsSkuTier)
 		return fmt.Errorf("`access_tier` is only available for accounts of kind set to one of: %+v", strings.Join(keys, " / "))
 	}
 	if skuTierSupported {
@@ -1417,8 +1410,8 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// AccountTier must be Premium for FileStorage
-	if accountKind == storageaccounts.KindFileStorage && accountTier == storageaccounts.SkuTierStandard {
-		return fmt.Errorf("a `account_tier` of `Standard` is not supported for FileStorage accounts")
+	if accountKind == storageaccounts.KindFileStorage && accountTier != storageaccounts.SkuTierPremium {
+		return fmt.Errorf("`account_tier` must be `Premium` for File Storage accounts")
 	}
 
 	// nolint staticcheck

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -888,6 +888,7 @@ func TestAccStorageAccount_replicationTypeGZRS(t *testing.T) {
 }
 
 func TestAccStorageAccount_largeFileShare(t *testing.T) {
+	// Note: this test causes a ForceNew when disabling large file shares
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
@@ -4122,7 +4123,6 @@ resource "azurerm_storage_account" "test" {
   account_tier                      = "Premium"
   account_replication_type          = "LRS"
   infrastructure_encryption_enabled = true
-  large_file_share_enabled          = true # defaulted on the API side
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -4612,7 +4612,6 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Premium"
   account_kind             = "FileStorage"
   account_replication_type = "ZRS"
-  large_file_share_enabled = true # defaulted in the API when FileStorage & Premium
 
   share_properties {
     smb {


### PR DESCRIPTION
The `large_file_share_enabled` property is conditionally ForceNew and has a moving default dictated by the service, so make it optional + computed again.