### PR TITLE
`azurerm_route_table` - add empty default value for `next_hop_in_ip_address`

### DIFF
--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -90,7 +90,8 @@ func resourceRouteTable() *pluginsdk.Resource {
 						"next_hop_in_ip_address": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Default:      "",
+							ValidateFunc: validation.IsIPv4Address,
 						},
 					},
 				},

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -68,7 +68,7 @@ A `route` block support:
 
 * `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 
-* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.
+* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`. Defaults to `""`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
It supposes that there is a TypeSet property A and this property includes a required sub property B and an optional sub property C. 

```
"A": {
	Type:       pluginsdk.TypeSet,
	Required:   true,
	Elem: &pluginsdk.Resource{
		Schema: map[string]*pluginsdk.Schema{
			"B": {
				Type:     pluginsdk.TypeString,
				Required: true,
			},

			"C": {
				Type:     pluginsdk.TypeString,
				Optional: true,
			},
		},
	},
},
```

At this time, I define a block for TypeSet property A with the required sub property B in tf config like below scenario 1 and run `tf apply`. TF would create the resource successfully without difference. And then I add a new block for TypeSet property A with the required sub property B and the optionl property C in the tf config and run `tf plan`. TF would always indicates that there is the difference on the first block and second block. This is unexpected behavior. Per my understanding, TF shouldn't indicate there is the difference on the first block since I didn't change it in the tf config.

We can try another scenario. If we define a block for TypeSet property A with the required sub property B and the optional sub property in tf config like below scenario 2 and run `tf apply`. TF would create the resource successfully without difference. And then I add a new block for TypeSet property A with the required sub property B and run `tf plan`. TF only indicates there is the difference on the second new block. It's expected behavior.

This issue is reported by customer via MS IcM ticket. After investigated, I found this issue can be fixed by adding empty default value on the optional sub property under the parent TypeSet property. So I raised this PR.

Note: There is a similar case in https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/storagecache/hpc_cache_nfs_target_resource.go#L81.

Scenario 1:
1. Only define a "route" block (TypeSet) without optional sub property "next_hop_in_ip_address" in the tf config and run `tf apply`.
```
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-rt-test04"
  location = "eastus"
}

resource "azurerm_route_table" "test" {
  name                          = "acctestrttest05656"
  location                      = azurerm_resource_group.test.location
  resource_group_name           = azurerm_resource_group.test.name
  bgp_route_propagation_enabled = false

  route {
    name           = "route1"
    address_prefix = "101.1.0.0/16"
    next_hop_type  = "Internet"
  }
}
```

2. Define a new "route" block (TypeSet) with optional sub property "next_hop_in_ip_address" in the tf config and run `tf plan`.
```
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-rt-test04"
  location = "eastus"
}

resource "azurerm_route_table" "test" {
  name                          = "acctestrttest05656"
  location                      = azurerm_resource_group.test.location
  resource_group_name           = azurerm_resource_group.test.name
  bgp_route_propagation_enabled = false

  route {
    name           = "route1"
    address_prefix = "101.1.0.0/16"
    next_hop_type  = "Internet"
  }

  route {
    name                   = "route3"
    address_prefix         = "12.1.0.0/16"
    next_hop_type          = "VirtualAppliance"
    next_hop_in_ip_address = "8.8.8.9"
  }
}
```

3. TF shows unexpected difference.
![image](https://github.com/user-attachments/assets/9628d612-98b5-4c94-bf8a-e79d3ad135c1)

Scenario 2:
1. Only define a "route" block (TypeSet) with optional sub property "next_hop_in_ip_address" in the tf config and run `tf apply`.
```
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-rt-test04"
  location = "eastus"
}

resource "azurerm_route_table" "test" {
  name                          = "acctestrttest05656"
  location                      = azurerm_resource_group.test.location
  resource_group_name           = azurerm_resource_group.test.name
  bgp_route_propagation_enabled = false

  route {
    name                   = "route3"
    address_prefix         = "12.1.0.0/16"
    next_hop_type          = "VirtualAppliance"
    next_hop_in_ip_address = "8.8.8.9"
  }
}
```

2. Define a new "route" block (TypeSet) without optional sub property "next_hop_in_ip_address" in the tf config and run `tf plan`.
```
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-rt-test04"
  location = "eastus"
}

resource "azurerm_route_table" "test" {
  name                          = "acctestrttest05656"
  location                      = azurerm_resource_group.test.location
  resource_group_name           = azurerm_resource_group.test.name
  bgp_route_propagation_enabled = false

  route {
    name                   = "route3"
    address_prefix         = "12.1.0.0/16"
    next_hop_type          = "VirtualAppliance"
    next_hop_in_ip_address = "8.8.8.9"
  }

  route {
    name           = "route1"
    address_prefix = "101.1.0.0/16"
    next_hop_type  = "Internet"
  }
}
```

3. TF shows the expected difference.
![image](https://github.com/user-attachments/assets/446ec990-d4ec-4437-8c3c-3d9e8821ee98)

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/9948303b-60be-4bc4-aa2e-f9649efdf371)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_route_table` - add empty default value for `next_hop_in_ip_address`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
