### PR TITLE
`azurerm_data_protection_backup_policy_blob_storage` : remove deprecated property `retention_duration`

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -100,17 +99,6 @@ resource "azurerm_data_protection_backup_vault" "test" {
 
 func (r DataProtectionBackupPolicyBlobStorageResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
-	if !features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
-  name               = "acctest-dbp-%d"
-  vault_id           = azurerm_data_protection_backup_vault.test.id
-  retention_duration = "P30D"
-}
-`, template, data.RandomInteger)
-	}
 	return fmt.Sprintf(`
 %s
 
@@ -124,46 +112,6 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
 
 func (r DataProtectionBackupPolicyBlobStorageResource) vaultBackup(data acceptance.TestData) string {
 	template := r.template(data)
-	if !features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
-  name                             = "acctest-dbp-%d"
-  vault_id                         = azurerm_data_protection_backup_vault.test.id
-  retention_duration               = "P30D"
-  vault_default_retention_duration = "P7D"
-  backup_repeating_time_intervals  = ["R/2024-05-08T11:30:00+00:00/P1W"]
-
-  retention_rule {
-    name     = "Monthly"
-    priority = 15
-    life_cycle {
-      duration        = "P6M"
-      data_store_type = "VaultStore"
-    }
-    criteria {
-      days_of_month = [1, 2, 0]
-    }
-  }
-
-  retention_rule {
-    name     = "Daily"
-    priority = 25
-    life_cycle {
-      duration        = "P7D"
-      data_store_type = "VaultStore"
-    }
-    criteria {
-      days_of_week           = ["Thursday"]
-      months_of_year         = ["November"]
-      weeks_of_month         = ["First"]
-      scheduled_backup_times = ["2024-05-08T02:30:00Z"]
-    }
-  }
-}
-`, template, data.RandomInteger)
-	}
 	return fmt.Sprintf(`
 %s
 
@@ -206,17 +154,6 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
 
 func (r DataProtectionBackupPolicyBlobStorageResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
-	if !features.FourPointOhBeta() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_data_protection_backup_policy_blob_storage" "import" {
-  name               = azurerm_data_protection_backup_policy_blob_storage.test.name
-  vault_id           = azurerm_data_protection_backup_policy_blob_storage.test.vault_id
-  retention_duration = "P30D"
-}
-`, config)
-	}
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
Remove the FourPointOhBeta() condition check:

- Remove deprecated property `retention_duration`.
- Remove computed = true for property `operational_default_retention_duration`.
- Remove  computed = true for property `vault_default_retention_duration`.

Related PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/25970