### PR TITLE
`streamanalytics` - fix tests that were being recreated instead of updated

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
@@ -162,7 +162,7 @@ func (r StreamAnalyticsOutputSqlResource) updated(data acceptance.TestData) stri
 %s
 
 resource "azurerm_stream_analytics_output_mssql" "test" {
-  name                      = "acctestoutput-updated-%d"
+  name                      = "acctestoutput-%d"
   stream_analytics_job_name = azurerm_stream_analytics_job.test.name
   resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
 
@@ -171,6 +171,8 @@ resource "azurerm_stream_analytics_output_mssql" "test" {
   password = azurerm_mssql_server.test.administrator_login_password
   database = azurerm_mssql_database.test.name
   table    = "AccTestTable"
+
+  max_batch_count = 1000
 }
 `, template, data.RandomInteger)
 }

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -153,13 +153,13 @@ func (r StreamAnalyticsOutputSynapseResource) updated(data acceptance.TestData) 
 %[1]s
 
 resource "azurerm_stream_analytics_output_synapse" "test" {
-  name                      = "acctestoutput-updated-%[2]d"
+  name                      = "acctestoutput-%[2]d"
   stream_analytics_job_name = azurerm_stream_analytics_job.test.name
   resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
 
   server   = azurerm_synapse_workspace.test.connectivity_endpoints["sqlOnDemand"]
   user     = azurerm_synapse_workspace.test.sql_administrator_login
-  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  password = "updatedPassword"
   database = "master"
   table    = "AccTestTable"
 }

--- a/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource_test.go
@@ -190,32 +190,21 @@ func (r StreamAnalyticsStreamInputIoTHubResource) updated(data acceptance.TestDa
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_iothub" "updated" {
-  name                = "acctestiot2-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku {
-    name     = "S1"
-    capacity = "1"
-  }
-}
-
 resource "azurerm_stream_analytics_stream_input_iothub" "test" {
   name                         = "acctestinput-%d"
   stream_analytics_job_name    = azurerm_stream_analytics_job.test.name
   resource_group_name          = azurerm_stream_analytics_job.test.resource_group_name
   endpoint                     = "messages/events"
   eventhub_consumer_group_name = "$Default"
-  iothub_namespace             = azurerm_iothub.updated.name
-  shared_access_policy_key     = azurerm_iothub.updated.shared_access_policy[0].primary_key
+  iothub_namespace             = azurerm_iothub.test.name
+  shared_access_policy_key     = azurerm_iothub.test.shared_access_policy[0].primary_key
   shared_access_policy_name    = "iothubowner"
 
   serialization {
     type = "Avro"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, template, data.RandomInteger)
 }
 
 func (r StreamAnalyticsStreamInputIoTHubResource) requiresImport(data acceptance.TestData) string {


### PR DESCRIPTION
```
--- PASS: TestAccStreamAnalyticsOutputSql_update (354.61s)
--- PASS: TestAccStreamAnalyticsOutputSynapse_update (538.99s)
--- PASS: TestAccStreamAnalyticsStreamInputIoTHub_update (377.82s)
```