### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - fix variable declaration for renamed properties

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -499,18 +499,11 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	}
 
 	count := d.Get("node_count").(int)
-	enableAutoScaling := d.Get("enable_auto_scaling").(bool)
-	if features.FourPointOh() {
-		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
-	}
-	hostEncryption := d.Get("enable_host_encryption").(bool)
-	if features.FourPointOh() {
-		hostEncryption = d.Get("host_encryption_enabled").(bool)
-	}
-	nodeIp := d.Get("enable_node_public_ip").(bool)
-	if features.FourPointOh() {
-		nodeIp = d.Get("node_public_ip_enabled").(bool)
-	}
+
+	enableAutoScaling := d.Get("auto_scaling_enabled").(bool)
+	hostEncryption := d.Get("host_encryption_enabled").(bool)
+	nodeIp := d.Get("node_public_ip_enabled").(bool)
+
 	evictionPolicy := d.Get("eviction_policy").(string)
 	mode := agentpools.AgentPoolMode(d.Get("mode").(string))
 	osType := d.Get("os_type").(string)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
@@ -218,15 +217,10 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"node_public_ip_prefix_id": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
-			RequiredWith: func() []string {
-				if !features.FourPointOh() {
-					return []string{"enable_node_public_ip"}
-				}
-				return []string{"node_public_ip_enabled"}
-			}(),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			RequiredWith: []string{"node_public_ip_enabled"},
 		},
 
 		// Node Taints control the behaviour of the Node Pool, as such they should not be computed and
@@ -398,32 +392,6 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 			ForceNew: true,
 		},
-	}
-
-	if !features.FourPointOh() {
-		s["enable_auto_scaling"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Optional:   true,
-			Deprecated: features.DeprecatedInFourPointOh("The property `enable_auto_scaling` will be renamed to `auto_scaling_enabled` in v4.0 of the AzureRM Provider."),
-		}
-
-		s["enable_node_public_ip"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Optional:   true,
-			ForceNew:   true,
-			Deprecated: features.DeprecatedInFourPointOh("The property `enable_node_public_ip` will be renamed to `node_public_ip_enabled` in v4.0 of the AzureRM Provider."),
-		}
-
-		s["enable_host_encryption"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Optional:   true,
-			ForceNew:   true,
-			Deprecated: features.DeprecatedInFourPointOh("The property `enable_host_encryption` will be renamed to `host_encryption_enabled` in v4.0 of the AzureRM Provider."),
-		}
-
-		delete(s, "auto_scaling_enabled")
-		delete(s, "node_public_ip_enabled")
-		delete(s, "host_encryption_enabled")
 	}
 
 	return s
@@ -633,20 +601,20 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		if maxCount >= 0 {
 			profile.MaxCount = utils.Int64(int64(maxCount))
 		} else {
-			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
+			return fmt.Errorf("`max_count` must be configured when `auto_scaling_enabled` is set to `true`")
 		}
 
 		if minCount >= 0 {
 			profile.MinCount = utils.Int64(int64(minCount))
 		} else {
-			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")
+			return fmt.Errorf("`min_count` must be configured when `auto_scaling_enabled` is set to `true`")
 		}
 
 		if minCount > maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else if minCount > 0 || maxCount > 0 {
-		return fmt.Errorf("`max_count` and `min_count` must be set to `null` when enable_auto_scaling is set to `false`")
+		return fmt.Errorf("`max_count` and `min_count` must be set to `null` when auto_scaling_enabled is set to `false`")
 	}
 
 	if kubeletConfig := d.Get("kubelet_config").([]interface{}); len(kubeletConfig) > 0 {
@@ -757,16 +725,9 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	log.Printf("[DEBUG] Determining delta for existing %s..", *id)
 
 	// delta patching
-	if features.FourPointOh() {
-		if d.HasChange("auto_scaling_enabled") {
-			enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
-			props.EnableAutoScaling = utils.Bool(enableAutoScaling)
-		}
-	} else {
-		if d.HasChange("enable_auto_scaling") {
-			enableAutoScaling = d.Get("enable_auto_scaling").(bool)
-			props.EnableAutoScaling = utils.Bool(enableAutoScaling)
-		}
+	if d.HasChange("auto_scaling_enabled") {
+		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
+		props.EnableAutoScaling = utils.Bool(enableAutoScaling)
 	}
 
 	if d.HasChange("max_count") || enableAutoScaling {
@@ -855,7 +816,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	}
 	if enableAutoScaling {
 		if maxCount == 0 {
-			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
+			return fmt.Errorf("`max_count` must be configured when `auto_scaling_enabled` is set to `true`")
 		}
 
 		if minCount > maxCount {
@@ -863,7 +824,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		}
 	} else {
 		if minCount > 0 || maxCount > 0 {
-			return fmt.Errorf("`max_count` and `min_count` must be set to `nil` when enable_auto_scaling is set to `false`")
+			return fmt.Errorf("`max_count` and `min_count` must be set to `nil` when `auto_scaling_enabled` is set to `false`")
 		}
 
 		// @tombuildsstuff: as of API version 2019-11-01 we need to explicitly nil these out
@@ -925,17 +886,9 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		props := model.Properties
 		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 
-		switch {
-		case features.FourPointOh():
-			d.Set("auto_scaling_enabled", props.EnableAutoScaling)
-			d.Set("node_public_ip_enabled", props.EnableNodePublicIP)
-			d.Set("host_encryption_enabled", props.EnableEncryptionAtHost)
-		case features.FourPointOhBeta():
-			d.Set("enable_auto_scaling", props.EnableAutoScaling)
-			d.Set("enable_node_public_ip", props.EnableNodePublicIP)
-			d.Set("enable_host_encryption", props.EnableEncryptionAtHost)
-		default:
-		}
+		d.Set("auto_scaling_enabled", props.EnableAutoScaling)
+		d.Set("node_public_ip_enabled", props.EnableNodePublicIP)
+		d.Set("host_encryption_enabled", props.EnableEncryptionAtHost)
 		d.Set("fips_enabled", props.EnableFIPS)
 		d.Set("ultra_ssd_enabled", props.EnableUltraSSD)
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -727,7 +727,7 @@ func TestAccKubernetesClusterNodePool_hostEncryption(t *testing.T) {
 			Config: r.hostEncryption(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enable_host_encryption").HasValue("true"),
+				check.That(data.ResourceName).Key("host_encryption_enabled").HasValue("true"),
 			),
 		},
 	})
@@ -1242,7 +1242,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
 }
@@ -1261,7 +1261,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = %d
   max_count             = %d
 }
@@ -1793,7 +1793,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale" {
   name                  = "autoscale"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
 }
@@ -1877,7 +1877,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id    = azurerm_kubernetes_cluster.test.id
   vm_size                  = "Standard_DS2_v2"
   node_count               = 1
-  enable_node_public_ip    = true
+  node_public_ip_enabled   = true
   node_public_ip_prefix_id = azurerm_public_ip_prefix.test.id
 }
 `, r.templateConfig(data), data.RandomInteger)
@@ -2107,7 +2107,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
   vnet_subnet_id        = azurerm_subnet.test.id
@@ -2374,7 +2374,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
   node_count            = 0
@@ -2391,11 +2391,11 @@ provider "azurerm" {
 	%s
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                   = "internal"
-  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
-  vm_size                = "Standard_DS2_v2"
-  enable_host_encryption = true
-  node_count             = 1
+  name                    = "internal"
+  kubernetes_cluster_id   = azurerm_kubernetes_cluster.test.id
+  vm_size                 = "Standard_DS2_v2"
+  host_encryption_enabled = true
+  node_count              = 1
 }
 `, r.templateConfig(data))
 }
@@ -2412,7 +2412,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 399
   node_count            = 1
@@ -2432,7 +2432,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = true
+  auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 1
   node_count            = 1
@@ -2636,7 +2636,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
-  enable_auto_scaling   = %t
+  auto_scaling_enabled  = %t
   min_count             = %d
   max_count             = %d
 }
@@ -2830,10 +2830,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_D2s_v3"
-  enable_node_public_ip = true
+  name                   = "internal"
+  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
+  vm_size                = "Standard_D2s_v3"
+  node_public_ip_enabled = true
   node_network_profile {
     node_public_ip_tags = {
       RoutingPreference = "Internet"
@@ -2879,10 +2879,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_D2s_v3"
-  enable_node_public_ip = true
+  name                   = "internal"
+  kubernetes_cluster_id  = azurerm_kubernetes_cluster.test.id
+  vm_size                = "Standard_D2s_v3"
+  node_public_ip_enabled = true
   node_network_profile {
     allowed_host_ports {
       port_start = 8001


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Testing
![image](https://github.com/user-attachments/assets/3328561b-e20b-4254-ae28-a24fec94d62f)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27158


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
