### PR TITLE
`azurerm_nginx_deployment`: add `capacity` setting for acc tests

### DIFF
--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -226,6 +226,7 @@ resource "azurerm_nginx_deployment" "test" {
   name                     = "acctest-%[1]d"
   resource_group_name      = azurerm_resource_group.test.name
   sku                      = "standard_Monthly"
+  capacity                 = 10
   location                 = azurerm_resource_group.test.location
   diagnose_support_enabled = false
 

--- a/internal/services/nginx/nginx_configuration_resource_test.go
+++ b/internal/services/nginx/nginx_configuration_resource_test.go
@@ -286,6 +286,7 @@ resource "azurerm_nginx_deployment" "test" {
   name                = "acctest-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "standard_Monthly"
+  capacity            = 10
   location            = azurerm_resource_group.test.location
 
   diagnose_support_enabled = false
@@ -297,6 +298,7 @@ resource "azurerm_nginx_deployment" "test" {
   network_interface {
     subnet_id = azurerm_subnet.test.id
   }
+
   tags = {
     foo = "bar"
   }

--- a/internal/services/nginx/nginx_deployment_data_source_test.go
+++ b/internal/services/nginx/nginx_deployment_data_source_test.go
@@ -25,7 +25,6 @@ func TestAccNginxDeploymentDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("nginx_version").Exists(),
 				check.That(data.ResourceName).Key("sku").Exists(),
 				check.That(data.ResourceName).Key("capacity").Exists(),
-				check.That(data.ResourceName).Key("managed_resource_group").Exists(),
 				check.That(data.ResourceName).Key("ip_address").Exists(),
 				check.That(data.ResourceName).Key("automatic_upgrade_channel").Exists(),
 			),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
This PR is to fix acc tests failures caused by removing default vaule of capacity in #27027. and to fix the test failure caused by deprecation of the `managed_resource_group` property (confirmed by service team).

Info From Service Team:

> We are deprecating the managedResourceGroup property since we don’t need it anymore after all NginxPlus deployments were migrated to VMSS dataplane architecture. Previously when using the VM architecture, we needed to create network interfaces in the customer’s subscription, hence the need for a managed resource group. 
> After this migration was completed a month or so ago, we have been leaving the managedResourceGroup property empty. 


```
    testcase.go:130: Step 1/1 error: Check failed: Check 5/7 error: data.azurerm_nginx_deployment.test: Attribute 'managed_resource_group' expected to be set
```

