### PR TITLE
`azurerm_windows_web_app` - Set `dotnet_version` when CurrentStack is set to `dotnetcore`

### DIFF
--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -100,6 +100,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				}, false),
 				AtLeastOneOf: windowsApplicationStackConstraint,
 				Description:  "The version of DotNetCore to use.",
+				Deprecated:   "This property has been deprecated in favour of `dotnet_version`.",
 			},
 
 			"php_version": {

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -829,7 +829,7 @@ func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, exist
 	return &expanded, nil
 }
 
-func (s *SiteConfigWindows) Flatten(appSiteConfig *webapps.SiteConfig, currentStack string) error {
+func (s *SiteConfigWindows) Flatten(appSiteConfig *webapps.SiteConfig, currentStack string, metadata sdk.ResourceMetaData) error {
 	if appSiteConfig != nil {
 		s.AlwaysOn = pointer.From(appSiteConfig.AlwaysOn)
 		s.AppCommandLine = pointer.From(appSiteConfig.AppCommandLine)
@@ -884,7 +884,9 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *webapps.SiteConfig, currentSt
 
 	var winAppStack ApplicationStackWindows
 	if currentStack == CurrentStackDotNetCore {
+		// Set both .NET Core and .NET Framework versions to prevent drift
 		winAppStack.NetCoreVersion = pointer.From(appSiteConfig.NetFrameworkVersion)
+		winAppStack.NetFrameworkVersion = pointer.From(appSiteConfig.NetFrameworkVersion)
 	} else {
 		winAppStack.NetFrameworkVersion = pointer.From(appSiteConfig.NetFrameworkVersion)
 	}

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -385,7 +385,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				}
 
 				siteConfig := helpers.SiteConfigWindows{}
-				err = siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack)
+				err = siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack, metadata)
 				if err != nil {
 					return err
 				}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -689,7 +689,7 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 					}
 
 					siteConfig := helpers.SiteConfigWindows{}
-					if err := siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack); err != nil {
+					if err := siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack, metadata); err != nil {
 						return err
 					}
 					siteConfig.SetHealthCheckEvictionTime(state.AppSettings)

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -175,6 +175,8 @@ ASP.NET V4.8 | v4.0
 
 * `dotnet_core_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnetcore`. Possible values include `v4.0`.
 
+~> **NOTE:** `dotnet_core_version` has been deprecated in favour of `dotnet_version`.
+
 * `tomcat_version` - (Optional) The version of Tomcat the Java App should use. Conflicts with `java_embedded_server_enabled`
 
 ~> **NOTE:** See the official documentation for current supported versions.  Some example valuess include: `10.0`, `10.0.20`.

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -168,7 +168,18 @@ An `application_stack` block supports the following:
 
 * `dotnet_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnet`. Possible values include `v2.0`,`v3.0`, `v4.0`, `v5.0`, `v6.0`, `v7.0` and `v8.0`.
 
+~> **NOTE:** The Portal displayed values and the actual underlying API values differ for this setting, as follows:
+Portal Value | API value
+:--|--:
+ASP.NET V3.5 | v2.0
+ASP.NET V4.8 | v4.0
+.NET 6 (LTS) | v6.0
+.NET 7 (STS) | v7.0
+.NET 8 (LTS) | v8.0
+
 * `dotnet_core_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnetcore`. Possible values include `v4.0`.
+
+~> **NOTE:** `dotnet_core_version` has been deprecated in favour of `dotnet_version`.
 
 * `tomcat_version` - (Optional) The version of Tomcat the Java App should use.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR resolves an issue where Terraform constantly creates diffs if the CurrentStack is set to `dotnetcore` and the version is set with the `dotnet_version` property. It also deprecates the `dotnetcore_version` property as it is no longer exposed as a separate stack type.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm % make acctests SERVICE='appservice' TESTARGS='-run="TestAccWindowsWebApp_(basic|complete|withDotNet|updateAppStack)"' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run="TestAccWindowsWebApp_(basic|complete|withDotNet|updateAppStack)" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWindowsWebApp_basic
=== PAUSE TestAccWindowsWebApp_basic
=== RUN   TestAccWindowsWebApp_complete
=== PAUSE TestAccWindowsWebApp_complete
=== RUN   TestAccWindowsWebApp_completeUpdated
=== PAUSE TestAccWindowsWebApp_completeUpdated
=== RUN   TestAccWindowsWebApp_withDotNetCore
=== PAUSE TestAccWindowsWebApp_withDotNetCore
=== RUN   TestAccWindowsWebApp_withDotNet4
=== PAUSE TestAccWindowsWebApp_withDotNet4
=== RUN   TestAccWindowsWebApp_withDotNet5
=== PAUSE TestAccWindowsWebApp_withDotNet5
=== RUN   TestAccWindowsWebApp_withDotNet60
=== PAUSE TestAccWindowsWebApp_withDotNet60
=== RUN   TestAccWindowsWebApp_withDotNet70
=== PAUSE TestAccWindowsWebApp_withDotNet70
=== RUN   TestAccWindowsWebApp_withDotNet80
=== PAUSE TestAccWindowsWebApp_withDotNet80
=== RUN   TestAccWindowsWebApp_updateAppStack
=== PAUSE TestAccWindowsWebApp_updateAppStack
=== CONT  TestAccWindowsWebApp_basic
=== CONT  TestAccWindowsWebApp_withDotNet5
=== CONT  TestAccWindowsWebApp_withDotNetCore
=== CONT  TestAccWindowsWebApp_completeUpdated
=== CONT  TestAccWindowsWebApp_withDotNet4
=== CONT  TestAccWindowsWebApp_withDotNet80
=== CONT  TestAccWindowsWebApp_withDotNet70
=== CONT  TestAccWindowsWebApp_complete
=== CONT  TestAccWindowsWebApp_withDotNet60
=== CONT  TestAccWindowsWebApp_updateAppStack
--- PASS: TestAccWindowsWebApp_withDotNet80 (342.98s)
--- PASS: TestAccWindowsWebApp_withDotNet5 (344.90s)
--- PASS: TestAccWindowsWebApp_withDotNet4 (350.99s)
--- PASS: TestAccWindowsWebApp_withDotNet70 (354.36s)
--- PASS: TestAccWindowsWebApp_basic (372.63s)
--- PASS: TestAccWindowsWebApp_withDotNet60 (375.29s)
--- PASS: TestAccWindowsWebApp_withDotNetCore (395.82s)
--- PASS: TestAccWindowsWebApp_complete (449.29s)
--- PASS: TestAccWindowsWebApp_updateAppStack (757.57s)
--- PASS: TestAccWindowsWebApp_completeUpdated (1136.71s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    1139.199s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_web_app` - resolve constant diffs between `dotnet_version` and `dotnetcore_version` [GH-00000]
* `azurerm_windows_web_app_slot` - resolve constant diffs between `dotnet_version` and `dotnetcore_version` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #22239
Fixes #24206


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
