### PR TITLE
Docs : Fix documentation issue for  deprecated property  `partition_key_path` 

### DIFF
--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_cosmosdb_sql_container" "example" {
   resource_group_name   = data.azurerm_cosmosdb_account.example.resource_group_name
   account_name          = data.azurerm_cosmosdb_account.example.name
   database_name         = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path    = "/definition/id"
+  partition_key_paths   = ["/definition/id"]
   partition_key_version = 1
   throughput            = 400
 
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed.
 


### PR DESCRIPTION
The `partition_key_path` is deprecated in favor of `partition_key_paths` in 4.0, Currently TF documentation has removed `partition_key_path`, but it is still used in example and property description. 

Given `partition_key_paths ` is required in documentation, removed the description "Requires `partition_key_path` to be set" for `autoscale_settings`.

Fix #27028.