### PR TITLE
`azurerm_bot_service_azure_bot` - send value for `developer_app_insights_api_key`

### DIFF
--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -47,14 +47,14 @@ func TestAccBotServiceAzureBot_completeUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("developer_app_insights_api_key"),
 		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("developer_app_insights_api_key"),
 	})
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `DiffSuppress` on the property was preventing the config value for `developer_app_insights_api_key` from being read and subsequently set in the payload properly. 

When tweaking the logic in the `DiffSuppress` I found that the logic required to correctly read the config value would result in a plan diff after applying because it wouldn't correctly suppress the diff anymore.

I've opted to remove the `DiffSuppress` entirely and set the value for this property in the read by taking it from the config like we do in other resources of the provider where sensitive properties aren't returned by the API.

When upgrading to a version that contains this fix users will receive an `update in-place` diff but it will be a no-op since the value for the property isn't changing. Applying the update will update the resource with the API key value as well as set it into state for the user. Given that this wasn't truly working at all previously, this should be acceptable for a minor release.

## Testing 

![image](https://github.com/user-attachments/assets/34304c13-a878-41f1-91ac-47544f782ebf)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
