### PR TITLE
New Data Source : `azurerm_vpn_server_configuration`

### DIFF
--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -36,6 +36,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 		ManagerDataSource{},
 		ManagerNetworkGroupDataSource{},
 		ManagerConnectivityConfigurationDataSource{},
+		VPNServerConfigurationDataSource{},
 	}
 }
 
@@ -94,7 +95,6 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_virtual_wan":                               dataSourceVirtualWan(),
 		"azurerm_local_network_gateway":                     dataSourceLocalNetworkGateway(),
 		"azurerm_vpn_gateway":                               dataSourceVPNGateway(),
-		"azurerm_vpn_server_configuration":                  dataSourceVPNServerConfiguration(),
 	}
 }
 

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -94,6 +94,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_virtual_wan":                               dataSourceVirtualWan(),
 		"azurerm_local_network_gateway":                     dataSourceLocalNetworkGateway(),
 		"azurerm_vpn_gateway":                               dataSourceVPNGateway(),
+		"azurerm_vpn_server_configuration":                  dataSourceVPNServerConfiguration(),
 	}
 }
 

--- a/internal/services/network/vpn_server_configuration_data_source_resource.go
+++ b/internal/services/network/vpn_server_configuration_data_source_resource.go
@@ -1,0 +1,489 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/virtualwans"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func dataSourceVPNServerConfiguration() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceVPNServerConfigurationRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"location": commonschema.LocationComputed(),
+
+			"vpn_authentication_types": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"azure_active_directory_authentication": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"audience": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"issuer": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"tenant": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"client_revoked_certificate": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"thumbprint": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"client_root_certificate": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"public_cert_data": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"ipsec_policy": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"dh_group": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"ike_encryption": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"ike_integrity": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"ipsec_encryption": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"ipsec_integrity": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"pfs_group": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"sa_lifetime_seconds": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"sa_data_size_kilobytes": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"radius": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"server": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"address": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+
+									"secret": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+
+									"score": {
+										Type:     pluginsdk.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"client_root_certificate": {
+							Type:     pluginsdk.TypeSet,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+
+									"thumbprint": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"server_root_certificate": {
+							Type:     pluginsdk.TypeSet,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+
+									"public_cert_data": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"vpn_protocols": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"tags": commonschema.TagsDataSource(),
+		},
+	}
+}
+
+func dataSourceVPNServerConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VirtualWANs
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+	defer cancel()
+
+	id := virtualwans.NewVpnServerConfigurationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	resp, err := client.VpnServerConfigurationsGet(ctx, id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	d.Set("name", id.VpnServerConfigurationName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+
+		if props := model.Properties; props != nil {
+			flattenedAADAuthentication := dataSourceFlattenVpnServerConfigurationAADAuthentication(props.AadAuthenticationParameters)
+			if err := d.Set("azure_active_directory_authentication", flattenedAADAuthentication); err != nil {
+				return fmt.Errorf("setting `azure_active_directory_authentication`: %+v", err)
+			}
+
+			flattenedClientRootCerts := dataSourceFlattenVpnServerConfigurationClientRootCertificates(props.VpnClientRootCertificates)
+			if err := d.Set("client_root_certificate", flattenedClientRootCerts); err != nil {
+				return fmt.Errorf("setting `client_root_certificate`: %+v", err)
+			}
+
+			flattenedClientRevokedCerts := dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(props.VpnClientRevokedCertificates)
+			if err := d.Set("client_revoked_certificate", flattenedClientRevokedCerts); err != nil {
+				return fmt.Errorf("setting `client_revoked_certificate`: %+v", err)
+			}
+
+			flattenedIPSecPolicies := dataSourceFlattenVpnServerConfigurationIPSecPolicies(props.VpnClientIPsecPolicies)
+			if err := d.Set("ipsec_policy", flattenedIPSecPolicies); err != nil {
+				return fmt.Errorf("setting `ipsec_policy`: %+v", err)
+			}
+
+			flattenedRadius := dataSourceFlattenVpnServerConfigurationRadius(props)
+			if err := d.Set("radius", flattenedRadius); err != nil {
+				return fmt.Errorf("setting `radius`: %+v", err)
+			}
+
+			vpnAuthenticationTypes := make([]interface{}, 0)
+			if props.VpnAuthenticationTypes != nil {
+				for _, v := range *props.VpnAuthenticationTypes {
+					vpnAuthenticationTypes = append(vpnAuthenticationTypes, string(v))
+				}
+			}
+			if err := d.Set("vpn_authentication_types", vpnAuthenticationTypes); err != nil {
+				return fmt.Errorf("setting `vpn_authentication_types`: %+v", err)
+			}
+
+			flattenedVpnProtocols := dataSourceFlattenVpnServerConfigurationVPNProtocols(props.VpnProtocols)
+			if err := d.Set("vpn_protocols", pluginsdk.NewSet(pluginsdk.HashString, flattenedVpnProtocols)); err != nil {
+				return fmt.Errorf("setting `vpn_protocols`: %+v", err)
+			}
+
+			if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func dataSourceFlattenVpnServerConfigurationAADAuthentication(input *virtualwans.AadAuthenticationParameters) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	audience := ""
+	if input.AadAudience != nil {
+		audience = *input.AadAudience
+	}
+
+	issuer := ""
+	if input.AadIssuer != nil {
+		issuer = *input.AadIssuer
+	}
+
+	tenant := ""
+	if input.AadTenant != nil {
+		tenant = *input.AadTenant
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"audience": audience,
+			"issuer":   issuer,
+			"tenant":   tenant,
+		},
+	}
+}
+
+func dataSourceFlattenVpnServerConfigurationClientRootCertificates(input *[]virtualwans.VpnServerConfigVpnClientRootCertificate) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		name := ""
+		if v.Name != nil {
+			name = *v.Name
+		}
+
+		publicCertData := ""
+		if v.PublicCertData != nil {
+			publicCertData = *v.PublicCertData
+		}
+
+		output = append(output, map[string]interface{}{
+			"name":             name,
+			"public_cert_data": publicCertData,
+		})
+	}
+
+	return output
+}
+
+func dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(input *[]virtualwans.VpnServerConfigVpnClientRevokedCertificate) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+	for _, v := range *input {
+		name := ""
+		if v.Name != nil {
+			name = *v.Name
+		}
+
+		thumbprint := ""
+		if v.Thumbprint != nil {
+			thumbprint = *v.Thumbprint
+		}
+
+		output = append(output, map[string]interface{}{
+			"name":       name,
+			"thumbprint": thumbprint,
+		})
+	}
+	return output
+}
+
+func dataSourceFlattenVpnServerConfigurationIPSecPolicies(input *[]virtualwans.IPsecPolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+	for _, v := range *input {
+		output = append(output, map[string]interface{}{
+			"dh_group":               string(v.DhGroup),
+			"ipsec_encryption":       string(v.IPsecEncryption),
+			"ipsec_integrity":        string(v.IPsecIntegrity),
+			"ike_encryption":         string(v.IkeEncryption),
+			"ike_integrity":          string(v.IkeIntegrity),
+			"pfs_group":              string(v.PfsGroup),
+			"sa_data_size_kilobytes": int(v.SaDataSizeKilobytes),
+			"sa_lifetime_seconds":    int(v.SaLifeTimeSeconds),
+		})
+	}
+	return output
+}
+
+func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurationProperties) []interface{} {
+	if input == nil || (input.RadiusServerAddress == nil && (input.RadiusServers == nil || len(*input.RadiusServers) == 0)) {
+		return []interface{}{}
+	}
+
+	clientRootCertificates := make([]interface{}, 0)
+	if input.RadiusClientRootCertificates != nil {
+		for _, v := range *input.RadiusClientRootCertificates {
+			name := ""
+			if v.Name != nil {
+				name = *v.Name
+			}
+
+			thumbprint := ""
+			if v.Thumbprint != nil {
+				thumbprint = *v.Thumbprint
+			}
+
+			clientRootCertificates = append(clientRootCertificates, map[string]interface{}{
+				"name":       name,
+				"thumbprint": thumbprint,
+			})
+		}
+	}
+
+	serverRootCertificates := make([]interface{}, 0)
+	if input.RadiusServerRootCertificates != nil {
+		for _, v := range *input.RadiusServerRootCertificates {
+			name := ""
+			if v.Name != nil {
+				name = *v.Name
+			}
+
+			publicCertData := ""
+			if v.PublicCertData != nil {
+				publicCertData = *v.PublicCertData
+			}
+
+			serverRootCertificates = append(serverRootCertificates, map[string]interface{}{
+				"name":             name,
+				"public_cert_data": publicCertData,
+			})
+		}
+	}
+
+	servers := make([]interface{}, 0)
+	if input.RadiusServers != nil && len(*input.RadiusServers) > 0 {
+		for _, v := range *input.RadiusServers {
+			servers = append(servers, map[string]interface{}{
+				"address": v.RadiusServerAddress,
+				"secret":  pointer.From(v.RadiusServerSecret),
+				"score":   pointer.From(v.RadiusServerScore),
+			})
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"client_root_certificate": clientRootCertificates,
+			"server_root_certificate": serverRootCertificates,
+			"server":                  servers,
+		},
+	}
+}
+
+func dataSourceFlattenVpnServerConfigurationVPNProtocols(input *[]virtualwans.VpnGatewayTunnelingProtocol) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		output = append(output, string(v))
+	}
+
+	return output
+}

--- a/internal/services/network/vpn_server_configuration_data_source_resource.go
+++ b/internal/services/network/vpn_server_configuration_data_source_resource.go
@@ -4,482 +4,495 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/virtualwans"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-func dataSourceVPNServerConfiguration() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Read: dataSourceVPNServerConfigurationRead,
+type VPNServerConfigurationDataSource struct{}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+var _ sdk.DataSource = VPNServerConfigurationDataSource{}
+
+type VPNServerConfigurationDataSourceModel struct {
+	Name                               string                                    `tfschema:"name"`
+	ResourceGroup                      string                                    `tfschema:"resource_group_name"`
+	Location                           string                                    `tfschema:"location"`
+	VpnAuthenticationTypes             []string                                  `tfschema:"vpn_authentication_types"`
+	AzureActiveDirectoryAuthentication []AzureActiveDirectoryAuthenticationModel `tfschema:"azure_active_directory_authentication"`
+	ClientRevokedCertificate           []ClientRevokedCertificateModel           `tfschema:"client_revoked_certificate"`
+	ClientRootCertificate              []ClientRootCertificateModel              `tfschema:"client_root_certificate"`
+	IpsecPolicy                        []IpsecPolicyModel                        `tfschema:"ipsec_policy"`
+	Radius                             []RadiusModel                             `tfschema:"radius"`
+	VpnProtocols                       []string                                  `tfschema:"vpn_protocols"`
+	Tags                               map[string]string                         `tfschema:"tags"`
+}
+
+type AzureActiveDirectoryAuthenticationModel struct {
+	Audience string `tfschema:"audience"`
+	Issuer   string `tfschema:"issuer"`
+	Tenant   string `tfschema:"tenant"`
+}
+
+type ClientRevokedCertificateModel struct {
+	Name       string `tfschema:"name"`
+	Thumbprint string `tfschema:"thumbprint"`
+}
+
+type ClientRootCertificateModel struct {
+	Name           string `tfschema:"name"`
+	PublicCertData string `tfschema:"public_cert_data"`
+}
+
+type IpsecPolicyModel struct {
+	DhGroup             string `tfschema:"dh_group"`
+	IkeEncryption       string `tfschema:"ike_encryption"`
+	IkeIntegrity        string `tfschema:"ike_integrity"`
+	IpsecEncryption     string `tfschema:"ipsec_encryption"`
+	IpsecIntegrity      string `tfschema:"ipsec_integrity"`
+	PfsGroup            string `tfschema:"pfs_group"`
+	SaLifetimeSeconds   int64  `tfschema:"sa_lifetime_seconds"`
+	SaDataSizeKilobytes int64  `tfschema:"sa_data_size_kilobytes"`
+}
+
+type RadiusModel struct {
+	Server                []ServerModel                      `tfschema:"server"`
+	ClientRootCertificate []RadiusClientRootCertificateModel `tfschema:"client_root_certificate"`
+	ServerRootCertificate []ClientRootCertificateModel       `tfschema:"server_root_certificate"`
+}
+
+type ServerModel struct {
+	Address string `tfschema:"address"`
+	Secret  string `tfschema:"secret"`
+	Score   int64  `tfschema:"score"`
+}
+
+type RadiusClientRootCertificateModel struct {
+	Name       string `tfschema:"name"`
+	Thumbprint string `tfschema:"thumbprint"`
+}
+
+func (d VPNServerConfigurationDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"location": commonschema.LocationComputed(),
-
-			"vpn_authentication_types": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
-			"azure_active_directory_authentication": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"audience": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"issuer": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"client_revoked_certificate": {
-				Type:     pluginsdk.TypeSet,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"thumbprint": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"client_root_certificate": {
-				Type:     pluginsdk.TypeSet,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"public_cert_data": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"ipsec_policy": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"dh_group": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"ike_encryption": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"ike_integrity": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"ipsec_encryption": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"ipsec_integrity": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"pfs_group": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"sa_lifetime_seconds": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
-
-						"sa_data_size_kilobytes": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"radius": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"server": {
-							Type:     pluginsdk.TypeList,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"address": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-
-									"secret": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-
-									"score": {
-										Type:     pluginsdk.TypeInt,
-										Computed: true,
-									},
-								},
-							},
-						},
-
-						"client_root_certificate": {
-							Type:     pluginsdk.TypeSet,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"name": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-
-									"thumbprint": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-
-						"server_root_certificate": {
-							Type:     pluginsdk.TypeSet,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"name": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-
-									"public_cert_data": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-
-			"vpn_protocols": {
-				Type:     pluginsdk.TypeSet,
-				Computed: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
-			"tags": commonschema.TagsDataSource(),
-		},
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 	}
 }
 
-func dataSourceVPNServerConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualWANs
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+func (d VPNServerConfigurationDataSource) ModelObject() interface{} {
+	return &VPNServerConfigurationDataSource{}
+}
 
-	defer cancel()
+func (d VPNServerConfigurationDataSource) ResourceType() string {
+	return "azurerm_vpn_server_configuration"
+}
 
-	id := virtualwans.NewVpnServerConfigurationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+func (d VPNServerConfigurationDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
 
-	resp, err := client.VpnServerConfigurationsGet(ctx, id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			return fmt.Errorf("%s was not found", id)
-		}
+		"vpn_authentication_types": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
 
-		return fmt.Errorf("retrieving %s: %+v", id, err)
+		"azure_active_directory_authentication": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"audience": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"issuer": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"tenant": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"client_revoked_certificate": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"thumbprint": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"client_root_certificate": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"public_cert_data": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"ipsec_policy": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"dh_group": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"ike_encryption": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"ike_integrity": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"ipsec_encryption": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"ipsec_integrity": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"pfs_group": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"sa_lifetime_seconds": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"sa_data_size_kilobytes": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"radius": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"server": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"address": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"secret": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"score": {
+									Type:     pluginsdk.TypeInt,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"client_root_certificate": {
+						Type:     pluginsdk.TypeSet,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"thumbprint": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"server_root_certificate": {
+						Type:     pluginsdk.TypeSet,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"public_cert_data": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"vpn_protocols": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"tags": commonschema.TagsDataSource(),
 	}
+}
 
-	d.SetId(id.ID())
+func (d VPNServerConfigurationDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Network.VirtualWANs
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	d.Set("name", id.VpnServerConfigurationName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-
-	if model := resp.Model; model != nil {
-		d.Set("location", location.NormalizeNilable(model.Location))
-
-		if props := model.Properties; props != nil {
-			flattenedAADAuthentication := dataSourceFlattenVpnServerConfigurationAADAuthentication(props.AadAuthenticationParameters)
-			if err := d.Set("azure_active_directory_authentication", flattenedAADAuthentication); err != nil {
-				return fmt.Errorf("setting `azure_active_directory_authentication`: %+v", err)
-			}
-
-			flattenedClientRootCerts := dataSourceFlattenVpnServerConfigurationClientRootCertificates(props.VpnClientRootCertificates)
-			if err := d.Set("client_root_certificate", flattenedClientRootCerts); err != nil {
-				return fmt.Errorf("setting `client_root_certificate`: %+v", err)
-			}
-
-			flattenedClientRevokedCerts := dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(props.VpnClientRevokedCertificates)
-			if err := d.Set("client_revoked_certificate", flattenedClientRevokedCerts); err != nil {
-				return fmt.Errorf("setting `client_revoked_certificate`: %+v", err)
-			}
-
-			flattenedIPSecPolicies := dataSourceFlattenVpnServerConfigurationIPSecPolicies(props.VpnClientIPsecPolicies)
-			if err := d.Set("ipsec_policy", flattenedIPSecPolicies); err != nil {
-				return fmt.Errorf("setting `ipsec_policy`: %+v", err)
-			}
-
-			flattenedRadius := dataSourceFlattenVpnServerConfigurationRadius(props)
-			if err := d.Set("radius", flattenedRadius); err != nil {
-				return fmt.Errorf("setting `radius`: %+v", err)
-			}
-
-			vpnAuthenticationTypes := make([]interface{}, 0)
-			if props.VpnAuthenticationTypes != nil {
-				for _, v := range *props.VpnAuthenticationTypes {
-					vpnAuthenticationTypes = append(vpnAuthenticationTypes, string(v))
-				}
-			}
-			if err := d.Set("vpn_authentication_types", vpnAuthenticationTypes); err != nil {
-				return fmt.Errorf("setting `vpn_authentication_types`: %+v", err)
-			}
-
-			flattenedVpnProtocols := dataSourceFlattenVpnServerConfigurationVPNProtocols(props.VpnProtocols)
-			if err := d.Set("vpn_protocols", pluginsdk.NewSet(pluginsdk.HashString, flattenedVpnProtocols)); err != nil {
-				return fmt.Errorf("setting `vpn_protocols`: %+v", err)
-			}
-
-			if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			var model VPNServerConfigurationDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
 				return err
 			}
-		}
-	}
 
-	return nil
-}
+			id := virtualwans.NewVpnServerConfigurationID(subscriptionId, model.ResourceGroup, model.Name)
 
-func dataSourceFlattenVpnServerConfigurationAADAuthentication(input *virtualwans.AadAuthenticationParameters) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
+			resp, err := client.VpnServerConfigurationsGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
 
-	audience := ""
-	if input.AadAudience != nil {
-		audience = *input.AadAudience
-	}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
 
-	issuer := ""
-	if input.AadIssuer != nil {
-		issuer = *input.AadIssuer
-	}
+			m := VPNServerConfigurationDataSourceModel{
+				Name:          id.VpnServerConfigurationName,
+				ResourceGroup: id.ResourceGroupName,
+			}
 
-	tenant := ""
-	if input.AadTenant != nil {
-		tenant = *input.AadTenant
-	}
+			if model := resp.Model; model != nil {
+				m.Location = pointer.ToString(model.Location)
+				if tags := model.Tags; tags != nil {
+					m.Tags = pointer.ToMapOfStringStrings(tags)
+				}
 
-	return []interface{}{
-		map[string]interface{}{
-			"audience": audience,
-			"issuer":   issuer,
-			"tenant":   tenant,
+				if props := resp.Model.Properties; props != nil {
+					m.AzureActiveDirectoryAuthentication = dataSourceFlattenVpnServerConfigurationAADAuthentication(props.AadAuthenticationParameters)
+					m.ClientRootCertificate = dataSourceFlattenVpnServerConfigurationClientRootCertificates(props.VpnClientRootCertificates)
+					m.ClientRevokedCertificate = dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(props.VpnClientRevokedCertificates)
+					m.IpsecPolicy = dataSourceFlattenVpnServerConfigurationIPSecPolicies(props.VpnClientIPsecPolicies)
+					m.Radius = dataSourceFlattenVpnServerConfigurationRadius(props)
+					m.VpnAuthenticationTypes = dataSourceFlattenVpnServerConfigurationVpnAuthenticationTypes(props.VpnAuthenticationTypes)
+					m.VpnProtocols = dataSourceFlattenVpnServerConfigurationVPNProtocols(props.VpnProtocols)
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&m)
 		},
 	}
 }
 
-func dataSourceFlattenVpnServerConfigurationClientRootCertificates(input *[]virtualwans.VpnServerConfigVpnClientRootCertificate) []interface{} {
+func dataSourceFlattenVpnServerConfigurationAADAuthentication(input *virtualwans.AadAuthenticationParameters) []AzureActiveDirectoryAuthenticationModel {
 	if input == nil {
-		return []interface{}{}
+		return []AzureActiveDirectoryAuthenticationModel{}
 	}
 
-	output := make([]interface{}, 0)
+	return []AzureActiveDirectoryAuthenticationModel{
+		{
+			Audience: pointer.ToString(input.AadAudience),
+			Issuer:   pointer.ToString(input.AadIssuer),
+			Tenant:   pointer.ToString(input.AadTenant),
+		},
+	}
+}
+
+func dataSourceFlattenVpnServerConfigurationClientRootCertificates(input *[]virtualwans.VpnServerConfigVpnClientRootCertificate) []ClientRootCertificateModel {
+	if input == nil {
+		return []ClientRootCertificateModel{}
+	}
+
+	output := make([]ClientRootCertificateModel, 0)
 
 	for _, v := range *input {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
+		if v.Name == nil {
+			continue
 		}
-
-		publicCertData := ""
-		if v.PublicCertData != nil {
-			publicCertData = *v.PublicCertData
-		}
-
-		output = append(output, map[string]interface{}{
-			"name":             name,
-			"public_cert_data": publicCertData,
+		output = append(output, ClientRootCertificateModel{
+			Name:           pointer.ToString(v.Name),
+			PublicCertData: pointer.ToString(v.PublicCertData),
 		})
 	}
 
 	return output
 }
 
-func dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(input *[]virtualwans.VpnServerConfigVpnClientRevokedCertificate) []interface{} {
+func dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(input *[]virtualwans.VpnServerConfigVpnClientRevokedCertificate) []ClientRevokedCertificateModel {
 	if input == nil {
-		return []interface{}{}
+		return []ClientRevokedCertificateModel{}
 	}
 
-	output := make([]interface{}, 0)
+	output := make([]ClientRevokedCertificateModel, 0)
 	for _, v := range *input {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
+		if v.Name == nil {
+			continue
 		}
 
-		thumbprint := ""
-		if v.Thumbprint != nil {
-			thumbprint = *v.Thumbprint
-		}
-
-		output = append(output, map[string]interface{}{
-			"name":       name,
-			"thumbprint": thumbprint,
+		output = append(output, ClientRevokedCertificateModel{
+			Name:       pointer.ToString(v.Name),
+			Thumbprint: pointer.ToString(v.Thumbprint),
 		})
 	}
 	return output
 }
 
-func dataSourceFlattenVpnServerConfigurationIPSecPolicies(input *[]virtualwans.IPsecPolicy) []interface{} {
+func dataSourceFlattenVpnServerConfigurationIPSecPolicies(input *[]virtualwans.IPsecPolicy) []IpsecPolicyModel {
 	if input == nil {
-		return []interface{}{}
+		return []IpsecPolicyModel{}
 	}
 
-	output := make([]interface{}, 0)
+	output := make([]IpsecPolicyModel, 0)
 	for _, v := range *input {
-		output = append(output, map[string]interface{}{
-			"dh_group":               string(v.DhGroup),
-			"ipsec_encryption":       string(v.IPsecEncryption),
-			"ipsec_integrity":        string(v.IPsecIntegrity),
-			"ike_encryption":         string(v.IkeEncryption),
-			"ike_integrity":          string(v.IkeIntegrity),
-			"pfs_group":              string(v.PfsGroup),
-			"sa_data_size_kilobytes": int(v.SaDataSizeKilobytes),
-			"sa_lifetime_seconds":    int(v.SaLifeTimeSeconds),
+		output = append(output, IpsecPolicyModel{
+			DhGroup:             string(v.DhGroup),
+			IkeEncryption:       string(v.IPsecEncryption),
+			IkeIntegrity:        string(v.IPsecIntegrity),
+			IpsecEncryption:     string(v.IkeEncryption),
+			IpsecIntegrity:      string(v.IkeIntegrity),
+			PfsGroup:            string(v.PfsGroup),
+			SaLifetimeSeconds:   v.SaDataSizeKilobytes,
+			SaDataSizeKilobytes: v.SaLifeTimeSeconds,
 		})
 	}
 	return output
 }
 
-func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurationProperties) []interface{} {
+func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurationProperties) []RadiusModel {
 	if input == nil || (input.RadiusServerAddress == nil && (input.RadiusServers == nil || len(*input.RadiusServers) == 0)) {
-		return []interface{}{}
+		return []RadiusModel{}
 	}
 
-	clientRootCertificates := make([]interface{}, 0)
+	clientRootCertificates := make([]RadiusClientRootCertificateModel, 0)
 	if input.RadiusClientRootCertificates != nil {
 		for _, v := range *input.RadiusClientRootCertificates {
-			name := ""
-			if v.Name != nil {
-				name = *v.Name
+			if v.Name == nil {
+				continue
 			}
-
-			thumbprint := ""
-			if v.Thumbprint != nil {
-				thumbprint = *v.Thumbprint
-			}
-
-			clientRootCertificates = append(clientRootCertificates, map[string]interface{}{
-				"name":       name,
-				"thumbprint": thumbprint,
+			clientRootCertificates = append(clientRootCertificates, RadiusClientRootCertificateModel{
+				Name:       pointer.ToString(v.Name),
+				Thumbprint: pointer.ToString(v.Thumbprint),
 			})
 		}
 	}
 
-	serverRootCertificates := make([]interface{}, 0)
+	serverRootCertificates := make([]ClientRootCertificateModel, 0)
 	if input.RadiusServerRootCertificates != nil {
 		for _, v := range *input.RadiusServerRootCertificates {
-			name := ""
-			if v.Name != nil {
-				name = *v.Name
+			if v.Name == nil {
+				continue
 			}
 
-			publicCertData := ""
-			if v.PublicCertData != nil {
-				publicCertData = *v.PublicCertData
-			}
-
-			serverRootCertificates = append(serverRootCertificates, map[string]interface{}{
-				"name":             name,
-				"public_cert_data": publicCertData,
+			serverRootCertificates = append(serverRootCertificates, ClientRootCertificateModel{
+				Name:           pointer.ToString(v.Name),
+				PublicCertData: pointer.ToString(v.PublicCertData),
 			})
 		}
 	}
 
-	servers := make([]interface{}, 0)
+	servers := make([]ServerModel, 0)
 	if input.RadiusServers != nil && len(*input.RadiusServers) > 0 {
 		for _, v := range *input.RadiusServers {
-			servers = append(servers, map[string]interface{}{
-				"address": v.RadiusServerAddress,
-				"secret":  pointer.From(v.RadiusServerSecret),
-				"score":   pointer.From(v.RadiusServerScore),
+			servers = append(servers, ServerModel{
+				Address: v.RadiusServerAddress,
+				Secret:  pointer.ToString(v.RadiusServerSecret),
+				Score:   pointer.ToInt64(v.RadiusServerScore),
 			})
 		}
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"client_root_certificate": clientRootCertificates,
-			"server_root_certificate": serverRootCertificates,
-			"server":                  servers,
+	return []RadiusModel{
+		{
+			Server:                servers,
+			ClientRootCertificate: clientRootCertificates,
+			ServerRootCertificate: serverRootCertificates,
 		},
 	}
 }
 
-func dataSourceFlattenVpnServerConfigurationVPNProtocols(input *[]virtualwans.VpnGatewayTunnelingProtocol) []interface{} {
+func dataSourceFlattenVpnServerConfigurationVpnAuthenticationTypes(input *[]virtualwans.VpnAuthenticationType) []string {
 	if input == nil {
-		return []interface{}{}
+		return []string{}
 	}
 
-	output := make([]interface{}, 0)
+	output := make([]string, 0)
+
+	for _, v := range *input {
+		output = append(output, string(v))
+	}
+
+	return output
+}
+
+func dataSourceFlattenVpnServerConfigurationVPNProtocols(input *[]virtualwans.VpnGatewayTunnelingProtocol) []string {
+	if input == nil {
+		return []string{}
+	}
+
+	output := make([]string, 0)
 
 	for _, v := range *input {
 		output = append(output, string(v))

--- a/internal/services/network/vpn_server_configuration_data_source_resource_test.go
+++ b/internal/services/network/vpn_server_configuration_data_source_resource_test.go
@@ -1,0 +1,280 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type VPNServerConfigurationDataSource struct{}
+
+func TestAccVPNServerConfigurationDataSource_azureAD(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.azureAD(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("azure_active_directory_authentication.0.audience").HasValue("00000000-abcd-abcd-abcd-999999999999"),
+				check.That(data.ResourceName).Key("vpn_authentication_types.0").HasValue("AAD"),
+				check.That(data.ResourceName).Key("azure_active_directory_authentication.0.issuer").Exists(),
+				check.That(data.ResourceName).Key("azure_active_directory_authentication.0.tenant").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccVPNServerConfigurationDataSource_certificate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.certificate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("client_root_certificate.0.name").HasValue("DigiCert-Federated-ID-Root-CA"),
+				check.That(data.ResourceName).Key("vpn_authentication_types.0").HasValue("Certificate"),
+				check.That(data.ResourceName).Key("client_root_certificate.0.public_cert_data").HasValue("MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\nd3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg\nUm9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV\nBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp\nY2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j\nQPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8\nzAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf\nGTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d\nGTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8\nDk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2\nDwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV\nHQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW\njKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP\n9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR\nQELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL\nuGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn\nWsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq\nM/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=\n"),
+			),
+		},
+	})
+}
+
+func TestAccVPNServerConfigurationDataSource_radius(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.singleRadius(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("vpn_authentication_types.0").HasValue("Radius"),
+				check.That(data.ResourceName).Key("radius.0.server.0.address").HasValue("10.105.1.1"),
+				check.That(data.ResourceName).Key("radius.0.server.0.secret").HasValue("vindicators-the-return-of-worldender"),
+				check.That(data.ResourceName).Key("radius.0.server.0.score").HasValue("15"),
+				check.That(data.ResourceName).Key("radius.0.server_root_certificate.0.name").HasValue("DigiCert-Federated-ID-Root-CA"),
+				check.That(data.ResourceName).Key("radius.0.server_root_certificate.0.public_cert_data").HasValue("MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\nd3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg\nUm9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV\nBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp\nY2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j\nQPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8\nzAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf\nGTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d\nGTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8\nDk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2\nDwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV\nHQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW\njKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP\n9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR\nQELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL\nuGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn\nWsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq\nM/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=\n"),
+			),
+		},
+	})
+}
+
+func TestAccVPNServerConfigurationDataSource_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.tags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("client_root_certificate.0.name").HasValue("DigiCert-Federated-ID-Root-CA"),
+				check.That(data.ResourceName).Key("vpn_authentication_types.0").HasValue("Certificate"),
+				check.That(data.ResourceName).Key("client_root_certificate.0.public_cert_data").HasValue("MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\nd3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg\nUm9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV\nBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp\nY2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j\nQPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8\nzAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf\nGTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d\nGTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8\nDk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2\nDwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV\nHQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW\njKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP\n9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR\nQELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL\nuGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn\nWsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq\nM/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=\n"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.Hello").HasValue("World"),
+			),
+		},
+	})
+}
+
+func (r VPNServerConfigurationDataSource) azureAD(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["AAD"]
+
+  azure_active_directory_authentication {
+    audience = "00000000-abcd-abcd-abcd-999999999999"
+    issuer   = "https://sts.windows.net/${data.azurerm_subscription.current.tenant_id}/"
+    tenant   = "https://login.microsoftonline.com/${data.azurerm_subscription.current.tenant_id}"
+  }
+}
+
+data "azurerm_vpn_server_configuration" "test" {
+  name                = azurerm_vpn_server_configuration.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VPNServerConfigurationDataSource) certificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["Certificate"]
+
+  client_root_certificate {
+    name             = "DigiCert-Federated-ID-Root-CA"
+    public_cert_data = <<EOF
+MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+EOF
+  }
+}
+
+data "azurerm_vpn_server_configuration" "test" {
+  name                = azurerm_vpn_server_configuration.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VPNServerConfigurationDataSource) singleRadius(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["Radius"]
+
+  radius {
+
+    server {
+      address = "10.105.1.1"
+      secret  = "vindicators-the-return-of-worldender"
+      score   = 15
+    }
+
+    server_root_certificate {
+      name             = "DigiCert-Federated-ID-Root-CA"
+      public_cert_data = <<EOF
+MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+EOF
+    }
+  }
+}
+
+data "azurerm_vpn_server_configuration" "test" {
+  name                = azurerm_vpn_server_configuration.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VPNServerConfigurationDataSource) tags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["Certificate"]
+
+  client_root_certificate {
+    name             = "DigiCert-Federated-ID-Root-CA"
+    public_cert_data = <<EOF
+MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+EOF
+  }
+
+  tags = {
+    Hello = "World"
+  }
+}
+data "azurerm_vpn_server_configuration" "test" {
+  name                = azurerm_vpn_server_configuration.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (VPNServerConfigurationDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_virtual_wan" "test" {
+  name                = "acctestsvwan-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/website/docs/d/vpn_server_configuration.html.markdown
+++ b/website/docs/d/vpn_server_configuration.html.markdown
@@ -1,0 +1,154 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_vpn_server_configuration"
+description: |-
+  Gets information about an existing VPN Server Configuration.
+---
+
+# Data Source: azurerm_vpn_server_configuration
+
+Use this data source to access information about an existing VPN Server Configuration.
+
+## Example Usage
+
+```hcl
+data "azurerm_vpn_server_configuration" "example" {
+  name                = "existing-local-vpn-server-configuration"
+  resource_group_name = "existing-resource-group"
+}
+
+output "azurerm_vpn_server_configuration" {
+  value = data.azurerm_vpn_server_configuration.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Name of the VPN Server Configuration.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the VPN Server Configuration exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the VPN Server Configuration.
+
+* `location` - The Azure Region where the VPN Server Configuration exists.
+
+* `vpn_authentication_types` -  The list of Authentication Types applicable for the VPN Server Configuration.
+
+* `ipsec_policy` - The `bgp_settings` block as defined below.
+
+* `vpn_protocols` -  The list of VPN Protocols to use for the VPN Server Configuration.
+
+* `tags` - A mapping of tags to assign to the VPN Server Configuration.
+
+---
+
+When `vpn_authentication_types` contains `AAD` the following arguments are exported:
+
+* `azure_active_directory_authentication` - A `azure_active_directory_authentication` block as defined below.
+
+---
+
+When `vpn_authentication_types` contains `Certificate` the following arguments are supported:
+
+* `client_root_certificate` - One or more `client_root_certificate` blocks as defined below.
+
+* `client_revoked_certificate` - One or more `client_revoked_certificate` blocks as defined below.
+
+---
+
+When `vpn_authentication_types` contains `Radius` the following arguments are exported:
+
+* `radius` - A `radius` block as defined below.
+
+A `azure_active_directory_authentication` block exports the following:
+
+* `audience` - The Audience which should be used for authentication.
+
+* `issuer` - The Issuer which should be used for authentication.
+
+* `tenant` - The Tenant which should be used for authentication.
+
+---
+
+A `client_revoked_certificate` block exports the following:
+
+* `name` - The name used to uniquely identify this certificate.
+
+* `thumbprint` - The Thumbprint of the Certificate.
+
+---
+
+A `client_root_certificate` block at the root of the resource exports the following:
+
+* `name` - The name used to uniquely identify this certificate.
+
+* `public_cert_data` - The Public Key Data associated with the Certificate.
+
+---
+
+A `ipsec_policy` block exports the following:
+
+* `dh_group` - The DH Group, used in IKE Phase 1.
+
+* `ike_encryption` - The IKE encryption algorithm, used for IKE Phase 2.
+
+* `ike_integrity` - The IKE encryption integrity algorithm, used for IKE Phase 2.
+
+* `ipsec_encryption` - The IPSec encryption algorithm, used for IKE phase 1.
+
+* `ipsec_integrity` - The IPSec integrity algorithm, used for IKE phase 1.
+
+* `pfs_group` - The Pfs Group, used in IKE Phase 2.
+
+* `sa_lifetime_seconds` - The IPSec Security Association lifetime in seconds for a Site-to-Site VPN tunnel.
+
+* `sa_data_size_kilobytes` - The IPSec Security Association payload size in KB for a Site-to-Site VPN tunnel.
+
+---
+
+A `radius` block exports the following:
+
+* `server` - One or more `server` blocks as defined below.
+
+* `client_root_certificate` - One or more `client_root_certificate` blocks as defined below.
+
+* `server_root_certificate` - One or more `server_root_certificate` blocks as defined below.
+
+---
+
+A `server` nested within the `radius` block exports the following::
+
+* `address` - The Address of the Radius Server.
+
+* `secret` - The Secret used to communicate with the Radius Server.
+
+* `score` - The Score of the Radius Server determines the priority of the server.
+
+---
+
+A `client_root_certificate` block nested within the `radius` block exports the following:
+
+* `name` - The name used to uniquely identify this certificate.
+
+* `thumbprint` - The Thumbprint of the Certificate.
+
+---
+
+A `server_root_certificate` block exports the following:
+
+* `name` - The name used to uniquely identify this certificate.
+
+* `public_cert_data` - The Public Key Data associated with the Certificate.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the VPN Server Configuration.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for a `azurerm_vpn_server_configuration` data source.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
PASS: TestAccVPNServerConfigurationDataSource_azureAD (289.43s)
PASS: TestAccVPNServerConfigurationDataSource_certificate (228.86s)
PASS: TestAccVPNServerConfigurationDataSource_radius (225.54s)
PASS: TestAccVPNServerConfigurationDataSource_tags (210.99s)
```

![image](https://github.com/user-attachments/assets/ed687337-6c6e-4aa8-b929-f769d718f3d1)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Data Source : `azurerm_vpn_server_configuration` [GH-26989]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26989
