### PR TITLE
`azurerm_data_factory_pipeline` - support type for `parameters` and `variables`

### DIFF
--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -97,6 +97,31 @@ func flattenDataFactoryParameters(input map[string]*datafactory.ParameterSpecifi
 	return output
 }
 
+func expandDataFactoryParametersFourPointOh(input []interface{}) map[string]*datafactory.ParameterSpecification {
+	parameters := make(map[string]*datafactory.ParameterSpecification)
+	for _, v := range input {
+		val := v.(map[string]interface{})
+		parameters[val["name"].(string)] = &datafactory.ParameterSpecification{
+			Type:         datafactory.ParameterType(val["type"].(string)),
+			DefaultValue: val["default_value"],
+		}
+	}
+	return parameters
+}
+
+func flattenDataFactoryParametersFourPointOh(input map[string]*datafactory.ParameterSpecification) []interface{} {
+	parameters := make([]interface{}, 0, len(input))
+	for k, v := range input {
+		param := map[string]interface{}{
+			"name":          k,
+			"type":          string(v.Type),
+			"default_value": v.DefaultValue,
+		}
+		parameters = append(parameters, param)
+	}
+	return parameters
+}
+
 func flattenDataFactoryAnnotations(input *[]interface{}) []string {
 	annotations := make([]string, 0)
 	if input == nil {
@@ -142,6 +167,39 @@ func flattenDataFactoryVariables(input map[string]*datafactory.VariableSpecifica
 	}
 
 	return output
+}
+
+func expandDataFactoryVariablesFourPointOh(input []interface{}) map[string]*datafactory.VariableSpecification {
+	variables := make(map[string]*datafactory.VariableSpecification)
+	for _, v := range input {
+		val := v.(map[string]interface{})
+
+		variables[val["name"].(string)] = &datafactory.VariableSpecification{
+			Type:         datafactory.VariableType(val["type"].(string)),
+			DefaultValue: val["default_value"],
+		}
+	}
+	return variables
+}
+
+func flattenDataFactoryVariablesFourPointOh(input map[string]*datafactory.VariableSpecification) []interface{} {
+	variables := make([]interface{}, 0, len(input))
+	for k, v := range input {
+
+		// convert value to string if it is bool
+		// this is needed because the API returns the default value as a bool
+		if _, ok := v.DefaultValue.(bool); ok {
+			v.DefaultValue = fmt.Sprintf("%v", v.DefaultValue)
+		}
+
+		variable := map[string]interface{}{
+			"name":          k,
+			"type":          string(v.Type),
+			"default_value": v.DefaultValue,
+		}
+		variables = append(variables, variable)
+	}
+	return variables
 }
 
 // DatasetColumn describes the attributes needed to specify a structure column for a dataset

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -175,6 +176,95 @@ resource "azurerm_data_factory_pipeline" "test" {
 }
 
 func (PipelineResource) update1(data acceptance.TestData) string {
+	if features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdfv2%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name            = "acctest%d"
+  data_factory_id = azurerm_data_factory.test.id
+  annotations     = ["test1", "test2", "test3"]
+  description     = "test description"
+
+  parameters {
+    name          = "teststring"
+    type          = "String"
+    default_value = "teststringvalue"
+  }
+
+  parameters {
+    name          = "testint"
+    type          = "Int"
+    default_value = "123"
+  }
+
+  parameters {
+    name          = "testfloat"
+    type          = "Float"
+    default_value = "123.45"
+  }
+
+  parameters {
+    name          = "testbool"
+    type          = "Bool"
+    default_value = "true"
+  }
+
+  parameters {
+    name          = "testarrayint"
+    type          = "Array"
+    default_value = "[1, 2, 3]"
+  }
+
+  parameters {
+    name          = "testarraystring"
+    type          = "Array"
+    default_value = jsonencode(["a", "b", "c"])
+  }
+
+  parameters {
+    name          = "testobject"
+    type          = "Object"
+    default_value = jsonencode({
+		key1 = "value1"
+		key2 = "value2"
+	  })
+  }
+
+  parameters {
+    name          = "testsecurestring"
+    type          = "SecureString"
+    default_value = "securestringvalue"
+  }
+
+  variables {
+    name          = "foo"
+    type          = "String"
+    default_value = "test1"
+  }
+
+  variables {
+    name          = "qux"
+    type          = "Array"
+    default_value = jsonencode(["a", "b", "c"])
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -210,6 +300,105 @@ resource "azurerm_data_factory_pipeline" "test" {
 }
 
 func (PipelineResource) update2(data acceptance.TestData) string {
+	if features.FourPointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdfv2%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name            = "acctest%d"
+  data_factory_id = azurerm_data_factory.test.id
+  annotations     = ["test1", "test2", "test3"]
+  description     = "test description"
+
+  parameters {
+    name          = "teststring"
+    type          = "String"
+    default_value = "teststringvalue"
+  }
+
+  parameters {
+    name          = "teststring2"
+    default_value = "teststringvalue"
+  }
+
+  parameters {
+    name          = "testint"
+    type          = "Int"
+    default_value = "123"
+  }
+
+  parameters {
+    name          = "testfloat"
+    type          = "Float"
+    default_value = "123.45"
+  }
+
+  parameters {
+    name          = "testbool"
+    type          = "Bool"
+    default_value = "true"
+  }
+
+  parameters {
+    name          = "testarrayint"
+    type          = "Array"
+    default_value = "[1, 2, 3]"
+  }
+
+  parameters {
+    name          = "testarraystring"
+    type          = "Array"
+    default_value = jsonencode(["a", "b", "c"])
+  }
+
+  parameters {
+    name          = "testobject"
+    type          = "Object"
+    default_value = jsonencode({
+		key1 = "value1"
+		key2 = "value2"
+	  })
+  }
+
+  parameters {
+    name          = "testsecurestring"
+    type          = "SecureString"
+    default_value = "securestringvalue"
+  }
+
+  variables {
+    name          = "foo"
+    type          = "String"
+    default_value = "test1"
+  }
+
+  variables {
+    name          = "bar"
+    default_value = "test2"
+  }
+
+  variables {
+    name          = "qux"
+    type          = "Array"
+    default_value = jsonencode(["a", "b", "c"])
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support type for `parameters` and `variables` for resource `azurerm_data_factory_pipeline`.
Example usage:
```terraform
variable "parameters" {
  description = "List of parameters with their types and default values"
  type = list(object({
    name          = string
    type          = string
    default_value = string
  }))
  default = [
    {
      name          = "teststring"
      type          = "String"
      default_value = "test-string-value"
    },
    {
      name          = "testint"
      type          = "Int"
      default_value = "123"
    },
    {
      name          = "testfloat"
      type          = "Float"
      default_value = "123.45"
    },
    {
      name          = "testbool"
      type          = "Bool"
      default_value = "true"
    },
    {
      name          = "testarraystring"
      type          = "Array"
      default_value = "[\"value1\", \"value2\"]"
    },
    {
      name          = "testarrayint"
      type          = "Array"
      default_value = "[1, 2]"
    },
    {
      name          = "testobject"
      type          = "Object"
      default_value = "{\"key1\":\"value1\",\"key2\":\"value2\"}"
    },
    {
      name          = "testsecurestring"
      type          = "SecureString"
      default_value = "test-secure-string-value"
    }
  ]
}

variable "variables" {
  description = "List of variables with their types and default values"
  type = list(object({
    name          = string
    type          = string
    default_value = string
  }))
  default = [
    {
      name          = "foo"
      type          = "String"
      default_value = "test1"
    },
    {
      name          = "bar"
      type          = "String"
      default_value = "test2"
    },
    {
      name          = "qux"
      type          = "Array"
      default_value = "[\"a\", \"b\"]"
    },
    {
      name          = "quux"
      type          = "Array"
      default_value = "[1, 2, 3]"
    }
  ]
}

resource "azurerm_data_factory_pipeline" "example" {
  name            = "example-pipeline-p43"
  data_factory_id = azurerm_data_factory.example.id

  dynamic "parameters" {
    for_each = var.parameters
    content {
      name          = parameters.value.name
      type          = parameters.value.type
      default_value = parameters.value.default_value
    }
  }

  dynamic "variables" {
    for_each = var.variables
    content {
      name          = variables.value.name
      type          = variables.value.type
      default_value = variables.value.default_value
    }
  }
}
```

The API can handle the conversion from string default_value to the specified type. However it does not currently for type being `Bool` for `Variables` (declaring with `type` as `Bool`, it still shows up as a String value in Azure Data Factory), hence the `Bool` type is not currently allowed in validatefunc for `Variables`'s `Type` property.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source. -- updating in v4.0
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/c2aae029-0f15-4f93-a30b-9884bbae120a)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_pipeline` - support type for `parameters` and `variables`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)
Feature request: https://github.com/hashicorp/terraform-provider-azurerm/issues/13131


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
