### PR TITLE
`subscriptions` - Fix `TestAccLocationDataSource_eastUS`

### DIFF
--- a/internal/services/subscription/extended_locations_data_source_test.go
+++ b/internal/services/subscription/extended_locations_data_source_test.go
@@ -33,7 +33,7 @@ func TestAccDataSourceExtendedLocations_westUS(t *testing.T) {
 			Config: ExtendedLocationsDataSource{}.basic("westus"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("extended_locations.#").HasValue("1"),
-				check.That(data.ResourceName).Key("extended_locations.0").HasValue("microsoftlosangeles1"),
+				check.That(data.ResourceName).Key("extended_locations.0").HasValue("losangeles"),
 			),
 		},
 	})

--- a/internal/services/subscription/location_data_source_test.go
+++ b/internal/services/subscription/location_data_source_test.go
@@ -25,14 +25,14 @@ func TestAccLocationDataSource_NonExistingRegion(t *testing.T) {
 	})
 }
 
-func TestAccLocationDataSource_westUS(t *testing.T) {
+func TestAccLocationDataSource_eastUS(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_location", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: LocationsDataSource{}.basic("westus"),
+			Config: LocationsDataSource{}.basic("eastus"),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("display_name").HasValue("West US"),
+				check.That(data.ResourceName).Key("display_name").HasValue("East US"),
 				check.That(data.ResourceName).Key("zone_mappings.0.logical_zone").HasValue("1"),
 				check.That(data.ResourceName).Key("zone_mappings.1.logical_zone").HasValue("2"),
 				check.That(data.ResourceName).Key("zone_mappings.2.logical_zone").HasValue("3"),


### PR DESCRIPTION
```
--- PASS: TestAccDataSourceExtendedLocations_westUS (28.17s)
--- PASS: TestAccLocationDataSource_eastUS (27.05s)
```