### PR TITLE
`azurerm_virtual_network_gateway_connection` - set `ingress_nat_rule_ids` in the update operation

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -623,7 +623,7 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if d.HasChange("ingress_nat_rule_ids") {
-		payload.Properties.EgressNatRules = expandVirtualNetworkGatewayConnectionNatRuleIds(d.Get("ingress_nat_rule_ids").(*pluginsdk.Set).List())
+		payload.Properties.IngressNatRules = expandVirtualNetworkGatewayConnectionNatRuleIds(d.Get("ingress_nat_rule_ids").(*pluginsdk.Set).List())
 	}
 
 	if d.HasChange("local_network_gateway_id") {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -1751,3 +1751,336 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
+
+func (VirtualNetworkGatewayConnectionResource) withoutIngressNatRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vnetgwconn-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "Vpn"
+  vpn_type                   = "RouteBased"
+  enable_bgp                 = true
+  active_active              = false
+  private_ip_address_enabled = false
+  sku                        = "VpnGw2"
+  generation                 = "Generation2"
+
+  ip_configuration {
+    name                          = "default"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  bgp_settings {
+    asn = "65000"
+
+    peering_addresses {
+      ip_configuration_name = "default"
+      apipa_addresses = [
+        "169.254.21.2",
+        "169.254.22.2"
+      ]
+    }
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+
+  bgp_settings {
+    asn                 = "64512"
+    bgp_peering_address = "169.254.21.1"
+  }
+}
+
+data "azurerm_virtual_network_gateway" "test" {
+  name                = azurerm_virtual_network_gateway.test.name
+  resource_group_name = azurerm_virtual_network_gateway.test.resource_group_name
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test" {
+  name                       = "acctestvnetgwegressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.1.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.2.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test4" {
+  name                       = "acctestvnetgwegressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.3.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  name                           = "acctestgwc-%d"
+  location                       = azurerm_resource_group.test.location
+  resource_group_name            = azurerm_resource_group.test.name
+  local_azure_ip_address_enabled = false
+  type                           = "IPsec"
+  connection_protocol            = "IKEv2"
+  enable_bgp                     = true
+  dpd_timeout_seconds            = 45
+  virtual_network_gateway_id     = azurerm_virtual_network_gateway.test.id
+  local_network_gateway_id       = azurerm_local_network_gateway.test.id
+  egress_nat_rule_ids            = [azurerm_virtual_network_gateway_nat_rule.test.id, azurerm_virtual_network_gateway_nat_rule.test4.id]
+  shared_key                     = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+
+  custom_bgp_addresses {
+    primary = "169.254.21.2"
+  }
+
+  ipsec_policy {
+    dh_group         = "DHGroup14"
+    ike_encryption   = "AES256"
+    ike_integrity    = "SHA256"
+    ipsec_encryption = "AES256"
+    ipsec_integrity  = "SHA256"
+    pfs_group        = "None"
+    sa_lifetime      = "3600"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayConnectionResource) withIngressNatRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vnetgwconn-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "Vpn"
+  vpn_type                   = "RouteBased"
+  enable_bgp                 = true
+  active_active              = false
+  private_ip_address_enabled = false
+  sku                        = "VpnGw2"
+  generation                 = "Generation2"
+
+  ip_configuration {
+    name                          = "default"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  bgp_settings {
+    asn = "65000"
+
+    peering_addresses {
+      ip_configuration_name = "default"
+      apipa_addresses = [
+        "169.254.21.2",
+        "169.254.22.2"
+      ]
+    }
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+
+  bgp_settings {
+    asn                 = "64512"
+    bgp_peering_address = "169.254.21.1"
+  }
+}
+
+data "azurerm_virtual_network_gateway" "test" {
+  name                = azurerm_virtual_network_gateway.test.name
+  resource_group_name = azurerm_virtual_network_gateway.test.resource_group_name
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test" {
+  name                       = "acctestvnetgwegressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.1.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.2.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test4" {
+  name                       = "acctestvnetgwegressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.3.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test2" {
+  name                       = "acctestvnetgwingressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "IngressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.7.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.8.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test3" {
+  name                       = "acctestvnetgwingressnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "IngressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.9.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.10.0.0/26"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  name                           = "acctestgwc-%d"
+  location                       = azurerm_resource_group.test.location
+  resource_group_name            = azurerm_resource_group.test.name
+  local_azure_ip_address_enabled = false
+  type                           = "IPsec"
+  connection_protocol            = "IKEv2"
+  enable_bgp                     = true
+  dpd_timeout_seconds            = 45
+  virtual_network_gateway_id     = azurerm_virtual_network_gateway.test.id
+  local_network_gateway_id       = azurerm_local_network_gateway.test.id
+  egress_nat_rule_ids            = [azurerm_virtual_network_gateway_nat_rule.test.id, azurerm_virtual_network_gateway_nat_rule.test4.id]
+  ingress_nat_rule_ids           = [azurerm_virtual_network_gateway_nat_rule.test2.id, azurerm_virtual_network_gateway_nat_rule.test3.id]
+  shared_key                     = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+
+  custom_bgp_addresses {
+    primary = "169.254.21.2"
+  }
+
+  ipsec_policy {
+    dh_group         = "DHGroup14"
+    ike_encryption   = "AES256"
+    ike_integrity    = "SHA256"
+    ipsec_encryption = "AES256"
+    ipsec_integrity  = "SHA256"
+    pfs_group        = "None"
+    sa_lifetime      = "3600"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -297,6 +297,28 @@ func TestAccVirtualNetworkGatewayConnection_natRuleIds(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkGatewayConnection_ingressNatRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
+	r := VirtualNetworkGatewayConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withoutIngressNatRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withIngressNatRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VirtualNetworkGatewayConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualnetworkgatewayconnections.ParseConnectionID(state.ID)
 	if err != nil {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
TF should set the ingressNatRules property in the request payload for `ingress_nat_rule_ids` but actually TF would set the egressNatRules property when `ingress_nat_rule_ids` is changed. This bug is introduced by [PR](https://github.com/hashicorp/terraform-provider-azurerm/commit/43234a1d54c1fb413ec09a62b562d4fe21a81114#diff-5fd83673add7a734c21116bb4de8a766a13b3cfce9556cd1262dc721fbc4ebdbR626). So I submitted this PR to fix it.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network_gateway_connection` - set `ingress_nat_rule_ids` in the update operation


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/27009


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
