### PR TITLE
`azurerm_service_fabric_managed_cluster` - hide a tag that azure is adding outside of Terraform

### DIFF
--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -651,7 +651,11 @@ func flattenClusterProperties(cluster *managedcluster.ManagedCluster) *ClusterRe
 	if t := cluster.Tags; t != nil {
 		modelTags := make(map[string]interface{})
 		for tag, value := range *t {
-			modelTags[tag] = value
+			// This tag is being added outside of Terraform. We'll ignore it when setting tags into state
+			// but if it becomes an issue, we can add it as its own attribute
+			if !strings.Contains(tag, "SFRP.DisableDefaultOutboundAccess") {
+				modelTags[tag] = value
+			}
 		}
 		model.Tags = modelTags
 	}

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -651,8 +651,9 @@ func flattenClusterProperties(cluster *managedcluster.ManagedCluster) *ClusterRe
 	if t := cluster.Tags; t != nil {
 		modelTags := make(map[string]interface{})
 		for tag, value := range *t {
-			// This tag is being added outside of Terraform. We'll ignore it when setting tags into state
-			// but if it becomes an issue, we can add it as its own attribute
+			// This tag is temporary and will be removed at a later date.
+			// More info can be found here https://azure.microsoft.com/en-us/updates/default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access/
+			// In the meantime, we'll ignore it when setting tags into state
 			if !strings.Contains(tag, "SFRP.DisableDefaultOutboundAccess") {
 				modelTags[tag] = value
 			}


### PR DESCRIPTION
`azurerm_service_fabric_managed_cluster` tests are currently failing because of a tag that Azure is adding outside of Terraform. `SFRP.DisableDefaultOutboundAccess": "true"`. 

I'm of the mind that we can just hide it away for now. We could add it back as it's own attribute if there is value there though.