### PR TITLE
[Draft] [Bug] azure_role_definition - Better error handling when importing azure role definitions

### DIFF
--- a/internal/services/authorization/parse/role_definition.go
+++ b/internal/services/authorization/parse/role_definition.go
@@ -45,7 +45,7 @@ func (r RoleDefinitionID) Segments() []resourceids.Segment {
 // It is formed of the Azure Resource ID for the Role and the Scope it is created against
 func RoleDefinitionId(input string) (*RoleDefinitionID, error) {
 	parts := strings.Split(input, "|")
-	if len(parts) != 2 {
+	if len(parts) != 2 || !strings.Contains(parts[0], "providers/Microsoft.Authorization/roleDefinitions/") {
 		return nil, fmt.Errorf("could not parse Role Definition ID, invalid format %q", input)
 	}
 

--- a/internal/services/authorization/parse/role_definition.go
+++ b/internal/services/authorization/parse/role_definition.go
@@ -44,17 +44,18 @@ func (r RoleDefinitionID) Segments() []resourceids.Segment {
 
 var roleDefinitionIdRegexp *regexp.Regexp = regexp.MustCompile(
 	"^(?i)(?:/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?" +
-		"/providers/Microsoft.Authorization/roleDefinitions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$")
+		"/providers/Microsoft\\.Authorization/roleDefinitions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$")
 
 var subscriptionScopeRegexp *regexp.Regexp = regexp.MustCompile(
-	"^(?i)(?:/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})" +
-		"(?:/resourceGroups/[_\\-.()0-9a-zA-Z]{1,89}[_\\-()0-9a-zA-Z]{1})?$")
+	"^(?i)(?:/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" +
+		"(?:/resourceGroups/[_\\-.()0-9a-zA-Z]{1,89}[_\\-()0-9a-zA-Z]{1}(?:/providers/.+)?)?)$")
 
 var mgmtGroupScopeRegexp *regexp.Regexp = regexp.MustCompile(
-	"^(?i)(?:/providers/Microsoft.Management/managementGroups/[_\\-.()0-9a-zA-Z]{1,89}[_\\-()0-9a-zA-Z]{1})" +
-		"(?:/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?$")
+	"^(?i)(?:/providers/Microsoft\\.Management/managementGroups/[_\\-.()0-9a-zA-Z]{1,89}[_\\-()0-9a-zA-Z]{1}" +
+		"(?:/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" +
+		"(?:/resourceGroups/[_\\-.()0-9a-zA-Z]{1,89}[_\\-()0-9a-zA-Z]{1}(?:/providers/.+)?)?)?)$")
 
-const allScopes string = "/"
+const allScopesToken string = "/"
 
 // RoleDefinitionId is a pseudo ID for storing Scope parameter as this it not retrievable from API
 // It is formed of the Azure Resource ID for the Role and the Scope it is created against
@@ -64,26 +65,26 @@ func RoleDefinitionId(input string) (*RoleDefinitionID, error) {
 		return nil, fmt.Errorf("could not parse Role Definition ID, invalid format %q", input)
 	}
 
-	roleID := roleDefinitionIdRegexp.FindStringSubmatch(parts[0])
-	if len(roleID) != 2 {
+	roleDefinition := roleDefinitionIdRegexp.FindStringSubmatch(parts[0])
+	if len(roleDefinition) != 2 {
 		return nil, fmt.Errorf("could not parse Role Definition ID, invalid format %q", parts[0])
 	}
 
 	var scope string = subscriptionScopeRegexp.FindString(parts[1])
-	if scope == "" {
+	if len(scope) == 0 {
 		scope = mgmtGroupScopeRegexp.FindString(parts[1])
-		if scope == "" {
+		if len(scope) == 0 {
 			scope = parts[1]
-			if scope != allScopes {
+			if scope != allScopesToken {
 				return nil, fmt.Errorf("could not parse scope from Role Definition ID, invalid format %q", parts[1])
 			}
 		}
 	}
 
 	roleDefinitionID := RoleDefinitionID{
-		ResourceID: roleID[0],
+		ResourceID: roleDefinition[0],
 		Scope:      scope,
-		RoleID:     roleID[1],
+		RoleID:     roleDefinition[1],
 	}
 
 	return &roleDefinitionID, nil

--- a/internal/services/authorization/parse/role_definition_test.go
+++ b/internal/services/authorization/parse/role_definition_test.go
@@ -5,57 +5,125 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseRoleDefinitionID(t *testing.T) {
 	testData := []struct {
-		RoleDefinitionID string
-		Expect           bool
+		Input       string
+		Expected    *RoleDefinitionID
+		ShouldParse bool
 	}{
 		{
-			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000",
-			Expect:           true,
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab",
+				Scope:      "/subscriptions/00000000-0000-0000-0000-000000000000",
+				RoleID:     "12345678-1234-1234-1234-1234567890ab",
+			},
+			ShouldParse: true,
 		},
 		{
-			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group",
-			Expect:           true,
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab",
+				Scope:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group",
+				RoleID:     "12345678-1234-1234-1234-1234567890ab",
+			},
+			ShouldParse: true,
 		},
 		{
-			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.",
-			Expect:           false,
+			Input:       "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.",
+			Expected:    nil,
+			ShouldParse: false,
 		},
 		{
-			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
-			Expect:           true,
+			Input: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+				Scope:      "/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+				RoleID:     "ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+			},
+			ShouldParse: true,
 		},
 		{
-			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234567890ab",
-			Expect:           true,
+			Input: "/pRoVidErs/MiCrOsOft.AuThORiZaTiOn/RoLeDeFinItiOns/ab65ee35-DC39-43AC-86a0-accaadf4abcd|/PrOviDeRs/MiCrOsOfT.MaNaGeMeNt/maNAGementGroups/Some-Management-Group",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/pRoVidErs/MiCrOsOft.AuThORiZaTiOn/RoLeDeFinItiOns/ab65ee35-DC39-43AC-86a0-accaadf4abcd",
+				Scope:      "/PrOviDeRs/MiCrOsOfT.MaNaGeMeNt/maNAGementGroups/Some-Management-Group",
+				RoleID:     "ab65ee35-DC39-43AC-86a0-accaadf4abcd",
+			},
+			ShouldParse: true,
 		},
 		{
-			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/",
-			Expect:           true,
+			Input: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+				Scope:      "/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab",
+				RoleID:     "ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+			},
+			ShouldParse: true,
 		},
 		{
-			RoleDefinitionID: "12345678-1234-1234-1234-1234567890ab|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
-			Expect:           false,
+			Input: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+				Scope:      "/",
+				RoleID:     "ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+			},
+			ShouldParse: true,
+		},
+		{
+			Input: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd|/",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd",
+				Scope:      "/",
+				RoleID:     "AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd",
+			},
+			ShouldParse: true,
+		},
+		{
+			Input:       "12345678-1234-1234-1234-1234567890ab|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expected:    nil,
+			ShouldParse: false,
+		},
+		{
+			Input:       "12345678-1234-inva-lid1-|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expected:    nil,
+			ShouldParse: false,
+		},
+		{
+			Input:       "12345678-nonsense",
+			Expected:    nil,
+			ShouldParse: false,
+		},
+		{
+			Input:       "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-INVALID-86a0-accaadf4abcd|/",
+			Expected:    nil,
+			ShouldParse: false,
 		},
 	}
 
 	for _, v := range testData {
-		t.Logf("parsing %q, expecting %+v", v.RoleDefinitionID, v.Expect)
+		t.Logf("[DEBUG] parsing %q, ShouldParse %+v", v.Input, v.ShouldParse)
 
-		roleDefinitionID, err := RoleDefinitionId(v.RoleDefinitionID)
-		if err != nil {
-			if v.Expect == true {
-				t.Fatalf("expected %q parse success, got %q", v.RoleDefinitionID, err)
+		roleDefinitionId, err := RoleDefinitionId(v.Input)
+
+		if v.ShouldParse {
+			switch {
+			case err != nil:
+				t.Fatalf("expected %q parse success, got failure: %q", v.Input, err)
+			case !cmp.Equal(v.Expected, roleDefinitionId):
+				t.Fatalf("parse succeeded but expected %+v, got %+v", v.Expected, roleDefinitionId)
+			default:
+				t.Logf("[DEBUG] parse succeeded as expected, got:\n%+v", roleDefinitionId)
 			}
-			t.Logf("parse failed as expected, got %q", err)
 		} else {
-			if v.Expect == false {
-				t.Fatalf("expected %q parse failure, got:\n%+v", v.RoleDefinitionID, roleDefinitionID)
+			if err == nil {
+				t.Fatalf("expected %q parse failure, got success: %+v", v.Input, roleDefinitionId)
 			}
-			t.Logf("parse succeeded as expected, got:\n%+v", roleDefinitionID)
+			t.Logf("[DEBUG] parse failed as expected, got %q", err)
 		}
 	}
 }

--- a/internal/services/authorization/parse/role_definition_test.go
+++ b/internal/services/authorization/parse/role_definition_test.go
@@ -34,6 +34,24 @@ func TestParseRoleDefinitionID(t *testing.T) {
 			ShouldParse: true,
 		},
 		{
+			Input: "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab",
+				Scope:      "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+				RoleID:     "12345678-1234-1234-1234-1234567890ab",
+			},
+			ShouldParse: true,
+		},
+		{
+			Input: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd|/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd",
+				Scope:      "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+				RoleID:     "AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd",
+			},
+			ShouldParse: true,
+		},
+		{
 			Input:       "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.",
 			Expected:    nil,
 			ShouldParse: false,
@@ -61,6 +79,15 @@ func TestParseRoleDefinitionID(t *testing.T) {
 			Expected: &RoleDefinitionID{
 				ResourceID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd",
 				Scope:      "/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab",
+				RoleID:     "ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+			},
+			ShouldParse: true,
+		},
+		{
+			Input: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+			Expected: &RoleDefinitionID{
+				ResourceID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd",
+				Scope:      "/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM",
 				RoleID:     "ab65ee35-dc39-43ac-86a0-accaadf4abcd",
 			},
 			ShouldParse: true,

--- a/internal/services/authorization/parse/role_definition_test.go
+++ b/internal/services/authorization/parse/role_definition_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"testing"
+)
+
+func TestParseRoleDefinitionID(t *testing.T) {
+	testData := []struct {
+		RoleDefinitionID string
+		Expect           bool
+	}{
+		{
+			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expect:           true,
+		},
+		{
+			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expect:           true,
+		},
+		{
+			RoleDefinitionID: "12345678-1234-1234-1234-1234567890ab|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expect:           false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("parsing %q, expecting %+v", v.RoleDefinitionID, v.Expect)
+
+		roleDefinitionID, err := RoleDefinitionId(v.RoleDefinitionID)
+		if err != nil {
+			if v.Expect == true {
+				t.Fatalf("expected %q parse success, got %q", v.RoleDefinitionID, err)
+			}
+			t.Logf("parse failed as expected, got %q", err)
+		} else {
+			if v.Expect == false {
+				t.Fatalf("expected %q parse failure, got %q", v.RoleDefinitionID, roleDefinitionID)
+			}
+			t.Logf("parse succeeded as expected, got %+v", roleDefinitionID)
+		}
+	}
+}

--- a/internal/services/authorization/parse/role_definition_test.go
+++ b/internal/services/authorization/parse/role_definition_test.go
@@ -17,7 +17,23 @@ func TestParseRoleDefinitionID(t *testing.T) {
 			Expect:           true,
 		},
 		{
+			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group",
+			Expect:           true,
+		},
+		{
+			RoleDefinitionID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.",
+			Expect:           false,
+		},
+		{
 			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group",
+			Expect:           true,
+		},
+		{
+			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234567890ab",
+			Expect:           true,
+		},
+		{
+			RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/",
 			Expect:           true,
 		},
 		{
@@ -37,9 +53,9 @@ func TestParseRoleDefinitionID(t *testing.T) {
 			t.Logf("parse failed as expected, got %q", err)
 		} else {
 			if v.Expect == false {
-				t.Fatalf("expected %q parse failure, got %q", v.RoleDefinitionID, roleDefinitionID)
+				t.Fatalf("expected %q parse failure, got:\n%+v", v.RoleDefinitionID, roleDefinitionID)
 			}
-			t.Logf("parse succeeded as expected, got %+v", roleDefinitionID)
+			t.Logf("parse succeeded as expected, got:\n%+v", roleDefinitionID)
 		}
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes a bug, in the parsing of azure role definition strings into `RoleDefinitionId`s, which leads to a crash. Also added a unit test.

Update: I added !fixup commits which make the parsing adhere to the Azure api docs more strictly, but which allow for case insensitivity. Also enhanced the unit test methodology and added additional test data for better coverage. Lastly, parse.RoleDefinitionIds() no longer relies on strings.Spilt.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```log
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestParseRoleDefinitionID$ github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse

=== RUN   TestParseRoleDefinitionID
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestParseRoleDefinitionID$ github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse

=== RUN   TestParseRoleDefinitionID
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/00000000-0000-0000-0000-000000000000", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab"
        Scope: "/subscriptions/00000000-0000-0000-0000-000000000000"
        Role Definition: "12345678-1234-1234-1234-1234567890ab")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab"
        Scope: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/valid.resource()-_group"
        Role Definition: "12345678-1234-1234-1234-1234567890ab")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab|/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/providers/Microsoft.Authorization/roleDefinitions/12345678-1234-1234-1234-1234567890ab"
        Scope: "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM"
        Role Definition: "12345678-1234-1234-1234-1234567890ab")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd|/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd"
        Scope: "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM"
        Role Definition: "AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.", ShouldParse false
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:153: [DEBUG] parse failed as expected, got "could not parse scope from Role Definition ID, invalid format \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/invalid.resource()-_group.\""
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd"
        Scope: "/providers/Microsoft.Management/managementGroups/Some-Management-Group"
        Role Definition: "ab65ee35-dc39-43ac-86a0-accaadf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/pRoVidErs/MiCrOsOft.AuThORiZaTiOn/RoLeDeFinItiOns/ab65ee35-DC39-43AC-86a0-accaadf4abcd|/PrOviDeRs/MiCrOsOfT.MaNaGeMeNt/maNAGementGroups/Some-Management-Group", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/pRoVidErs/MiCrOsOft.AuThORiZaTiOn/RoLeDeFinItiOns/ab65ee35-DC39-43AC-86a0-accaadf4abcd"
        Scope: "/PrOviDeRs/MiCrOsOfT.MaNaGeMeNt/maNAGementGroups/Some-Management-Group"
        Role Definition: "ab65ee35-DC39-43AC-86a0-accaadf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd"
        Scope: "/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab"
        Role Definition: "ab65ee35-dc39-43ac-86a0-accaadf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd"
        Scope: "/providers/Microsoft.Management/managementGroups/Some-Management-Group/subscriptions/12345678-1234-1234-1234-1234567890ab/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM"
        Role Definition: "ab65ee35-dc39-43ac-86a0-accaadf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd|/", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-dc39-43ac-86a0-accaadf4abcd"
        Scope: "/"
        Role Definition: "ab65ee35-dc39-43ac-86a0-accaadf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd|/", ShouldParse true
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:147: [DEBUG] parse succeeded as expected, got:
        Role Definition (Resource ID: "/providers/Microsoft.Authorization/rOlEdEfiNiTiOns/AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd"
        Scope: "/"
        Role Definition: "AB65ee35-Dc39-43aC-86a0-aCCaaDf4abcd")
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "12345678-1234-1234-1234-1234567890ab|/providers/Microsoft.Management/managementGroups/Some-Management-Group", ShouldParse false
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:153: [DEBUG] parse failed as expected, got "could not parse Role Definition ID, invalid format \"12345678-1234-1234-1234-1234567890ab\""
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "12345678-1234-inva-lid1-|/providers/Microsoft.Management/managementGroups/Some-Management-Group", ShouldParse false
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:153: [DEBUG] parse failed as expected, got "could not parse Role Definition ID, invalid format \"12345678-1234-inva-lid1-\""
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "12345678-nonsense", ShouldParse false
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:153: [DEBUG] parse failed as expected, got "could not parse Role Definition ID, invalid format \"12345678-nonsense\""
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:136: [DEBUG] parsing "/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-INVALID-86a0-accaadf4abcd|/", ShouldParse false
    c:\Go\src\github.com\hashicorp\terraform-provider-azurerm\internal\services\authorization\parse\role_definition_test.go:153: [DEBUG] parse failed as expected, got "could not parse Role Definition ID, invalid format \"/providers/Microsoft.Authorization/roleDefinitions/ab65ee35-INVALID-86a0-accaadf4abcd\""
--- PASS: TestParseRoleDefinitionID (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse   0.132s
```

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_definition` - stricter parsing of RoleDefinitionId to fix crash [GH-26682]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26682
