### PR TITLE
`shared_image` - add `hibernation_enabled` updated data source

### DIFF
--- a/internal/services/compute/shared_image_data_source.go
+++ b/internal/services/compute/shared_image_data_source.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -126,6 +127,36 @@ func dataSourceSharedImage() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"trusted_launch_supported": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"trusted_launch_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"confidential_vm_supported": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"confidential_vm_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"accelerated_network_support_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"hibernation_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -173,6 +204,10 @@ func dataSourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 			if err := d.Set("purchase_plan", flattenGalleryImageDataSourcePurchasePlan(props.PurchasePlan)); err != nil {
 				return fmt.Errorf("setting `purchase_plan`: %+v", err)
+			}
+
+			if err := flattenAndSetGalleryImageFeatures(d, model.Properties.Features); err != nil {
+				return fmt.Errorf("setting `features`: %+v", err)
 			}
 		}
 
@@ -223,4 +258,44 @@ func flattenGalleryImageDataSourcePurchasePlan(input *galleryimages.ImagePurchas
 			"product":   product,
 		},
 	}
+}
+
+func flattenAndSetGalleryImageFeatures(d *pluginsdk.ResourceData, input *[]galleryimages.GalleryImageFeature) error {
+	trustedLaunchSupported := false
+	trustedLaunchEnabled := false
+	cvmEnabled := false
+	cvmSupported := false
+	acceleratedNetworkSupportEnabled := false
+	hibernationEnabled := false
+	if input != nil {
+		for _, feature := range *input {
+			if feature.Name == nil || feature.Value == nil {
+				continue
+			}
+
+			if strings.EqualFold(*feature.Name, "SecurityType") {
+				trustedLaunchSupported = strings.EqualFold(*feature.Value, "TrustedLaunchSupported")
+				trustedLaunchEnabled = strings.EqualFold(*feature.Value, "TrustedLaunch")
+				cvmSupported = strings.EqualFold(*feature.Value, "ConfidentialVmSupported")
+				cvmEnabled = strings.EqualFold(*feature.Value, "ConfidentialVm")
+			}
+
+			if strings.EqualFold(*feature.Name, "IsAcceleratedNetworkSupported") {
+				acceleratedNetworkSupportEnabled = strings.EqualFold(*feature.Value, "true")
+			}
+
+			if strings.EqualFold(*feature.Name, "IsHibernateSupported") {
+				hibernationEnabled = strings.EqualFold(*feature.Value, "true")
+			}
+		}
+	}
+
+	d.Set("confidential_vm_supported", cvmSupported)
+	d.Set("confidential_vm_enabled", cvmEnabled)
+	d.Set("trusted_launch_supported", trustedLaunchSupported)
+	d.Set("trusted_launch_enabled", trustedLaunchEnabled)
+	d.Set("accelerated_network_support_enabled", acceleratedNetworkSupportEnabled)
+	d.Set("hibernation_enabled", hibernationEnabled)
+
+	return nil
 }

--- a/internal/services/compute/shared_image_data_source_test.go
+++ b/internal/services/compute/shared_image_data_source_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceSharedImage_basic(t *testing.T) {
 			Config: r.basic(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("hibernation_enabled").HasValue("false"),
 			),
 		},
 	})
@@ -57,6 +58,90 @@ func TestAccDataSourceSharedImage_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceSharedImage_hibernationEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withHibernationEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("hibernation_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImage_acceleratedNetworkSupportEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withAcceleratedNetworkSupportEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("accelerated_network_support_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImage_trustedLaunchEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withTrustedLaunchEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("trusted_launch_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImage_trustedLaunchSupported(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withTrustedLaunchSupported(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("trusted_launch_supported").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImage_confidentialVMEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withConfidentialVM(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("confidential_vm_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImage_confidentialVMSupported(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withConfidentialVMSupported(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("confidential_vm_supported").HasValue("true"),
+			),
+		},
+	})
+}
+
 func (SharedImageDataSource) basic(data acceptance.TestData, hyperVGen string) string {
 	return fmt.Sprintf(`
 %s
@@ -79,4 +164,76 @@ data "azurerm_shared_image" "test" {
   resource_group_name = azurerm_shared_image.test.resource_group_name
 }
 `, SharedImageResource{}.completeWithHyperVGen(data, hyperVGen))
+}
+
+func (SharedImageDataSource) withHibernationEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withHibernationEnabled(data))
+}
+
+func (SharedImageDataSource) withAcceleratedNetworkSupportEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withAcceleratedNetworkSupportEnabled(data))
+}
+
+func (SharedImageDataSource) withTrustedLaunchEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withTrustedLaunchEnabled(data))
+}
+
+func (SharedImageDataSource) withTrustedLaunchSupported(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withTrustedLaunchSupported(data))
+}
+
+func (SharedImageDataSource) withConfidentialVM(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withConfidentialVM(data))
+}
+
+func (SharedImageDataSource) withConfidentialVMSupported(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image" "test" {
+  name                = azurerm_shared_image.test.name
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+}
+`, SharedImageResource{}.withConfidentialVmSupported(data))
 }

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -186,6 +186,20 @@ func TestAccSharedImage_withAcceleratedNetworkSupportEnabled(t *testing.T) {
 	})
 }
 
+func TestAccSharedImage_withHibernationEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withHibernationEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSharedImage_description(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
 	r := SharedImageResource{}
@@ -711,6 +725,41 @@ resource "azurerm_shared_image" "test" {
   os_type             = "Linux"
 
   accelerated_network_support_enabled = true
+
+  identifier {
+    publisher = "AccTesPublisher%d"
+    offer     = "AccTesOffer%d"
+    sku       = "AccTesSku%d"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (SharedImageResource) withHibernationEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  hibernation_enabled = true
 
   identifier {
     publisher = "AccTesPublisher%d"

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -57,17 +57,17 @@ The following attributes are exported:
 
 * `release_note_uri` - The URI containing the Release Notes for this Shared Image.
 
-* `trusted_launch_supported` - (Optional) Specifies if supports creation of both Trusted Launch virtual machines and Gen2 virtual machines with standard security created from the Shared Image. Changing this forces a new resource to be created.
+* `trusted_launch_supported` - Specifies if supports creation of both Trusted Launch virtual machines and Gen2 virtual machines with standard security created from the Shared Image.
 
-* `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image. Changing this forces a new resource to be created.
+* `trusted_launch_enabled` - Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image.
 
-* `confidential_vm_supported` - (Optional) Specifies if supports creation of both Confidential virtual machines and Gen2 virtual machines with standard security from a compatible Gen2 OS disk VHD or Gen2 Managed image. Changing this forces a new resource to be created.
+* `confidential_vm_supported` - Specifies if supports creation of both Confidential virtual machines and Gen2 virtual machines with standard security from a compatible Gen2 OS disk VHD or Gen2 Managed image.
 
-* `confidential_vm_enabled` - (Optional) Specifies if Confidential Virtual Machines enabled. It will enable all the features of trusted, with higher confidentiality features for isolate machines or encrypted data. Available for Gen2 machines. Changing this forces a new resource to be created.
+* `confidential_vm_enabled` - Specifies if Confidential Virtual Machines enabled. It will enable all the features of trusted, with higher confidentiality features for isolate machines or encrypted data. Available for Gen2 machines.
 
-* `accelerated_network_support_enabled` - (Optional) Specifies if the Shared Image supports Accelerated Network. Changing this forces a new resource to be created.
+* `accelerated_network_support_enabled` - Specifies if the Shared Image supports Accelerated Network.
 
-* `hibernation_enabled` - (Optional) Specifies if the Shared Image supports hibernation. Changing this forces a new resource to be created.
+* `hibernation_enabled` - Specifies if the Shared Image supports hibernation.
 
 * `tags` - A mapping of tags assigned to the Shared Image.
 

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -57,6 +57,18 @@ The following attributes are exported:
 
 * `release_note_uri` - The URI containing the Release Notes for this Shared Image.
 
+* `trusted_launch_supported` - (Optional) Specifies if supports creation of both Trusted Launch virtual machines and Gen2 virtual machines with standard security created from the Shared Image. Changing this forces a new resource to be created.
+
+* `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image. Changing this forces a new resource to be created.
+
+* `confidential_vm_supported` - (Optional) Specifies if supports creation of both Confidential virtual machines and Gen2 virtual machines with standard security from a compatible Gen2 OS disk VHD or Gen2 Managed image. Changing this forces a new resource to be created.
+
+* `confidential_vm_enabled` - (Optional) Specifies if Confidential Virtual Machines enabled. It will enable all the features of trusted, with higher confidentiality features for isolate machines or encrypted data. Available for Gen2 machines. Changing this forces a new resource to be created.
+
+* `accelerated_network_support_enabled` - (Optional) Specifies if the Shared Image supports Accelerated Network. Changing this forces a new resource to be created.
+
+* `hibernation_enabled` - (Optional) Specifies if the Shared Image supports hibernation. Changing this forces a new resource to be created.
+
 * `tags` - A mapping of tags assigned to the Shared Image.
 
 ---

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -106,6 +106,8 @@ The following arguments are supported:
 
 * `accelerated_network_support_enabled` - (Optional) Specifies if the Shared Image supports Accelerated Network. Changing this forces a new resource to be created.
 
+* `hibernation_enabled` - (Optional) Specifies if the Shared Image supports hibernation. Changing this forces a new resource to be created.
+
 * `tags` - (Optional) A mapping of tags to assign to the Shared Image.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds one attribute to the `shared_image` resource and brings the `shared_image` data source up to date with the resource.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_shared_image` - support for the `hibernation_enabled` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `hibernation_enabled` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `confidential_vm_supported` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `confidential_vm_enabled` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `trusted_launch_supported` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `trusted_launch_enabled` property [GH-00000]
* Data Source: `azurerm_shared_image` - support for the `accelerated_network_support_enabled` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
