### PR TITLE
New Data Source: `azurerm_key_vault_secret_versions`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -174,7 +174,7 @@ service/iot-hub:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_iothub((.|\n)*)###'
 
 service/key-vault:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(key_vault\W+|key_vault_access_policy\W+|key_vault_certificate\W+|key_vault_certificate_contacts\W+|key_vault_certificate_data\W+|key_vault_certificate_issuer\W+|key_vault_certificates\W+|key_vault_encrypted_value\W+|key_vault_key\W+|key_vault_managed_storage_account\W+|key_vault_managed_storage_account_sas_token_definition\W+|key_vault_secret\W+|key_vault_secrets\W+)((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(key_vault\W+|key_vault_access_policy\W+|key_vault_certificate\W+|key_vault_certificate_contacts\W+|key_vault_certificate_data\W+|key_vault_certificate_issuer\W+|key_vault_certificates\W+|key_vault_encrypted_value\W+|key_vault_key\W+|key_vault_managed_storage_account\W+|key_vault_managed_storage_account_sas_token_definition\W+|key_vault_secret\W+|key_vault_secret_versions\W+|key_vault_secrets\W+)((.|\n)*)###'
 
 service/kusto:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_kusto_((.|\n)*)###'

--- a/internal/services/keyvault/key_vault_secret_versions_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_versions_data_source.go
@@ -1,0 +1,170 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+)
+
+var _ sdk.DataSource = KeyVaultSecretVersionsDataSource{}
+
+type KeyVaultSecretVersionsDataSource struct{}
+
+type KeyVaultSecretVersionsDataSourceModel struct {
+	Name       string               `tfschema:"name"`
+	KeyVaultId string               `tfschema:"key_vault_id"`
+	Versions   []secretVersionModel `tfschema:"versions"`
+}
+
+type secretVersionModel struct {
+	ID             string `tfschema:"id"`
+	CreatedDate    string `tfschema:"created_date"`
+	Enabled        bool   `tfschema:"enabled"`
+	NotBeforeDate  string `tfschema:"not_before_date"`
+	ExpirationDate string `tfschema:"expiration_date"`
+	UpdatedDate    string `tfschema:"updated_date"`
+}
+
+func (r KeyVaultSecretVersionsDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: keyVaultValidate.NestedItemName,
+		},
+
+		"key_vault_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: keyVaultValidate.NestedItemId,
+		},
+
+		"max_results": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  25,
+		},
+	}
+}
+
+func (r KeyVaultSecretVersionsDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"versions": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"created_date": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"enabled": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
+
+					"not_before_date": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"expiration_date": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"updated_date": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r KeyVaultSecretVersionsDataSource) ResourceType() string {
+	return "azurerm_key_vault_secret_versions"
+}
+
+func (r KeyVaultSecretVersionsDataSource) ModelObject() interface{} {
+	return &KeyVaultSecretVersionsDataSourceModel{}
+}
+
+func (r KeyVaultSecretVersionsDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			keyVaultsClient := metadata.Client.KeyVault.VaultsClient
+			client := metadata.Client.KeyVault.ManagementClient
+			name := metadata.ResourceData.Get("name").(string)
+			maxResults := metadata.ResourceData.Get("max_results").(int32)
+			keyVaultId, err := commonids.ParseKeyVaultID(metadata.ResourceData.Get("key_vault_id").(string))
+			if err != nil {
+				return err
+			}
+
+			keyVaultBaseUri, err := keyVaultsClient.Get(ctx, *keyVaultId)
+			if err != nil {
+				return fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, *keyVaultId, err)
+			}
+
+			resp, err := client.GetSecretVersions(ctx, *keyVaultBaseUri.Model.Properties.VaultUri, name, &maxResults)
+			if err != nil {
+				return fmt.Errorf("making List Versions request on Azure KeyVault Secret %s: %+v", name, err)
+			}
+
+			var versions []map[string]interface{}
+
+			if resp.Values() != nil {
+				for resp.NotDone() {
+					for _, v := range resp.Values() {
+						versions = append(versions, expandSecretVersion(&v))
+					}
+					err = resp.NextWithContext(ctx)
+					if err != nil {
+						return fmt.Errorf("iterating over Secret Versions: %+v", err)
+					}
+				}
+			}
+
+			metadata.ResourceData.Set("versions", versions)
+
+			return nil
+		},
+	}
+}
+
+func expandSecretVersion(v *keyvault.SecretItem) map[string]interface{} {
+	item := make(map[string]interface{})
+	item["id"] = *v.ID
+	item["created_date"] = time.Time(*v.Attributes.Created).Format(time.RFC3339)
+	item["enabled"] = *v.Attributes.Enabled
+	if notBefore := v.Attributes.NotBefore; notBefore != nil {
+		item["not_before_date"] = time.Time(*notBefore).Format(time.RFC3339)
+	}
+	if expires := v.Attributes.Expires; expires != nil {
+		item["expiration_date"] = time.Time(*expires).Format(time.RFC3339)
+	}
+	if updated := v.Attributes.Updated; updated != nil {
+		item["updated_date"] = time.Time(*updated).Format(time.RFC3339)
+	}
+
+	return item
+}

--- a/internal/services/keyvault/key_vault_secret_versions_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_versions_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 var _ sdk.DataSource = KeyVaultSecretVersionsDataSource{}
@@ -22,6 +23,7 @@ type KeyVaultSecretVersionsDataSource struct{}
 type KeyVaultSecretVersionsDataSourceModel struct {
 	Name       string               `tfschema:"name"`
 	KeyVaultId string               `tfschema:"key_vault_id"`
+	MaxResults int32                `tfschema:"max_results"`
 	Versions   []secretVersionModel `tfschema:"versions"`
 }
 
@@ -45,7 +47,7 @@ func (r KeyVaultSecretVersionsDataSource) Arguments() map[string]*schema.Schema 
 		"key_vault_id": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: keyVaultValidate.NestedItemId,
+			ValidateFunc: commonids.ValidateKeyVaultID,
 		},
 
 		"max_results": {
@@ -111,31 +113,34 @@ func (r KeyVaultSecretVersionsDataSource) Read() sdk.ResourceFunc {
 		Timeout: 5 * time.Minute,
 
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			keyVaultsClient := metadata.Client.KeyVault.VaultsClient
 			client := metadata.Client.KeyVault.ManagementClient
-			name := metadata.ResourceData.Get("name").(string)
-			maxResults := metadata.ResourceData.Get("max_results").(int32)
-			keyVaultId, err := commonids.ParseKeyVaultID(metadata.ResourceData.Get("key_vault_id").(string))
+
+			var model KeyVaultSecretVersionsDataSourceModel
+
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			keyVaultId, err := commonids.ParseKeyVaultID(model.KeyVaultId)
 			if err != nil {
 				return err
 			}
 
-			keyVaultBaseUri, err := keyVaultsClient.Get(ctx, *keyVaultId)
+			keyVaultUri, err := metadata.Client.KeyVault.BaseUriForKeyVault(ctx, *keyVaultId)
 			if err != nil {
-				return fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, *keyVaultId, err)
+				return err
 			}
 
-			resp, err := client.GetSecretVersions(ctx, *keyVaultBaseUri.Model.Properties.VaultUri, name, &maxResults)
+			resp, err := client.GetSecretVersions(ctx, *keyVaultUri, model.Name, &model.MaxResults)
 			if err != nil {
-				return fmt.Errorf("making List Versions request on Azure KeyVault Secret %s: %+v", name, err)
+				return fmt.Errorf("making List Versions request on Azure KeyVault Secret %s: %+v", model.Name, err)
 			}
-
-			var versions []map[string]interface{}
 
 			if resp.Values() != nil {
 				for resp.NotDone() {
 					for _, v := range resp.Values() {
-						versions = append(versions, expandSecretVersion(&v))
+						model.Versions = append(model.Versions, expandSecretVersion(&v))
+						//versions = append(versions, expandSecretVersion(&v))
 					}
 					err = resp.NextWithContext(ctx)
 					if err != nil {
@@ -144,26 +149,27 @@ func (r KeyVaultSecretVersionsDataSource) Read() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.ResourceData.Set("versions", versions)
+			metadata.ResourceData.SetId(fmt.Sprintf("%s/%s", model.KeyVaultId, model.Name))
 
-			return nil
+			return metadata.Encode(&model)
 		},
 	}
 }
 
-func expandSecretVersion(v *keyvault.SecretItem) map[string]interface{} {
-	item := make(map[string]interface{})
-	item["id"] = *v.ID
-	item["created_date"] = time.Time(*v.Attributes.Created).Format(time.RFC3339)
-	item["enabled"] = *v.Attributes.Enabled
+func expandSecretVersion(v *keyvault.SecretItem) secretVersionModel {
+	var item secretVersionModel
+	
+	item.ID = *v.ID
+	item.CreatedDate = time.Time(*v.Attributes.Created).Format(time.RFC3339)
+	item.Enabled = *v.Attributes.Enabled
 	if notBefore := v.Attributes.NotBefore; notBefore != nil {
-		item["not_before_date"] = time.Time(*notBefore).Format(time.RFC3339)
+		item.NotBeforeDate = time.Time(*notBefore).Format(time.RFC3339)
 	}
 	if expires := v.Attributes.Expires; expires != nil {
-		item["expiration_date"] = time.Time(*expires).Format(time.RFC3339)
+		item.ExpirationDate = time.Time(*expires).Format(time.RFC3339)
 	}
 	if updated := v.Attributes.Updated; updated != nil {
-		item["updated_date"] = time.Time(*updated).Format(time.RFC3339)
+		item.UpdatedDate = time.Time(*updated).Format(time.RFC3339)
 	}
 
 	return item

--- a/internal/services/keyvault/key_vault_secret_versions_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_versions_data_source_test.go
@@ -1,0 +1,4 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package keyvault_test

--- a/internal/services/keyvault/key_vault_secret_versions_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_versions_data_source_test.go
@@ -2,3 +2,74 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package keyvault_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type KeyVaultSecretVersionsDataSource struct{}
+
+func TestAccDataSourceKeyVaultSecretVersions_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secret_versions", "test")
+	r := KeyVaultSecretVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").HasValue("1"),
+				check.That(data.ResourceName).Key("versions.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("versions.0.created_date").MatchesRegex(regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+				check.That(data.ResourceName).Key("versions.0.id").MatchesRegex(regexp.MustCompile(`^w+$`)),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKeyVaultSecretVersions_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secret_versions", "test")
+	r := KeyVaultSecretVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").HasValue("1"),
+				check.That(data.ResourceName).Key("versions.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("versions.0.created_date").MatchesRegex(regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+				check.That(data.ResourceName).Key("versions.0.not_before_date").HasValue("2019-01-01T01:02:03Z"),
+				check.That(data.ResourceName).Key("versions.0.expiration_date").HasValue("2020-01-01T01:02:03Z"),
+				check.That(data.ResourceName).Key("versions.0.updated_date").MatchesRegex(regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+				check.That(data.ResourceName).Key("versions.0.id").MatchesRegex(regexp.MustCompile(`^w+$`)),
+				check.That(data.ResourceName).Key("versions.0.uri").MatchesRegex(regexp.MustCompile(`^https://acctestkv-\w+.vault.azure.net/secrets/secret-\w+/\w+$`)),
+			),
+		},
+	})
+}
+
+func (KeyVaultSecretVersionsDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_secret_versions" "test" {
+  name		   = azurerm_key_vault_secret.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, KeyVaultSecretResource{}.basic(data))
+}
+
+func (KeyVaultSecretVersionsDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_secret_versions" "test" {
+  name		   = azurerm_key_vault_secret.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, KeyVaultSecretResource{}.complete(data))
+}

--- a/internal/services/keyvault/registration.go
+++ b/internal/services/keyvault/registration.go
@@ -63,6 +63,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		EncryptedValueDataSource{},
+		KeyVaultSecretVersionsDataSource{},
 	}
 }
 

--- a/website/docs/d/key_vault_secret_versions.html.markdown
+++ b/website/docs/d/key_vault_secret_versions.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_key_vault_secret_versions"
+description: |-
+  Gets information about an existing Key Vault Secret Versions.
+---
+
+# Data Source: azurerm_key_vault_secret_versions
+
+Use this data source to access information about an existing Key Vault Secret Versions.
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault_secret_versions" "example" {
+  name = "existing"
+  key_vault_id = "TODO"
+}
+
+output "id" {
+  value = data.azurerm_key_vault_secret_versions.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `key_vault_id` - (Required) The ID of the TODO.
+
+* `name` - (Required) The name of this Key Vault Secret Versions.
+
+---
+
+* `max_results` - (Optional) TODO. Defaults to `25`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Key Vault Secret Versions.
+
+* `versions` - A `versions` block as defined below.
+
+---
+
+A `versions` block exports the following:
+
+* `created_date` - TODO.
+
+* `enabled` - Is the TODO enabled?
+
+* `expiration_date` - TODO.
+
+* `id` - TODO.
+
+* `not_before_date` - TODO.
+
+* `updated_date` - TODO.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Secret Versions.

--- a/website/docs/d/key_vault_secret_versions.html.markdown
+++ b/website/docs/d/key_vault_secret_versions.html.markdown
@@ -3,23 +3,28 @@ subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: Data Source: azurerm_key_vault_secret_versions"
 description: |-
-  Gets information about an existing Key Vault Secret Versions.
+  Get a list of versions for an existing Key Vault Secret.
 ---
 
 # Data Source: azurerm_key_vault_secret_versions
 
-Use this data source to access information about an existing Key Vault Secret Versions.
+Use this data source to access information about an existing Key Vault Secret's versions. The secret version values is not included. The `key_vault_secret` data source can be used to retrieve the value of a given secret version using it's `id`.
 
 ## Example Usage
 
 ```hcl
-data "azurerm_key_vault_secret_versions" "example" {
-  name = "existing"
-  key_vault_id = "TODO"
+data "azurerm_key_vault" "example" {
+  name                = "mykeyvault"
+  resource_group_name = "some-resource-group"
 }
 
-output "id" {
-  value = data.azurerm_key_vault_secret_versions.example.id
+data "azurerm_key_vault_secret_versions" "example" {
+  name         = "mysecret"
+  key_vault_id = data.azurerm_key_vault.example.id
+}
+
+output "versions" {
+  value = data.azurerm_key_vault_secret_versions.example.versions
 }
 ```
 
@@ -27,37 +32,39 @@ output "id" {
 
 The following arguments are supported:
 
-* `key_vault_id` - (Required) The ID of the TODO.
+* `key_vault_id` - (Required) The ID of the Key Vault containing the secret.
 
-* `name` - (Required) The name of this Key Vault Secret Versions.
+* `name` - (Required) The name of the Key Vault Secret to retrieve versions from.
 
 ---
 
-* `max_results` - (Optional) TODO. Defaults to `25`.
+* `max_results` - (Optional) Maximum number of versions to retrieve. Defaults to `25`.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Key Vault Secret Versions.
+* `id` - The ID of the Key Vault Secret.
 
-* `versions` - A `versions` block as defined below.
+* `versions` - A `versions` list as defined below. The list of versions are sorted by `created_date` descending, meaning the most recently created secret version will be first in the list.
 
 ---
 
-A `versions` block exports the following:
+The `versions` entries in the list export the following:
 
-* `created_date` - TODO.
+* `created_date` - The date and time when the Key Vault Secret version was created.
 
-* `enabled` - Is the TODO enabled?
+* `enabled` - Is the version enabled? Returns a `bool` value.
 
-* `expiration_date` - TODO.
+* `expiration_date` - The date and time at which the Key Vault Secret version expires and is no longer valid.
 
-* `id` - TODO.
+* `id` - The Key Vault Secret version ID.
 
-* `not_before_date` - TODO.
+* `not_before_date` - The earliest date and time at which the Key Vault Secret version can be used.
 
-* `updated_date` - TODO.
+* `updated_date` - The date and time when the Key Vault Secret version was last updated.
+
+* `uri` - The full URI of the secret version.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This is a new data source that will retrieve the versions of an existing Key Vault Secret. The returned value is called `versions` and is a list of each version and its attributes. It *does not* include the secret value for each version. The number of returned results can be set with the `max_results` argument that defaults to `25`.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```bash
$ make acctests SERVICE='keyvault' TESTARGS='-run=TestAccDataSourceKeyVaultSecretVersions_complete' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault -run=TestAccDataSourceKeyVaultSecretVersions_complete -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceKeyVaultSecretVersions_complete
=== PAUSE TestAccDataSourceKeyVaultSecretVersions_complete
=== CONT  TestAccDataSourceKeyVaultSecretVersions_complete
--- PASS: TestAccDataSourceKeyVaultSecretVersions_complete (824.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      824.387s

$ make acctests SERVICE='keyvault' TESTARGS='-run=TestAccDataSourceKeyVaultSecretVersions_basic' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault -run=TestAccDataSourceKeyVaultSecretVersions_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceKeyVaultSecretVersions_basic
=== PAUSE TestAccDataSourceKeyVaultSecretVersions_basic
=== CONT  TestAccDataSourceKeyVaultSecretVersions_basic
--- PASS: TestAccDataSourceKeyVaultSecretVersions_basic (826.40s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      826.415s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_secret_versions` - new data source to retrieve versions of a secret [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27347

