### PR TITLE
`azurerm_kusto_attached_database_configuration` - change the property name from `cluster_resource_id` to `cluster_id`

### DIFF
--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -73,8 +73,7 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 				ValidateFunc: validation.Any(validate.DatabaseName, validation.StringInSlice([]string{"*"}, false)),
 			},
 
-			// TODO: this should become `cluster_id` in 4.0
-			"cluster_resource_id": {
+			"cluster_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
@@ -223,7 +222,7 @@ func resourceKustoAttachedDatabaseConfigurationRead(d *pluginsdk.ResourceData, m
 			if parseErr != nil {
 				return parseErr
 			}
-			d.Set("cluster_resource_id", clusterResourceId.ID())
+			d.Set("cluster_id", clusterResourceId.ID())
 			d.Set("database_name", props.DatabaseName)
 			d.Set("default_principal_modification_kind", props.DefaultPrincipalsModificationKind)
 			d.Set("attached_database_names", props.AttachedDatabaseNames)
@@ -259,7 +258,7 @@ func resourceKustoAttachedDatabaseConfigurationDelete(d *pluginsdk.ResourceData,
 func expandKustoAttachedDatabaseConfigurationProperties(d *pluginsdk.ResourceData) *attacheddatabaseconfigurations.AttachedDatabaseConfigurationProperties {
 	AttachedDatabaseConfigurationProperties := &attacheddatabaseconfigurations.AttachedDatabaseConfigurationProperties{}
 
-	if clusterResourceID, ok := d.GetOk("cluster_resource_id"); ok {
+	if clusterResourceID, ok := d.GetOk("cluster_id"); ok {
 		AttachedDatabaseConfigurationProperties.ClusterResourceId = clusterResourceID.(string)
 	}
 

--- a/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
@@ -104,7 +104,7 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   cluster_name        = azurerm_kusto_cluster.cluster1.name
-  cluster_resource_id = azurerm_kusto_cluster.cluster2.id
+  cluster_id          = azurerm_kusto_cluster.cluster2.id
   database_name       = azurerm_kusto_database.test.name
 
   sharing {

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_kusto_attached_database_configuration" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.follower_cluster.name
-  cluster_resource_id = azurerm_kusto_cluster.followed_cluster.id
+  cluster_id          = azurerm_kusto_cluster.followed_cluster.id
   database_name       = azurerm_kusto_database.example.name
 
   sharing {
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `cluster_name` - (Required) Specifies the name of the Kusto Cluster for which the configuration will be created. Changing this forces a new resource to be created.
 
-* `cluster_resource_id` - (Required) The resource id of the cluster where the databases you would like to attach reside. Changing this forces a new resource to be created.
+* `cluster_id` - (Required) The resource id of the cluster where the databases you would like to attach reside. Changing this forces a new resource to be created.
 
 * `database_name` - (Required) The name of the database which you would like to attach, use * if you want to follow all current and future databases. Changing this forces a new resource to be created.
 
@@ -115,7 +115,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The Kusto Attached Database Configuration ID.
 
-* `attached_database_names` - The list of databases from the `cluster_resource_id` which are currently attached to the cluster.
+* `attached_database_names` - The list of databases from the `cluster_id` which are currently attached to the cluster.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
> [!NOTE] 
> This PR is a breaking change in resource `azurerm_kusto_attached_database_configuration`

For resource `azurerm_kusto_attached_database_configuration`
- change the property name from cluster_resource_id to cluster_id in version 4.0
- delete the comment `// TODO: this should become cluster_id in 4.0`
- update test cases and document accordingly

Following the suggested naming pattern, we have to make this breaking change in resource `azurerm_kusto_attached_database_configuration` in version 4.0

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\<alias>\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\<alias>\<pathtogoland>\___TestAccKustoAttachedDatabaseConfiguration_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\<alias>\<pathtogoland>\___TestAccKustoAttachedDatabaseConfiguration_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccKustoAttachedDatabaseConfiguration_basic\E$ #gosetup
=== RUN   TestAccKustoAttachedDatabaseConfiguration_basic
=== PAUSE TestAccKustoAttachedDatabaseConfiguration_basic
=== CONT  TestAccKustoAttachedDatabaseConfiguration_basic
--- PASS: TestAccKustoAttachedDatabaseConfiguration_basic (1216.11s)
PASS


Process finished with the exit code 0
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kusto_attached_database_configuration` - change the property name from `cluster_resource_id` to `cluster_id` [GH-27475]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change