### PR TITLE
Fix Terraform configuration and network interface

### DIFF
--- a/examples/custom-windows-vm-setup/install-software.ps1
+++ b/examples/custom-windows-vm-setup/install-software.ps1
@@ -1,0 +1,66 @@
+# Enable TLS 1.2 for secure downloads
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Function to check if a port is available
+function Test-PortAvailable {
+    param ([int]$port)
+    $tcpListener = New-Object System.Net.Sockets.TcpListener([System.Net.IPAddress]::Any, $port)
+    try {
+        $tcpListener.Start()
+        $tcpListener.Stop()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+# Install Chocolatey if not already installed
+if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Chocolatey..."
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+}
+
+# Install JDK 8 using Chocolatey
+if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing JDK 8..."
+    choco install -y jdk8
+} else {
+    Write-Host "JDK already installed."
+}
+
+# Set JAVA_HOME environment variable (required for Tomcat)
+$javaPath = (Get-Command java).Path
+$javaHome = [System.IO.Path]::GetDirectoryName($javaPath)
+$env:JAVA_HOME = $javaHome
+[System.Environment]::SetEnvironmentVariable("JAVA_HOME", $javaHome, "Machine")
+
+# Install XAMPP using Chocolatey
+if (-not (Test-Path "C:\xampp")) {
+    Write-Host "Installing XAMPP..."
+    choco install -y xampp
+} else {
+    Write-Host "XAMPP already installed."
+}
+
+# Check if Tomcat port is available (default is 8080)
+$port = 8080
+if (-not (Test-PortAvailable $port)) {
+    Write-Host "Port 8080 is not available. Changing Tomcat to use port 8081."
+    $port = 8081
+
+    # Update the Tomcat server.xml to use the new port
+    $serverXmlPath = "C:\xampp\tomcat\conf\server.xml"
+    (Get-Content $serverXmlPath) -replace 'port="8080"', 'port="8081"' | Set-Content $serverXmlPath
+}
+
+# Start XAMPP Control Panel
+Write-Host "Starting XAMPP services..."
+Start-Process "C:\xampp\xampp-control.exe"
+
+# Start Tomcat via XAMPP
+Write-Host "Starting Tomcat..."
+Start-Process "C:\xampp\tomcat_start.bat"
+
+Write-Host "XAMPP and Tomcat setup completed."
+
+

--- a/examples/custom-windows-vm-setup/main.tf
+++ b/examples/custom-windows-vm-setup/main.tf
@@ -1,0 +1,176 @@
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+}
+
+# Resource Group
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-rg"
+  location = var.location
+}
+
+# Virtual Network
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+# Subnet (Only one definition for azurerm_subnet.main now)
+resource "azurerm_subnet" "main" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+# Public IP for the VM
+resource "azurerm_public_ip" "main" {
+  name                = "${var.prefix}-public-ip"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+# Network Security Group (NSG)
+resource "azurerm_network_security_group" "main" {
+  name                = "${var.prefix}-nsg"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  security_rule {
+    name                       = "Allow-RDP"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "3389"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+# Network Interface (depends on Subnet and NSG)
+resource "azurerm_network_interface" "main" {
+  name                = "${var.prefix}-nic"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.main.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.main.id
+  }
+
+  depends_on = [azurerm_subnet.main, azurerm_network_security_group.main]
+}
+
+# Associate the NSG with the Network Interface
+resource "azurerm_network_interface_security_group_association" "main" {
+  network_interface_id      = azurerm_network_interface.main.id
+  network_security_group_id = azurerm_network_security_group.main.id
+}
+
+# Windows Virtual Machine
+resource "azurerm_windows_virtual_machine" "main" {
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "azureuser"
+  admin_password      = var.admin_password
+
+  network_interface_ids = [
+    azurerm_network_interface.main.id,
+  ]
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  # Ensure the VM depends on NIC, NSG, and Subnet
+  depends_on = [azurerm_network_interface.main]
+}
+
+# Storage Account to Store the PowerShell Script
+resource "azurerm_storage_account" "storage" {
+  name                     = "${var.prefix}storage"
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Storage Container to hold the script
+resource "azurerm_storage_container" "container" {
+  name                  = "scripts"
+  storage_account_name  = azurerm_storage_account.storage.name
+  container_access_type = "blob"
+}
+
+# Upload the PowerShell script to Blob storage
+resource "azurerm_storage_blob" "script" {
+  name                   = "install-software.ps1"
+  storage_account_name   = azurerm_storage_account.storage.name
+  storage_container_name = azurerm_storage_container.container.name
+  type                   = "Block"
+  source                 = "install-software.ps1"
+}
+
+# Custom Script Extension to run the uploaded script on the VM
+resource "azurerm_virtual_machine_extension" "run_script" {
+  name                 = "run_script"
+  virtual_machine_id   = azurerm_windows_virtual_machine.main.id
+  publisher            = "Microsoft.Compute"
+  type                 = "CustomScriptExtension"
+  type_handler_version = "1.10"
+
+  settings = <<SETTINGS
+    {
+      "fileUris": ["${azurerm_storage_blob.script.url}"],
+      "commandToExecute": "powershell -ExecutionPolicy Unrestricted -File install-software.ps1"
+    }
+SETTINGS
+
+  depends_on = [
+    azurerm_windows_virtual_machine.main,
+    azurerm_storage_blob.script
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/custom-windows-vm-setup/variables.tf
+++ b/examples/custom-windows-vm-setup/variables.tf
@@ -1,0 +1,35 @@
+variable "prefix" {
+  description = "The prefix to use for all resources"
+  default     = "winvm2022"
+}
+
+variable "location" {
+  description = "The Azure region to deploy resources in"
+  default     = "East US"
+}
+
+variable "subscription_id" {
+  description = "Azure Subscription ID"
+}
+
+variable "tenant_id" {
+  description = "Azure Tenant ID"
+}
+
+variable "client_id" {
+  description = "Azure Client ID"
+}
+
+variable "client_secret" {
+  description = "Azure Client Secret"
+}
+
+variable "admin_password" {
+  description = "Admin password for the Windows VM"
+  type        = string
+}
+
+
+
+
+


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
