### PR TITLE
`azurerm_search_service` - support attribute `customer_managed_key_encryption_compliance_status`

### DIFF
--- a/internal/services/search/search_service_data_source.go
+++ b/internal/services/search/search_service_data_source.go
@@ -39,6 +39,11 @@ func dataSourceSearchService() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
+			"customer_managed_key_encryption_compliance_status": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"replica_count": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -115,6 +120,10 @@ func dataSourceSearchServiceRead(d *pluginsdk.ResourceData, meta interface{}) er
 			partitionCount := 1
 			replicaCount := 1
 			publicNetworkAccess := true
+
+			if props.EncryptionWithCmk != nil && props.EncryptionWithCmk.EncryptionComplianceStatus != nil {
+				d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
+			}
 
 			if count := props.PartitionCount; count != nil {
 				partitionCount = int(*count)

--- a/internal/services/search/search_service_data_source.go
+++ b/internal/services/search/search_service_data_source.go
@@ -121,7 +121,7 @@ func dataSourceSearchServiceRead(d *pluginsdk.ResourceData, meta interface{}) er
 			replicaCount := 1
 			publicNetworkAccess := true
 
-			if props.EncryptionWithCmk != nil && props.EncryptionWithCmk.EncryptionComplianceStatus != nil {
+			if props.EncryptionWithCmk != nil && props.EncryptionWithCmk {
 				d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
 			}
 

--- a/internal/services/search/search_service_data_source.go
+++ b/internal/services/search/search_service_data_source.go
@@ -121,7 +121,7 @@ func dataSourceSearchServiceRead(d *pluginsdk.ResourceData, meta interface{}) er
 			replicaCount := 1
 			publicNetworkAccess := true
 
-			if props.EncryptionWithCmk != nil && props.EncryptionWithCmk {
+			if props.EncryptionWithCmk != nil {
 				d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
 			}
 

--- a/internal/services/search/search_service_data_source_test.go
+++ b/internal/services/search/search_service_data_source_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceSearchService_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("customer_managed_key_encryption_compliance_status").Exists(),
 				check.That(data.ResourceName).Key("replica_count").Exists(),
 				check.That(data.ResourceName).Key("partition_count").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -125,6 +125,11 @@ func resourceSearchService() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"customer_managed_key_encryption_compliance_status": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"primary_key": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
@@ -557,6 +562,9 @@ func resourceSearchServiceRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 			if props.EncryptionWithCmk != nil {
 				cmkEnforcement = strings.EqualFold(string(pointer.From(props.EncryptionWithCmk.Enforcement)), string(services.SearchEncryptionWithCmkEnabled))
+				if props.EncryptionWithCmk.EncryptionComplianceStatus != nil {
+					d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
+				}
 			}
 
 			// I am using 'DisableLocalAuth' here because when you are in

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -562,9 +562,7 @@ func resourceSearchServiceRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 			if props.EncryptionWithCmk != nil {
 				cmkEnforcement = strings.EqualFold(string(pointer.From(props.EncryptionWithCmk.Enforcement)), string(services.SearchEncryptionWithCmkEnabled))
-				if props.EncryptionWithCmk.EncryptionComplianceStatus != nil {
-					d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
-				}
+				d.Set("customer_managed_key_encryption_compliance_status", string(pointer.From(props.EncryptionWithCmk.EncryptionComplianceStatus)))
 			}
 
 			// I am using 'DisableLocalAuth' here because when you are in

--- a/internal/services/search/search_service_resource_test.go
+++ b/internal/services/search/search_service_resource_test.go
@@ -337,6 +337,7 @@ func TestAccSearchService_customerManagedKeyEnforcement(t *testing.T) {
 			Config: r.customerManagedKeyEnforcement(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("customer_managed_key_encryption_compliance_status").HasValue("Compliant"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/d/search_service.html.markdown
+++ b/website/docs/d/search_service.html.markdown
@@ -38,6 +38,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Search Service.
 
+* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer-encrypted resources. If a service has more than one non-customer-encrypted resource and 'Enforcement' is 'enabled' then the service will be marked as 'NonCompliant'. If all the resources are customer-encrypted, then the service will be marked as 'Compliant'.
+
 * `primary_key` - The Primary Key used for Search Service Administration.
 
 * `secondary_key` - The Secondary Key used for Search Service Administration.

--- a/website/docs/d/search_service.html.markdown
+++ b/website/docs/d/search_service.html.markdown
@@ -38,7 +38,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Search Service.
 
-* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer-encrypted resources. If a service has more than one non-customer-encrypted resource and 'Enforcement' is 'enabled' then the service will be marked as 'NonCompliant'. If all the resources are customer-encrypted, then the service will be marked as 'Compliant'.
+* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer encrypted resources. If a service has more than one non-customer encrypted resource and `Enforcement` is `enabled` then the service will be marked as `NonCompliant`. If all the resources are customer encrypted, then the service will be marked as `Compliant`.
 
 * `primary_key` - The Primary Key used for Search Service Administration.
 

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -128,6 +128,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Search Service.
 
+* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer-encrypted resources. If a service has more than one non-customer-encrypted resource and 'Enforcement' is 'enabled' then the service will be marked as 'NonCompliant'. If all the resources are customer-encrypted, then the service will be marked as 'Compliant'.
+
 * `primary_key` - The Primary Key used for Search Service Administration.
 
 * `query_keys` - A `query_keys` block as defined below.

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -128,7 +128,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Search Service.
 
-* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer-encrypted resources. If a service has more than one non-customer-encrypted resource and 'Enforcement' is 'enabled' then the service will be marked as 'NonCompliant'. If all the resources are customer-encrypted, then the service will be marked as 'Compliant'.
+* `customer_managed_key_encryption_compliance_status` - Describes whether the search service is compliant or not with respect to having non-customer encrypted resources. If a service has more than one non-customer encrypted resource and `Enforcement` is `enabled` then the service will be marked as `NonCompliant`. If all the resources are customer encrypted, then the service will be marked as `Compliant`.
 
 * `primary_key` - The Primary Key used for Search Service Administration.
 


### PR DESCRIPTION
…search_service

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Customer now is blocked to create AI Search resource due to missing setting of `encryptionComplianceStatus` while deploying service via Terraform template. Basically, only enforcement property is supported to be inserted in Terraform, while 'Microsoft.Search/searchServices/encryptionWithCmk.encryptionComplianceStatus' is not available in Terraform.

1. Add readonly attribute `customer_managed_key_encryption_compliance_status` to `azurerm_search_service` resource
2. Add the same attribute for datasource `azurerm_search_service` as well
3. Updating document accordingly

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
GOROOT=C:\Users\<alias>\go\go1.22.7 #gosetup
GOPATH=C:\Users\<alias>\go #gosetup
C:\Users\<alias>\go\go1.22.7\bin\go.exe test -c -o C:\Users\<alias>\<golandpath>\___TestAccDataSourceSearchService_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_search.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/search #gosetup
C:\Users\<alias>\go\go1.22.7\bin\go.exe tool test2json -t C:\Users\<alias>\<golandpath>\___TestAccDataSourceSearchService_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_search.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccDataSourceSearchService_basic\E$ #gosetup
=== RUN   TestAccDataSourceSearchService_basic
=== PAUSE TestAccDataSourceSearchService_basic
=== CONT  TestAccDataSourceSearchService_basic
--- PASS: TestAccDataSourceSearchService_basic (508.04s)
PASS


Process finished with the exit code 0

GOROOT=C:\Users\<alias>\go\go1.22.7 #gosetup
GOPATH=C:\Users\<alias>\go #gosetup
C:\Users\<alias>\go\go1.22.7\bin\go.exe test -c -o C:\Users\<alias>\<golandpath>\___TestAccSearchService_customerManagedKeyEnforcement_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_search.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/search #gosetup
C:\Users\<alias>\go\go1.22.7\bin\go.exe tool test2json -t C:\Users\<alias>\<golandpath>\___TestAccSearchService_customerManagedKeyEnforcement_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_search.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccSearchService_customerManagedKeyEnforcement\E$ #gosetup
=== RUN   TestAccSearchService_customerManagedKeyEnforcement
=== PAUSE TestAccSearchService_customerManagedKeyEnforcement
=== CONT  TestAccSearchService_customerManagedKeyEnforcement
--- PASS: TestAccSearchService_customerManagedKeyEnforcement (183.91s)
PASS


Process finished with the exit code 0
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_search_service` - support attribute `customer_managed_key_encryption_compliance_status` [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change
