### PR TITLE
`azurerm_api_management_diagnostic` : remove default value for property `operation_name_format`

### DIFF
--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/logger"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
@@ -115,12 +114,6 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 			"operation_name_format": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default: func() interface{} {
-					if !features.FourPointOh() {
-						return string(diagnostic.OperationNameFormatName)
-					}
-					return nil
-				}(),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(diagnostic.OperationNameFormatName),
 					string(diagnostic.OperationNameFormatUrl),
@@ -160,8 +153,6 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 	if d.Get("identifier") == "applicationinsights" {
 		if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
 			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
-		} else if !features.FourPointOh() {
-			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
 		}
 	}
 
@@ -274,9 +265,6 @@ func resourceApiManagementDiagnosticRead(d *pluginsdk.ResourceData, meta interfa
 			}
 
 			format := ""
-			if !features.FourPointOh() {
-				format = string(diagnostic.OperationNameFormatName)
-			}
 			if props.OperationNameFormat != nil {
 				format = string(pointer.From(props.OperationNameFormat))
 			}


### PR DESCRIPTION
Remove the FourPointOhBeta() condition check:

Remove default value for property `operation_name_format`.

Related PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/23736
