### PR TITLE
`azurerm_automation_runbook` - revert removing computed on `content` in 4.0

### DIFF
--- a/internal/services/automation/automation_runbook_resource.go
+++ b/internal/services/automation/automation_runbook_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/helper"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -153,9 +152,10 @@ func resourceAutomationRunbook() *pluginsdk.Resource {
 			},
 
 			"content": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     !features.FourPointOhBeta(),
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				// NOTE: O+C the API returns some defaults for this if `publish_content_link` is specified
+				Computed:     true,
 				AtLeastOneOf: []string{"content", "publish_content_link", "draft"},
 				ValidateFunc: validation.StringIsNotEmpty,
 			},

--- a/internal/services/automation/automation_runbook_resource_test.go
+++ b/internal/services/automation/automation_runbook_resource_test.go
@@ -303,9 +303,6 @@ resource "azurerm_automation_runbook" "test" {
       value     = "115775B8FF2BE672D8A946BD0B489918C724DDE15A440373CA54461D53010A80"
     }
   }
-  lifecycle {
-    ignore_changes = [content]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Supersedes #27014
Supersedes #26997