### PR TITLE
log_analytics_solution_resource - updated import validation to include () and []

### DIFF
--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -224,13 +224,31 @@ func (s LogAnalyticsSolutionResource) Read() sdk.ResourceFunc {
 				// expecting resp.Name to be in format "SolutionName(WorkspaceName)".
 				if v := model.Name; v != nil {
 					val := pointer.From(v)
-					segments := strings.Split(val, "(")
-					if len(segments) != 2 {
-						return fmt.Errorf("expected %q to match 'Solution(WorkspaceName)'", val)
+
+					var segments []string
+					var solutionName, workspaceName string
+
+					if strings.Contains(val, "(") && strings.Contains(val, ")") {
+						// Handle case with parentheses
+						segments = strings.Split(val, "(")
+						if len(segments) != 2 {
+							return fmt.Errorf("expected %q to match 'Solution(WorkspaceName)'", val)
+						}
+						solutionName = segments[0]
+						workspaceName = strings.TrimSuffix(segments[1], ")")
+					} else if strings.Contains(val, "[") && strings.Contains(val, "]") {
+						// Handle case with square brackets
+						segments = strings.Split(val, "[")
+						if len(segments) != 2 {
+							return fmt.Errorf("expected %q to match 'Solution[WorkspaceName]'", val)
+						}
+						solutionName = segments[0]
+						workspaceName = strings.TrimSuffix(segments[1], "]")
+					} else {
+						return fmt.Errorf("expected %q to match either 'Solution(WorkspaceName)' or 'Solution[WorkspaceName]'", val)
 					}
 
-					solutionName := segments[0]
-					workspaceName := strings.TrimSuffix(segments[1], ")")
+					// Set extracted values
 					state.SolutionName = solutionName
 					state.WorkspaceName = workspaceName
 				}


### PR DESCRIPTION
I have updated the validation to ensure that it allows both Solution(WorkspaceName) and Solution[WorkspaceName] when importing resources

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When importing Log Analytics Solutions into TFState, some will failed due to them not being the the correct format expected by this provider.

Typically, the LA Solution will be in the format of Solution(WorkspaceName) (note; using parenthesis), however on some resources, they will be in the format of Solution[WorkspaceName] (note; using brackets). 

Currently the provider will throw an error suggesting that the solution has to be in the parenthesis format. I have updated the validation so that it will allow both parenthesis and brackets as both are possible. If the format does not match these, then it will throw an error.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_solution` - support for importing resource IDs with parenthesis and brackets.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #10230


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
