### PR TITLE
Provider Registration at Startup - Update Azure resource provider registration error message

### DIFF
--- a/internal/resourceproviders/errors.go
+++ b/internal/resourceproviders/errors.go
@@ -7,11 +7,41 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 var ErrNoAuthorization = errors.New("authorization failed")
 
 const registrationErrorFmt = `%s.
+
+Terraform automatically attempts to register the Azure Resource Providers it supports, to
+ensure it is able to provision resources.
+
+If you don't have permission to register Resource Providers you may wish to disable this
+functionality by adding the following to the Provider block:
+
+provider "azurerm" {
+  skip_provider_registration = true
+}
+
+Please note that if you opt out of Resource Provider Registration and Terraform tries
+to provision a resource from a Resource Provider which is unregistered, then the errors
+may appear misleading - for example:
+
+> API version 2019-XX-XX was not found for Microsoft.Foo
+
+Could suggest that the Resource Provider "Microsoft.Foo" requires registration, but
+this could also indicate that this Azure Region doesn't support this API version.
+
+More information on the "skip_provider_registration" property can be found here:
+https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#skip_provider_registration
+
+Encountered the following errors:
+
+%v`
+
+const registrationErrorFourPointOhBetaFmt = `%s.
 
 Terraform automatically attempts to register the Azure Resource Providers it supports, to
 ensure it is able to provision resources.
@@ -33,7 +63,7 @@ Could suggest that the Resource Provider "Microsoft.Foo" requires registration, 
 this could also indicate that this Azure Region doesn't support this API version.
 
 More information on the "resource_provider_registrations" property can be found here:
-https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#resource_provider_registrations
+https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#improved-resource-provider-registration
 
 Encountered the following errors:
 
@@ -43,7 +73,13 @@ Encountered the following errors:
 // resource providers.
 func userError(err error) error {
 	if errors.Is(err, ErrNoAuthorization) {
+		if features.FourPointOhBeta() {
+			return fmt.Errorf(registrationErrorFourPointOhBetaFmt, "Terraform does not have the necessary permissions to register Resource Providers", err)
+		}
 		return fmt.Errorf(registrationErrorFmt, "Terraform does not have the necessary permissions to register Resource Providers", err)
+	}
+	if features.FourPointOhBeta() {
+		return fmt.Errorf(registrationErrorFourPointOhBetaFmt, "Encountered an error whilst ensuring Resource Providers are registered", err)
 	}
 	return fmt.Errorf(registrationErrorFmt, "Encountered an error whilst ensuring Resource Providers are registered", err)
 }


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

    Update Azure resource provider registration error message.

    The AzureRM provider currently checks to ensure that all providers have been registered at startup. This process
    has become more granular in 4.0-beta and the provider features have also been updated to reflect the more granular
    registration abilities.

    Thus we add a distinct registration provider error message for 4.0-beta, while retaining a separate error message for
    lower versions.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tested both code paths, without environment variable `ARM_FOURPOINTZERO_BETA` set and also with it set. Screenshot is below:

![image](https://github.com/user-attachments/assets/a11fb89f-9170-46b5-96a7-d20cf3d75be8)


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27110

