### PR TITLE
`azurerm_stack_hci_logical_network` - mark`subnet.route.name` property as optional

### DIFF
--- a/internal/services/azurestackhci/stack_hci_logical_network_resource.go
+++ b/internal/services/azurestackhci/stack_hci_logical_network_resource.go
@@ -66,7 +66,7 @@ type StackHCIIPPoolModel struct {
 }
 
 type StackHCIRouteModel struct {
-	Name             string `tfschema:"name,removedInNextMajorVersion"`
+	Name             string `tfschema:"name,removedInNextMajorVersion"` // remove in 5.0
 	AddressPrefix    string `tfschema:"address_prefix"`
 	NextHopIpAddress string `tfschema:"next_hop_ip_address"`
 }

--- a/internal/services/azurestackhci/stack_hci_logical_network_resource.go
+++ b/internal/services/azurestackhci/stack_hci_logical_network_resource.go
@@ -196,6 +196,7 @@ func (StackHCILogicalNetworkResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			ForceNew: true,
+			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"address_prefix": {

--- a/internal/services/azurestackhci/stack_hci_logical_network_resource.go
+++ b/internal/services/azurestackhci/stack_hci_logical_network_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2024-01-01/logicalnetworks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -66,13 +65,13 @@ type StackHCIIPPoolModel struct {
 }
 
 type StackHCIRouteModel struct {
-	Name             string `tfschema:"name,removedInNextMajorVersion"` // remove in 5.0
+	Name             string `tfschema:"name"`
 	AddressPrefix    string `tfschema:"address_prefix"`
 	NextHopIpAddress string `tfschema:"next_hop_ip_address"`
 }
 
 func (StackHCILogicalNetworkResource) Arguments() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -174,6 +173,16 @@ func (StackHCILogicalNetworkResource) Arguments() map[string]*pluginsdk.Schema {
 									ForceNew:     true,
 									ValidateFunc: validation.IsIPv4Address,
 								},
+
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+									ValidateFunc: validation.StringMatch(
+										regexp.MustCompile(`^[a-zA-Z0-9][\-\.\_a-zA-Z0-9]{0,78}[a-zA-Z0-9]$`),
+										"name must be between 2 and 80 characters and can only contain alphanumberic characters, hyphen, dot and underline",
+									),
+								},
 							},
 						},
 					},
@@ -190,43 +199,6 @@ func (StackHCILogicalNetworkResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
-
-	if !features.FivePointOhBeta() {
-		schema["route"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			ForceNew: true,
-			MaxItems: 1,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"address_prefix": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ForceNew:     true,
-						ValidateFunc: validation.IsCIDR,
-					},
-
-					"next_hop_ip_address": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ForceNew:     true,
-						ValidateFunc: validation.IsIPv4Address,
-					},
-
-					"name": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						ValidateFunc: validation.StringMatch(
-							regexp.MustCompile(`^[a-zA-Z0-9][\-\.\_a-zA-Z0-9]{0,78}[a-zA-Z0-9]$`),
-							"name must be between 2 and 80 characters and can only contain alphanumberic characters, hyphen, dot and underline",
-						),
-					},
-				},
-			},
-		}
-	}
-	return schema
 }
 
 func (StackHCILogicalNetworkResource) Attributes() map[string]*pluginsdk.Schema {
@@ -482,10 +454,8 @@ func expandStackHCILogicalNetworkRouteTable(input []StackHCIRouteModel) *logical
 			},
 		}
 
-		if !features.FivePointOhBeta() {
-			if v.Name != "" {
-				route.Name = pointer.To(v.Name)
-			}
+		if v.Name != "" {
+			route.Name = pointer.To(v.Name)
 		}
 
 		routes = append(routes, route)
@@ -505,10 +475,8 @@ func flattenStackHCILogicalNetworkRouteTable(input *logicalnetworks.RouteTable) 
 
 	results := make([]StackHCIRouteModel, 0)
 	for _, v := range *input.Properties.Routes {
-		route := StackHCIRouteModel{}
-
-		if !features.FivePointOhBeta() {
-			route.Name = pointer.From(v.Name)
+		route := StackHCIRouteModel{
+			Name: pointer.From(v.Name),
 		}
 
 		if v.Properties != nil {

--- a/internal/services/azurestackhci/stack_hci_logical_network_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_logical_network_resource_test.go
@@ -26,12 +26,12 @@ const (
 )
 
 func TestAccStackHCILogicalNetwork_dynamic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_stack_hci_logical_network", "test")
-	r := StackHCILogicalNetworkResource{}
-
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)
 	}
+
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_logical_network", "test")
+	r := StackHCILogicalNetworkResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -45,23 +45,16 @@ func TestAccStackHCILogicalNetwork_dynamic(t *testing.T) {
 }
 
 func TestAccStackHCILogicalNetwork_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_stack_hci_logical_network", "test")
-	r := StackHCILogicalNetworkResource{}
-
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)
 	}
 
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_logical_network", "test")
+	r := StackHCILogicalNetworkResource{}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -94,7 +87,7 @@ func TestAccStackHCILogicalNetwork_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.dynamic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -210,14 +203,8 @@ resource "azurerm_stack_hci_logical_network" "test" {
       end   = "10.0.0.239"
     }
     route {
-      name                = "test-route"
       address_prefix      = "10.0.0.0/28"
-      next_hop_ip_address = "10.0.20.1"
-    }
-    route {
-      name                = "test-route2"
-      address_prefix      = "10.0.0.128/28"
-      next_hop_ip_address = "10.0.20.2"
+      next_hop_ip_address = "10.0.0.1"
     }
   }
 }
@@ -254,14 +241,8 @@ resource "azurerm_stack_hci_logical_network" "test" {
       end   = "10.0.0.239"
     }
     route {
-      name                = "test-route"
       address_prefix      = "10.0.0.0/28"
-      next_hop_ip_address = "10.0.20.1"
-    }
-    route {
-      name                = "test-route2"
-      address_prefix      = "10.0.0.128/28"
-      next_hop_ip_address = "10.0.20.2"
+      next_hop_ip_address = "10.0.0.1"
     }
   }
 
@@ -294,22 +275,16 @@ resource "azurerm_stack_hci_logical_network" "test" {
     address_prefix       = "10.0.0.0/24"
     vlan_id              = 123
     ip_pool {
-      start = "10.0.0.218"
-      end   = "10.0.0.230"
+      start = "10.0.0.208"
+      end   = "10.0.0.210"
     }
     ip_pool {
-      start = "10.0.0.234"
-      end   = "10.0.0.239"
+      start = "10.0.0.244"
+      end   = "10.0.0.249"
     }
     route {
-      name                = "test-route"
       address_prefix      = "10.0.0.0/28"
-      next_hop_ip_address = "10.0.20.1"
-    }
-    route {
-      name                = "test-route2"
-      address_prefix      = "10.0.0.128/28"
-      next_hop_ip_address = "10.0.20.2"
+      next_hop_ip_address = "10.0.0.1"
     }
   }
 

--- a/website/docs/r/stack_hci_logical_network.html.markdown
+++ b/website/docs/r/stack_hci_logical_network.html.markdown
@@ -29,12 +29,11 @@ resource "azurerm_stack_hci_logical_network" "example" {
   subnet {
     ip_allocation_method = "Static"
     address_prefix       = "10.0.0.0/24"
+    vlan_id              = 123
     route {
-      name                = "example-route"
       address_prefix      = "0.0.0.0/0"
-      next_hop_ip_address = "10.0.20.1"
+      next_hop_ip_address = "10.0.0.1"
     }
-    vlan_id = 123
   }
 
   tags = {
@@ -75,11 +74,13 @@ A `ip_pool` block supports the following:
 
 A `route` block supports the following:
 
-* `name` - (Required) The name of the route. Changing this forces a new resource to be created.
-
 * `address_prefix` - (Optional) The Address in CIDR notation. Changing this forces a new resource to be created.
 
 * `next_hop_ip_address` - (Optional) The IPv4 address of the next hop. Changing this forces a new resource to be created.
+
+* `name` - (Optional) The name of the route. Changing this forces a new resource to be created.
+
+-> **Note:** `name` is deprecated and will be remove in the next major release.
 
 ---
 
@@ -91,7 +92,7 @@ A `subnet` block supports the following:
 
 * `ip_pool` - (Optional) One or more `ip_pool` block as defined above. Changing this forces a new resource to be created.
 
-* `route` - (Optional) One or more `route` block as defined above. Changing this forces a new resource to be created.
+* `route` - (Optional) A `route` block as defined above. Changing this forces a new resource to be created.
 
 * `vlan_id` - (Optional) The VLAN ID for the Logical Network. Changing this forces a new resource to be created.
 

--- a/website/docs/r/stack_hci_logical_network.html.markdown
+++ b/website/docs/r/stack_hci_logical_network.html.markdown
@@ -80,8 +80,6 @@ A `route` block supports the following:
 
 * `name` - (Optional) The name of the route. Changing this forces a new resource to be created.
 
--> **Note:** `name` is deprecated and will be removed in the next major release.
-
 ---
 
 A `subnet` block supports the following:

--- a/website/docs/r/stack_hci_logical_network.html.markdown
+++ b/website/docs/r/stack_hci_logical_network.html.markdown
@@ -80,7 +80,7 @@ A `route` block supports the following:
 
 * `name` - (Optional) The name of the route. Changing this forces a new resource to be created.
 
--> **Note:** `name` is deprecated and will be remove in the next major release.
+-> **Note:** `name` is deprecated and will be removed in the next major release.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

From service team, the `subnet.route.name` property should be optional. And for now only one `route` block is allowed.
This PR also fix recreate in update test case

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
![image](https://github.com/user-attachments/assets/d6437f32-97ab-47ad-a2ac-6cc5a6074d60)
The test depends on a custom location generated during HCI deployment, the my test log is available at https://gist.github.com/teowa/57d06a52574b377a63dc1a33effab732
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_stack_hci_logical_network` - deprecate `subnet.route.name` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
