### PR TITLE
`azurerm_kubernetes_cluster` - set `host_encryption_enabled` and remove 4.0 flags

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -38,7 +38,7 @@ func TestAccKubernetesCluster_hostEncryption(t *testing.T) {
 			Config: r.hostEncryption(data, currentKubernetesVersion),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.enable_host_encryption").HasValue("true"),
+				check.That(data.ResourceName).Key("default_node_pool.0.host_encryption_enabled").HasValue("true"),
 			),
 		},
 	})
@@ -319,10 +319,10 @@ resource "azurerm_kubernetes_cluster" "test" {
   kubernetes_version  = %q
 
   default_node_pool {
-    name                   = "default"
-    node_count             = 1
-    vm_size                = "Standard_DS2_v2"
-    enable_host_encryption = true
+    name                    = "default"
+    node_count              = 1
+    vm_size                 = "Standard_DS2_v2"
+    host_encryption_enabled = true
     upgrade_settings {
       max_surge = "10%%"
     }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -37,7 +37,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: func() map[string]*pluginsdk.Schema {
-				s := map[string]*pluginsdk.Schema{
+				return map[string]*pluginsdk.Schema{
 					// Required and conditionally ForceNew: updating `name` back to name when it's been set to the value
 					// of `temporary_name_for_rotation` during the resizing of the default node pool should be allowed and
 					// not force cluster recreation
@@ -152,12 +152,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional:     true,
 						ForceNew:     true,
 						ValidateFunc: publicipprefixes.ValidatePublicIPPrefixID,
-						RequiredWith: func() []string {
-							if !features.FourPointOh() {
-								return []string{"default_node_pool.0.enable_node_public_ip"}
-							}
-							return []string{"default_node_pool.0.node_public_ip_enabled"}
-						}(),
+						RequiredWith: []string{"default_node_pool.0.node_public_ip_enabled"},
 					},
 
 					"tags": commonschema.Tags(),
@@ -275,39 +270,13 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional: true,
 					},
 				}
-
-				if !features.FourPointOh() {
-					// These properties are not undergoing a soft deprecation but are being renamed, so they need to be put behind the FourPointOh flag
-					s["enable_auto_scaling"] = &pluginsdk.Schema{
-						Type:       pluginsdk.TypeBool,
-						Optional:   true,
-						Deprecated: features.DeprecatedInFourPointOh("The property `enable_auto_scaling` will be renamed to `auto_scaling_enabled` in v4.0 of the AzureRM Provider."),
-					}
-
-					s["enable_node_public_ip"] = &pluginsdk.Schema{
-						Type:       pluginsdk.TypeBool,
-						Optional:   true,
-						Deprecated: features.DeprecatedInFourPointOh("The property `enable_node_public_ip` will be renamed to `node_public_ip_enabled` in v4.0 of the AzureRM Provider."),
-					}
-
-					s["enable_host_encryption"] = &pluginsdk.Schema{
-						Type:       pluginsdk.TypeBool,
-						Optional:   true,
-						Deprecated: features.DeprecatedInFourPointOh("The property `enable_host_encryption` will be renamed to `host_encryption_enabled` in v4.0 of the AzureRM Provider."),
-					}
-					delete(s, "auto_scaling_enabled")
-					delete(s, "node_public_ip_enabled")
-					delete(s, "host_encryption_enabled")
-				}
-
-				return s
 			}(),
 		},
 	}
 }
 
 func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
-	schema := pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MaxItems: 1,
@@ -369,7 +338,7 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 					Optional: true,
 				},
 
-				// TODO 4.0: change this to `container_log_max_files`
+				// TODO 5.0: change this to `container_log_max_files`
 				"container_log_max_line": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
@@ -383,17 +352,10 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 			},
 		},
 	}
-
-	// TODO 4.0: change the default value to `true` in the document
-	if !features.FourPointOhBeta() {
-		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
-	}
-
-	return &schema
 }
 
 func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
-	schema := pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		ForceNew: true,
@@ -464,7 +426,7 @@ func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
 					ForceNew: true,
 				},
 
-				// TODO 4.0: change this to `container_log_max_files`
+				// TODO 5.0: change this to `container_log_max_files`
 				"container_log_max_line": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
@@ -480,13 +442,6 @@ func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
 			},
 		},
 	}
-
-	// TODO 4.0: change the default value to `true` in the document
-	if !features.FourPointOhBeta() {
-		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
-	}
-
-	return &schema
 }
 
 func schemaNodePoolLinuxOSConfig() *pluginsdk.Schema {
@@ -1175,12 +1130,8 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 	input := d.Get("default_node_pool").([]interface{})
 
 	raw := input[0].(map[string]interface{})
-	var enableAutoScaling bool
-	if !features.FourPointOh() {
-		enableAutoScaling = raw["enable_auto_scaling"].(bool)
-	} else {
-		enableAutoScaling = raw["auto_scaling_enabled"].(bool)
-	}
+
+	enableAutoScaling := raw["auto_scaling_enabled"].(bool)
 
 	nodeLabelsRaw := raw["node_labels"].(map[string]interface{})
 	nodeLabels := expandNodeLabels(nodeLabelsRaw)
@@ -1201,25 +1152,11 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 
 	t := raw["tags"].(map[string]interface{})
 
-	var nodePublicIp bool
-	if !features.FourPointOh() {
-		nodePublicIp = raw["enable_node_public_ip"].(bool)
-	} else {
-		nodePublicIp = raw["node_public_ip_enabled"].(bool)
-	}
-
-	var hostEncryption bool
-	if !features.FourPointOh() {
-		hostEncryption = raw["enable_host_encryption"].(bool)
-	} else {
-		nodePublicIp = raw["host_encryption_enabled"].(bool)
-	}
-
 	profile := managedclusters.ManagedClusterAgentPoolProfile{
 		EnableAutoScaling:      utils.Bool(enableAutoScaling),
 		EnableFIPS:             utils.Bool(raw["fips_enabled"].(bool)),
-		EnableNodePublicIP:     utils.Bool(nodePublicIp),
-		EnableEncryptionAtHost: utils.Bool(hostEncryption),
+		EnableNodePublicIP:     utils.Bool(raw["node_public_ip_enabled"].(bool)),
+		EnableEncryptionAtHost: utils.Bool(raw["host_encryption_enabled"].(bool)),
 		KubeletDiskType:        pointer.To(managedclusters.KubeletDiskType(raw["kubelet_disk_type"].(string))),
 		Name:                   raw["name"].(string),
 		NodeLabels:             nodeLabels,
@@ -1731,8 +1668,10 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 	networkProfile := flattenClusterPoolNetworkProfile(agentPool.NetworkProfile)
 
 	out := map[string]interface{}{
+		"auto_scaling_enabled":          enableAutoScaling,
 		"fips_enabled":                  enableFIPS,
 		"gpu_instance":                  gpuInstanceProfile,
+		"host_encryption_enabled":       enableHostEncryption,
 		"host_group_id":                 hostGroupID,
 		"kubelet_disk_type":             kubeletDiskType,
 		"max_count":                     maxCount,
@@ -1742,6 +1681,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"node_count":                    count,
 		"node_labels":                   nodeLabels,
 		"node_network_profile":          networkProfile,
+		"node_public_ip_enabled":        enableNodePublicIP,
 		"node_public_ip_prefix_id":      nodePublicIPPrefixID,
 		"os_disk_size_gb":               osDiskSizeGB,
 		"os_disk_type":                  string(osDiskType),
@@ -1764,16 +1704,6 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"linux_os_config":               linuxOSConfig,
 		"zones":                         zones.FlattenUntyped(agentPool.AvailabilityZones),
 		"capacity_reservation_group_id": capacityReservationGroupId,
-	}
-
-	if features.FourPointOh() {
-		out["auto_scaling_enabled"] = enableAutoScaling
-		out["node_public_ip_enabled"] = enableNodePublicIP
-		out["host_encryption_enabled"] = enableHostEncryption
-	} else {
-		out["enable_auto_scaling"] = enableAutoScaling
-		out["enable_node_public_ip"] = enableNodePublicIP
-		out["enable_host_encryption"] = enableHostEncryption
 	}
 
 	return &[]interface{}{

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -482,7 +482,7 @@ A `kubelet_config` block supports the following:
 
 * `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10MB) of container log file before it is rotated.
 
-* `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled?
+* `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled? Defaults to `true`.
 
 * `cpu_cfs_quota_period` - (Optional) Specifies the CPU CFS quota period value.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes a bug where `host_encryption_enabled` is not being set correctly and removes 4.0 flags around these since 4.0 has now been released


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Testing in TC


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster` - `host_encryption_enabled` and `node_public_ip_enabled` are now set correctly

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27201


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
