### PR TITLE
Revert "Documentation updates - updated examples to use provider version 4.x"

### DIFF
--- a/website/docs/guides/aks_workload_identity.html.markdown
+++ b/website/docs/guides/aks_workload_identity.html.markdown
@@ -108,7 +108,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -130,7 +130,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -123,7 +123,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -149,7 +149,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -177,7 +177,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -98,7 +98,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -120,7 +120,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -127,7 +127,7 @@ $ export ARM_SUBSCRIPTION_ID="20000000-0000-0000-0000-000000000000"
 > $env:ARM_SUBSCRIPTION_ID = "20000000-0000-0000-0000-000000000000"
 ```
 
-The following Terraform and Provider blocks can be specified - where `4.x` is the major version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `3.0.0` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
 # We strongly recommend using the required_providers block to set the
@@ -136,7 +136,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -168,7 +168,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -184,7 +184,7 @@ export ARM_SUBSCRIPTION_ID="20000000-0000-0000-0000-000000000000"
 > $env:ARM_TENANT_ID = "10000000-0000-0000-0000-000000000000"
 > $env:ARM_SUBSCRIPTION_ID = "20000000-0000-0000-0000-000000000000"
 ```
-The following Terraform and Provider blocks can be specified - where `4.x` is the major version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `3.0.0` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
 # We strongly recommend using the required_providers block to set the
@@ -193,7 +193,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }
@@ -224,7 +224,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.x"
+      version = "=3.0.0"
     }
   }
 }


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-azurerm#27184 as we recommend pinning specific versions of the provider in most cases.