### PR TITLE
New resource: `azurerm_key_vault_managed_hardware_security_module_key_rotation_policy`

### DIFF
--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
@@ -329,7 +329,7 @@ resource "azurerm_key_vault_managed_hardware_security_module" "test" {
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
@@ -337,7 +337,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
@@ -29,7 +29,7 @@ func (r KeyVaultMHSMKeyRotationPolicyResource) ModelObject() interface{} {
 
 type MHSMKeyRotationPolicyResourceSchema struct {
 	ManagedHSMKeyID   string `tfschema:"managed_hsm_key_id"`
-	ExipreAfter       string `tfschema:"expire_after"`
+	ExpireAfter       string `tfschema:"expire_after"`
 	TimeAfterCreation string `tfschema:"time_after_creation"`
 	TimeBeforeExpiry  string `tfschema:"time_before_expiry"`
 }
@@ -218,7 +218,7 @@ func (r KeyVaultMHSMKeyRotationPolicyResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			// settign a blank policy to delete the existing policy
+			// setting a blank policy to delete the existing policy
 			if _, err := client.UpdateKeyRotationPolicy(ctx, id.BaseUri(), id.KeyName, keyvault.KeyRotationPolicy{
 				LifetimeActions: pointer.To([]keyvault.LifetimeActions{}),
 				Attributes:      &keyvault.KeyRotationPolicyAttributes{},
@@ -234,8 +234,8 @@ func (r KeyVaultMHSMKeyRotationPolicyResource) Delete() sdk.ResourceFunc {
 func expandKeyRotationPolicy(policy MHSMKeyRotationPolicyResourceSchema) keyvault.KeyRotationPolicy {
 
 	var expiryTime *string // = nil // needs to be set to nil if not set
-	if policy.ExipreAfter != "" {
-		expiryTime = pointer.To(policy.ExipreAfter)
+	if policy.ExpireAfter != "" {
+		expiryTime = pointer.To(policy.ExpireAfter)
 	}
 
 	lifetimeActions := make([]keyvault.LifetimeActions, 0)
@@ -266,7 +266,7 @@ func expandKeyRotationPolicy(policy MHSMKeyRotationPolicyResourceSchema) keyvaul
 func flattenKeyRotationPolicy(p keyvault.KeyRotationPolicy) MHSMKeyRotationPolicyResourceSchema {
 	var res MHSMKeyRotationPolicyResourceSchema
 	if p.Attributes != nil {
-		res.ExipreAfter = pointer.From(p.Attributes.ExpiryTime)
+		res.ExpireAfter = pointer.From(p.Attributes.ExpiryTime)
 	}
 
 	if p.LifetimeActions != nil {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
@@ -60,7 +60,7 @@ func (r KeyVaultMHSMKeyRotationPolicyResource) Arguments() map[string]*pluginsdk
 		"time_after_creation": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ValidateFunc: validate2.ISO8601Duration,
+			ValidateFunc: validate2.ISO8601DurationBetween("P28D", "P100Y"),
 			ExactlyOneOf: []string{
 				"time_after_creation",
 				"time_before_expiry",

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
@@ -80,12 +80,7 @@ func (r KeyVaultMHSMKeyRotationPolicyResource) Arguments() map[string]*pluginsdk
 }
 
 func (r KeyVaultMHSMKeyRotationPolicyResource) Attributes() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-		"versioned_id": {
-			Computed: true,
-			Type:     pluginsdk.TypeString,
-		},
-	}
+	return map[string]*pluginsdk.Schema{}
 }
 
 func (r KeyVaultMHSMKeyRotationPolicyResource) Create() sdk.ResourceFunc {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource.go
@@ -1,0 +1,340 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package managedhsm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+)
+
+type KeyVaultMHSMKeyRotationPolicyResource struct{}
+
+var _ sdk.ResourceWithUpdate = KeyVaultMHSMKeyRotationPolicyResource{}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) ModelObject() interface{} {
+	return &MHSMKeyRotationPolicyResourceSchema{}
+}
+
+type RotateAutomatic struct {
+	TimeAfterCreation string `tfschema:"time_after_creation"`
+	TimeBeforeExpiry  string `tfschema:"time_before_expiry"`
+}
+
+type MHSMKeyRotationPolicyResourceSchema struct {
+	ManagedHSMKeyID    string            `tfschema:"managed_hsm_key_id"`
+	ExipreAfter        string            `tfschema:"expire_after"`
+	NotifyBeforeExpiry string            `tfschema:"notify_before_expiry"`
+	Automatic          []RotateAutomatic `tfschema:"automatic"`
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.ManagedHSMDataPlaneVersionlessKeyID
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) ResourceType() string {
+	return "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy"
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"managed_hsm_key_id": {
+			ForceNew: true,
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+
+		"expire_after": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validate2.ISO8601DurationBetween("P28D", "P100Y"),
+			AtLeastOneOf: []string{
+				"expire_after",
+				"automatic",
+			},
+			RequiredWith: []string{
+				"expire_after",
+				"notify_before_expiry",
+			},
+		},
+
+		// <= expiry_time - 7, >=7
+		"notify_before_expiry": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validate2.ISO8601DurationBetween("P7D", "P36493D"),
+			RequiredWith: []string{
+				"expire_after",
+				"notify_before_expiry",
+			},
+		},
+
+		"automatic": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"time_after_creation": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validate2.ISO8601Duration,
+						AtLeastOneOf: []string{
+							"automatic.0.time_after_creation",
+							"automatic.0.time_before_expiry",
+						},
+					},
+					"time_before_expiry": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validate2.ISO8601Duration,
+						AtLeastOneOf: []string{
+							"automatic.0.time_after_creation",
+							"automatic.0.time_before_expiry",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"versioned_id": {
+			Computed: true,
+			Type:     pluginsdk.TypeString,
+		},
+	}
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ManagedHSMs.DataPlaneKeysClient
+			domainSuffix, ok := metadata.Client.Account.Environment.ManagedHSM.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine Managed HSM domain suffix for environment %q", metadata.Client.Account.Environment.Name)
+			}
+
+			var config MHSMKeyRotationPolicyResourceSchema
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			keyID, err := parse.ManagedHSMDataPlaneVersionlessKeyID(config.ManagedHSMKeyID, domainSuffix)
+			if err != nil {
+				return fmt.Errorf("parsing Managed HSM Key ID: %+v", err)
+			}
+
+			_, err = client.GetKey(ctx, keyID.BaseUri(), keyID.KeyName, "")
+			if err != nil {
+				return fmt.Errorf("checking for the presence of an existing %s: %+v", keyID, err)
+			}
+
+			// check key has rotation policy
+			respPolicy, err := client.GetKeyRotationPolicy(ctx, keyID.BaseUri(), keyID.KeyName)
+			if err != nil {
+				switch {
+				case utils.ResponseWasForbidden(respPolicy.Response):
+					// If client is not authorized to access the policy:
+					return fmt.Errorf("current client lacks permissions to read Key Rotation Policy for Key %q: %v", keyID, err)
+
+				case utils.ResponseWasNotFound(respPolicy.Response):
+					break
+				default:
+					return err
+				}
+			}
+
+			if respPolicy.Attributes != nil && respPolicy.Attributes.ExpiryTime != nil {
+				if respPolicy.LifetimeActions != nil && len(*respPolicy.LifetimeActions) > 0 {
+					return metadata.ResourceRequiresImport(r.ResourceType(), keyID)
+				}
+			}
+
+			if _, err := client.UpdateKeyRotationPolicy(ctx, keyID.BaseUri(), keyID.KeyName, expandKeyRotationPolicy(config)); err != nil {
+				return fmt.Errorf("creating HSM Key Rotation Policy for Key %q: %v", keyID, err)
+			}
+
+			metadata.SetID(keyID)
+			return nil
+		},
+	}
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ManagedHSMs.DataPlaneKeysClient
+			domainSuffix, ok := metadata.Client.Account.Environment.ManagedHSM.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine Managed HSM domain suffix for environment %q", metadata.Client.Account.Environment.Name)
+			}
+
+			id, err := parse.ManagedHSMDataPlaneVersionlessKeyID(metadata.ResourceData.Id(), domainSuffix)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetKeyRotationPolicy(ctx, id.BaseUri(), id.KeyName)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					return metadata.MarkAsGone(*id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			schema := flattenKeyRotationPolicy(resp)
+			schema.ManagedHSMKeyID = id.ID()
+
+			return metadata.Encode(&schema)
+		},
+	}
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ManagedHSMs.DataPlaneRoleAssignmentsClient
+			domainSuffix, ok := metadata.Client.Account.Environment.ManagedHSM.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine Managed HSM domain suffix for environment %q", metadata.Client.Account.Environment.Name)
+			}
+
+			var config MHSMKeyRotationPolicyResourceSchema
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := parse.ManagedHSMDataPlaneVersionlessKeyID(metadata.ResourceData.Id(), domainSuffix)
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.UpdateKeyRotationPolicy(ctx, id.BaseUri(), id.KeyName, expandKeyRotationPolicy(config)); err != nil {
+				return fmt.Errorf("updating HSM Key Rotation Policy for Key %q: %v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r KeyVaultMHSMKeyRotationPolicyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ManagedHSMs.DataPlaneKeysClient
+
+			domainSuffix, ok := metadata.Client.Account.Environment.ManagedHSM.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine Managed HSM domain suffix for environment %q", metadata.Client.Account.Environment.Name)
+			}
+
+			id, err := parse.ManagedHSMDataPlaneVersionlessKeyID(metadata.ResourceData.Id(), domainSuffix)
+			if err != nil {
+				return err
+			}
+
+			// settign a blank policy to delete the existing policy
+			if _, err := client.UpdateKeyRotationPolicy(ctx, id.BaseUri(), id.KeyName, keyvault.KeyRotationPolicy{
+				LifetimeActions: pointer.To([]keyvault.LifetimeActions{}),
+				Attributes:      &keyvault.KeyRotationPolicyAttributes{},
+			}); err != nil {
+				return fmt.Errorf("deleting HSM Key Rotation Policy for Key %q: %v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandKeyRotationPolicy(policy MHSMKeyRotationPolicyResourceSchema) keyvault.KeyRotationPolicy {
+
+	var expiryTime *string // = nil // needs to be set to nil if not set
+	if policy.ExipreAfter != "" {
+		expiryTime = utils.String(policy.ExipreAfter)
+	}
+
+	lifetimeActions := make([]keyvault.LifetimeActions, 0)
+	if policy.NotifyBeforeExpiry != "" {
+		lifetimeActionNotify := keyvault.LifetimeActions{
+			Trigger: &keyvault.LifetimeActionsTrigger{
+				TimeBeforeExpiry: utils.String(policy.NotifyBeforeExpiry), // for Type: keyvault.Notify always TimeBeforeExpiry
+			},
+			Action: &keyvault.LifetimeActionsType{
+				Type: keyvault.ActionTypeNotify,
+			},
+		}
+		lifetimeActions = append(lifetimeActions, lifetimeActionNotify)
+	}
+
+	if len(policy.Automatic) == 1 {
+		lifetimeActionRotate := keyvault.LifetimeActions{
+			Action: &keyvault.LifetimeActionsType{
+				Type: keyvault.ActionTypeRotate,
+			},
+			Trigger: &keyvault.LifetimeActionsTrigger{},
+		}
+		autoItem := policy.Automatic[0]
+
+		if autoItem.TimeAfterCreation != "" {
+			lifetimeActionRotate.Trigger.TimeAfterCreate = pointer.To(autoItem.TimeAfterCreation)
+		}
+
+		if autoItem.TimeBeforeExpiry != "" {
+			lifetimeActionRotate.Trigger.TimeBeforeExpiry = pointer.To(autoItem.TimeBeforeExpiry)
+		}
+
+		lifetimeActions = append(lifetimeActions, lifetimeActionRotate)
+	}
+
+	return keyvault.KeyRotationPolicy{
+		LifetimeActions: &lifetimeActions,
+		Attributes: &keyvault.KeyRotationPolicyAttributes{
+			ExpiryTime: expiryTime,
+		},
+	}
+}
+
+func flattenKeyRotationPolicy(p keyvault.KeyRotationPolicy) MHSMKeyRotationPolicyResourceSchema {
+	var res MHSMKeyRotationPolicyResourceSchema
+	if p.Attributes != nil {
+		res.ExipreAfter = pointer.From(p.Attributes.ExpiryTime)
+	}
+
+	if p.LifetimeActions != nil {
+		for _, ltAction := range *p.LifetimeActions {
+			action := ltAction.Action
+			trigger := ltAction.Trigger
+
+			if action != nil && trigger != nil {
+				switch action.Type {
+				case keyvault.ActionTypeNotify:
+					res.NotifyBeforeExpiry = pointer.From(trigger.TimeBeforeExpiry)
+				case keyvault.ActionTypeRotate:
+					rotate := RotateAutomatic{
+						TimeAfterCreation: pointer.From(trigger.TimeAfterCreate),
+						TimeBeforeExpiry:  pointer.From(trigger.TimeBeforeExpiry),
+					}
+					res.Automatic = append(res.Automatic, rotate)
+				}
+			}
+		}
+	}
+
+	return res
+}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -97,7 +97,7 @@ provider "azurerm" {
 resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "test" {
   managed_hsm_key_id  = azurerm_key_vault_managed_hardware_security_module_key.test.id
   expire_after        = "P60D"
-  time_after_creation = "P3D"
+  time_after_creation = "P28D"
 }
 
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package managedhsm_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type MHSMKeyRotationPolicyTestResource struct{}
+
+func TestAccMHSMKeyRotationPolicy_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_key", "test")
+	r := MHSMKeyRotationPolicyTestResource{}
+
+	print(r.basic(data))
+	t.Skip()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r MHSMKeyRotationPolicyTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	domainSuffix, ok := clients.Account.Environment.ManagedHSM.DomainSuffix()
+	if !ok {
+		return nil, fmt.Errorf("could not determine Managed HSM domain suffix for environment %q", clients.Account.Environment.Name)
+	}
+	id, err := parse.ManagedHSMDataPlaneVersionlessKeyID(state.ID, domainSuffix)
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionId := commonids.NewSubscriptionID(clients.Account.SubscriptionId)
+	resourceManagerId, err := clients.ManagedHSMs.ManagedHSMIDFromBaseUrl(ctx, subscriptionId, id.BaseUri(), domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("determining Resource Manager ID for %q: %+v", id, err)
+	}
+	if resourceManagerId == nil {
+		return nil, fmt.Errorf("unable to determine the Resource Manager ID for %s", id)
+	}
+
+	resp, err := clients.ManagedHSMs.DataPlaneKeysClient.GetKeyRotationPolicy(ctx, id.BaseUri(), id.KeyName)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Attributes != nil), nil
+}
+
+func (r MHSMKeyRotationPolicyTestResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "test" {
+    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.id
+    automatic {
+      time_before_expiry = "P30D"
+    }
+
+    expire_after         = "P60D"
+    notify_before_expiry = "P7D"
+}
+
+`, r.template(data))
+}
+
+func (r MHSMKeyRotationPolicyTestResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "test" {
+    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.id
+    automatic {
+      time_before_expiry = "P3D"
+    }
+
+    expire_after         = "P60D"
+    notify_before_expiry = "P7D"
+}
+
+`, r.template(data))
+}
+
+func (r MHSMKeyRotationPolicyTestResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-KV-%[1]s"
+  location = "%[2]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acc%[3]d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "GetRotationPolicy",
+    ]
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
+    ]
+  }
+  tags = {
+    environment = "Production"
+  }
+}
+resource "azurerm_key_vault_certificate" "cert" {
+  count        = 3
+  name         = "acchsmcert${count.index}"
+  key_vault_id = azurerm_key_vault.test.id
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+    x509_certificate_properties {
+      extended_key_usage = []
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                     = "kvHsm%[3]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+
+  security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
+  security_domain_quorum                    = 3
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
+  scope              = "/keys"
+  role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
+  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
+  scope              = "/keys"
+  role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_key" "test" {
+  name           = "acctestHSMK-%[1]s"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+  key_type       = "EC-HSM"
+  curve          = "P-521"
+  key_opts       = ["sign"]
+
+  depends_on = [
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test1
+  ]
+}
+`, data.RandomString, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -20,7 +20,7 @@ import (
 type MHSMKeyRotationPolicyTestResource struct{}
 
 func testAccMHSMKeyRotationPolicy_all(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_key", "test")
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy", "test")
 	r := MHSMKeyRotationPolicyTestResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -19,7 +19,7 @@ import (
 
 type MHSMKeyRotationPolicyTestResource struct{}
 
-func TestAccMHSMKeyRotationPolicy_update(t *testing.T) {
+func testAccMHSMKeyRotationPolicy_all(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_key", "test")
 	r := MHSMKeyRotationPolicyTestResource{}
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -23,9 +23,6 @@ func TestAccMHSMKeyRotationPolicy_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_key", "test")
 	r := MHSMKeyRotationPolicyTestResource{}
 
-	print(r.basic(data))
-	t.Skip()
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -80,14 +77,11 @@ provider "azurerm" {
 %s
 
 resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "test" {
-    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.id
-    automatic {
-      time_before_expiry = "P30D"
-    }
-
-    expire_after         = "P60D"
-    notify_before_expiry = "P7D"
+  managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.id
+  time_before_expiry = "P30D"
+  expire_after       = "P60D"
 }
+
 
 `, r.template(data))
 }
@@ -101,14 +95,13 @@ provider "azurerm" {
 %s
 
 resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "test" {
-    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.id
-    automatic {
-      time_before_expiry = "P3D"
-    }
-
-    expire_after         = "P60D"
-    notify_before_expiry = "P7D"
+  managed_hsm_key_id  = azurerm_key_vault_managed_hardware_security_module_key.test.id
+  expire_after        = "P60D"
+  time_after_creation = "P3D"
 }
+
+
+
 
 `, r.template(data))
 }
@@ -222,7 +215,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -81,8 +81,6 @@ resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy
   time_before_expiry = "P30D"
   expire_after       = "P60D"
 }
-
-
 `, r.template(data))
 }
 
@@ -99,10 +97,6 @@ resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy
   expire_after        = "P60D"
   time_after_creation = "P28D"
 }
-
-
-
-
 `, r.template(data))
 }
 
@@ -153,6 +147,7 @@ resource "azurerm_key_vault" "test" {
     environment = "Production"
   }
 }
+
 resource "azurerm_key_vault_certificate" "cert" {
   count        = 3
   name         = "acchsmcert${count.index}"
@@ -193,6 +188,7 @@ resource "azurerm_key_vault_certificate" "cert" {
     }
   }
 }
+
 resource "azurerm_key_vault_managed_hardware_security_module" "test" {
   name                     = "kvHsm%[3]d"
   resource_group_name      = azurerm_resource_group.test.name

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -55,7 +55,7 @@ func TestAccKeyVaultManagedHardwareSecurityModule(t *testing.T) {
 			"complete":           testAccKeyVaultMHSMKey_complete,
 			"purge":              testAccKeyVaultHSMKey_purge,
 			"softDeleteRecovery": testAccKeyVaultHSMKey_softDeleteRecovery,
-			"rotationPolicy":     TestAccMHSMKeyRotationPolicy_update,
+			"rotationPolicy":     testAccMHSMKeyRotationPolicy_all,
 		},
 	})
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -55,6 +55,7 @@ func TestAccKeyVaultManagedHardwareSecurityModule(t *testing.T) {
 			"complete":           testAccKeyVaultMHSMKey_complete,
 			"purge":              testAccKeyVaultHSMKey_purge,
 			"softDeleteRecovery": testAccKeyVaultHSMKey_softDeleteRecovery,
+			"rotationPolicy":     TestAccMHSMKeyRotationPolicy_update,
 		},
 	})
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
@@ -161,7 +161,7 @@ data "azurerm_key_vault_managed_hardware_security_module_role_definition" "offic
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = local.assignmentOfficerName
   scope              = "/keys"
   role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.officer.resource_manager_id
@@ -179,7 +179,7 @@ locals {
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = local.assignmentTestName
   scope              = "/keys"
   role_definition_id = azurerm_key_vault_managed_hardware_security_module_role_definition.test.resource_manager_id

--- a/internal/services/managedhsm/registration.go
+++ b/internal/services/managedhsm/registration.go
@@ -57,5 +57,6 @@ func (r Registration) Resources() []sdk.Resource {
 		KeyVaultMHSMKeyResource{},
 		KeyVaultMHSMRoleDefinitionResource{},
 		KeyVaultManagedHSMRoleAssignmentResource{},
+		KeyVaultMHSMKeyRotationPolicyResource{},
 	}
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -5185,7 +5185,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
@@ -5193,7 +5193,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
@@ -5201,7 +5201,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "user" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad20"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"

--- a/website/docs/r/key_vault_managed_hardware_security_module_key.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_key_vault_managed_hardware_security_module" "example" {
 
 // this gives your service principal the HSM Crypto User role which lets you create and destroy hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm-crypto-user" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
@@ -45,7 +45,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "h
 
 // this gives your service principal the HSM Crypto Officer role which lets you purge hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm-crypto-officer" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -32,15 +32,13 @@ resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy
 
 The following arguments are supported:
 
-* `expire_after` - (Required) Specify the expiration time of the key.
-
 * `managed_hsm_key_id` - (Required) The ID of the Managed HSM Key. Changing this forces a new Key Vault to be created.
 
----
+* `expire_after` - (Required) Specify the expiration duration on a newly rotated key as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minumum duration is `P28D`.
 
-* `time_after_creation` - (Optional) Specify the rotation time after creation in the format of ISO86061. Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+* `time_after_creation` - (Optional) Rotate automatically at a duration after create as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 
-* `time_before_expiry` - (Optional) Specify the rotation time before expiration in the format of ISO86061. Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+* `time_before_expiry` - (Optional) Rotate automatically at a duration before expiry as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `time_after_creation` - (Optional) Rotate automatically at a duration after create as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 
-* `time_before_expiry` - (Optional) Rotate automatically at a duration before expiry as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+* `time_before_expiry` - (Optional) Rotate automatically at a duration before key expiry as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -15,7 +15,7 @@ Manages a Managed HSM Key rotation policy.
 ```hcl
 resource "azurerm_key_vault_managed_hardware_security_module_key" "example" {
   name           = "example-key"
-  managed_hsm_id = <azurerm_key_vault_managed_hardware_security_module.example.id>
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.example.id
   key_type       = "EC-HSM"
   curve          = "P-521"
   key_opts       = ["sign"]

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_managed_hardware_security_module_key_rotation_policy"
+description: |-
+  Manages a Managed HSM Key rotation policy.
+---
+
+# azurerm_key_vault_managed_hardware_security_module_key_rotation_policy
+
+Manages a Managed HSM Key rotation policy.
+
+## Example Usage
+
+```hcl
+resource "azurerm_key_vault_managed_hardware_security_module_key" "example" {
+  name           = "example-key"
+  managed_hsm_id = <azurerm_key_vault_managed_hardware_security_module.example.id>
+  key_type       = "EC-HSM"
+  curve          = "P-521"
+  key_opts       = ["sign"]
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy" "example" {
+  managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.example.id
+  expire_after       = "P60D"
+  time_before_expiry = "P30D"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `expire_after` - (Required) Specify the expiration time of the key.
+
+* `managed_hsm_key_id` - (Required) The ID of the Managed HSM Key. Changing this forces a new Key Vault to be created.
+
+---
+
+* `time_after_creation` - (Optional) Specify the rotation time after creation in the format of ISO86061. Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+
+* `time_before_expiry` - (Optional) Specify the rotation time before expiration in the format of ISO86061. Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Managed HSM Key Rotation policy.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Key Vault.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault.
+* `update` - (Defaults to 30 minutes) Used when updating the Key Vault.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault.
+
+## Import
+
+Key Vaults can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_key_vault_managed_hardware_security_module_key_rotation_policy.example https://example-hsm.managedhsm.azure.net/keys/example
+```

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `expire_after` - (Required) Specify the expiration duration on a newly rotated key as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minimum duration is `P28D`.
 
-* `time_after_creation` - (Optional) Rotate automatically at a duration after create as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
+* `time_after_creation` - (Optional) Rotate automatically at a duration after key creation as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 
 * `time_before_expiry` - (Optional) Rotate automatically at a duration before key expiry as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_key_rotation_policy
 
 The following arguments are supported:
 
-* `managed_hsm_key_id` - (Required) The ID of the Managed HSM Key. Changing this forces a new Key Vault to be created.
+* `managed_hsm_key_id` - (Required) The ID of the Managed HSM Key. Changing this forces a new Managed HSM Key rotation policy to be created.
 
 * `expire_after` - (Required) Specify the expiration duration on a newly rotated key as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minimum duration is `P28D`.
 
@@ -50,14 +50,14 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Key Vault.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault.
-* `update` - (Defaults to 30 minutes) Used when updating the Key Vault.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault.
+* `create` - (Defaults to 30 minutes) Used when creating the Managed HSM Key rotation policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Managed HSM Key rotation policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Managed HSM Key rotation policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Managed HSM Key rotation policy.
 
 ## Import
 
-Key Vaults can be imported using the `resource id`, e.g.
+Managed HSM Key rotation policy can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_key_vault_managed_hardware_security_module_key_rotation_policy.example https://example-hsm.managedhsm.azure.net/keys/example

--- a/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key_rotation_policy.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `managed_hsm_key_id` - (Required) The ID of the Managed HSM Key. Changing this forces a new Key Vault to be created.
 
-* `expire_after` - (Required) Specify the expiration duration on a newly rotated key as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minumum duration is `P28D`.
+* `expire_after` - (Required) Specify the expiration duration on a newly rotated key as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minimum duration is `P28D`.
 
 * `time_after_creation` - (Optional) Rotate automatically at a duration after create as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Exactly one of `time_after_creation` or `time_before_expiry` should be specified.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add key rotation policy support for Managed HSM Keys. Since this based on a Data plane API, I created a New resource for it instead of integrating into the Managed HSM Key resource. Based on my test, notification is not supported in MHSM Key. There is only one rotate policy for each key and there is no separation resource/id for it, so the new resource just resuse the managed hsm key id as its resource id.

https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/key-rotation

Given that creating a Managed HSM resource is a heavy operation, I created only one AccTest with both basic and update included. The creation/update of the rotation policy is fast.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


```
--- PASS: TestAccMHSMKeyRotationPolicy_all (2749.04s)
PASS
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_managed_hardware_security_module_key_rotation_policy` - New resource for Managed HSM Key rotation policy

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
