### PR TITLE
`azurerm_kubernetes_cluster_node_pool` Fix deprecated attribute handling

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -499,18 +499,24 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	}
 
 	count := d.Get("node_count").(int)
-	enableAutoScaling := d.Get("enable_auto_scaling").(bool)
 	if features.FourPointOh() {
 		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
+	} else {
+		enableAutoScaling := d.Get("enable_auto_scaling").(bool)
 	}
-	hostEncryption := d.Get("enable_host_encryption").(bool)
+
 	if features.FourPointOh() {
 		hostEncryption = d.Get("host_encryption_enabled").(bool)
+	} else {
+		hostEncryption := d.Get("enable_host_encryption").(bool)
 	}
-	nodeIp := d.Get("enable_node_public_ip").(bool)
+
 	if features.FourPointOh() {
 		nodeIp = d.Get("node_public_ip_enabled").(bool)
+	} else {
+		nodeIp := d.Get("enable_node_public_ip").(bool)
 	}
+
 	evictionPolicy := d.Get("eviction_policy").(string)
 	mode := agentpools.AgentPoolMode(d.Get("mode").(string))
 	osType := d.Get("os_type").(string)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -500,19 +500,19 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	count := d.Get("node_count").(int)
 	if features.FourPointOh() {
-		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
+		enableAutoScaling := d.Get("auto_scaling_enabled").(bool)
 	} else {
 		enableAutoScaling := d.Get("enable_auto_scaling").(bool)
 	}
 
 	if features.FourPointOh() {
-		hostEncryption = d.Get("host_encryption_enabled").(bool)
+		hostEncryption := d.Get("host_encryption_enabled").(bool)
 	} else {
 		hostEncryption := d.Get("enable_host_encryption").(bool)
 	}
 
 	if features.FourPointOh() {
-		nodeIp = d.Get("node_public_ip_enabled").(bool)
+		nodeIp := d.Get("node_public_ip_enabled").(bool)
 	} else {
 		nodeIp := d.Get("enable_node_public_ip").(bool)
 	}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -727,7 +727,7 @@ func TestAccKubernetesClusterNodePool_hostEncryption(t *testing.T) {
 			Config: r.hostEncryption(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enable_host_encryption").HasValue("true"),
+				check.That(data.ResourceName).Key("host_encryption_enabled").HasValue("true"),
 			),
 		},
 	})
@@ -1242,7 +1242,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
 }
@@ -1261,7 +1261,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = %d
   max_count             = %d
 }
@@ -1793,7 +1793,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale" {
   name                  = "autoscale"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
 }
@@ -1877,7 +1877,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id    = azurerm_kubernetes_cluster.test.id
   vm_size                  = "Standard_DS2_v2"
   node_count               = 1
-  enable_node_public_ip    = true
+  node_public_ip_enabled   = true
   node_public_ip_prefix_id = azurerm_public_ip_prefix.test.id
 }
 `, r.templateConfig(data), data.RandomInteger)
@@ -2107,7 +2107,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
   vnet_subnet_id        = azurerm_subnet.test.id
@@ -2374,7 +2374,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
   node_count            = 0
@@ -2391,11 +2391,11 @@ provider "azurerm" {
 	%s
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                   = "internal"
-  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
-  vm_size                = "Standard_DS2_v2"
-  enable_host_encryption = true
-  node_count             = 1
+  name                    = "internal"
+  kubernetes_cluster_id   = azurerm_kubernetes_cluster.test.id
+  vm_size                 = "Standard_DS2_v2"
+  host_encryption_enabled = true
+  node_count              = 1
 }
 `, r.templateConfig(data))
 }
@@ -2412,7 +2412,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 399
   node_count            = 1
@@ -2432,7 +2432,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 1
   node_count            = 1
@@ -2636,7 +2636,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = %t
+  auto_scaling_enabled  = %t
   min_count             = %d
   max_count             = %d
 }
@@ -2830,10 +2830,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_D2s_v3"
-  enable_node_public_ip = true
+  name                   = "internal"
+  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
+  vm_size                = "Standard_D2s_v3"
+  node_public_ip_enabled = true
   node_network_profile {
     node_public_ip_tags = {
       RoutingPreference = "Internet"
@@ -2879,10 +2879,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_D2s_v3"
-  enable_node_public_ip = true
+  name                   = "internal"
+  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
+  vm_size                = "Standard_D2s_v3"
+  node_public_ip_enabled = true
   node_network_profile {
     allowed_host_ports {
       port_start = 8001


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fix an issue causing failures when deploying an `azurerm_kubernetes_cluster_node_pool` resource.

```
│ Error: Plugin did not respond
│ 
│   with module.aks_cluster.module.aks_monitoring.module.action_group_critical.azurerm_monitor_action_group.mag,
│   on .terraform/modules/aks_cluster.aks_monitoring.action_group_critical/main.tf line 1, in resource "azurerm_monitor_action_group" "mag":
│    1: resource "azurerm_monitor_action_group" "mag" {
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
```
```
Stack trace from the terraform-provider-azurerm_v4.0.0_x5 plugin:

panic: interface conversion: interface {} is nil, not bool

goroutine 2857 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/containers.resourceKubernetesClusterNodePoolCreate(0x0?, {0x729db00?, 0xc002188000?})
	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go:502 +0x3aa5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x8b0c1d8?, {0x8b0c1d8?, 0xc002c8eab0?}, 0xd?, {0x729db00?, 0xc002188000?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/resource.go:766 +0x163
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000e36a80, {0x8b0c1d8, 0xc002c8eab0}, 0xc001580820, 0xc002c19f80, {0x729db00, 0xc002188000})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/resource.go:909 +0xa89
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0008dbe48, {0x8b0c1d8?, 0xc002c8e9c0?}, 0xc0004bc000)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/grpc_provider.go:1078 +0xdbc
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ApplyResourceChange(0x8b0c210?, {0x8b0c1d8?, 0xc002c8e6c0?}, 0xc0004bc000)
	github.com/hashicorp/terraform-plugin-mux@v0.15.0/tf5muxserver/mux_server_ApplyResourceChange.go:36 +0x193
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00196a140, {0x8b0c1d8?, 0xc0026a9d70?}, 0xc000fdc380)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/tf5server/server.go:865 +0x3d0
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x7fbd580?, 0xc00196a140}, {0x8b0c1d8, 0xc0026a9d70}, 0xc002c19c80, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:518 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0005a4400, {0x8b0c1d8, 0xc0026a9ce0}, {0x8b38bc0, 0xc00019a300}, 0xc0021f0900, 0xc001126ab0, 0xe173798, 0x0)
	google.golang.org/grpc@v1.63.2/server.go:1369 +0xe23
google.golang.org/grpc.(*Server).handleStream(0xc0005a4400, {0x8b38bc0, 0xc00019a300}, 0xc0021f0900)
	google.golang.org/grpc@v1.63.2/server.go:1780 +0x1016
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.63.2/server.go:1019 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 38
	google.golang.org/grpc@v1.63.2/server.go:1030 +0x135

Error: The terraform-provider-azurerm_v4.0.0_x5 plugin crashed!

```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster_node_pool` - correctly support renamed attributes `auto_scaling_enabled` `host_encryption_enabled` `node_public_ip_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes [#27158](https://github.com/hashicorp/terraform-provider-azurerm/issues/27158)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
