### PR TITLE
[TestCase] `azurerm_bot_channel_direct_line_speech` - fix acctest

### DIFF
--- a/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
+++ b/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -26,11 +25,7 @@ func TestAccBotChannelDirectLineSpeech_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cognitiveAccount(data),
-		},
-		{
-			PreConfig: func() { time.Sleep(5 * time.Minute) },
-			Config:    r.basic(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -45,11 +40,7 @@ func TestAccBotChannelDirectLineSpeech_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cognitiveAccount(data),
-		},
-		{
-			PreConfig: func() { time.Sleep(5 * time.Minute) },
-			Config:    r.basic(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -64,11 +55,7 @@ func TestAccBotChannelDirectLineSpeech_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cognitiveAccount(data),
-		},
-		{
-			PreConfig: func() { time.Sleep(5 * time.Minute) },
-			Config:    r.complete(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -83,22 +70,14 @@ func TestAccBotChannelDirectLineSpeech_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cognitiveAccount(data),
-		},
-		{
-			PreConfig: func() { time.Sleep(5 * time.Minute) },
-			Config:    r.complete(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("cognitive_service_location", "cognitive_service_access_key"), // not returned from API
 		{
-			Config: r.cognitiveAccountForUpdate(data),
-		},
-		{
-			PreConfig: func() { time.Sleep(5 * time.Minute) },
-			Config:    r.update(data),
+			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -139,12 +118,20 @@ func (BotChannelDirectLineSpeechResource) basic(data acceptance.TestData) string
 	return fmt.Sprintf(`
 %s
 
+resource "time_sleep" "wait_5_minute" {
+  depends_on = [azurerm_cognitive_account.test]
+
+  create_duration = "5m"
+}
+
 resource "azurerm_bot_channel_direct_line_speech" "test" {
   bot_name                     = azurerm_bot_channels_registration.test.name
   location                     = azurerm_bot_channels_registration.test.location
   resource_group_name          = azurerm_resource_group.test.name
   cognitive_service_location   = azurerm_cognitive_account.test.location
   cognitive_service_access_key = azurerm_cognitive_account.test.primary_access_key
+
+  depends_on = [time_sleep.wait_5_minute]
 }
 `, BotChannelDirectLineSpeechResource{}.cognitiveAccount(data))
 }
@@ -167,6 +154,12 @@ func (BotChannelDirectLineSpeechResource) complete(data acceptance.TestData) str
 	return fmt.Sprintf(`
 %s
 
+resource "time_sleep" "wait_5_minute" {
+  depends_on = [azurerm_cognitive_account.test]
+
+  create_duration = "5m"
+}
+
 resource "azurerm_bot_channel_direct_line_speech" "test" {
   bot_name                     = azurerm_bot_channels_registration.test.name
   location                     = azurerm_bot_channels_registration.test.location
@@ -176,6 +169,8 @@ resource "azurerm_bot_channel_direct_line_speech" "test" {
   cognitive_service_access_key = azurerm_cognitive_account.test.primary_access_key
   custom_speech_model_id       = "a9316355-7b04-4468-9f6e-114419e6c9cc"
   custom_voice_deployment_id   = "58dd86d4-31e3-4cf7-9b17-ee1d3dd77695"
+
+  depends_on = [time_sleep.wait_5_minute]
 }
 `, BotChannelDirectLineSpeechResource{}.cognitiveAccount(data))
 }
@@ -203,6 +198,12 @@ func (BotChannelDirectLineSpeechResource) update(data acceptance.TestData) strin
 	return fmt.Sprintf(`
 %s
 
+resource "time_sleep" "wait_5_minute" {
+  depends_on = [azurerm_cognitive_account.test, azurerm_cognitive_account.test2]
+
+  create_duration = "5m"
+}
+
 resource "azurerm_bot_channel_direct_line_speech" "test" {
   bot_name                     = azurerm_bot_channels_registration.test.name
   location                     = azurerm_bot_channels_registration.test.location
@@ -212,6 +213,8 @@ resource "azurerm_bot_channel_direct_line_speech" "test" {
   cognitive_service_access_key = azurerm_cognitive_account.test2.primary_access_key
   custom_speech_model_id       = "cf7a4202-9be3-4195-9619-5a747260626d"
   custom_voice_deployment_id   = "b815f623-c217-4327-b765-f6e0fd7dceef"
+
+  depends_on = [time_sleep.wait_5_minute]
 }
 `, BotChannelDirectLineSpeechResource{}.cognitiveAccountForUpdate(data))
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently test cases related with Bot Channel Direct Line Speech failed on Teamcity Daily Run. After I checked, I noticed that TF complains that the target resource under test cannot be found when this target resource under test isn't defined in the config of the test steps as prerequisite.

Note: As service team confirmed that it needs to wait a moment until cognitive account is ready and then create direct line speech channel after cognitive account is created, so waiting logic is still needed in the test case. And service team mentioned that user wouldn't immediately create Bot Channel Direct Line Speech after Cognitive Account is created as real business scenario.

Error Message:
```
=== CONT  TestAccBotChannelDirectLineSpeech_update
    testcase.go:173: Step 1/8 error: Pre-apply plan check(s) failed:
        azurerm_bot_channel_direct_line_speech.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccBotChannelDirectLineSpeech_update (13.00s)
```
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![image](https://github.com/user-attachments/assets/62e410b7-d688-4f12-b6a6-ce314406fe74)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] `azurerm_bot_channel_direct_line_speech` - fix acctest


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
