### PR TITLE
`azurerm_storage_share_file` - Base64 to hex encoding before setting `content_md5`

### DIFF
--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -300,7 +300,17 @@ func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 	d.Set("content_type", props.ContentType)
 	d.Set("content_encoding", props.ContentEncoding)
-	d.Set("content_md5", props.ContentMD5)
+
+	// Set the ContentMD5 value to md5 hash in hex
+	contentMD5 := ""
+	if props.ContentMD5 != "" {
+		contentMD5, err = convertBase64ToHexEncoding(props.ContentMD5)
+		if err != nil {
+			return fmt.Errorf("converting hex to base64 encoding for content_md5: %v", err)
+		}
+	}
+	d.Set("content_md5", contentMD5)
+
 	d.Set("content_disposition", props.ContentDisposition)
 
 	if props.ContentLength == nil {

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -349,7 +349,8 @@ resource "azurerm_storage_share_file" "test" {
   name             = "test"
   storage_share_id = azurerm_storage_share.test.id
 
-  source = "%s"
+  source      = "%[2]s"
+  content_md5 = filemd5(%[2]q)
 
   metadata = {
     hello = "world"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds up a missing part in the #25715, that the `content_md5` is not processed back to its md5 hex form once returned back from API.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
$ TF_ACC=1 go test -v -timeout=20h -run="TestAccAzureRMStorageShareFile_withEmptyFile|TestAccAzureRMStorageShareFile_withFile|TestAccAzureRMStorageShareFile_complete" ./internal/services/storage
=== RUN   TestAccAzureRMStorageShareFile_complete
=== PAUSE TestAccAzureRMStorageShareFile_complete
=== RUN   TestAccAzureRMStorageShareFile_withFile
=== PAUSE TestAccAzureRMStorageShareFile_withFile
=== RUN   TestAccAzureRMStorageShareFile_withEmptyFile
=== PAUSE TestAccAzureRMStorageShareFile_withEmptyFile
=== CONT  TestAccAzureRMStorageShareFile_complete
=== CONT  TestAccAzureRMStorageShareFile_withEmptyFile
=== CONT  TestAccAzureRMStorageShareFile_withFile
--- PASS: TestAccAzureRMStorageShareFile_withEmptyFile (209.91s)
--- PASS: TestAccAzureRMStorageShareFile_complete (258.36s)
--- PASS: TestAccAzureRMStorageShareFile_withFile (265.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       265.564s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share_file` - Base64 to hex encoding before setting `content_md5` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27072


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
