### PR TITLE
#27228: Support smb3_protocol_encryption_enabled part of azurerm_netapp_volume resource

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -149,6 +149,13 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 				ForceNew:    true,
 			},
 
+			"smb3_protocol_encryption_enabled": {
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Description: "SMB3 encryption option should be used only for SMB/DualProtocol volumes. Using it for any other workloads is not supported.",
+				ForceNew:    true,
+			},
+
 			"security_style": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -405,6 +412,7 @@ func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	subnetID := d.Get("subnet_id").(string)
 	kerberosEnabled := d.Get("kerberos_enabled").(bool)
 	smbContiuouslyAvailable := d.Get("smb_continuous_availability_enabled").(bool)
+	smbEncryption := d.Get("smb3_protocol_encryption_enabled").(bool)
 	networkFeatures := volumes.NetworkFeatures(d.Get("network_features").(string))
 
 	smbNonBrowsable := volumes.SmbNonBrowsableDisabled
@@ -533,6 +541,7 @@ func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) err
 			SubnetId:                  subnetID,
 			KerberosEnabled:           &kerberosEnabled,
 			SmbContinuouslyAvailable:  &smbContiuouslyAvailable,
+			SmbEncryption:             &smbEncryption,
 			NetworkFeatures:           &networkFeatures,
 			SmbNonBrowsable:           &smbNonBrowsable,
 			SmbAccessBasedEnumeration: &smbAccessBasedEnumeration,
@@ -741,6 +750,7 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("subnet_id", props.SubnetId)
 		d.Set("kerberos_enabled", props.KerberosEnabled)
 		d.Set("smb_continuous_availability_enabled", props.SmbContinuouslyAvailable)
+		d.Set("smb3_protocol_encryption_enabled", props.SmbEncryption)
 		d.Set("network_features", string(pointer.From(props.NetworkFeatures)))
 		d.Set("protocols", props.ProtocolTypes)
 		d.Set("security_style", string(pointer.From(props.SecurityStyle)))

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -35,6 +35,22 @@ func TestAccNetAppVolume_basic(t *testing.T) {
 	})
 }
 
+func TestAccNetAppVolume_smbEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
+	r := NetAppVolumeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.smbEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("smb3_protocol_encryption_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNetAppVolume_availabilityZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
 	r := NetAppVolumeResource{}
@@ -498,6 +514,33 @@ resource "azurerm_netapp_volume" "test" {
   subnet_id           = azurerm_subnet.test.id
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) smbEncryption(data acceptance.TestData) string {
+	template := NetAppVolumeResource{}.templateSmbEncryption(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                             = "acctest-NetAppVolume-smbencryption-%d"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  account_name                     = azurerm_netapp_account.test.name
+  pool_name                        = azurerm_netapp_pool.test.name
+  volume_path                      = "my-unique-file-path-%d"
+  service_level                    = "Standard"
+  subnet_id                        = azurerm_subnet.test.id
+  storage_quota_in_gb              = 100
+  throughput_in_mibps              = 1.562
+  protocols                        = ["CIFS"]
+  smb3_protocol_encryption_enabled = true
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1158,6 +1201,101 @@ resource "azurerm_netapp_pool" "test_secondary" {
   }
 }
 `, r.template(data), data.RandomInteger, "eastus2")
+}
+
+func (NetAppVolumeResource) templateSmbEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  alias = "all1"
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-netapp-%d"
+  location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-VirtualNetwork-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.6.0.0/16"]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-Subnet-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.6.2.0/24"]
+
+  delegation {
+    name = "testdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  active_directory {
+    username                          = "aduser"
+    password                          = "aduserpwd"
+    smb_server_name                   = "SMB-SERVER"
+    dns_servers                       = ["1.2.3.4", "1.2.3.5"]
+    domain                            = "westcentralus.com"
+    organizational_unit               = "OU=FirstLevel"
+    site_name                         = "My-Site-Name"
+    kerberos_ad_name                  = "My-AD-Server"
+    kerberos_kdc_ip                   = "192.168.1.1"
+    aes_encryption_enabled            = true
+    local_nfs_users_with_ldap_allowed = true
+    ldap_over_tls_enabled             = true
+    server_root_ca_certificate        = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNZekNDQWN5Z0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRVUZBREF1TVFzd0NRWURWUVFHRXdKVlV6RU0gCk1Bb0dBMVVFQ2hNRFNVSk5NUkV3RHdZRFZRUUxFd2hNYjJOaGJDQkRRVEFlRncwNU9URXlNakl3TlRBd01EQmEgCkZ3MHdNREV5TWpNd05EVTVOVGxhTUM0eEN6QUpCZ05WQkFZVEFsVlRNUXd3Q2dZRFZRUUtFd05KUWsweEVUQVAgCkJnTlZCQXNUQ0V4dlkyRnNJRU5CTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEMmJaRW8gCjd4R2FYMi8wR0hrck5GWnZseEJvdTl2MUptdC9QRGlUTVB2ZThyOUZlSkFRMFFkdkZTVC8wSlBRWUQyMHJIMGIgCmltZERMZ05kTnlubXlSb1MyUy9JSW5mcG1mNjlpeWMyRzBUUHlSdm1ISWlPWmJkQ2QrWUJIUWkxYWRrajE3TkQgCmNXajZTMTR0VnVyRlg3M3p4MHNOb01TNzlxM3R1WEtyRHN4ZXV3SURBUUFCbzRHUU1JR05NRXNHQ1ZVZER3R0cgCitFSUJEUVErRXp4SFpXNWxjbUYwWldRZ1lua2dkR2hsSUZObFkzVnlaVmRoZVNCVFpXTjFjbWwwZVNCVFpYSjIgClpYSWdabTl5SUU5VEx6TTVNQ0FvVWtGRFJpa3dEZ1lEVlIwUEFRSC9CQVFEQWdBR01BOEdBMVVkRXdFQi93UUYgCk1BTUJBZjh3SFFZRFZSME9CQllFRkozK29jUnlDVEp3MDY3ZExTd3IvbmFseDZZTU1BMEdDU3FHU0liM0RRRUIgCkJRVUFBNEdCQU1hUXp0K3phajFHVTc3eXpscjhpaU1CWGdkUXJ3c1paV0pvNWV4bkF1Y0pBRVlRWm1PZnlMaU0gCkQ2b1lxK1puZnZNMG44Ry9ZNzlxOG5od3Z1eHBZT25SU0FYRnA2eFNrcklPZVp0Sk1ZMWgwMExLcC9KWDNOZzEgCnN2WjJhZ0UxMjZKSHNRMGJoek41VEtzWWZid2ZUd2ZqZFdBR3k2VmYxbllpL3JPK3J5TU8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSA="
+    ldap_signing_enabled              = true
+  }
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_pool" "test" {
+  name                = "acctest-NetAppPool-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, data.RandomInteger, "westeurope", data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (NetAppVolumeResource) template(data acceptance.TestData) string {

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -156,6 +156,8 @@ The following arguments are supported:
 
 * `smb_continuous_availability_enabled` - (Optional) Enable SMB Continuous Availability.
 
+* `smb3_protocol_encryption_enabled` - (Optional) Enable SMB encryption.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 -> **Note:** It is highly recommended to use the **lifecycle** property as noted in the example since it will prevent an accidental deletion of the volume if the `protocols` argument changes to a different protocol type.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ x ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests. Tests failed with below error as I don't have correct `active_directory` details. It is must for `CIFS` protocol. If maintainers have, please let me know how to proceed. But `SMB3 Encryption` was enabled. 

> {"id":"/subscriptions/000000-00000/providers/Microsoft.NetApp/locations/westeurope/operationResults/a33356d0-9647-4158-81c0-02ac41a8707f","name":"a33356d0-9647-4158-81c0-02ac41a8707f","status":"Failed","startTime":"2024-09-02T14:23:25.3891339Z","endTime":"2024-09-02T14:30:53.5435832Z","percentComplete":100.0,"properties":{"resourceName":"/subscriptions/000000-00000/resourceGroups/acctestRG-netapp-240902162138898180/providers/Microsoft.NetApp/netAppAccounts/acctest-NetAppAccount-240902162138898180/capacityPools/acctest-NetAppPool-240902162138898180/volumes/acctest-NetAppVolume-smbencryption-240902162138898180","action":"CREATE"},"error":{"code":"Conflict","message":"Unable to create SMB volume due to not being able to query the DNS server configured on the NetAppAccount (acctest-NetAppAccount-240902162138898180). Please verify that the DNS server, IP addresses and other AD details are correctly configured on the NetAppAccount (acctest-NetAppAccount-240902162138898180) and that the DNS server is reachable (e.g. verify there are no firewalls blocking access) and then try again.","details":[{"code":"ErrorFromNFSaaSErrorState","message":"Unable to create SMB volume due to not being able to query the DNS server configured on the NetAppAccount (acctest-NetAppAccount-240902162138898180). Please verify that the DNS server, IP addresses and other AD details are correctly configured on the NetAppAccount (acctest-NetAppAccount-240902162138898180) and that the DNS server is reachable (e.g. verify there are no firewalls blocking access) and then try again."}]}}

- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ x ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

> Please see above section for more details.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_netapp_volume` - support for the `smb3_protocol_encryption_enabled` property [GH-27228]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ x ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27228


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
