### PR TITLE
azurerm_nginx_deployment - remove default `capacity` for v4.0

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-const defaultCapacity = 20
+const defaultCapacity = 20 // TODO: remove this in v4.0
 
 type FrontendPrivate struct {
 	IpAddress        string `tfschema:"ip_address"`
@@ -126,7 +126,6 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:          pluginsdk.TypeInt,
 			Optional:      true,
 			ConflictsWith: []string{"auto_scale_profile"},
-			Default:       defaultCapacity,
 			ValidateFunc:  validation.IntPositive,
 		},
 
@@ -267,6 +266,8 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 	}
 
 	if !features.FourPointOhBeta() {
+		resource["capacity"].Default = defaultCapacity
+
 		resource["configuration"] = &pluginsdk.Schema{
 			Deprecated: "The `configuration` block has been superseded by the `azurerm_nginx_configuration` resource and will be removed in v4.0 of the AzureRM Provider.",
 			Type:       pluginsdk.TypeList,
@@ -439,13 +440,29 @@ func (m DeploymentResource) Create() sdk.ResourceFunc {
 			}
 
 			isBasicSKU := strings.HasPrefix(model.Sku, "basic")
-			if isBasicSKU && (model.Capacity != defaultCapacity || len(model.AutoScaleProfile) > 0) {
-				return fmt.Errorf("basic SKUs are incompatible with `capacity` or `auto_scale_profiles`")
-			}
+			if !features.FourPointOhBeta() {
+				if isBasicSKU && (model.Capacity != defaultCapacity || len(model.AutoScaleProfile) > 0) {
+					return fmt.Errorf("basic SKUs are incompatible with `capacity` or `auto_scale_profiles`")
+				}
 
-			if model.Capacity > 0 && !isBasicSKU {
-				prop.ScalingProperties = &nginxdeployment.NginxDeploymentScalingProperties{
-					Capacity: pointer.FromInt64(model.Capacity),
+				if model.Capacity > 0 && !isBasicSKU {
+					prop.ScalingProperties = &nginxdeployment.NginxDeploymentScalingProperties{
+						Capacity: pointer.FromInt64(model.Capacity),
+					}
+				}
+			} else {
+				hasScaling := (model.Capacity > 0 || len(model.AutoScaleProfile) > 0)
+				if isBasicSKU && hasScaling {
+					return fmt.Errorf("basic SKUs are incompatible with `capacity` or `auto_scale_profiles`")
+				}
+				if !isBasicSKU && !hasScaling {
+					return fmt.Errorf("scaling is required for `sku` '%s', please provide `capacity` or `auto_scale_profiles`", model.Sku)
+				}
+
+				if model.Capacity > 0 {
+					prop.ScalingProperties = &nginxdeployment.NginxDeploymentScalingProperties{
+						Capacity: pointer.FromInt64(model.Capacity),
+					}
 				}
 			}
 
@@ -743,6 +760,10 @@ func (m DeploymentResource) Update() sdk.ResourceFunc {
 				req.Properties.AutoUpgradeProfile = &nginxdeployment.AutoUpgradeProfile{
 					UpgradeChannel: model.UpgradeChannel,
 				}
+			}
+
+			if strings.HasPrefix(model.Sku, "basic") && req.Properties.ScalingProperties != nil {
+				return fmt.Errorf("basic SKUs are incompatible with `capacity` or `auto_scale_profiles`")
 			}
 
 			if err := client.DeploymentsUpdateThenPoll(ctx, *id, req); err != nil {

--- a/website/docs/guides/4.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/4.0-upgrade-guide.html.markdown
@@ -934,6 +934,7 @@ The deprecated data source has been superseded by `azurerm_mssql_server` and has
 ### `azurerm_nginx_deployment`
 
 * The deprecated block `configuration` has been removed in favour of the `azurerm_nginx_configuration` resource.
+* The property `capacity` no longer has a default value of 20. `sku`s that support scaling now require either `capacity` or `auto_scale_profiles`.
 
 ### `azurerm_orchestrated_virtual_machine_scale_set`
 

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -57,7 +57,7 @@ resource "azurerm_subnet" "example" {
 resource "azurerm_nginx_deployment" "example" {
   name                      = "example-nginx"
   resource_group_name       = azurerm_resource_group.example.name
-  sku                       = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                       = "standard_Monthly"
   location                  = azurerm_resource_group.example.location
   managed_resource_group    = "example"
   diagnose_support_enabled  = true
@@ -88,13 +88,13 @@ The following arguments are supported:
 
 * `sku` - (Required) Specifies the NGINX Deployment SKU. Possible values are `standard_Monthly` and `basic_Monthly`. Changing this forces a new resource to be created.
 
--> **NOTE:** If you are setting the `sku` to `basic_Monthly`, setting a non-default `capacity` or `auto_scale_profile` will fail. You should use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
+-> **NOTE:** If you are setting the `sku` to `basic_Monthly`, you cannot specify a `capacity` or `auto_scale_profile`; basic plans do not support scaling. Other `sku`s require either `capacity` or `auto_scale_profile`. If you're using `basic_Monthly` with deployments created before v4.0, you may need to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
 
 * `managed_resource_group` - (Optional) Specify the managed resource group to deploy VNet injection related network resources. Changing this forces a new NGINX Deployment to be created.
 
 ---
 
-* `capacity` - (Optional) Specify the number of NGINX capacity units for this NGINX deployment. Defaults to `20`.
+* `capacity` - (Optional) Specify the number of NGINX capacity units for this NGINX deployment.
 
 -> **Note** For more information on NGINX capacity units, please refer to the [NGINX scaling guidance documentation](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/)
 
@@ -168,7 +168,7 @@ An `auto_scale_profile` block supports the following:
 
 * `max_capacity` - (Required) Specify the maximum number of NGINX capacity units for this NGINX Deployment.
 
--> **NOTE:** If you're using autoscaling, you should use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
+-> **NOTE:** If you're using autoscaling with deployments created before v4.0, you may need to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to ignore changes to the `capacity` field.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The default value has caused headaches around autoscaling and new SKUs, requiring `ignore_changes` workarounds and making it harder for users to express their desired state.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Manually tested locally a variety of cases:

| `sku` | `capacity` | `auto_scale_profiles` | outcome |
|-|-|-|-|
| `basic_Monthly` | absent | absent | PUT request does not include any scaling |
| `basic_Monthly` | present | absent | error during apply, but before PUT | 
| `basic_Monthly` | absent | present | error during apply, but before PUT | 
| `basic_Monthly` | present | present | error during planning | 
| `standard_Monthly` | absent | absent | error during apply, but before PUT |
| `standard_Monthly` | present | absent | PUT request includes `capacity` | 
| `standard_Monthly` | absent | present | PUT request includes `autoScaleProfiles` | 
| `standard_Monthly` | present | present | error during planning | 


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nginx_deployment` -  remove default capacity for v4.0 [GH-27027]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
