### PR TITLE
`azurerm_data_protection_backup_vault` : support new property `cross_region_restore_enabled`

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_vault_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_resource.go
@@ -71,6 +71,11 @@ func resourceDataProtectionBackupVault() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"cross_region_restore_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"retention_duration_in_days": {
@@ -93,6 +98,21 @@ func resourceDataProtectionBackupVault() *pluginsdk.Resource {
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.ForceNewIfChange("soft_delete", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old.(string) == string(backupvaults.SoftDeleteStateAlwaysOn) && new.(string) != string(backupvaults.SoftDeleteStateAlwaysOn)
+			}),
+
+			// Once `cross_region_restore_enabled` is enabled it cannot be disabled.
+			pluginsdk.ForceNewIfChange("cross_region_restore_enabled", func(ctx context.Context, old, new, meta interface{}) bool {
+				return old.(bool) && new.(bool) != old.(bool)
+			}),
+
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				redundancy := d.Get("redundancy").(string)
+				crossRegionRestore := d.GetRawConfig().AsValueMap()["cross_region_restore_enabled"]
+				if !crossRegionRestore.IsNull() && redundancy != string(backupvaults.StorageSettingTypesGeoRedundant) {
+					// Cross region restore is only allowed on `GeoRedundant` vault.
+					return fmt.Errorf("`cross_region_restore_enabled` can only be specified when `redundancy` is specified for `GeoRedundant`.")
+				}
+				return nil
 			}),
 		),
 	}
@@ -175,6 +195,17 @@ func resourceDataProtectionBackupVaultCreateUpdate(d *pluginsdk.ResourceData, me
 		Tags:     expandTags(d.Get("tags").(map[string]interface{})),
 	}
 
+	if !pluginsdk.IsExplicitlyNullInConfig(d, "cross_region_restore_enabled") {
+		parameters.Properties.FeatureSettings = &backupvaults.FeatureSettings{
+			CrossRegionRestoreSettings: &backupvaults.CrossRegionRestoreSettings{},
+		}
+		if d.Get("cross_region_restore_enabled").(bool) {
+			parameters.Properties.FeatureSettings.CrossRegionRestoreSettings.State = pointer.To(backupvaults.CrossRegionRestoreStateEnabled)
+		} else {
+			parameters.Properties.FeatureSettings.CrossRegionRestoreSettings.State = pointer.To(backupvaults.CrossRegionRestoreStateDisabled)
+		}
+	}
+
 	if v, ok := d.GetOk("retention_duration_in_days"); ok {
 		parameters.Properties.SecuritySettings.SoftDeleteSettings.RetentionDurationInDays = pointer.To(v.(float64))
 	}
@@ -223,6 +254,16 @@ func resourceDataProtectionBackupVaultRead(d *pluginsdk.ResourceData, meta inter
 				d.Set("retention_duration_in_days", pointer.From(softDelete.RetentionDurationInDays))
 			}
 		}
+		crossRegionStoreEnabled := false
+		if featureSetting := model.Properties.FeatureSettings; featureSetting != nil {
+			if featureSetting := model.Properties.FeatureSettings; featureSetting != nil {
+				if pointer.From(featureSetting.CrossRegionRestoreSettings.State) == backupvaults.CrossRegionRestoreStateEnabled {
+					crossRegionStoreEnabled = true
+				}
+			}
+		}
+
+		d.Set("cross_region_restore_enabled", crossRegionStoreEnabled)
 
 		if err = d.Set("identity", flattenBackupVaultDppIdentityDetails(model.Identity)); err != nil {
 			return fmt.Errorf("setting `identity`: %+v", err)

--- a/internal/services/dataprotection/data_protection_backup_vault_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_resource_test.go
@@ -33,6 +33,20 @@ func TestAccDataProtectionBackupVault_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataProtectionBackupVault_crossRegionRestore(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_vault", "test")
+	r := DataProtectionBackupVaultResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossRegionRestore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataProtectionBackupVault_zoneRedundant(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_vault", "test")
 	r := DataProtectionBackupVaultResource{}
@@ -174,6 +188,22 @@ resource "azurerm_data_protection_backup_vault" "test" {
   location            = azurerm_resource_group.test.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupVaultResource) crossRegionRestore(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_vault" "test" {
+  name                         = "acctest-bv-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  datastore_type               = "VaultStore"
+  redundancy                   = "GeoRedundant"
+  cross_region_restore_enabled = true
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/data_protection_backup_vault.html.markdown
+++ b/website/docs/r/data_protection_backup_vault.html.markdown
@@ -43,6 +43,10 @@ The following arguments are supported:
 
 * `redundancy` - (Required) Specifies the backup storage redundancy. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Changing this forces a new Backup Vault to be created.
 
+* `cross_region_restore_enabled` - (Optional) Whether to enable cross-region restore for the Backup Vault.
+ 
+-> **Note:** The `cross_region_restore_enabled` can only be specified when `redundancy` is specified for `GeoRedundant`. Once `cross_region_restore_enabled` is enabled, it cannot be disabled.
+
 ---
 
 * `identity` - (Optional) An `identity` block as defined below.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Swagger: https://github.com/Azure/azure-rest-api-specs/blob/30d040e41a4cea0d31a6c7e56726ea2df17fdcc5/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2024-04-01/dataprotection.json#L5789

Support new property `cross_region_restore_enabled` for `azurerm_data_protection_backup_vault`.

Please do note that in the `cross_region_restore_enabled` can only be specified value if the `redundancy` is set to `GeoRedundant` and that once enabled it cannot be disabled.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

PASS: TestAccDataProtectionBackupVault_crossRegionRestore (314.37s)
![image](https://github.com/user-attachments/assets/35a71e19-d907-421f-9779-a624697a5218)
![image](https://github.com/user-attachments/assets/620343a4-552d-4bc5-8a59-936a989f5a3f)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_protection_backup_vault` - support for the `cross_region_restore_enabled` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


