### PR TITLE
`mssql_managed_instance` - increase TC timeout and add `prevent_deletion_if_contains_resources` to tests

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -129,7 +129,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "mssql" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false)),
 
         // MSSQL Managed Instance creation can impact the service so limit the frequency and number of tests
-        "mssqlmanagedinstance" to testConfiguration(parallelism = 4, daysOfWeek = "7", locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false)),
+        "mssqlmanagedinstance" to testConfiguration(parallelism = 4, daysOfWeek = "7", locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false), timeout = 18),
 
         // MySQL has quota available in certain locations
         "mysql" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false)),

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1241,6 +1241,10 @@ func (r MsSqlManagedInstanceResource) basic(data acceptance.TestData) string {
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -1280,6 +1284,10 @@ func (r MsSqlManagedInstanceResource) premium(data acceptance.TestData) string {
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -1319,6 +1327,10 @@ func (r MsSqlManagedInstanceResource) storageType(data acceptance.TestData, stor
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -1359,6 +1371,10 @@ func (r MsSqlManagedInstanceResource) identity(data acceptance.TestData) string 
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -1402,6 +1418,10 @@ func (r MsSqlManagedInstanceResource) update(data acceptance.TestData) string {
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -1445,6 +1465,10 @@ func (r MsSqlManagedInstanceResource) multiple(data acceptance.TestData) string 
 provider "azurerm" {
   features {
     resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
       prevent_deletion_if_contains_resources = false
     }
   }
@@ -2405,6 +2429,19 @@ resource "azurerm_subnet_route_table_association" "secondary_2" {
 func (r MsSqlManagedInstanceResource) withMaintenanceConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service, 
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be 
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1238,6 +1238,14 @@ func (r MsSqlManagedInstanceResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1268,6 +1276,14 @@ resource "azurerm_mssql_managed_instance" "test" {
 func (r MsSqlManagedInstanceResource) premium(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
 
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
@@ -1300,6 +1316,14 @@ func (r MsSqlManagedInstanceResource) storageType(data acceptance.TestData, stor
 	return fmt.Sprintf(`
 %[1]s
 
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1331,6 +1355,14 @@ resource "azurerm_mssql_managed_instance" "test" {
 func (r MsSqlManagedInstanceResource) identity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
 
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
@@ -1367,6 +1399,14 @@ func (r MsSqlManagedInstanceResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1401,6 +1441,14 @@ resource "azurerm_mssql_managed_instance" "test" {
 func (r MsSqlManagedInstanceResource) multiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
 
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
@@ -325,6 +325,14 @@ provider "azurerm" {
       purge_soft_delete_on_destroy       = false
       purge_soft_deleted_keys_on_destroy = false
     }
+
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service, 
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be 
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
+    }
   }
 }
 
@@ -362,6 +370,8 @@ resource "azurerm_mssql_managed_instance" "test" {
 }
 
 
+
+
 `, db.template(data, data.Locations.Primary), data.RandomInteger)
 }
 
@@ -374,6 +384,13 @@ provider "azurerm" {
     key_vault {
       purge_soft_delete_on_destroy       = false
       purge_soft_deleted_keys_on_destroy = false
+    }
+    resource_group {
+      /* Due to the creation of unmanaged Microsoft.Network/networkIntentPolicies in this service,
+      prevent_deletion_if_contains_resources has been added here to allow the test resources to be
+       deleted until this can be properly investigated
+      */
+      prevent_deletion_if_contains_resources = false
     }
   }
 }
@@ -419,6 +436,12 @@ resource "azurerm_mssql_managed_instance" "test" {
     database    = "test"
   }
 }
+
+
+
+
+
+
 
 
 `, db.template(data, data.Locations.Primary), data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adds `prevent_deletion_if_contains_resources = false` to managed_instance tests to workaround the creation of unmanaged `Microsoft.Network/networkIntentPolicies`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Tests running in TC

