### PR TITLE
Check storage account name in a given subscription during create and update calls for azurerm_machine_learning_datastore_datalake_gen2 resource

### DIFF
--- a/website/docs/r/machine_learning_datastore_datalake_gen2.html.markdown
+++ b/website/docs/r/machine_learning_datastore_datalake_gen2.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `storage_container_id` - (Required) The ID of the Storage Account Container. Changing this forces a new Machine Learning DataStore to be created.
 
+~> **Note** `storage_container_id` should be in the same subscription as `azurerm_machine_learning_datastore_datalake_gen2` resource.
+
 ---
 * `tenant_id` - (Optional) The ID of the Tenant which the Service Principal belongs to.
 


### PR DESCRIPTION
…update calls

	modified:   internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation. (difficult to test as it requires alias via providers I am not sure which subscription to use for testing)
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_machine_learning_datastore_datalake_gen2` - support for the `storage_container_id` property [GH-27254]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ x ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27254


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
