### PR TITLE
`azurerm_role_assignment` - fix id parsing for root or provider scoped role assignments

### DIFF
--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -96,8 +96,18 @@ func (id RoleAssignmentId) AzureResourceID() string {
 		return fmt.Sprintf(fmtString, id.Name)
 	}
 
-	fmtString := "/subscriptions/%s/providers/Microsoft.Authorization/roleAssignments/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionID, id.Name)
+	if id.SubscriptionID != "" {
+		fmtString := "/subscriptions/%s/providers/Microsoft.Authorization/roleAssignments/%s"
+		return fmt.Sprintf(fmtString, id.SubscriptionID, id.Name)
+	}
+
+	if id.ResourceProvider != "" {
+		fmtString := "/providers/%s/providers/Microsoft.Authorization/roleAssignments/%s"
+		return fmt.Sprintf(fmtString, id.ResourceProvider, id.Name)
+	}
+
+	fmtString := "/providers/Microsoft.Authorization/roleAssignments/%s"
+	return fmt.Sprintf(fmtString, id.Name)
 }
 
 func (id RoleAssignmentId) ID() string {
@@ -179,6 +189,22 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 		}
 		roleAssignmentId.Name = idParts[1]
 		roleAssignmentId.ManagementGroup = strings.TrimPrefix(idParts[0], "/providers/Microsoft.Management/managementGroups/")
+	case strings.HasPrefix(input, "/providers/") && !strings.HasPrefix(input, "/providers/Microsoft.Authorization/roleAssignments"):
+		idParts := strings.Split(input, "/providers/Microsoft.Authorization/roleAssignments/")
+		if len(idParts) != 2 {
+			return nil, fmt.Errorf("could not parse Role Assignment ID %q for Ressource Provider", input)
+		}
+		if idParts[1] == "" {
+			return nil, fmt.Errorf("ID was missing a value for the roleAssignments element")
+		}
+		roleAssignmentId.Name = idParts[1]
+		roleAssignmentId.ResourceProvider = strings.TrimPrefix(idParts[0], "/providers/")
+	case strings.HasPrefix(input, "/providers/Microsoft.Authorization/roleAssignments"):
+		name := strings.TrimPrefix(input, "/providers/Microsoft.Authorization/roleAssignments/")
+		if name == "" {
+			return nil, fmt.Errorf("ID was missing a value for the roleAssignments element")
+		}
+		roleAssignmentId.Name = name
 	default:
 		return nil, fmt.Errorf("could not parse Role Assignment ID %q", input)
 	}

--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -192,7 +192,7 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 	case strings.HasPrefix(input, "/providers/") && !strings.HasPrefix(input, "/providers/Microsoft.Authorization/roleAssignments"):
 		idParts := strings.Split(input, "/providers/Microsoft.Authorization/roleAssignments/")
 		if len(idParts) != 2 {
-			return nil, fmt.Errorf("could not parse Role Assignment ID %q for Ressource Provider", input)
+			return nil, fmt.Errorf("could not parse Role Assignment ID %q for Resource Provider", input)
 		}
 		if idParts[1] == "" {
 			return nil, fmt.Errorf("ID was missing a value for the roleAssignments element")

--- a/internal/services/authorization/parse/role_assignment_test.go
+++ b/internal/services/authorization/parse/role_assignment_test.go
@@ -255,6 +255,30 @@ func TestRoleAssignmentID(t *testing.T) {
 				TenantId:         "34567812-3456-7653-6742-345678901234",
 			},
 		},
+		{
+			Input: "/providers/Microsoft.Capacity/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:   "",
+				ResourceGroup:    "",
+				ResourceProvider: "Microsoft.Capacity",
+				ResourceScope:    "",
+				ManagementGroup:  "",
+				Name:             "23456781-2349-8764-5631-234567890121",
+				TenantId:         "34567812-3456-7653-6742-345678901234",
+			},
+		},
+		{
+			Input: "/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:   "",
+				ResourceGroup:    "",
+				ResourceProvider: "",
+				ResourceScope:    "",
+				ManagementGroup:  "",
+				Name:             "23456781-2349-8764-5631-234567890121",
+				TenantId:         "34567812-3456-7653-6742-345678901234",
+			},
+		},
 	}
 
 	for _, v := range testData {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

With the azurerm_role_assignment resource it is possible to make RBAC assignments on root or resource provider scope.
The functionality was added in #26663.

The creation succeeds, but the provider cannot parse the resource ID from the ARM-response.
Following error is displayed:
```
Error: could not parse Role Assignment ID "/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121"
```

The PR is intended to fix the parsing of the resource ID and thus enable an assignment on root or resource provider scope.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
