### PR TITLE
bugfix: provider validation for `subscription_id`

### DIFF
--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -56,8 +56,7 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 			"subscription_id": schema.StringAttribute{
 				// Note: There is no equivalent of `DefaultFunc` in the provider schema package. This property is Required, but can be
 				// set via env var instead of provider config, so needs to be toggled in schema based on the presence of that env var.
-				Required:    getEnvStringOrDefault(types.StringUnknown(), "ARM_SUBSCRIPTION_ID", "") == "",
-				Optional:    getEnvStringOrDefault(types.StringUnknown(), "ARM_SUBSCRIPTION_ID", "") != "",
+				Optional:    true,
 				Description: "The Subscription ID which should be used.",
 			},
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -177,45 +177,46 @@ func TestAccProvider_resourceProviders_deprecatedSkip(t *testing.T) {
 	}
 }
 
-// TODO - Test expected value needs updating, commenting out for now
-// func TestAccProvider_resourceProviders_legacyWithAdditional(t *testing.T) {
-//	if !features.FourPointOhBeta() {
-//		t.Skip("skipping 4.0 specific test")
-//	}
-//
-//	if os.Getenv("TF_ACC") == "" {
-//		t.Skip("TF_ACC not set")
-//	}
-//
-//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-//	defer cancel()
-//
-//	logging.SetOutput(t)
-//
-//	provider := TestAzureProvider()
-//	config := map[string]interface{}{
-//		"resource_providers_to_register": []interface{}{
-//			"Microsoft.ApiManagement",
-//			"Microsoft.ContainerService",
-//			"Microsoft.KeyVault",
-//			"Microsoft.Kubernetes",
-//		},
-//	}
-//
-//	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
-//		t.Fatalf("provider failed to configure: %v", diags)
-//	}
-//
-//	expectedResourceProviders := resourceproviders.Legacy().Merge(resourceproviders.ResourceProviders{
-//		"Microsoft.ApiManagement": {},
-//		"Microsoft.KeyVault":      {},
-//	})
-//	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
-//
-//	if !reflect.DeepEqual(registeredResourceProviders, expectedResourceProviders) {
-//		t.Fatalf("unexpected value for RegisteredResourceProviders: %#v", registeredResourceProviders)
-//	}
-// }
+func TestAccProvider_resourceProviders_legacyWithAdditional(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		t.Skip("skipping 4.0 specific test")
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	logging.SetOutput(t)
+
+	provider := TestAzureProvider()
+	config := map[string]interface{}{
+		"resource_providers_to_register": []interface{}{
+			"Microsoft.ApiManagement",
+			"Microsoft.ContainerService",
+			"Microsoft.KeyVault",
+			"Microsoft.Kubernetes",
+		},
+	}
+
+	if diags := provider.Configure(ctx, terraform.NewResourceConfigRaw(config)); diags != nil && diags.HasError() {
+		t.Fatalf("provider failed to configure: %v", diags)
+	}
+
+	expectedResourceProviders := resourceproviders.Legacy().Merge(resourceproviders.ResourceProviders{
+		"Microsoft.ApiManagement":    {},
+		"Microsoft.ContainerService": {},
+		"Microsoft.KeyVault":         {},
+		"Microsoft.Kubernetes":       {},
+	})
+	registeredResourceProviders := provider.Meta().(*clients.Client).Account.RegisteredResourceProviders
+
+	if !reflect.DeepEqual(registeredResourceProviders, expectedResourceProviders) {
+		t.Fatalf("unexpected value for RegisteredResourceProviders: %#v", registeredResourceProviders)
+	}
+}
 
 func TestAccProvider_resourceProviders_core(t *testing.T) {
 	if !features.FourPointOhBeta() {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -103,13 +103,15 @@ The following arguments are supported:
 
 * `features` - (Required) A `features` block as defined below which can be used to customize the behaviour of certain Azure Provider resources.
 
+* `subscription_id` - (Required) The Subscription ID which should be used. This can also be sourced from the `ARM_SUBSCRIPTION_ID` Environment Variable.
+
+-> The `subscription_id` property is required when performing a plan or apply operation, but is not required to run `terraform validate`.
+
 * `client_id` - (Optional) The Client ID which should be used. This can also be sourced from the `ARM_CLIENT_ID` Environment Variable.
 
 * `client_id_file_path` (Optional) The path to a file containing the Client ID which should be used. This can also be sourced from the `ARM_CLIENT_ID_FILE_PATH` Environment Variable.
 
 * `environment` - (Optional) The Cloud Environment which should be used. Possible values are `public`, `usgovernment`, `german`, and `china`. Defaults to `public`. This can also be sourced from the `ARM_ENVIRONMENT` Environment Variable. Not used when `metadata_host` is specified.
-
-* `subscription_id` - (Optional) The Subscription ID which should be used. This can also be sourced from the `ARM_SUBSCRIPTION_ID` Environment Variable.
 
 * `tenant_id` - (Optional) The Tenant ID which should be used. This can also be sourced from the `ARM_TENANT_ID` Environment Variable.
 
@@ -228,4 +230,4 @@ To view the latest specific Azure Resource Providers included in each set, pleas
 
 In addition to, or in place of, the sets described above, you can also configure the AzureRM Provider to register specific Azure Resource Providers, by setting the `resource_providers_to_register` provider property. This should be a list of strings, containing the exact names of Azure Resource Providers to register. For a list of all resource providers, please refer to [official Azure documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types).
 
-->**Note on Permissions** The User, Service Principal or Managed Identity running Terraform should have permissions to register [Azure Resource Providers](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types). If the principal running Terraform has insufficient permissions to register Resource Providers then we recommend setting the property [`resource_provider_registrations`](#resource_provider_registrations) to `none` in the provider block to prevent auto-registration.
+-> **Note on Permissions** The User, Service Principal or Managed Identity running Terraform should have permissions to register [Azure Resource Providers](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types). If the principal running Terraform has insufficient permissions to register Resource Providers then we recommend setting the property [`resource_provider_registrations`](#resource_provider_registrations) to `none` in the provider block to prevent auto-registration.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -205,10 +205,6 @@ For some advanced scenarios, such as where more granular permissions are necessa
 
 ~> **Note:** The Files Storage API does not support authenticating via AzureAD and will continue to use a SharedKey when AAD authentication is enabled.
 
-* `use_msal` - (Optional) When `true`, and when using service principal authentication, the provider will obtain [v2 authentication tokens](https://docs.microsoft.com/azure/active-directory/develop/access-tokens#token-formats-and-ownership) from the Microsoft Identity Platform. Has no effect when authenticating via Managed Identity or the Azure CLI. Can also be set via the `ARM_USE_MSAL` or `ARM_USE_MSGRAPH` environment variables.
-
--> **Note:** This will behaviour will be defaulted on in version 3.0 of the AzureRM (with no opt-out) due to [the deprecation of Azure Active Directory Graph](https://docs.microsoft.com/azure/active-directory/develop/msal-migration).
-
 It's also possible to use multiple Provider blocks within a single Terraform configuration, for example, to work with resources across multiple Subscriptions - more information can be found [in the documentation for Providers](https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances).
 
 ## Features


### PR DESCRIPTION
Using the following test configuration:

```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "4.0.0"
    }
  }
}

provider "azurerm" {
  features {}
}

data "azurerm_client_config" "test" {}

resource "azurerm_resource_group" "test" {
  name     = "aaatest-foo"
  location = "westeurope"
}
```

### `terraform validate` with no subscription ID

<img width="1156" alt="Screenshot 2024-08-23 at 19 27 16" src="https://github.com/user-attachments/assets/9db04e38-2e54-4e5f-962f-00db3d5e98ca">

### `terraform validate` with invalid subscription ID

<img width="1159" alt="Screenshot 2024-08-23 at 19 28 04" src="https://github.com/user-attachments/assets/27f70dae-3c2c-48b2-a60d-7cd05262d1ee">

### `terraform validate` with valid subscription ID

![SCR-20240823-r25](https://github.com/user-attachments/assets/029381ab-8950-4833-8214-29ae34b37815)

### `terraform plan` with no subscription ID

<img width="1157" alt="Screenshot 2024-08-23 at 19 29 45" src="https://github.com/user-attachments/assets/7d2b85c8-52ab-4595-a422-d7b8df9a4586">

### `terraform plan` with invalid subscription ID

<img width="1160" alt="Screenshot 2024-08-23 at 19 30 16" src="https://github.com/user-attachments/assets/62d5976e-6331-43d4-af8a-8f76f27cc065">

### `terraform plan` with valid subscription ID

![SCR-20240823-r59](https://github.com/user-attachments/assets/b524876a-61eb-4bb2-a0dc-bc6fb5f144a2)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* provider: fix a validation that prevents `terraform validate` from working when `subscription_id` is not specified


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.

fixes: #27154 #27175