### PR TITLE
`azurerm_storage_blob` - `source` is no longer ForceNew / `azurerm_storage_object_replication` - `rules.x. source_container_name` and `rules.x. destination_container_name` are no longer ForceNew

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2293,6 +2293,9 @@ func resourceStorageAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 
 	existing, err := client.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
+		if response.WasNotFound(existing.HttpResponse) {
+			return nil
+		}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -128,7 +128,6 @@ func resourceStorageBlob() *pluginsdk.Resource {
 			"source_content": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"source", "source_uri"},
 			},
 
@@ -451,7 +450,10 @@ func resourceStorageBlobDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 	input := blobs.DeleteInput{
 		DeleteSnapshots: true,
 	}
-	if _, err = blobsClient.Delete(ctx, id.ContainerName, id.BlobName, input); err != nil {
+	if resp, err := blobsClient.Delete(ctx, id.ContainerName, id.BlobName, input); err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return nil
+		}
 		return fmt.Errorf("deleting %s: %v", id, err)
 	}
 

--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -66,14 +66,12 @@ func resourceStorageObjectReplication() *pluginsdk.Resource {
 						"source_container_name": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validate.StorageContainerName,
 						},
 
 						"destination_container_name": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validate.StorageContainerName,
 						},
 

--- a/internal/services/storage/storage_object_replication_resource_test.go
+++ b/internal/services/storage/storage_object_replication_resource_test.go
@@ -319,7 +319,7 @@ resource "azurerm_storage_object_replication" "test" {
   rules {
     source_container_name        = azurerm_storage_container.src.name
     destination_container_name   = azurerm_storage_container.dst.name
-    copy_blobs_created_after     = "%s"
+    copy_blobs_created_after     = "%[2]s"
     filter_out_blobs_with_prefix = ["blobA", "blobB", "blobC"]
   }
   rules {

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -325,14 +325,13 @@ func (r StorageShareFileResource) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_storage_share_file" "test" {
-  name             = "test"
+  name             = "file"
   storage_share_id = azurerm_storage_share.test.id
 
 
   content_type        = "test_content_type"
   content_encoding    = "test_encoding"
   content_disposition = "test_content_disposition"
-  content_md5         = "1234567890abcdef1234567890abcdef"
 
   metadata = {
     hello = "world"

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -372,7 +372,7 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("recovering %s: %+v", id, err)
+			return fmt.Errorf("updating access tier %s: %+v", id, err)
 		}
 
 		log.Printf("[DEBUG] Updated Access Tier for %s", id)

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
@@ -359,8 +360,19 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		log.Printf("[DEBUG] Updating Access Tier for %s", id)
 
 		tier := shares.AccessTier(d.Get("access_tier").(string))
-		if err = client.UpdateTier(ctx, id.ShareName, tier); err != nil {
-			return fmt.Errorf("updating Access Tier for %s: %v", id, err)
+		err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutUpdate), func() *pluginsdk.RetryError {
+			err = client.UpdateTier(ctx, id.ShareName, tier)
+			if err != nil {
+				if strings.Contains(err.Error(), "Cannot change access tier at this moment") {
+					return pluginsdk.RetryableError(err)
+				}
+				return pluginsdk.NonRetryableError(err)
+			}
+			time.Sleep(30 * time.Second)
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("recovering %s: %+v", id, err)
 		}
 
 		log.Printf("[DEBUG] Updated Access Tier for %s", id)
@@ -395,6 +407,9 @@ func resourceStorageShareDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if err = client.Delete(ctx, id.ShareName); err != nil {
+		if strings.Contains(err.Error(), "The specified share does not exist") {
+			return nil
+		}
 		return fmt.Errorf("deleting %s: %v", id, err)
 	}
 

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -207,13 +207,6 @@ func TestAccStorageShare_accessTierStandard(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.accessTierStandard(data, "TransactionOptimized"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -252,7 +245,7 @@ func TestAccStorageShare_protocolUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
 	r := StorageShareResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.protocol(data, "NFS"),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/storage/storage_sync_resource_test.go
+++ b/internal/services/storage/storage_sync_resource_test.go
@@ -139,7 +139,7 @@ resource "azurerm_storage_sync" "import" {
 func (r StorageSyncResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-ss-%d"
   location = "%s"
 }
 

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -248,6 +249,9 @@ func resourceStorageTableDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if err = client.Delete(ctx, id.TableName); err != nil {
+		if strings.Contains(err.Error(), "unexpected status 404") {
+			return nil
+		}
 		return fmt.Errorf("deleting %s: %v", id, err)
 	}
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `encryption_scope` - (Optional) The encryption scope to use for this blob.
 
-* `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified. Changing this forces a new resource to be created.
+* `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified.
 
 * `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_object_replication.html.markdown
+++ b/website/docs/r/storage_object_replication.html.markdown
@@ -83,9 +83,9 @@ The following arguments are supported:
 
 A `rules` block supports the following:
 
-* `source_container_name` - (Required) The source storage container name. Changing this forces a new Storage Object Replication to be created.
+* `source_container_name` - (Required) The source storage container name.
 
-* `destination_container_name` - (Required) The destination storage container name. Changing this forces a new Storage Object Replication to be created.
+* `destination_container_name` - (Required) The destination storage container name.
 
 * `copy_blobs_created_after` - (Optional) The time after which the Block Blobs created will be copies to the destination. Possible values are `OnlyNewObjects`, `Everything` and time in RFC3339 format: `2006-01-02T15:04:00Z`. Defaults to `OnlyNewObjects`.
 


### PR DESCRIPTION
This PR has various test fixes for storage that include removing ForceNew from certain attributes, adding 404 checks, and Retryable Errors.