### PR TITLE
`doc`: fix document of `dedicated_hardware_security_module` should reference to a Standard public ip

### DIFF
--- a/website/docs/r/dedicated_hardware_security_module.html.markdown
+++ b/website/docs/r/dedicated_hardware_security_module.html.markdown
@@ -66,7 +66,8 @@ resource "azurerm_public_ip" "example" {
   name                = "example-pip"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_virtual_network_gateway" "example" {

--- a/website/docs/r/dedicated_hardware_security_module.html.markdown
+++ b/website/docs/r/dedicated_hardware_security_module.html.markdown
@@ -67,7 +67,6 @@ resource "azurerm_public_ip" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
-  sku                 = "Standard"
 }
 
 resource "azurerm_virtual_network_gateway" "example" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to update the documentation that the `azurerm_virtual_network_gateway` requires the public ip be `Standard` SKU.



## Related Issue(s)
Fixes #27078
