### PR TITLE
`azurerm_private_dns_resolver_inbound_endpoint`: add `forceNew` and `MaxItem` for `ip_configurations` block

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -69,6 +69,8 @@ func (r PrivateDNSResolverInboundEndpointResource) Arguments() map[string]*plugi
 		"ip_configurations": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
+			MaxItems: 1,
+			ForceNew: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"subnet_id": {
@@ -177,17 +179,6 @@ func (r PrivateDNSResolverInboundEndpointResource) Update() sdk.ResourceFunc {
 			properties := resp.Model
 			if properties == nil {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
-			}
-
-			if metadata.ResourceData.HasChange("ip_configurations") {
-				iPConfigurationsValue, err := expandIPConfigurationModel(model.IPConfigurations)
-				if err != nil {
-					return err
-				}
-
-				if iPConfigurationsValue != nil {
-					properties.Properties.IPConfigurations = *iPConfigurationsValue
-				}
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
@@ -79,13 +79,6 @@ func TestAccDNSResolverInboundEndpoint_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.forceNew(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -216,6 +209,7 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
 }
 
 func (r DNSResolverInboundEndpointResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
 	%s
 
@@ -230,62 +224,7 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
     key = "updated value"
   }
 }
-`, r.template(data), data.RandomInteger)
-}
-
-func (r DNSResolverInboundEndpointResource) forceNew(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_private_dns_resolver" "test" {
-  name                = "acctest-dr-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_network_id  = azurerm_virtual_network.test.id
-}
-
-resource "azurerm_subnet" "test1" {
-  name                 = "inbounddns1"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.0.64/28"]
-
-  delegation {
-    name = "Microsoft.Network.dnsResolvers"
-    service_delegation {
-      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-      name    = "Microsoft.Network/dnsResolvers"
-    }
-  }
-}
-
-resource "azurerm_private_dns_resolver_inbound_endpoint" "test" {
-  name                    = "acctest-drie-%[1]d"
-  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-  location                = azurerm_private_dns_resolver.test.location
-  ip_configurations {
-    subnet_id = azurerm_subnet.test1.id
-  }
-  tags = {
-    key = "updated value"
-  }
-}
-`, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r DNSResolverInboundEndpointResource) static(data acceptance.TestData) string {

--- a/website/docs/r/private_dns_resolver_inbound_endpoint.html.markdown
+++ b/website/docs/r/private_dns_resolver_inbound_endpoint.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `private_dns_resolver_id` - (Required) Specifies the ID of the Private DNS Resolver Inbound Endpoint. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 
-* `ip_configurations` - (Required) Can be specified multiple times to define multiple IP configurations. Each `ip_configurations` block as defined below.
+* `ip_configurations` - (Required) Specific one IP configuration. One `ip_configurations` block as defined below. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 
 * `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Inbound Endpoint should exist. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 

--- a/website/docs/r/private_dns_resolver_inbound_endpoint.html.markdown
+++ b/website/docs/r/private_dns_resolver_inbound_endpoint.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `private_dns_resolver_id` - (Required) Specifies the ID of the Private DNS Resolver Inbound Endpoint. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 
-* `ip_configurations` - (Required) Specific one IP configuration. One `ip_configurations` block as defined below. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
+* `ip_configurations` - (Required) One `ip_configurations` block as defined below. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 
 * `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Inbound Endpoint should exist. Changing this forces a new Private DNS Resolver Inbound Endpoint to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

According to the documentation, https://learn.microsoft.com/en-us/azure/dns/private-resolver-endpoints-rulesets#inbound-endpoints, the number of IP configuration should be 1 and can not update it once provisioned. we might need rename the `ip_configurations` to `ip_configuration` but that would introduce a breaking change, so I'll just leave it as is.

my test result also confirms this:

```
        Message: "The number of IP configurations must be 1. inboundEndpointResourceId=/subscriptions/xxx/resourceGroups/acctest-rg-240814135548298235/dnsResolvers/acctest-dr-240814135548298235/inboundEndpoints/acctest-drie-240814135548298235, numIpConfigurations=2"
---
        Message: "IP allocation method cannot be changed after creation. inboundEndpointResourceId=/subscriptions/xxx/resourceGroups/acctest-rg-240814115318360033/dnsResolvers/acctest-dr-240814115318360033/inboundEndpoints/acctest-drie-240814115318360033, ipAllocationMethod=0, existingIpAllocationMethod=1"
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccDNSResolverInboundEndpoint_update (1269.49s)
PASS
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_dns_resolver_inbound_endpoint` - mark `ip_configurations` as force new.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26987


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
