### PR TITLE
`azurerm_kubernetes_cluster` - remove four point oh feature flag

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
@@ -52,19 +51,11 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 		Update: resourceKubernetesClusterUpdate,
 		Delete: resourceKubernetesClusterDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceIdThen(
+		Importer: pluginsdk.ImporterValidatingResourceId(
 			func(id string) error {
 				_, err := commonids.ParseKubernetesClusterID(id)
 				return err
-			},
-
-			func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
-				if !features.FourPointOhBeta() {
-					d.Set("public_network_access_enabled", true)
-				}
-				return []*pluginsdk.ResourceData{d}, nil
-			},
-		),
+			}),
 
 		CustomizeDiff: pluginsdk.CustomDiffInSequence(
 			// The behaviour of the API requires this, but this could be removed when https://github.com/Azure/azure-rest-api-specs/issues/27373 has been addressed
@@ -121,9 +112,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				// Once it is GA, an additional logic is needed to handle the uninstallation of network policy.
 				return old.(string) != ""
 			}),
-			pluginsdk.ForceNewIfChange("custom_ca_trust_certificates_base64", func(ctx context.Context, old, new, meta interface{}) bool {
-				return !features.FourPointOhBeta() && len(old.([]interface{})) > 0 && len(new.([]interface{})) == 0
-			}),
 		),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -154,20 +142,12 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"api_server_access_profile": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Computed: !features.FourPointOhBeta(),
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"authorized_ip_ranges": {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
-							Computed: !features.FourPointOhBeta(),
-							ConflictsWith: func() []string {
-								if !features.FourPointOhBeta() {
-									return []string{"api_server_authorized_ip_ranges"}
-								}
-								return []string{}
-							}(),
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
 								ValidateFunc: validate.CIDR,
@@ -175,6 +155,17 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 					},
 				},
+			},
+
+			"automatic_upgrade_channel": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(managedclusters.UpgradeChannelPatch),
+					string(managedclusters.UpgradeChannelRapid),
+					string(managedclusters.UpgradeChannelStable),
+					string(managedclusters.UpgradeChannelNodeNegativeimage),
+				}, false),
 			},
 
 			"auto_scaler_profile": {
@@ -278,7 +269,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"skip_nodes_with_local_storage": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default:  !features.FourPointOhBeta(),
 						},
 						"skip_nodes_with_system_pods": {
 							Type:     pluginsdk.TypeBool,
@@ -993,22 +983,10 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"network_data_plane": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Computed: !features.FourPointOhBeta(),
-							Default: func() interface{} {
-								if !features.FourPointOhBeta() {
-									return nil
-								}
-								return string(managedclusters.NetworkDataplaneAzure)
-							}(),
+							Default:  string(managedclusters.NetworkDataplaneAzure),
 							ValidateFunc: validation.StringInSlice(
 								managedclusters.PossibleValuesForNetworkDataplane(),
 								false),
-							ConflictsWith: func() []string {
-								if !features.FourPointOhBeta() {
-									return []string{"network_profile.0.ebpf_data_plane"}
-								}
-								return []string{}
-							}(),
 						},
 
 						"network_plugin_mode": {
@@ -1191,6 +1169,18 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
+			"node_os_upgrade_channel": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(managedclusters.NodeOSUpgradeChannelNodeImage),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(managedclusters.NodeOSUpgradeChannelNodeImage),
+					string(managedclusters.NodeOSUpgradeChannelNone),
+					string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
+					string(managedclusters.NodeOSUpgradeChannelUnmanaged),
+				}, false),
+			},
+
 			"node_resource_group": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -1317,6 +1307,17 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
+							},
+						},
+
+						"revisions": {
+							Type:     pluginsdk.TypeList,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 2,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
 							},
 						},
 					},
@@ -1478,322 +1479,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 		resource.Schema[k] = v
 	}
 
-	if !features.FourPointOhBeta() {
-		resource.Schema["enable_pod_security_policy"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Deprecated: "The AKS API has removed support for this field on 2020-10-15 and it is no longer possible to configure Pod Security Policy. This property will be removed in v4.0 of the AzureRM provider.",
-			Optional:   true,
-		}
-		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["ebpf_data_plane"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Computed: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.NetworkDataplaneCilium),
-			}, false),
-			Deprecated:    "This property has been superseded by the property `network_data_plane` and will be removed in v4.0 of the AzureRM provider.",
-			ConflictsWith: []string{"network_profile.0.network_data_plane"},
-		}
-		resource.Schema["api_server_authorized_ip_ranges"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			Computed: true,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validate.CIDR,
-			},
-			Deprecated:    "This property has been renamed to `authorized_ip_ranges` within the `api_server_access_profile` block and will be removed in v4.0 of the provider",
-			ConflictsWith: []string{"api_server_access_profile.0.authorized_ip_ranges"},
-		}
-		resource.Schema["api_server_access_profile"].Elem.(*pluginsdk.Resource).Schema["vnet_integration_enabled"] = &pluginsdk.Schema{
-			Deprecated: "This property is not available in the stable API and will be removed in v4.0 of the Azure Provider. Please see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#aks-migration-to-stable-api for more details.",
-			Type:       pluginsdk.TypeBool,
-			Optional:   true,
-		}
-		resource.Schema["api_server_access_profile"].Elem.(*pluginsdk.Resource).Schema["subnet_id"] = &pluginsdk.Schema{
-			Deprecated:   "This property is not available in the stable API and will be removed in v4.0 of the Azure Provider. Please see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#aks-migration-to-stable-api for more details.",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: commonids.ValidateSubnetID,
-		}
-		resource.Schema["custom_ca_trust_certificates_base64"] = &pluginsdk.Schema{
-			Deprecated: "This property is not available in the stable API and will be removed in v4.0 of the Azure Provider. Please see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#aks-migration-to-stable-api for more details.",
-			Type:       pluginsdk.TypeList,
-			Optional:   true,
-			MaxItems:   10,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.StringIsBase64,
-			},
-		}
-		resource.Schema["storage_profile"].Elem.(*pluginsdk.Resource).Schema["disk_driver_version"] = &pluginsdk.Schema{
-			Deprecated: "This property is not available in the stable API and will be removed in v4.0 of the Azure Provider. Please see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#aks-migration-to-stable-api for more details.",
-			Type:       pluginsdk.TypeString,
-			Optional:   true,
-			Default:    "v1",
-			ValidateFunc: validation.StringInSlice([]string{
-				"v1",
-				"v2",
-			}, false),
-		}
-		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["docker_bridge_cidr"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ForceNew:     true,
-			Deprecated:   "`docker_bridge_cidr` has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.",
-			ValidateFunc: validate.CIDR,
-		}
-		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["network_plugin_mode"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.NetworkPluginModeOverlay),
-				"Overlay",
-			}, false),
-		}
-		resource.Schema["windows_profile"].Elem.(*pluginsdk.Resource).Schema["admin_password"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringLenBetween(8, 123),
-		}
-		resource.Schema["image_cleaner_enabled"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
-			Optional: true,
-			Default:  false,
-		}
-		resource.Schema["image_cleaner_interval_hours"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			Default:      48,
-			ValidateFunc: validation.IntBetween(24, 2160),
-		}
-		resource.Schema["automatic_channel_upgrade"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.UpgradeChannelPatch),
-				string(managedclusters.UpgradeChannelRapid),
-				string(managedclusters.UpgradeChannelStable),
-				string(managedclusters.UpgradeChannelNodeNegativeimage),
-			}, false),
-			Deprecated: features.DeprecatedInFourPointOh("The property `automatic_channel_upgrade` will be renamed to `automatic_upgrade_channel` in v4.0 of the AzureRM Provider."),
-		}
-		resource.Schema["node_os_channel_upgrade"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.NodeOSUpgradeChannelNodeImage),
-				string(managedclusters.NodeOSUpgradeChannelNone),
-				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
-				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
-			}, false),
-			Deprecated: features.DeprecatedInFourPointOh("The property `node_os_channel_upgrade` will be renamed to `node_os_upgrade_channel` in v4.0 of the AzureRM Provider."),
-		}
-		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["outbound_ip_prefix_ids"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeSet,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"},
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: azure.ValidateResourceID,
-			},
-		}
-		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["outbound_ip_address_ids"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeSet,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids"},
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: azure.ValidateResourceID,
-			},
-		}
-		resource.Schema["azure_active_directory_role_based_access_control"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"client_app_id": {
-						Deprecated:   "Azure AD Integration (legacy) (https://aka.ms/aks/aad-legacy) is deprecated and clusters can no longer be created with the Azure AD integration (legacy) enabled. This field will be removed in v4.0 of the AzureRM Provider.",
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.IsUUID,
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-
-					"server_app_id": {
-						Deprecated:   "Azure AD Integration (legacy) (https://aka.ms/aks/aad-legacy) is deprecated and clusters can no longer be created with the Azure AD integration (legacy) enabled. This field will be removed in v4.0 of the AzureRM Provider.",
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.IsUUID,
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-
-					"server_app_secret": {
-						Deprecated:   "Azure AD Integration (legacy) (https://aka.ms/aks/aad-legacy) is deprecated and clusters can no longer be created with the Azure AD integration (legacy) enabled. This field will be removed in v4.0 of the AzureRM Provider.",
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Sensitive:    true,
-						ValidateFunc: validation.StringIsNotEmpty,
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-
-					"tenant_id": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						Computed: true,
-						// OrEmpty since this can be sourced from the client config if it's not specified
-						ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty),
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-
-					"managed": {
-						Deprecated: "Azure AD Integration (legacy) (https://aka.ms/aks/aad-legacy) is deprecated and clusters can no longer be created with the Azure AD integration (legacy) enabled. This field must be supplied with the value `true` for AKS-managed Entra Integration, but will be removed and defaulted to `true` for the user in v4.0 of the AzureRM Provider.",
-						Type:       pluginsdk.TypeBool,
-						Optional:   true,
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-
-					"azure_rbac_enabled": {
-						Type:     pluginsdk.TypeBool,
-						Optional: true,
-					},
-
-					"admin_group_object_ids": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
-						Elem: &pluginsdk.Schema{
-							Type:         pluginsdk.TypeString,
-							ValidateFunc: validation.IsUUID,
-						},
-						AtLeastOneOf: []string{
-							"azure_active_directory_role_based_access_control.0.client_app_id", "azure_active_directory_role_based_access_control.0.server_app_id",
-							"azure_active_directory_role_based_access_control.0.server_app_secret", "azure_active_directory_role_based_access_control.0.tenant_id",
-							"azure_active_directory_role_based_access_control.0.managed", "azure_active_directory_role_based_access_control.0.admin_group_object_ids",
-						},
-					},
-				},
-			},
-		}
-		resource.Schema["workload_autoscaler_profile"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"keda_enabled": {
-						Type:     pluginsdk.TypeBool,
-						Optional: true,
-						Default:  false,
-					},
-					"vertical_pod_autoscaler_enabled": {
-						Type:     pluginsdk.TypeBool,
-						Optional: true,
-						Default:  false,
-					},
-					"vertical_pod_autoscaler_update_mode": {
-						Type:       pluginsdk.TypeString,
-						Computed:   true,
-						Deprecated: "The AKS API has removed support for this field on 2023-07-02-preview and is no longer possible to export this value. This property will be removed in v4.0 of the AzureRM provider.",
-					},
-					"vertical_pod_autoscaler_controlled_values": {
-						Type:       pluginsdk.TypeString,
-						Computed:   true,
-						Deprecated: "The AKS API has removed support for this field on 2023-07-02-preview and is no longer possible to export this value. This property will be removed in v4.0 of the AzureRM provider.",
-					},
-				},
-			},
-		}
-		resource.Schema["web_app_routing"].Elem.(*pluginsdk.Resource).Schema["dns_zone_id"] = &pluginsdk.Schema{
-			Deprecated: "`dns_zone_id` has been deprecated in favor of `dns_zone_ids` and will be removed in v4.0 of the AzureRM Provider.",
-			Type:       pluginsdk.TypeString,
-			Optional:   true,
-			ValidateFunc: validation.Any(
-				dnsValidate.ValidateDnsZoneID,
-				privatezones.ValidatePrivateDnsZoneID,
-				validation.StringIsEmpty,
-			),
-			ConflictsWith: []string{"web_app_routing.0.dns_zone_ids"},
-		}
-		resource.Schema["web_app_routing"].Elem.(*pluginsdk.Resource).Schema["dns_zone_ids"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
-				ValidateFunc: validation.Any(
-					dnsValidate.ValidateDnsZoneID,
-					privatezones.ValidatePrivateDnsZoneID,
-					validation.StringIsEmpty,
-				),
-			},
-			ConflictsWith: []string{"web_app_routing.0.dns_zone_id"},
-		}
-		resource.Schema["public_network_access_enabled"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeBool,
-			Optional:   true,
-			Default:    true,
-			Deprecated: "`public_network_access_enabled` is currently not functional and is not be passed to the API, this property will be removed in v4.0 of the AzureRM provider.",
-		}
-	}
-
-	if features.FourPointOhBeta() {
-		resource.Schema["automatic_upgrade_channel"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.UpgradeChannelPatch),
-				string(managedclusters.UpgradeChannelRapid),
-				string(managedclusters.UpgradeChannelStable),
-				string(managedclusters.UpgradeChannelNodeNegativeimage),
-			}, false),
-		}
-		resource.Schema["node_os_upgrade_channel"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  string(managedclusters.NodeOSUpgradeChannelNodeImage),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedclusters.NodeOSUpgradeChannelNodeImage),
-				string(managedclusters.NodeOSUpgradeChannelNone),
-				string(managedclusters.NodeOSUpgradeChannelSecurityPatch),
-				string(managedclusters.NodeOSUpgradeChannelUnmanaged),
-			}, false),
-		}
-		resource.Schema["service_mesh_profile"].Elem.(*pluginsdk.Resource).Schema["revisions"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Required: true,
-			MinItems: 1,
-			MaxItems: 2,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-		}
-	}
-
 	return resource
 }
 
@@ -1891,12 +1576,6 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	nodeResourceGroup := d.Get("node_resource_group").(string)
 
-	if !features.FourPointOhBeta() {
-		if d.Get("enable_pod_security_policy").(bool) {
-			return fmt.Errorf("the AKS API has removed support for this field on 2020-10-15 and it is no longer possible to configure Pod Security Policy - as such you'll need to set `enable_pod_security_policy` to `false`")
-		}
-	}
-
 	autoScalerProfileRaw := d.Get("auto_scaler_profile").([]interface{})
 	autoScalerProfile := expandKubernetesClusterAutoScalerProfile(autoScalerProfileRaw)
 
@@ -1935,7 +1614,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	if !features.FourPointOhBeta() || d.Get("image_cleaner_enabled").(bool) {
+	if d.Get("image_cleaner_enabled").(bool) {
 		securityProfile.ImageCleaner = &managedclusters.ManagedClusterSecurityProfileImageCleaner{
 			Enabled:       utils.Bool(d.Get("image_cleaner_enabled").(bool)),
 			IntervalHours: utils.Int64(int64(d.Get("image_cleaner_interval_hours").(int))),
@@ -1950,21 +1629,12 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	autoUpgradeProfile := &managedclusters.ManagedClusterAutoUpgradeProfile{}
 
-	var autoChannelUpgrade, nodeOsChannelUpgrade string
-	if !features.FourPointOhBeta() {
-		autoChannelUpgrade = d.Get("automatic_channel_upgrade").(string)
-		nodeOsChannelUpgrade = d.Get("node_os_channel_upgrade").(string)
-	} else {
-		autoChannelUpgrade = d.Get("automatic_upgrade_channel").(string)
-		nodeOsChannelUpgrade = d.Get("node_os_upgrade_channel").(string)
-	}
+	autoChannelUpgrade := d.Get("automatic_upgrade_channel").(string)
+	nodeOsChannelUpgrade := d.Get("node_os_upgrade_channel").(string)
 
 	// this check needs to be separate and gated since node_os_channel_upgrade is a preview feature
 	if nodeOsChannelUpgrade != "" && autoChannelUpgrade != "" {
 		if autoChannelUpgrade == string(managedclusters.UpgradeChannelNodeNegativeimage) && nodeOsChannelUpgrade != string(managedclusters.NodeOSUpgradeChannelNodeImage) {
-			if !features.FourPointOhBeta() {
-				return fmt.Errorf("`node_os_channel_upgrade` cannot be set to a value other than `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
-			}
 			return fmt.Errorf("`node_os_upgrade_channel` cannot be set to a value other than `NodeImage` if `automatic_upgrade_channel` is set to `node-image`")
 		}
 	}
@@ -2257,12 +1927,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		existing.Model.Properties.AzureMonitorProfile = azureMonitorProfile
 	}
 
-	if !features.FourPointOhBeta() {
-		if d.HasChange("enable_pod_security_policy") && d.Get("enable_pod_security_policy").(bool) {
-			return fmt.Errorf("The AKS API has removed support for this field on 2020-10-15 and it is no longer possible to configure Pod Security Policy - as such you'll need to set `enable_pod_security_policy` to `false`")
-		}
-	}
-
 	if d.HasChange("linux_profile") {
 		updateCluster = true
 		linuxProfileRaw := d.Get("linux_profile").([]interface{})
@@ -2405,13 +2069,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			existing.Model.Properties.NetworkProfile.NatGatewayProfile = &natGatewayProfile
 		}
 
-		if !features.FourPointOhBeta() {
-			if key := "network_profile.0.ebpf_data_plane"; d.HasChange(key) {
-				ebpfDataPlane := d.Get(key).(string)
-				existing.Model.Properties.NetworkProfile.NetworkDataplane = pointer.To(managedclusters.NetworkDataplane(ebpfDataPlane))
-			}
-		}
-
 		if d.HasChange("network_profile.0.network_data_plane") {
 			existing.Model.Properties.NetworkProfile.NetworkDataplane = pointer.To(managedclusters.NetworkDataplane(d.Get("network_profile.0.network_data_plane").(string)))
 		}
@@ -2476,10 +2133,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	autoUpgradeChannel := "automatic_upgrade_channel"
 	nodeOsUpgradeChannel := "node_os_upgrade_channel"
-	if !features.FourPointOhBeta() {
-		autoUpgradeChannel = "automatic_channel_upgrade"
-		nodeOsUpgradeChannel = "node_os_channel_upgrade"
-	}
 	if d.HasChange(autoUpgradeChannel) {
 		updateCluster = true
 		if existing.Model.Properties.AutoUpgradeProfile == nil {
@@ -2495,9 +2148,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange(nodeOsUpgradeChannel) {
 		updateCluster = true
 		if d.Get(autoUpgradeChannel).(string) == string(managedclusters.UpgradeChannelNodeNegativeimage) && d.Get(nodeOsUpgradeChannel).(string) != string(managedclusters.NodeOSUpgradeChannelNodeImage) {
-			if !features.FourPointOhBeta() {
-				return fmt.Errorf("`node_os_channel_upgrade` must be set to `NodeImage` if `automatic_channel_upgrade` is set to `node-image`")
-			}
 			return fmt.Errorf("`node_os_upgrade_channel` must be set to `NodeImage` if `automatic_upgrade_channel` is set to `node-image`")
 		}
 		if existing.Model.Properties.AutoUpgradeProfile == nil {
@@ -2662,10 +2312,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		hostEncryptionEnabled := "default_node_pool.0.host_encryption_enabled"
 		nodePublicIpEnabled := "default_node_pool.0.node_public_ip_enabled"
-		if !features.FourPointOhBeta() {
-			hostEncryptionEnabled = "default_node_pool.0.enable_host_encryption"
-			nodePublicIpEnabled = "default_node_pool.0.enable_node_public_ip"
-		}
 
 		cycleNodePoolProperties := []string{
 			"default_node_pool.0.name",
@@ -2889,9 +2535,6 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("disk_encryption_set_id", props.DiskEncryptionSetID)
 			d.Set("kubernetes_version", props.KubernetesVersion)
 			d.Set("current_kubernetes_version", props.CurrentKubernetesVersion)
-			if !features.FourPointOhBeta() {
-				d.Set("enable_pod_security_policy", props.EnablePodSecurityPolicy)
-			}
 			d.Set("local_account_disabled", props.DisableLocalAccounts)
 
 			nodeResourceGroup := ""
@@ -2914,21 +2557,8 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 			}
 
-			if !features.FourPointOhBeta() {
-				d.Set("automatic_channel_upgrade", upgradeChannel)
-			} else {
-				d.Set("automatic_upgrade_channel", upgradeChannel)
-			}
-
-			if !features.FourPointOhBeta() {
-				// this was a preview feature and returns `node_os_channel_upgrade` when `automatic_channel_upgrade` is set to `node-image`
-				// which is why we were only setting this explicitly if it had been set in the config, keeping this as is for now
-				if v, ok := d.GetOk("node_os_channel_upgrade"); ok && v.(string) != "" {
-					d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
-				}
-			} else {
-				d.Set("node_os_upgrade_channel", nodeOSUpgradeChannel)
-			}
+			d.Set("automatic_upgrade_channel", upgradeChannel)
+			d.Set("node_os_upgrade_channel", nodeOSUpgradeChannel)
 
 			enablePrivateCluster := false
 			enablePrivateClusterPublicFQDN := false
@@ -2940,12 +2570,6 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("setting `api_server_access_profile`: %+v", err)
 			}
 			if accessProfile := props.ApiServerAccessProfile; accessProfile != nil {
-				if !features.FourPointOhBeta() {
-					apiServerAuthorizedIPRanges := utils.FlattenStringSlice(accessProfile.AuthorizedIPRanges)
-					if err := d.Set("api_server_authorized_ip_ranges", apiServerAuthorizedIPRanges); err != nil {
-						return fmt.Errorf("setting `api_server_authorized_ip_ranges`: %+v", err)
-					}
-				}
 				if accessProfile.EnablePrivateCluster != nil {
 					enablePrivateCluster = *accessProfile.EnablePrivateCluster
 				}
@@ -3331,12 +2955,6 @@ func expandKubernetesClusterWindowsProfile(input []interface{}) *managedclusters
 }
 
 func expandKubernetesClusterAPIAccessProfile(d *pluginsdk.ResourceData) *managedclusters.ManagedClusterAPIServerAccessProfile {
-	apiServerAuthorizedIPRangesRaw := []interface{}{}
-	if !features.FourPointOhBeta() {
-		apiServerAuthorizedIPRangesRaw = d.Get("api_server_authorized_ip_ranges").(*pluginsdk.Set).List()
-	}
-	apiServerAuthorizedIPRanges := utils.ExpandStringSlice(apiServerAuthorizedIPRangesRaw)
-
 	enablePrivateCluster := false
 	if v, ok := d.GetOk("private_cluster_enabled"); ok {
 		enablePrivateCluster = v.(bool)
@@ -3344,7 +2962,7 @@ func expandKubernetesClusterAPIAccessProfile(d *pluginsdk.ResourceData) *managed
 
 	apiAccessProfile := &managedclusters.ManagedClusterAPIServerAccessProfile{
 		EnablePrivateCluster:           &enablePrivateCluster,
-		AuthorizedIPRanges:             apiServerAuthorizedIPRanges,
+		AuthorizedIPRanges:             &[]string{},
 		EnablePrivateClusterPublicFQDN: utils.Bool(d.Get("private_cluster_public_fqdn_enabled").(bool)),
 		DisableRunCommand:              utils.Bool(!d.Get("run_command_enabled").(bool)),
 	}
@@ -3536,12 +3154,6 @@ func expandKubernetesClusterNetworkProfile(input []interface{}) (*managedcluster
 		networkProfile.NetworkDataplane = pointer.To(managedclusters.NetworkDataplane(networkDataPlane))
 	}
 
-	if !features.FourPointOhBeta() {
-		if ebpfDataPlane := config["ebpf_data_plane"].(string); ebpfDataPlane != "" {
-			networkProfile.NetworkDataplane = pointer.To(managedclusters.NetworkDataplane(ebpfDataPlane))
-		}
-	}
-
 	if networkPluginMode := config["network_plugin_mode"].(string); networkPluginMode != "" {
 		networkProfile.NetworkPluginMode = pointer.To(managedclusters.NetworkPluginMode(networkPluginMode))
 	}
@@ -3720,16 +3332,6 @@ func flattenKubernetesClusterNetworkProfile(profile *managedclusters.ContainerSe
 		dnsServiceIP = *profile.DnsServiceIP
 	}
 
-	dockerBridgeCidr := ""
-	if !features.FourPointOhBeta() {
-		if len(raw) != 0 && raw[0] != nil {
-			config := raw[0].(map[string]interface{})
-			if v, ok := config["docker_bridge_cidr"]; ok && v.(string) != "" {
-				dockerBridgeCidr = v.(string)
-			}
-		}
-	}
-
 	serviceCidr := ""
 	if profile.ServiceCidr != nil {
 		serviceCidr = *profile.ServiceCidr
@@ -3870,18 +3472,6 @@ func flattenKubernetesClusterNetworkProfile(profile *managedclusters.ContainerSe
 		"outbound_type":         outboundType,
 	}
 
-	if !features.FourPointOhBeta() {
-		result["docker_bridge_cidr"] = dockerBridgeCidr
-
-		ebpfDataPlane := ""
-		// 2023-02-02-preview returns the default value `azure` for this new property
-		// @stephybun: we should look into replacing `ebpf_data_plane` with a new property called `network_data_plane`
-		if v := profile.NetworkDataplane; v != nil && *v != managedclusters.NetworkDataplaneAzure {
-			ebpfDataPlane = string(*v)
-		}
-		result["ebpf_data_plane"] = ebpfDataPlane
-	}
-
 	return []interface{}{result}
 }
 
@@ -3892,65 +3482,14 @@ func expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(input []i
 
 	azureAdRaw := input[0].(map[string]interface{})
 
-	if features.FourPointOhBeta() {
-		adminGroupObjectIdsRaw := azureAdRaw["admin_group_object_ids"].([]interface{})
-		adminGroupObjectIds := utils.ExpandStringSlice(adminGroupObjectIdsRaw)
-		return &managedclusters.ManagedClusterAADProfile{
-			TenantID:            pointer.To(azureAdRaw["tenant_id"].(string)),
-			Managed:             pointer.To(true),
-			AdminGroupObjectIDs: adminGroupObjectIds,
-			EnableAzureRBAC:     pointer.To(azureAdRaw["azure_rbac_enabled"].(bool)),
-		}, nil
-	}
-
-	var aad *managedclusters.ManagedClusterAADProfile
-	clientAppId := azureAdRaw["client_app_id"].(string)
-	serverAppId := azureAdRaw["server_app_id"].(string)
-	serverAppSecret := azureAdRaw["server_app_secret"].(string)
-	tenantId := azureAdRaw["tenant_id"].(string)
-	managed := azureAdRaw["managed"].(bool)
-	azureRbacEnabled := azureAdRaw["azure_rbac_enabled"].(bool)
 	adminGroupObjectIdsRaw := azureAdRaw["admin_group_object_ids"].([]interface{})
 	adminGroupObjectIds := utils.ExpandStringSlice(adminGroupObjectIdsRaw)
-
-	if tenantId == "" {
-		tenantId = providerTenantId
-	}
-
-	if managed {
-		aad = &managedclusters.ManagedClusterAADProfile{
-			TenantID:            utils.String(tenantId),
-			Managed:             utils.Bool(managed),
-			AdminGroupObjectIDs: adminGroupObjectIds,
-			EnableAzureRBAC:     utils.Bool(azureRbacEnabled),
-		}
-
-		if clientAppId != "" || serverAppId != "" || serverAppSecret != "" {
-			return nil, fmt.Errorf("can't specify client_app_id or server_app_id or server_app_secret when using managed aad rbac (managed = true)")
-		}
-	} else {
-		aad = &managedclusters.ManagedClusterAADProfile{
-			ClientAppID:     utils.String(clientAppId),
-			ServerAppID:     utils.String(serverAppId),
-			ServerAppSecret: utils.String(serverAppSecret),
-			TenantID:        utils.String(tenantId),
-			Managed:         utils.Bool(managed),
-		}
-
-		if len(*adminGroupObjectIds) > 0 {
-			return nil, fmt.Errorf("can't specify admin_group_object_ids when using managed aad rbac (managed = false)")
-		}
-
-		if clientAppId == "" || serverAppId == "" || serverAppSecret == "" {
-			return nil, fmt.Errorf("you must specify client_app_id and server_app_id and server_app_secret when using managed aad rbac (managed = false)")
-		}
-
-		if azureRbacEnabled {
-			return nil, fmt.Errorf("you must enable Managed AAD before Azure RBAC can be enabled")
-		}
-	}
-
-	return aad, nil
+	return &managedclusters.ManagedClusterAADProfile{
+		TenantID:            pointer.To(azureAdRaw["tenant_id"].(string)),
+		Managed:             pointer.To(true),
+		AdminGroupObjectIDs: adminGroupObjectIds,
+		EnableAzureRBAC:     pointer.To(azureAdRaw["azure_rbac_enabled"].(bool)),
+	}, nil
 }
 
 func expandKubernetesClusterManagedClusterIdentity(input []interface{}) (*identity.SystemOrUserAssignedMap, error) {
@@ -3975,61 +3514,6 @@ func expandKubernetesClusterManagedClusterIdentity(input []interface{}) (*identi
 
 func flattenKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(input *managedclusters.ManagedClusterProperties, d *pluginsdk.ResourceData) []interface{} {
 	results := make([]interface{}, 0)
-	if !features.FourPointOhBeta() {
-		if profile := input.AadProfile; profile != nil {
-			adminGroupObjectIds := utils.FlattenStringSlice(profile.AdminGroupObjectIDs)
-
-			clientAppId := ""
-			if profile.ClientAppID != nil {
-				clientAppId = *profile.ClientAppID
-			}
-
-			managed := false
-			if profile.Managed != nil {
-				managed = *profile.Managed
-			}
-
-			azureRbacEnabled := false
-			if profile.EnableAzureRBAC != nil {
-				azureRbacEnabled = *profile.EnableAzureRBAC
-			}
-
-			serverAppId := ""
-			if profile.ServerAppID != nil {
-				serverAppId = *profile.ServerAppID
-			}
-
-			serverAppSecret := ""
-			// since input.ServerAppSecret isn't returned we're pulling this out of the existing state (which won't work for Imports)
-			// azure_active_directory_role_based_access_control.0.server_app_secret
-			if existing, ok := d.GetOk("azure_active_directory_role_based_access_control"); ok {
-				aadRbacRaw := existing.([]interface{})
-				if len(aadRbacRaw) > 0 {
-					aadRbac := aadRbacRaw[0].(map[string]interface{})
-					if v := aadRbac["server_app_secret"]; v != nil {
-						serverAppSecret = v.(string)
-					}
-				}
-			}
-
-			tenantId := ""
-			if profile.TenantID != nil {
-				tenantId = *profile.TenantID
-			}
-
-			results = append(results, map[string]interface{}{
-				"admin_group_object_ids": adminGroupObjectIds,
-				"client_app_id":          clientAppId,
-				"managed":                managed,
-				"server_app_id":          serverAppId,
-				"server_app_secret":      serverAppSecret,
-				"tenant_id":              tenantId,
-				"azure_rbac_enabled":     azureRbacEnabled,
-			})
-		}
-
-		return results
-	}
 
 	if profile := input.AadProfile; profile != nil {
 		adminGroupObjectIds := utils.FlattenStringSlice(profile.AdminGroupObjectIDs)
@@ -4820,10 +4304,8 @@ func expandKubernetesClusterServiceMeshProfile(input []interface{}, existing *ma
 			profile.Istio.CertificateAuthority = certificateAuthority
 		}
 
-		if features.FourPointOhBeta() {
-			if raw["revisions"] != nil {
-				profile.Istio.Revisions = utils.ExpandStringSlice(raw["revisions"].([]interface{}))
-			}
+		if raw["revisions"] != nil {
+			profile.Istio.Revisions = utils.ExpandStringSlice(raw["revisions"].([]interface{}))
 		}
 	}
 
@@ -4866,12 +4348,6 @@ func expandKubernetesClusterIngressProfile(d *pluginsdk.ResourceData, input []in
 	}
 	if input[0] != nil {
 		config := input[0].(map[string]interface{})
-		if !features.FourPointOhBeta() {
-			dnsZoneResourceId := config["dns_zone_id"].(string)
-			if dnsZoneResourceId != "" {
-				out.WebAppRouting.DnsZoneResourceIds = pointer.To([]string{dnsZoneResourceId})
-			}
-		}
 		if v := config["dns_zone_ids"]; v != nil {
 			if dnsZoneResourceIds, ok := v.([]interface{}); ok && len(dnsZoneResourceIds) > 0 {
 				out.WebAppRouting.DnsZoneResourceIds = utils.ExpandStringSlice(dnsZoneResourceIds)
@@ -4887,20 +4363,7 @@ func flattenKubernetesClusterIngressProfile(input *managedclusters.ManagedCluste
 	}
 
 	out := map[string]interface{}{}
-	useDnsZoneId := false
-	if !features.FourPointOhBeta() {
-		if len(old) > 0 && old[0] != nil {
-			oldConfig := old[0].(map[string]interface{})
-			useDnsZoneId = oldConfig["dns_zone_id"].(string) != ""
-		}
-	}
-	if useDnsZoneId {
-		if v := input.WebAppRouting.DnsZoneResourceIds; v != nil && len(*v) != 0 {
-			out["dns_zone_id"] = (*v)[0]
-		}
-	} else {
-		out["dns_zone_ids"] = utils.FlattenStringSlice(input.WebAppRouting.DnsZoneResourceIds)
-	}
+	out["dns_zone_ids"] = utils.FlattenStringSlice(input.WebAppRouting.DnsZoneResourceIds)
 
 	webAppRoutingIdentity := []interface{}{}
 
@@ -4972,10 +4435,8 @@ func flattenKubernetesClusterAzureServiceMeshProfile(input *managedclusters.Serv
 		returnMap["certificate_authority"] = flattenKubernetesClusterServiceMeshProfileCertificateAuthority(input.Istio.CertificateAuthority)
 	}
 
-	if features.FourPointOhBeta() {
-		if input.Istio.Revisions != nil {
-			returnMap["revisions"] = utils.FlattenStringSlice(input.Istio.Revisions)
-		}
+	if input.Istio.Revisions != nil {
+		returnMap["revisions"] = utils.FlattenStringSlice(input.Istio.Revisions)
 	}
 
 	return []interface{}{returnMap}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2953,7 +2953,6 @@ func expandKubernetesClusterAPIAccessProfile(d *pluginsdk.ResourceData) *managed
 
 	apiAccessProfile := &managedclusters.ManagedClusterAPIServerAccessProfile{
 		EnablePrivateCluster:           &enablePrivateCluster,
-		AuthorizedIPRanges:             &[]string{},
 		EnablePrivateClusterPublicFQDN: utils.Bool(d.Get("private_cluster_public_fqdn_enabled").(bool)),
 		DisableRunCommand:              utils.Bool(!d.Get("run_command_enabled").(bool)),
 	}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1554,10 +1554,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	var azureADProfile *managedclusters.ManagedClusterAADProfile
 	if v, ok := d.GetOk("azure_active_directory_role_based_access_control"); ok {
-		azureADProfile, err = expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(v.([]interface{}))
-		if err != nil {
-			return err
-		}
+		azureADProfile = expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(v.([]interface{}))
 	}
 
 	t := d.Get("tags").(map[string]interface{})
@@ -1872,10 +1869,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	if d.HasChange("azure_active_directory_role_based_access_control") {
 		azureADRaw := d.Get("azure_active_directory_role_based_access_control").([]interface{})
-		azureADProfile, err := expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(azureADRaw)
-		if err != nil {
-			return err
-		}
+		azureADProfile := expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(azureADRaw)
 
 		props.AadProfile = azureADProfile
 		if props.AadProfile != nil && (props.AadProfile.Managed == nil || !*props.AadProfile.Managed) {
@@ -3472,9 +3466,9 @@ func flattenKubernetesClusterNetworkProfile(profile *managedclusters.ContainerSe
 	return []interface{}{result}
 }
 
-func expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(input []interface{}) (*managedclusters.ManagedClusterAADProfile, error) {
+func expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(input []interface{}) *managedclusters.ManagedClusterAADProfile {
 	if len(input) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	azureAdRaw := input[0].(map[string]interface{})
@@ -3486,7 +3480,7 @@ func expandKubernetesClusterAzureActiveDirectoryRoleBasedAccessControl(input []i
 		Managed:             pointer.To(true),
 		AdminGroupObjectIDs: adminGroupObjectIds,
 		EnableAzureRBAC:     pointer.To(azureAdRaw["azure_rbac_enabled"].(bool)),
-	}, nil
+	}
 }
 
 func expandKubernetesClusterManagedClusterIdentity(input []interface{}) (*identity.SystemOrUserAssignedMap, error) {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -851,47 +850,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func (KubernetesClusterResource) storageProfile(data acceptance.TestData, controlPlaneVersion string) string {
-	if !features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
-}
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
-  kubernetes_version  = %q
-
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-    upgrade_settings {
-      max_surge = "10%%"
-    }
-  }
-
-  identity {
-    type = "SystemAssigned"
-  }
-
-  storage_profile {
-    blob_driver_enabled         = true
-    disk_driver_enabled         = true
-    disk_driver_version         = "v1"
-    file_driver_enabled         = false
-    snapshot_controller_enabled = false
-  }
-}
-  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion)
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/applicationsecuritygroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/publicipprefixes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -1136,14 +1135,6 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 	nodeLabelsRaw := raw["node_labels"].(map[string]interface{})
 	nodeLabels := expandNodeLabels(nodeLabelsRaw)
 	var nodeTaints *[]string
-	if !features.FourPointOhBeta() {
-		nodeTaintsRaw := raw["node_taints"].([]interface{})
-		nodeTaints = utils.ExpandStringSlice(nodeTaintsRaw)
-	}
-
-	if !features.FourPointOhBeta() && len(*nodeTaints) != 0 {
-		return nil, fmt.Errorf("The AKS API has removed support for tainting all nodes in the default node pool and it is no longer possible to configure this. To taint a node pool, create a separate one.")
-	}
 
 	criticalAddonsEnabled := raw["only_critical_addons_enabled"].(bool)
 	if criticalAddonsEnabled {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
