### PR TITLE
`azurerm_cosmosdb_account` - add state migration for `ip_range_filter` underlying type change

### DIFF
--- a/internal/services/cosmos/common/ip_rules.go
+++ b/internal/services/cosmos/common/ip_rules.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-// CosmosDBIpRulesToIpRangeFilterThreePointOh todo Remove for 4.0
-func CosmosDBIpRulesToIpRangeFilterThreePointOh(ipRules *[]cosmosdb.IPAddressOrRange) string {
+// CosmosDBIpRulesToIpRangeFilterDataSource todo Remove for 4.0
+func CosmosDBIpRulesToIpRangeFilterDataSource(ipRules *[]cosmosdb.IPAddressOrRange) string {
 	ipRangeFilter := make([]string, 0)
 	if ipRules != nil {
 		for _, ipRule := range *ipRules {

--- a/internal/services/cosmos/cosmosdb_account_data_source.go
+++ b/internal/services/cosmos/cosmosdb_account_data_source.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-05-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -249,35 +248,6 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FourPointOhBeta() {
-		dataSource.Schema["connection_strings"] = &pluginsdk.Schema{
-			Type:      pluginsdk.TypeList,
-			Computed:  true,
-			Sensitive: true,
-			Elem: &pluginsdk.Schema{
-				Type:      pluginsdk.TypeString,
-				Sensitive: true,
-			},
-			Deprecated: "This property has been superseded by the primary and secondary connection strings for sql, mongodb and readonly and will be removed in v4.0 of the AzureRM provider",
-		}
-		dataSource.Schema["enable_free_tier"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Computed:   true,
-			Deprecated: "This property has been renamed to `free_tier_enabled` and will be removed in v4.0 of the AzureRM provider",
-		}
-		dataSource.Schema["enable_automatic_failover"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Computed:   true,
-			Deprecated: "This property has been renamed to `automatic_failover_enabled` and will be removed in v4.0 of the AzureRM provider",
-		}
-		dataSource.Schema["enable_multiple_write_locations"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Computed:   true,
-			Deprecated: "This property has been renamed to `multiple_write_locations_enabled` and will be removed in v4.0 of the AzureRM provider",
-		}
-
-	}
-
 	return dataSource
 }
 
@@ -309,15 +279,9 @@ func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 
 		if props := model.Properties; props != nil {
 			d.Set("offer_type", string(pointer.From(props.DatabaseAccountOfferType)))
-			d.Set("ip_range_filter", common.CosmosDBIpRulesToIpRangeFilterThreePointOh(props.IPRules))
+			d.Set("ip_range_filter", common.CosmosDBIpRulesToIpRangeFilterDataSource(props.IPRules))
 			d.Set("endpoint", props.DocumentEndpoint)
 			d.Set("is_virtual_network_filter_enabled", props.IsVirtualNetworkFilterEnabled)
-			if !features.FourPointOhBeta() {
-				d.Set("enable_free_tier", props.EnableFreeTier)
-				d.Set("enable_automatic_failover", props.EnableAutomaticFailover)
-				d.Set("enable_multiple_write_locations", props.EnableMultipleWriteLocations)
-			}
-
 			d.Set("free_tier_enabled", props.EnableFreeTier)
 			d.Set("automatic_failover_enabled", props.EnableAutomaticFailover)
 			d.Set("multiple_write_locations_enabled", props.EnableMultipleWriteLocations)
@@ -439,10 +403,6 @@ func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 						d.Set(propertyName, v.ConnectionString) // lintignore:R001
 					}
 				}
-			}
-
-			if !features.FourPointOhBeta() {
-				d.Set("connection_strings", connStrings)
 			}
 		}
 	}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1032,8 +1032,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			networkByPass = cosmosdb.NetworkAclBypassAzureServices
 		}
 
-		var ipRangeFilter *[]cosmosdb.IPAddressOrRange
-		ipRangeFilter = common.CosmosDBIpRangeFilterToIpRules(*utils.ExpandStringSlice(d.Get("ip_range_filter").(*pluginsdk.Set).List()))
+		ipRangeFilter := common.CosmosDBIpRangeFilterToIpRules(*utils.ExpandStringSlice(d.Get("ip_range_filter").(*pluginsdk.Set).List()))
 
 		publicNetworkAccess := cosmosdb.PublicNetworkAccessEnabled
 		if enabled := d.Get("public_network_access_enabled").(bool); !enabled {

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/validate"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
@@ -182,6 +183,12 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(180 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(180 * time.Minute),
 		},
+
+		SchemaVersion: 1,
+
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CosmosDBAccountV0toV1{},
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -786,8 +786,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	kind := d.Get("kind").(string)
 	offerType := d.Get("offer_type").(string)
 
-	var ipRangeFilter *[]cosmosdb.IPAddressOrRange
-	ipRangeFilter = common.CosmosDBIpRangeFilterToIpRules(*utils.ExpandStringSlice(d.Get("ip_range_filter").(*pluginsdk.Set).List()))
+	ipRangeFilter := common.CosmosDBIpRangeFilterToIpRules(*utils.ExpandStringSlice(d.Get("ip_range_filter").(*pluginsdk.Set).List()))
 	isVirtualNetworkFilterEnabled := d.Get("is_virtual_network_filter_enabled").(bool)
 
 	enableFreeTier := d.Get("free_tier_enabled").(bool)

--- a/internal/services/cosmos/migration/cosmosdb_account.go
+++ b/internal/services/cosmos/migration/cosmosdb_account.go
@@ -1,0 +1,528 @@
+package migration
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-05-15/cosmosdb"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = CosmosDBAccountV0toV1{}
+
+type CosmosDBAccountV0toV1 struct{}
+
+func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"location": commonschema.Location(),
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"offer_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"analytical_storage": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"schema_type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"capacity": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_throughput_limit": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		// per Microsoft's documentation, as of April 1 2023 the default minimal TLS version for all new accounts is 1.2
+		"minimal_tls_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"create_mode": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		// Per Documentation: "The default identity needs to be explicitly set by the users." This should not be optional without a default anymore.
+		// DOC: https://learn.microsoft.com/en-us/java/api/com.azure.resourcemanager.cosmos.models.databaseaccountupdateparameters?view=azure-java-stable#method-details
+		"default_identity_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "FirstPartyIdentity",
+		},
+
+		"kind": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(cosmosdb.DatabaseAccountKindGlobalDocumentDB),
+		},
+
+		"ip_range_filter": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"free_tier_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"analytical_storage_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"automatic_failover_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: !features.FourPointOhBeta(),
+		},
+
+		"key_vault_key_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"consistency_policy": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"consistency_level": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					// This value can only change if the 'consistency_level' is set to 'BoundedStaleness'
+					"max_interval_in_seconds": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  5,
+					},
+
+					// This value can only change if the 'consistency_level' is set to 'BoundedStaleness'
+					"max_staleness_prefix": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  100,
+					},
+				},
+			},
+		},
+
+		"geo_location": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"location": commonschema.LocationWithoutForceNew(),
+
+					"failover_priority": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+
+					"zone_redundant": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
+
+		"capabilities": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"is_virtual_network_filter_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"virtual_network_rule": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: azure.ValidateResourceID,
+					},
+					"ignore_missing_vnet_service_endpoint": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
+
+		"access_key_metadata_writes_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"local_authentication_disabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"mongo_server_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"multiple_write_locations_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+
+		"network_acl_bypass_for_azure_services": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"network_acl_bypass_ids": {
+			Type:     pluginsdk.TypeList,
+			Optional: true, Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"partition_merge_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"burst_capacity_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"backup": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					// Though `tier` has the default value `Continuous30Days` but `tier` is only for the backup type `Continuous`. So the default value isn't added in the property schema.
+					"tier": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+
+					"interval_in_minutes": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+
+					"retention_in_hours": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+
+					"storage_redundancy": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+
+		"cors_rule": common.SchemaCorsRule(),
+
+		"connection_strings": {
+			Type:      pluginsdk.TypeList,
+			Computed:  true,
+			Sensitive: true,
+			Elem: &pluginsdk.Schema{
+				Type:      pluginsdk.TypeString,
+				Sensitive: true,
+			},
+		},
+
+		"enable_multiple_write_locations": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+
+		"enable_free_tier": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+
+		"enable_automatic_failover": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+
+		"restore": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"source_cosmosdb_account_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"restore_timestamp_in_utc": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"database": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						ForceNew: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ForceNew: true,
+								},
+
+								"collection_names": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									ForceNew: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"gremlin_database": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ForceNew: true,
+								},
+
+								"graph_names": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									ForceNew: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"tables_to_restore": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"read_endpoints": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"write_endpoints": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"primary_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_readonly_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_readonly_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_sql_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_sql_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_readonly_sql_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_readonly_sql_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_mongodb_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_mongodb_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_readonly_mongodb_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_readonly_mongodb_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (c CosmosDBAccountV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		ipfString := rawState["ip_range_filter"].(string)
+		ipfSet := make([]string, 0)
+		if ipfString != "" {
+			ipfSet = strings.Split(ipfString, ",")
+		}
+		rawState["ip_range_filter"] = ipfSet
+
+		return rawState, nil
+	}
+}

--- a/internal/services/cosmos/migration/cosmosdb_account.go
+++ b/internal/services/cosmos/migration/cosmosdb_account.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-05-15/cosmosdb"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -22,18 +19,13 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"location": {
-			Type:             pluginsdk.TypeString,
-			Required:         true,
-			ForceNew:         true,
-			ValidateFunc:     location.EnhancedValidate,
-			StateFunc:        location.StateFunc,
-			DiffSuppressFunc: location.DiffSuppressFunc,
+			Type:     pluginsdk.TypeString,
+			Required: true,
 		},
 
 		"resource_group_name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"offer_type": {
@@ -44,8 +36,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"analytical_storage": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"schema_type": {
@@ -60,7 +50,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"total_throughput_limit": {
@@ -81,20 +70,16 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Computed: true,
-			ForceNew: true,
 		},
 
 		"default_identity_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  "FirstPartyIdentity",
 		},
 
 		"kind": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
-			Default:  string(cosmosdb.DatabaseAccountKindGlobalDocumentDB),
 		},
 
 		"ip_range_filter": {
@@ -110,13 +95,11 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"analytical_storage_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"public_network_access_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  true,
 		},
 
 		"automatic_failover_enabled": {
@@ -128,13 +111,11 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"key_vault_key_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"consistency_policy": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"consistency_level": {
@@ -145,13 +126,11 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"max_interval_in_seconds": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						Default:  5,
 					},
 
 					"max_staleness_prefix": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						Default:  100,
 					},
 				},
 			},
@@ -168,11 +147,8 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					},
 
 					"location": {
-						Type:             pluginsdk.TypeString,
-						Required:         true,
-						ValidateFunc:     location.EnhancedValidate,
-						StateFunc:        location.StateFunc,
-						DiffSuppressFunc: location.DiffSuppressFunc,
+						Type:     pluginsdk.TypeString,
+						Required: true,
 					},
 
 					"failover_priority": {
@@ -183,7 +159,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"zone_redundant": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  false,
 					},
 				},
 			},
@@ -206,7 +181,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"is_virtual_network_filter_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"virtual_network_rule": {
@@ -215,14 +189,12 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"id": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: azure.ValidateResourceID,
+						Type:     pluginsdk.TypeString,
+						Required: true,
 					},
 					"ignore_missing_vnet_service_endpoint": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  false,
 					},
 				},
 			},
@@ -231,13 +203,11 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"access_key_metadata_writes_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  true,
 		},
 
 		"local_authentication_disabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"mongo_server_version": {
@@ -255,7 +225,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"network_acl_bypass_for_azure_services": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"network_acl_bypass_ids": {
@@ -268,20 +237,17 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"partition_merge_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"burst_capacity_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"backup": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"type": {
@@ -319,7 +285,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"identity": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"type": {
@@ -348,13 +313,11 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"cors_rule": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"allowed_origins": {
 						Type:     pluginsdk.TypeList,
 						Required: true,
-						MaxItems: 64,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -363,7 +326,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"exposed_headers": {
 						Type:     pluginsdk.TypeList,
 						Required: true,
-						MaxItems: 64,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -372,7 +334,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"allowed_headers": {
 						Type:     pluginsdk.TypeList,
 						Required: true,
-						MaxItems: 64,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -381,7 +342,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"allowed_methods": {
 						Type:     pluginsdk.TypeList,
 						Required: true,
-						MaxItems: 64,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -426,7 +386,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 		"restore": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"source_cosmosdb_account_id": {
@@ -438,25 +397,21 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"restore_timestamp_in_utc": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 
 					"database": {
 						Type:     pluginsdk.TypeSet,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"name": {
 									Type:     pluginsdk.TypeString,
 									Required: true,
-									ForceNew: true,
 								},
 
 								"collection_names": {
 									Type:     pluginsdk.TypeSet,
 									Optional: true,
-									ForceNew: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
@@ -468,19 +423,16 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"gremlin_database": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"name": {
 									Type:     pluginsdk.TypeString,
 									Required: true,
-									ForceNew: true,
 								},
 
 								"graph_names": {
 									Type:     pluginsdk.TypeList,
 									Optional: true,
-									ForceNew: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
@@ -492,7 +444,6 @@ func (c CosmosDBAccountV0toV1) Schema() map[string]*pluginsdk.Schema {
 					"tables_to_restore": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Migrates the type of `ip_range_filter` from `string` to `set`.
Removes pre-4.0 code paths

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes #27192
Closes #27242


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
