### PR TITLE
`tests` - `azurerm_managed_lustre_file_system` change test zone from 2 to 1

### DIFF
--- a/internal/services/storagecache/managed_lustre_file_system_resource_test.go
+++ b/internal/services/storagecache/managed_lustre_file_system_resource_test.go
@@ -147,7 +147,7 @@ resource "azurerm_managed_lustre_file_system" "test" {
   sku_name               = "AMLFS-Durable-Premium-250"
   subnet_id              = azurerm_subnet.test.id
   storage_capacity_in_tb = 8
-  zones                  = ["2"]
+  zones                  = ["1"]
 
   maintenance_window {
     day_of_week        = "Friday"
@@ -278,7 +278,7 @@ resource "azurerm_managed_lustre_file_system" "test" {
   sku_name               = "AMLFS-Durable-Premium-250"
   subnet_id              = azurerm_subnet.test.id
   storage_capacity_in_tb = 8
-  zones                  = ["2"]
+  zones                  = ["1"]
 
   maintenance_window {
     day_of_week        = "Friday"
@@ -362,7 +362,7 @@ resource "azurerm_managed_lustre_file_system" "test" {
   sku_name               = "AMLFS-Durable-Premium-250"
   subnet_id              = azurerm_subnet.test.id
   storage_capacity_in_tb = 8
-  zones                  = ["2"]
+  zones                  = ["1"]
 
   maintenance_window {
     day_of_week        = "Thursday"


### PR DESCRIPTION
This PR swaps the zones for `azurerm_managed_lustre_file_system` from 2 to 1 as that seems to be the zone we have better access to in the portal

```
--- PASS: TestAccManagedLustreFileSystem_complete (1914.31s)
--- PASS: TestAccManagedLustreFileSystem_requiresImport (1152.23s)
```