### PR TITLE
`azurerm_role_management_policy` - Support for resource scope

### DIFF
--- a/internal/services/authorization/role_management_policy_data_source.go
+++ b/internal/services/authorization/role_management_policy_data_source.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/rolemanagementpolicies"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 )
 
 type RoleManagementPolicyDataSource struct{}

--- a/internal/services/authorization/role_management_policy_data_source.go
+++ b/internal/services/authorization/role_management_policy_data_source.go
@@ -16,6 +16,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 )
 
 type RoleManagementPolicyDataSource struct{}

--- a/internal/services/authorization/role_management_policy_data_source.go
+++ b/internal/services/authorization/role_management_policy_data_source.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 )
 

--- a/internal/services/authorization/role_management_policy_data_source.go
+++ b/internal/services/authorization/role_management_policy_data_source.go
@@ -109,9 +109,16 @@ func (r RoleManagementPolicyDataSource) Arguments() map[string]*pluginsdk.Schema
 			Type:        pluginsdk.TypeString,
 			Required:    true,
 			ValidateFunc: validation.Any(
+				// Elevated access for a global admin is needed to assign roles in this scope:
+				// https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin#azure-cli
+				// It seems only user account is allowed to be elevated access.
+				validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Subscription.*"), "Subscription scope is invalid"),
+
+				billingValidate.EnrollmentID,
 				commonids.ValidateManagementGroupID,
-				commonids.ValidateResourceGroupID,
 				commonids.ValidateSubscriptionID,
+				commonids.ValidateResourceGroupID,
+				azure.ValidateResourceID,
 			),
 		},
 	}

--- a/internal/services/authorization/role_management_policy_data_source_test.go
+++ b/internal/services/authorization/role_management_policy_data_source_test.go
@@ -55,6 +55,20 @@ func TestAccRoleManagementPolicyDataSource_subscription(t *testing.T) {
 	})
 }
 
+func TestAccRoleManagementPolicyDataSource_resource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_role_management_policy", "test")
+	r := RoleManagementPolicyDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.resource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+			),
+		},
+	})
+}
+
 func (RoleManagementPolicyDataSource) managementGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {}
@@ -115,4 +129,33 @@ data "azurerm_role_management_policy" "test" {
   scope              = data.azurerm_subscription.test.id
 }
 `
+}
+
+func (RoleManagementPolicyDataSource) resource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]s"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accteststg%[1]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+data "azurerm_role_definition" "contributor" {
+  name  = "Contributor"
+  scope = azurerm_resource_group.test.id
+}
+
+data "azurerm_role_management_policy" "test" {
+  role_definition_id = data.azurerm_role_definition.contributor.id
+  scope              = azurerm_storage_account.test.id
+}
+`, data.RandomString, data.Locations.Primary)
 }

--- a/internal/services/authorization/role_management_policy_resource.go
+++ b/internal/services/authorization/role_management_policy_resource.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 )
 
 type RoleManagementPolicyResource struct{}

--- a/internal/services/authorization/role_management_policy_resource.go
+++ b/internal/services/authorization/role_management_policy_resource.go
@@ -111,9 +111,16 @@ func (r RoleManagementPolicyResource) Arguments() map[string]*pluginsdk.Schema {
 			Required:    true,
 			ForceNew:    true,
 			ValidateFunc: validation.Any(
+				// Elevated access for a global admin is needed to assign roles in this scope:
+				// https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin#azure-cli
+				// It seems only user account is allowed to be elevated access.
+				validation.StringMatch(regexp.MustCompile("/providers/Microsoft.Subscription.*"), "Subscription scope is invalid"),
+
+				billingValidate.EnrollmentID,
 				commonids.ValidateManagementGroupID,
-				commonids.ValidateResourceGroupID,
 				commonids.ValidateSubscriptionID,
+				commonids.ValidateResourceGroupID,
+				azure.ValidateResourceID,
 			),
 		},
 

--- a/internal/services/authorization/role_management_policy_resource.go
+++ b/internal/services/authorization/role_management_policy_resource.go
@@ -6,18 +6,19 @@ package authorization
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2020-10-01/rolemanagementpolicies"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
+	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	billingValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/validate"
 )
 
 type RoleManagementPolicyResource struct{}

--- a/internal/services/authorization/role_management_policy_resource_test.go
+++ b/internal/services/authorization/role_management_policy_resource_test.go
@@ -125,6 +125,36 @@ func TestAccRoleManagementPolicy_subscription(t *testing.T) {
 	})
 }
 
+func TestAccRoleManagementPolicy_resource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_management_policy", "test")
+	r := RoleManagementPolicyResource{}
+
+	// Ignore the dangling resource post-test as the policy remains while the resource exists, or is in a pending deletion state
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.resource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("active_assignment_rules.0.expire_after").HasValue("P30D"),
+				check.That(data.ResourceName).Key("eligible_assignment_rules.0.expiration_required").HasValue("false"),
+				check.That(data.ResourceName).Key("notification_rules.0.eligible_assignments.0.approver_notifications.0.notification_level").HasValue("All"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.resourceUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("active_assignment_rules.0.expire_after").HasValue("P15D"),
+				check.That(data.ResourceName).Key("eligible_assignment_rules.0.expiration_required").HasValue("true"),
+				check.That(data.ResourceName).Key("activation_rules.0.approval_stage.0.primary_approver.0.type").HasValue("Group"),
+				check.That(data.ResourceName).Key("notification_rules.0.eligible_assignments.0.approver_notifications.0.notification_level").HasValue("Critical"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (RoleManagementPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Authorization.RoleManagementPoliciesClient
 
@@ -450,4 +480,112 @@ resource "azurerm_role_management_policy" "test" {
   }
 }
 `, r.resourceGroupTemplate(data), data.RandomString, requireApproval)
+}
+
+func (RoleManagementPolicyResource) resourceTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]s"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accteststg%[1]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+data "azurerm_role_definition" "contributor" {
+  name  = "Contributor"
+  scope = azurerm_storage_account.test.id
+}
+`, data.RandomString, data.Locations.Primary)
+}
+
+func (r RoleManagementPolicyResource) resource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_role_management_policy" "test" {
+  scope              = azurerm_storage_account.test.id
+  role_definition_id = data.azurerm_role_definition.contributor.id
+
+  active_assignment_rules {
+    expire_after = "P30D"
+  }
+
+  eligible_assignment_rules {
+    expiration_required = false
+  }
+
+  notification_rules {
+    eligible_assignments {
+      approver_notifications {
+        notification_level    = "All"
+        default_recipients    = false
+        additional_recipients = ["someone@example.com"]
+      }
+    }
+  }
+}
+`, r.resourceTemplate(data), data.RandomString)
+}
+
+func (r RoleManagementPolicyResource) resourceUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azuread" {}
+
+resource "azuread_group" "approver" {
+  display_name     = "PIM Approver Test %[2]s"
+  mail_enabled     = false
+  security_enabled = true
+}
+
+resource "azurerm_role_management_policy" "test" {
+  scope              = azurerm_storage_account.test.id
+  role_definition_id = data.azurerm_role_definition.contributor.id
+
+  active_assignment_rules {
+    expire_after = "P15D"
+  }
+
+  eligible_assignment_rules {
+    expiration_required = true
+  }
+
+  activation_rules {
+    maximum_duration = "PT1H"
+    require_approval = true
+    approval_stage {
+      primary_approver {
+        object_id = azuread_group.approver.object_id
+        type      = "Group"
+      }
+    }
+  }
+
+  notification_rules {
+    eligible_assignments {
+      approver_notifications {
+        notification_level    = "Critical"
+        default_recipients    = false
+        additional_recipients = ["someone@example.com"]
+      }
+    }
+    eligible_activations {
+      assignee_notifications {
+        notification_level    = "All"
+        default_recipients    = true
+        additional_recipients = ["someone.else@example.com"]
+      }
+    }
+  }
+}
+`, r.resourceTemplate(data), data.RandomString)
 }

--- a/website/docs/d/role_management_policy.html.markdown
+++ b/website/docs/d/role_management_policy.html.markdown
@@ -51,7 +51,7 @@ data "azurerm_role_management_policy" "example" {
 ## Argument Reference
 
 * `role_definition_id` - (Required) The scoped Role Definition ID of the role for which this policy applies.
-* `scope` - (Required) The scope to which this Role Management Policy applies. Can refer to a management group, a subscription or a resource group.
+* `scope` - (Required) The scope to which this Role Management Policy applies. Can refer to a management group, a subscription, a resource group or a resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/role_management_policy.html.markdown
+++ b/website/docs/r/role_management_policy.html.markdown
@@ -119,7 +119,7 @@ resource "azurerm_role_management_policy" "example" {
 * `eligible_assignment_rules` - (Optional) An `eligible_assignment_rules` block as defined below.
 * `notification_rules` - (Optional) A `notification_rules` block as defined below.
 * `role_definition_id` - (Required) The scoped Role Definition ID of the role for which this policy will apply. Changing this forces a new resource to be created.
-* `scope` - (Required) The scope to which this Role Management Policy will apply. Can refer to a management group, a subscription or a resource group. Changing this forces a new resource to be created.
+* `scope` - (Required) The scope to which this Role Management Policy will apply. Can refer to a management group, a subscription, a resource group or a resource. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
As described in the [documentation](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-resource-roles-configure-role-settings) provided by Microsoft, role management policies can be configured on resource scope.
Currently the resource will fail with an error saying it is not an valid management group id:
``parsing "/subscriptions/xxxx/resourceGroups/xxxx/providers/Microsoft.KeyVault/vaults/xxx": parsing segment "providers": parsing the ManagementGroup ID: the segment at position 0 didn't match``.
Since resource scope is actually valid, I made the scope validation the same as of the other 'role type' resources, in order to allow it.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

--- PASS: TestAccRoleManagementPolicyDataSource_resource (125.02s)
--- PASS: TestAccRoleManagementPolicy_resource (162.81s)

side note: I had to ran the test with the primary_approver.object_id hardcored, since I don't have admin access to an Entra ID tenant in which I can create groups.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_management_policy`  - Support for resource scope


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
closes #26396

