### PR TITLE
`azurerm_notification_hub` : Support new property `browser_credential`

### DIFF
--- a/internal/services/notificationhub/notification_hub_resource.go
+++ b/internal/services/notificationhub/notification_hub_resource.go
@@ -150,6 +150,7 @@ func resourceNotificationHub() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
+							Sensitive:    true,
 						},
 						"vapid_public_key": {
 							Type:         pluginsdk.TypeString,

--- a/internal/services/notificationhub/notification_hub_resource.go
+++ b/internal/services/notificationhub/notification_hub_resource.go
@@ -134,6 +134,32 @@ func resourceNotificationHub() *pluginsdk.Resource {
 				},
 			},
 
+			"browser_credential": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"subject": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"vapid_private_key": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"vapid_public_key": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
 			"gcm_credential": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -177,8 +203,9 @@ func resourceNotificationHubCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	parameters := hubs.NotificationHubResource{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &hubs.NotificationHubProperties{
-			ApnsCredential: expandNotificationHubsAPNSCredentials(d.Get("apns_credential").([]interface{})),
-			GcmCredential:  expandNotificationHubsGCMCredentials(d.Get("gcm_credential").([]interface{})),
+			ApnsCredential:    expandNotificationHubsAPNSCredentials(d.Get("apns_credential").([]interface{})),
+			BrowserCredential: expandNotificationHubsBrowserCredentials(d.Get("browser_credential").([]interface{})),
+			GcmCredential:     expandNotificationHubsGCMCredentials(d.Get("gcm_credential").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -265,6 +292,10 @@ func resourceNotificationHubRead(d *pluginsdk.ResourceData, meta interface{}) er
 			if setErr := d.Set("apns_credential", apns); setErr != nil {
 				return fmt.Errorf("setting `apns_credential`: %+v", setErr)
 			}
+			browser := flattenNotificationHubsBrowserCredentials(props.BrowserCredential)
+			if setErr := d.Set("browser_credential", browser); setErr != nil {
+				return fmt.Errorf("setting `browser_credential`: %+v", setErr)
+			}
 			gcm := flattenNotificationHubsGCMCredentials(props.GcmCredential)
 			if setErr := d.Set("gcm_credential", gcm); setErr != nil {
 				return fmt.Errorf("setting `gcm_credential`: %+v", setErr)
@@ -331,6 +362,22 @@ func expandNotificationHubsAPNSCredentials(inputs []interface{}) *hubs.ApnsCrede
 	return &credentials
 }
 
+func expandNotificationHubsBrowserCredentials(inputs []interface{}) *hubs.BrowserCredential {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	input := inputs[0].(map[string]interface{})
+	credentials := hubs.BrowserCredential{
+		Properties: hubs.BrowserCredentialProperties{
+			Subject:         input["subject"].(string),
+			VapidPrivateKey: input["vapid_private_key"].(string),
+			VapidPublicKey:  input["vapid_public_key"].(string),
+		},
+	}
+	return &credentials
+}
+
 func flattenNotificationHubsAPNSCredentials(input *hubs.ApnsCredential) []interface{} {
 	if input == nil {
 		return make([]interface{}, 0)
@@ -360,6 +407,20 @@ func flattenNotificationHubsAPNSCredentials(input *hubs.ApnsCredential) []interf
 	if token := input.Properties.Token; token != nil {
 		output["token"] = *token
 	}
+
+	return []interface{}{output}
+}
+
+func flattenNotificationHubsBrowserCredentials(input *hubs.BrowserCredential) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	output := make(map[string]interface{})
+
+	output["subject"] = input.Properties.Subject
+	output["vapid_private_key"] = input.Properties.VapidPrivateKey
+	output["vapid_public_key"] = input.Properties.VapidPublicKey
 
 	return []interface{}{output}
 }

--- a/internal/services/notificationhub/notification_hub_resource_test.go
+++ b/internal/services/notificationhub/notification_hub_resource_test.go
@@ -34,6 +34,20 @@ func TestAccNotificationHub_basic(t *testing.T) {
 	})
 }
 
+func TestAccNotificationHub_browserCredential(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_notification_hub", "test")
+	r := NotificationHubResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.browserCredential(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNotificationHub_updateTag(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_notification_hub", "test")
 	r := NotificationHubResource{}
@@ -119,6 +133,44 @@ resource "azurerm_notification_hub" "test" {
   namespace_name      = azurerm_notification_hub_namespace.test.name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+
+  tags = {
+    env = "Test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (NotificationHubResource) browserCredential(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRGpol-%d"
+  location = "%s"
+}
+
+resource "azurerm_notification_hub_namespace" "test" {
+  name                = "acctestnhn-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  namespace_type      = "NotificationHub"
+  sku_name            = "Free"
+}
+
+resource "azurerm_notification_hub" "test" {
+  name                = "acctestnh-%d"
+  namespace_name      = azurerm_notification_hub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  browser_credential {
+    subject           = "testSubject"
+    vapid_private_key = "X4X_Awjb4HyD70adCrw6FmFgA4wiu_TTWSZFcayBN6U"
+    vapid_public_key  = "BC1XlIUxB6kQ2a214VqTMT4hnX44LRnhWDaiNxEi5bRtkdE5bFkRClX6gunX4_YWIn0UY8TD20gBGqvOg6T-go4"
+  }
 
   tags = {
     env = "Test"

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -80,9 +80,9 @@ A `browser_credential` block contains:
 
 * `subject` - (Required) The subject name of web push.
 
-* `vapid_private_key` - (Required) The VAPID private key.
+* `vapid_private_key` - (Required) The Voluntary Application Server Identification (VAPID) private key.
 
-* `vapid_public_key` - (Required) The VAPID public key.
+* `vapid_public_key` - (Required) The Voluntary Application Server Identification (VAPID) public key.
 
 ---
 

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 ~> **NOTE:** Removing the `apns_credential` block will currently force a recreation of this resource [due to this bug in the Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go/issues/2246) - we'll remove this limitation when the SDK bug is fixed.
 
+* `browser_credential` - (Optional) A `browser_credential` block as defined below.
+
 * `gcm_credential` - (Optional) A `gcm_credential` block as defined below.
 
 ~> **NOTE:** Removing the `gcm_credential` block will currently force a recreation of this resource [due to this bug in the Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go/issues/2246) - we'll remove this limitation when the SDK bug is fixed.
@@ -71,6 +73,16 @@ A `apns_credential` block contains:
 * `team_id` - (Required) The ID of the team the Token.
 
 * `token` - (Required) The Push Token associated with the Apple Developer Account. This is the contents of the `key` downloaded from [the Apple Developer Portal](https://developer.apple.com/account/ios/authkey/) between the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` blocks.
+
+---
+
+A `browser_credential` block contains:
+
+* `subject` - (Required) The subject name of web push.
+
+* `vapid_private_key` - (Required) The VAPID private key.
+
+* `vapid_public_key` - (Required) The VAPID public key.
 
 ---
 

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 ---
 
-A `apns_credential` block contains:
+A `apns_credential` supports the following:
 
 * `application_mode` - (Required) The Application Mode which defines which server the APNS Messages should be sent to. Possible values are `Production` and `Sandbox`.
 
@@ -76,7 +76,7 @@ A `apns_credential` block contains:
 
 ---
 
-A `browser_credential` block contains:
+A `browser_credential` supports the following:
 
 * `subject` - (Required) The subject name of web push.
 
@@ -86,7 +86,7 @@ A `browser_credential` block contains:
 
 ---
 
-A `gcm_credential` block contains:
+A `gcm_credential` supports the following:
 
 * `api_key` - (Required) The API Key associated with the Google Cloud Messaging service.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support new property `browser_credential`.

Swagger:
https://github.com/Azure/azure-rest-api-specs/blob/abad0096677005817d2c19df2364663e5583c8fc/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json#L2069


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
PASS: TestAccNotificationHub_browserCredential (619.26s)
PASS: TestAccNotificationHub_basic (588.45s)
PASS: TestAccNotificationHub_updateTag (983.93s)
PASS: TestAccNotificationHub_requiresImport (584.19s)
PASS: TestAccNotificationHubNamespaceDataSource_free (378.68s)
```

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NOTIFICATIONHUB/219255?buildTab=tests
![image](https://github.com/user-attachments/assets/1c85555f-bcba-4c98-8c5e-8c33a145792f)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_notification_hub` - support for the `browser_credential` property [GH-25588]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25588

