### PR TITLE
Docs: fix documentation for wrong resource

### DIFF
--- a/website/docs/d/application_gateway.html.markdown
+++ b/website/docs/d/application_gateway.html.markdown
@@ -507,8 +507,6 @@ A `waf_configuration` block exports the following:
 
 * `request_body_check` - Is Request Body Inspection enabled?
 
-* `request_body_enforcement` - Is Request Body limit enabled?
-
 * `max_request_body_size_kb` - The Maximum Request Body Size in KB.
 
 * `exclusion` - One or more `exclusion` blocks as defined below.

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -553,8 +553,6 @@ A `waf_configuration` block supports the following:
 
 * `request_body_check` - (Optional) Is Request Body Inspection enabled? Defaults to `true`.
 
-* `request_body_enforcement` - (Optional) Whether the firewall should block a request with body size greater then `max_request_body_size_kb`. Defaults to `true`.
-
 * `max_request_body_size_kb` - (Optional) The Maximum Request Body Size in KB. Accepted values are in the range `1`KB to `128`KB. Defaults to `128`KB.
 
 * `exclusion` - (Optional) One or more `exclusion` blocks as defined below.

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -190,6 +190,8 @@ The `policy_settings` block supports the following:
 
 * `log_scrubbing` - (Optional) One `log_scrubbing` block as defined below.
 
+* `request_body_enforcement` - (Optional) Whether the firewall should block a request with body size greater then `max_request_body_size_in_kb`. Defaults to `true`.
+
 * `request_body_inspect_limit_in_kb` - (Optional) Specifies the maximum request body inspection limit in KB for the Web Application Firewall. Defaults to `128`.
 
 * `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie validity lifetime in minutes. The user is challenged after the lifetime expires. Accepted values are in the range `5` to `1440`. Defaults to `30`.


### PR DESCRIPTION
[PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/27094/files) supports the property `request_body_enforcement ` for resource `azurerm_web_application_firewall_policy`. However, the documentation is added to resource `azurerm_application_gateway`. Correct the documentation to fix #27290.