### PR TITLE
`azurerm_log_analytics_workspace_table` - set `total_retention_in_days` when `sku` is `Basic`

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -133,8 +133,12 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 
 			if model.Plan == string(tables.TablePlanEnumAnalytics) {
 				updateInput.Properties.RetentionInDays = pointer.To(model.RetentionInDays)
+			}
+
+			if model.TotalRetentionInDays != 0 {
 				updateInput.Properties.TotalRetentionInDays = pointer.To(model.TotalRetentionInDays)
 			}
+
 			if err := client.CreateOrUpdateThenPoll(ctx, id, updateInput); err != nil {
 				return fmt.Errorf("failed to update table %s in workspace %s in resource group %s: %s", tableName, workspaceId.WorkspaceName, workspaceId.ResourceGroupName, err)
 			}
@@ -183,10 +187,10 @@ func (r LogAnalyticsWorkspaceTableResource) Update() sdk.ResourceFunc {
 						if metadata.ResourceData.HasChange("retention_in_days") {
 							updateInput.Properties.RetentionInDays = pointer.To(state.RetentionInDays)
 						}
+					}
 
-						if metadata.ResourceData.HasChange("total_retention_in_days") {
-							updateInput.Properties.TotalRetentionInDays = pointer.To(state.TotalRetentionInDays)
-						}
+					if metadata.ResourceData.HasChange("total_retention_in_days") {
+						updateInput.Properties.TotalRetentionInDays = pointer.To(state.TotalRetentionInDays)
 					}
 
 					if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
@@ -233,8 +237,8 @@ func (r LogAnalyticsWorkspaceTableResource) Read() sdk.ResourceFunc {
 				if props := model.Properties; props != nil {
 					if pointer.From(props.Plan) == tables.TablePlanEnumAnalytics {
 						state.RetentionInDays = pointer.From(props.RetentionInDays)
-						state.TotalRetentionInDays = pointer.From(props.TotalRetentionInDays)
 					}
+					state.TotalRetentionInDays = pointer.From(props.TotalRetentionInDays)
 					state.Plan = string(pointer.From(props.Plan))
 				}
 			}

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -104,9 +104,10 @@ resource "azurerm_log_analytics_workspace" "test" {
   retention_in_days   = 30
 }
 resource "azurerm_log_analytics_workspace_table" "test" {
-  name         = "AppTraces"
-  workspace_id = azurerm_log_analytics_workspace.test.id
-  plan         = "Basic"
+  name                    = "AppTraces"
+  workspace_id            = azurerm_log_analytics_workspace.test.id
+  plan                    = "Basic"
+  total_retention_in_days = 32
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The previous code ignored `total_retention_in_days` when `sku` is `Basic`.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
❯❯ tftest loganalytics TestAccLogAnalyticsWorkspaceTable
=== RUN   TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== PAUSE TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== RUN   TestAccLogAnalyticsWorkspaceTable_plan
=== PAUSE TestAccLogAnalyticsWorkspaceTable_plan
=== CONT  TestAccLogAnalyticsWorkspaceTable_updateTableRetention
=== CONT  TestAccLogAnalyticsWorkspaceTable_plan
--- PASS: TestAccLogAnalyticsWorkspaceTable_plan (232.77s)
--- PASS: TestAccLogAnalyticsWorkspaceTable_updateTableRetention (235.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	236.060s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_workspace_table` - set `total_retention_in_days` when `sku` is `Basic` [GH-27420]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27358


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
