### PR TITLE
`azurerm_sentinel_data_connector_microsoft_threat_intelligence` - remove deprecated property `bing_safety_phishing_url_lookback_date`

### DIFF
--- a/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
@@ -48,11 +48,7 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace. Changing this forces a new Data Connector to be created.
 
-* `microsoft_emerging_threat_feed_lookback_date` - (Optional) The lookback date for the Microsoft Emerging Threat Feed in RFC3339. Changing this forces a new Data Connector to be created.
-
--> **Note:** `microsoft_emerging_threat_feed_lookback_date` will be required in version 4.0 of the provider.
-
--> **NOTE:** At least one of `bing_safety_phishing_url_lookback_date` and `microsoft_emerging_threat_feed_lookback_date` must be specified.
+* `microsoft_emerging_threat_feed_lookback_date` - (Required) The lookback date for the Microsoft Emerging Threat Feed in RFC3339. Changing this forces a new Data Connector to be created.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The `bing_safety_phishing_url_lookback_date` was deprecated in 4.0 and removed from the schema but still being set in the create/read causing an error. This can be completely removed now that 4.0 is released.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->




## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

=== RUN   TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
=== PAUSE TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
=== CONT  TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
--- PASS: TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic (155.09s)
PASS

=== RUN   TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
=== PAUSE TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
=== CONT  TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
--- PASS: TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete (199.78s)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_sentinel_data_connector_microsoft_threat_intelligence` - remove deprecated property `bing_safety_phishing_url_lookback_date` [GH-27171]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27168


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
