### PR TITLE
`testing` - inject refresh steps to compensate for 1.6.0 change to implicit refreshing

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -44,11 +44,20 @@ func (td TestData) DataSourceTestInSequence(t *testing.T, steps []TestStep) {
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {
 	// Testing framework as of 1.6.0 no longer auto-refreshes state, so adding it back in here for all steps that update
 	// the config rather than having to modify 1000's of tests individually to add a refresh-only step
-	for index, step := range steps {
-		if !step.ImportState && index != 0 {
-			step.RefreshState = true
+	var refreshStep = TestStep{
+		RefreshState: true,
+	}
+
+	newSteps := make([]TestStep, 0)
+	for _, step := range steps {
+		if !step.ImportState {
+			newSteps = append(newSteps, step)
+		} else {
+			newSteps = append(newSteps, refreshStep)
+			newSteps = append(newSteps, step)
 		}
 	}
+	steps = newSteps
 
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
forces a refresh between steps to ensure state is settled before checks are run.


