### PR TITLE
tests - `servicebus` test fixes

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -309,7 +309,6 @@ func TestAccAzureRMServiceBusNamespace_networkRuleSet(t *testing.T) {
 			Config: r.networkRuleSetEmpty(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("network_rule_set.0.default_action").HasValue("Allow"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -81,14 +81,6 @@ func TestAccServiceBusQueue_enablePartitioningStandard(t *testing.T) {
 	r := ServiceBusQueueResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("partitioning_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-		{
 			Config: r.enablePartitioningStandard(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("partitioning_enabled").HasValue("true"),
@@ -150,14 +142,6 @@ func TestAccServiceBusQueue_enableDuplicateDetection(t *testing.T) {
 	r := ServiceBusQueueResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("requires_duplicate_detection").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-		{
 			Config: r.enableDuplicateDetection(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("requires_duplicate_detection").HasValue("true"),
@@ -171,14 +155,6 @@ func TestAccServiceBusQueue_enableRequiresSession(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_queue", "test")
 	r := ServiceBusQueueResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("requires_session").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
 		{
 			Config: r.enableRequiresSession(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -459,6 +435,8 @@ resource "azurerm_servicebus_queue" "test" {
 }
 
 func (ServiceBusQueueResource) PremiumNamespacePartitioned(data acceptance.TestData, enabled bool) string {
+	// Limited regional availability for premium namespace partitions
+	data.Locations.Primary = "westus"
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -115,19 +115,13 @@ func TestAccServiceBusSubscription_updateEnableBatched(t *testing.T) {
 	})
 }
 
-func TestAccServiceBusSubscription_updateRequiresSession(t *testing.T) {
+func TestAccServiceBusSubscription_requiresSession(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
 	r := ServiceBusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.updateRequiresSession(data),
+			Config: r.requiresSession(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("requires_session").HasValue("true"),
 			),
@@ -335,7 +329,7 @@ func (ServiceBusSubscriptionResource) updateEnableBatched(data acceptance.TestDa
 		"batched_operations_enabled = true\n")
 }
 
-func (ServiceBusSubscriptionResource) updateRequiresSession(data acceptance.TestData) string {
+func (ServiceBusSubscriptionResource) requiresSession(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"requires_session = true\n")
 }

--- a/internal/services/servicebus/servicebus_topic_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_resource_test.go
@@ -139,13 +139,6 @@ func TestAccServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
 			Config: r.enablePartitioningStandard(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("partitioning_enabled").HasValue("true"),
@@ -200,13 +193,6 @@ func TestAccServiceBusTopic_enableDuplicateDetection(t *testing.T) {
 	r := ServiceBusTopicResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 		{
 			Config: r.enableDuplicateDetection(data),
 			Check: acceptance.ComposeTestCheckFunc(


### PR DESCRIPTION
Many tests were enabling attributes that are ForceNew so we removed the initial test step