### PR TITLE
`tests` - removing redundant service connector tests

### DIFF
--- a/internal/services/serviceconnector/service_connector_app_service_resource_test.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource_test.go
@@ -125,27 +125,6 @@ func TestAccServiceConnectorAppServiceStorageBlob_secretStore(t *testing.T) {
 	})
 }
 
-func TestAccServiceConnectorAppServiceCosmosdb_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_app_service_connection", "test")
-	r := ServiceConnectorAppServiceResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.cosmosdbBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.cosmosdbUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccServiceConnectorAppService_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_connection", "test")
 	r := ServiceConnectorAppServiceResource{}
@@ -296,45 +275,6 @@ resource "azurerm_app_service_connection" "test" {
     type            = "userAssignedIdentity"
     subscription_id = data.azurerm_subscription.test.subscription_id
     client_id       = azurerm_user_assigned_identity.test.client_id
-  }
-}
-`, template, data.RandomString, data.RandomInteger)
-}
-
-func (r ServiceConnectorAppServiceResource) cosmosdbUpdate(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_cosmosdb_sql_database" "update" {
-  name                = "cosmos-sql-db-update"
-  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
-  account_name        = azurerm_cosmosdb_account.test.name
-  throughput          = 400
-}
-
-resource "azurerm_cosmosdb_sql_container" "update" {
-  name                = "test-containerupdate%[2]s"
-  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
-  account_name        = azurerm_cosmosdb_account.test.name
-  database_name       = azurerm_cosmosdb_sql_database.update.name
-  partition_key_paths = ["/definitionupdate"]
-}
-
-resource "azurerm_service_plan" "update" {
-  location            = azurerm_resource_group.test.location
-  name                = "testserviceplanupdate%[2]s"
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "P1v2"
-  os_type             = "Linux"
-}
-
-resource "azurerm_app_service_connection" "test" {
-  name               = "acctestserviceconnector%[3]d"
-  app_service_id     = azurerm_linux_web_app.test.id
-  target_resource_id = azurerm_cosmosdb_sql_database.update.id
-  authentication {
-    type = "systemAssignedIdentity"
   }
 }
 `, template, data.RandomString, data.RandomInteger)


### PR DESCRIPTION
The removed tests are spinning up a new cosmosdb account to attach to the service connector but this forces a new resource to be created so we'll just remove these tests