### PR TITLE
`azurerm_storage_account` - Ensure `infrastructure_encryption_enabled` property is included during update

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1730,6 +1730,18 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("expanding `customer_managed_key`: %+v", err)
 		}
+
+		infrastructureEncryption := d.Get("infrastructure_encryption_enabled").(bool)
+
+		if infrastructureEncryption {
+			validPremiumConfiguration := accountTier == storageaccounts.SkuTierPremium && (accountKind == storageaccounts.KindBlockBlobStorage) || accountKind == storageaccounts.KindFileStorage
+			validV2Configuration := accountKind == storageaccounts.KindStorageVTwo
+			if !(validPremiumConfiguration || validV2Configuration) {
+				return fmt.Errorf("`infrastructure_encryption_enabled` can only be used with account kind `StorageV2`, or account tier `Premium` and account kind is one of `BlockBlobStorage` or `FileStorage`")
+			}
+			encryption.RequireInfrastructureEncryption = &infrastructureEncryption
+		}
+
 		props.Encryption = encryption
 	}
 	if d.HasChange("shared_access_key_enabled") {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When a Storage Account's `customer_managed_key` is updated, the AzureRM provider did not take into account the `infrastructure_encryption_enabled` property for the Storage Account encryption settings. This change ensures that `infrastructure_encryption_enabled` is now included in the update as well, with the same behavior as during resource creation.

This was notably an issue with Azure's policy engine. During resource update, the `infrastructure_encryption_enabled` property wasn't included at all which most likely meant nothing would change on Azure's side. However any policies that are in place could still expect this property to be included and set to `true` (as was the case with us).


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

I'm not familiar enough with this codebase to determine how to properly add a test case for this change. I have however verified this fix through local execution.

Before the fix:

```
╷
│ Error: updating Storage Account (Subscription: "xxx"
│ Resource Group Name: "xxx"
│ Storage Account Name: "xxx"): performing Create: unexpected status 403 (403 Forbidden) with error: RequestDisallowedByPolicy: Resource 'xxx' was disallowed by policy. Policy identifiers: [REDACTED].
│ 
│   with azurerm_storage_account.xxx-storage,
│   on storage-account.tf line 11, in resource "azurerm_storage_account" "xxx-storage":
│   11: resource "azurerm_storage_account" "xxx-storage" {
│ 
╵
```

After this fix:

```
Terraform will perform the following actions:

  # azurerm_storage_account.xxx-storage will be updated in-place
  ~ resource "azurerm_storage_account" "xxx-storage" {
        id                                 = "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Storage/storageAccounts/xxx"
        name                               = "xxx"
        # (97 unchanged attributes hidden)

      ~ customer_managed_key {
          - key_vault_key_id          = "https://xxx-kv.vault.azure.net/keys/xxx-cmk-d" -> null
          + managed_hsm_key_id        = "https://xxx.managedhsm.azure.net/keys/xxx-d-sa-key/xxx"
            # (1 unchanged attribute hidden)
        }

        # (6 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_storage_account.xxx-storage: Modifying... [id=/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Storage/storageAccounts/xxx]
azurerm_storage_account.xxx-storage: Still modifying... [id=/subscriptions/xxx-...t.Storage/storageAccounts/xxx, 10s elapsed]
azurerm_storage_account.xxx-storage: Modifications complete after 19s [id=/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Storage/storageAccounts/xxx]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - fix omission of `infrastructure_encryption_enabled` property during CMK update


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
