### PR TITLE
`azurerm_management_group_subscription_association` - add migration for SDK update

### DIFF
--- a/internal/services/managementgroup/migration/subscription_association_v0_to_v1.go
+++ b/internal/services/managementgroup/migration/subscription_association_v0_to_v1.go
@@ -1,0 +1,46 @@
+package migration
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ManagementGroupSubscriptionAssociationV0ToV1{}
+
+type ManagementGroupSubscriptionAssociationV0ToV1 struct{}
+
+func (ManagementGroupSubscriptionAssociationV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(strings.Replace(rawState["id"].(string), "/managementGroup/", "/providers/Microsoft.Management/managementGroups/", 1), "/subscription/", "/subscriptions/", 1)
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}
+
+func (ManagementGroupSubscriptionAssociationV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"management_group_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ManagementGroupID,
+		},
+
+		"subscription_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateSubscriptionID,
+		},
+	}
+}

--- a/internal/services/managementgroup/subscription_association_resource.go
+++ b/internal/services/managementgroup/subscription_association_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managementgroups/2020-05-01/managementgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -27,6 +28,11 @@ func resourceManagementGroupSubscriptionAssociation() *pluginsdk.Resource {
 		Create: resourceManagementGroupSubscriptionAssociationCreate,
 		Read:   resourceManagementGroupSubscriptionAssociationRead,
 		Delete: resourceManagementGroupSubscriptionAssociationDelete,
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ManagementGroupSubscriptionAssociationV0ToV1{},
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/website/docs/r/management_group_subscription_association.html.markdown
+++ b/website/docs/r/management_group_subscription_association.html.markdown
@@ -56,5 +56,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Managements can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_management_group_subscription_association.example /managementGroup/MyManagementGroup/subscription/12345678-1234-1234-1234-123456789012
+terraform import azurerm_management_group_subscription_association.example /providers/Microsoft.Management/managementGroups/MyManagementGroup/subscriptions/12345678-1234-1234-1234-123456789012
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/27449
The ID format changed after SDK update for `azurerm_management_group_subscription_association`. Need to add a migration to update the old ID to the new format.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_management_group_subscription_association` - add migration for SDK update [GH-27449]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/27449


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
