### PR TITLE
`azurerm_api_management_logger` : support `connection_string` of `application_insights`

### DIFF
--- a/internal/services/apimanagement/api_management_logger_resource.go
+++ b/internal/services/apimanagement/api_management_logger_resource.go
@@ -114,11 +114,31 @@ func resourceApiManagementLogger() *pluginsdk.Resource {
 				ConflictsWith: []string{"eventhub"},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"instrumentation_key": {
+						"connection_string": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							Sensitive:    true,
 							ValidateFunc: validation.StringIsNotEmpty,
+							AtLeastOneOf: []string{
+								"application_insights.0.connection_string",
+								"application_insights.0.instrumentation_key",
+							},
+							ConflictsWith: []string{
+								"application_insights.0.instrumentation_key",
+							},
+						},
+						"instrumentation_key": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
+							AtLeastOneOf: []string{
+								"application_insights.0.connection_string",
+								"application_insights.0.instrumentation_key",
+							},
+							ConflictsWith: []string{
+								"application_insights.0.connection_string",
+							},
 						},
 					},
 				},
@@ -313,7 +333,12 @@ func expandApiManagementLoggerEventHub(input []interface{}) *map[string]string {
 func expandApiManagementLoggerApplicationInsights(input []interface{}) *map[string]string {
 	credentials := make(map[string]string)
 	ai := input[0].(map[string]interface{})
-	credentials["instrumentationKey"] = ai["instrumentation_key"].(string)
+	if ai["instrumentation_key"].(string) != "" {
+		credentials["instrumentationKey"] = ai["instrumentation_key"].(string)
+	}
+	if ai["connection_string"].(string) != "" {
+		credentials["connectionString"] = ai["connection_string"].(string)
+	}
 	return &credentials
 }
 

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -71,7 +71,11 @@ The following arguments are supported:
 
 An `application_insights` block supports the following:
 
-* `instrumentation_key` - (Required) The instrumentation key used to push data to Application Insights.
+* `connection_string` - (Optional) The connection string of Application Insights.
+
+* `instrumentation_key` - (Optional) The instrumentation key used to push data to Application Insights.
+
+~> **Note:** Either `connection_string` or `instrumentation_key` have to be specified.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for Application Insights `connection_string` in `azurerm_api_management_logger`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

PASS: TestAccApiManagementLogger_applicationInsightsConnectionString (473.00s)

![image](https://github.com/user-attachments/assets/b43cdfd5-bfbe-4207-b272-0c4d1b13b575)
![image](https://github.com/user-attachments/assets/21da018e-030e-4883-8cff-7bf6a1accf0b)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_logger` - support for the `connection_string` of `application_insights`[GH-25750]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25750

