### PR TITLE
`azurerm_container_app` - Relax validation on the ingress traffic

### DIFF
--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -437,7 +437,7 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 			if err := metadata.DecodeDiff(&app); err != nil {
 				return err
 			}
-			//Ingress traffic weight validations
+			// Ingress traffic weight validations
 			if len(app.Ingress) != 0 {
 				ingress := app.Ingress[0]
 

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -437,39 +437,13 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 			if err := metadata.DecodeDiff(&app); err != nil {
 				return err
 			}
-			// Ingress traffic weight validations
+			//Ingress traffic weight validations
 			if len(app.Ingress) != 0 {
 				ingress := app.Ingress[0]
-				if metadata.ResourceDiff.HasChange("name") {
-					// Validation for create time
-					// (Above is a trick to tell whether this is for a new create apply, as the "name" is a force new property)
-					if len(ingress.TrafficWeights) != 0 {
-						if len(ingress.TrafficWeights) > 1 {
-							return fmt.Errorf("at most one `ingress.0.traffic_weight` can be specified during creation")
-						}
-						tw := ingress.TrafficWeights[0]
-						if !tw.LatestRevision {
-							return fmt.Errorf("`ingress.0.traffic_weight.0.latest_revision` must be set to true during creation")
-						}
-						if tw.RevisionSuffix != "" {
-							return fmt.Errorf("`ingress.0.traffic_weight.0.revision_suffix` must not be set during creation")
-						}
-					}
-				} else {
-					// Validation for update time
-					var latestRevCount int
-					for i, tw := range ingress.TrafficWeights {
-						if tw.LatestRevision {
-							latestRevCount++
-							if tw.RevisionSuffix != "" {
-								return fmt.Errorf("`ingress.0.traffic_weight.%[1]d.revision_suffix` conflicts with `ingress.0.traffic_weight.%[1]d.latest_revision`", i)
-							}
-						} else if tw.RevisionSuffix == "" {
-							return fmt.Errorf("`ingress.0.traffic_weight.%[1]d.revision_suffix` is not specified", i)
-						}
-					}
-					if latestRevCount > 1 {
-						return fmt.Errorf("more than one `ingress.0.traffic_weight` has `latest_revision` set to `true`")
+
+				for i, tw := range ingress.TrafficWeights {
+					if !tw.LatestRevision && tw.RevisionSuffix == "" {
+						return fmt.Errorf("`either ingress.0.traffic_weight.%[1]d.revision_suffix` or `ingress.0.traffic_weight.%[1]d.latest_revision` should be specified", i)
 					}
 				}
 			}

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -570,16 +570,8 @@ func TestAccContainerAppResource_ingressTrafficValidation(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.ingressTrafficValidation(data, r.trafficBlockMoreThanOne()),
-			ExpectError: regexp.MustCompile(fmt.Sprintf(`at most one %s can be specified during creation`, "`ingress.0.traffic_weight`")),
-		},
-		{
-			Config:      r.ingressTrafficValidation(data, r.trafficBlockLatestRevisionNotSet()),
-			ExpectError: regexp.MustCompile(fmt.Sprintf(`%s must be set to true during creation`, "`ingress.0.traffic_weight.0.latest_revision`")),
-		},
-		{
-			Config:      r.ingressTrafficValidation(data, r.trafficBlockRevisionSuffixSet()),
-			ExpectError: regexp.MustCompile(fmt.Sprintf(`%s must not be set during creation`, "`ingress.0.traffic_weight.0.revision_suffix`")),
+			Config:      r.ingressTrafficValidation(data, r.latestRevisionFalseRevisionSuffixEmpty()),
+			ExpectError: regexp.MustCompile(fmt.Sprintf("`either ingress.0.traffic_weight.0.revision_suffix` or `ingress.0.traffic_weight.0.latest_revision` should be specified")),
 		},
 	})
 }
@@ -2832,31 +2824,11 @@ resource "azurerm_container_app" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r ContainerAppResource) trafficBlockMoreThanOne() string {
+func (r ContainerAppResource) latestRevisionFalseRevisionSuffixEmpty() string {
 	return `
 traffic_weight {
-  percentage = 50
-}
-traffic_weight {
-  percentage = 50
-}
-`
-}
-
-func (r ContainerAppResource) trafficBlockLatestRevisionNotSet() string {
-	return `
-traffic_weight {
+  latest_revision = false
   percentage = 100
-}
-`
-}
-
-func (r ContainerAppResource) trafficBlockRevisionSuffixSet() string {
-	return `
-traffic_weight {
-  percentage      = 100
-  latest_revision = true
-  revision_suffix = "foo"
 }
 `
 }

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -571,7 +571,7 @@ func TestAccContainerAppResource_ingressTrafficValidation(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.ingressTrafficValidation(data, r.latestRevisionFalseRevisionSuffixEmpty()),
-			ExpectError: regexp.MustCompile(fmt.Sprintf("`either ingress.0.traffic_weight.0.revision_suffix` or `ingress.0.traffic_weight.0.latest_revision` should be specified")),
+			ExpectError: regexp.MustCompile("`either ingress.0.traffic_weight.0.revision_suffix` or `ingress.0.traffic_weight.0.latest_revision` should be specified"),
 		},
 	})
 }

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -415,7 +415,7 @@ A `traffic_weight` block supports the following:
 
 * `revision_suffix` - (Optional) The suffix string to which this `traffic_weight` applies.
 
-~> **Note:** `latest_revision` conflicts with `revision_suffix`, which means you shall either set `latest_revision` to `true` or specify `revision_suffix`. Especially for creation, there shall only be one `traffic_weight`, with the `latest_revision` set to `true`, and leave the `revision_suffix` empty.
+~> **Note:** If `latest_revision` is `false`, the `revision_suffix` shall be specified.
 
 * `percentage` - (Required) The percentage of traffic which should be sent this revision.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR relax some of the validations introduced by https://github.com/hashicorp/terraform-provider-azurerm/pull/24042. As it blocks some otherwise valid configuration, such as #27221.

The initial reason for adding above validations is that some configuration will trigger a bug in the service side, causing the API timeout. The service has confirmed this issue now. They suggest that a PUT shall ensure `latestRevision` is `true`, or `revisionName` is not empty, in the ingress traffic. Especially, the `revisionName` shall be an existing one, or comply with the format `{containerAppName}--{revisionSuffix}`.

Fix #27221.

Relating to #20435

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm on  main via 🐹 v1.23.0
💤  TF_ACC=1 go test -v -timeout=20h -run="TestAccContainerAppResource_ingressTrafficValidation" ./internal/services/containerapps
=== RUN   TestAccContainerAppResource_ingressTrafficValidation
=== PAUSE TestAccContainerAppResource_ingressTrafficValidation
=== CONT  TestAccContainerAppResource_ingressTrafficValidation
--- PASS: TestAccContainerAppResource_ingressTrafficValidation (3.78s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps 3.793s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` - Relax validation on the ingress traffic [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27221


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
