### PR TITLE
`managedapplications` - fix `TestAccManagedApplicationDefinition_update` and `TestAccManagedApplication_plan`

### DIFF
--- a/internal/services/managedapplications/managed_application_definition_resource.go
+++ b/internal/services/managedapplications/managed_application_definition_resource.go
@@ -216,11 +216,21 @@ func resourceManagedApplicationDefinitionUpdate(d *pluginsdk.ResourceData, meta 
 	}
 
 	if d.HasChange("create_ui_definition") {
-		payload.Properties.CreateUiDefinition = pointer.To(d.Get("create_ui_definition"))
+		// handle API error: The 'MainTemplate, CreateUiDefinition' properties should be empty if package zip file uri is provided.
+		if v, ok := d.GetOk("create_ui_definition"); ok {
+			payload.Properties.CreateUiDefinition = pointer.To(v)
+		} else {
+			payload.Properties.CreateUiDefinition = nil
+		}
 	}
 
 	if d.HasChange("main_template") {
-		payload.Properties.MainTemplate = pointer.To(d.Get("main_template"))
+		// handle API error: The 'MainTemplate, CreateUiDefinition' properties should be empty if package zip file uri is provided.
+		if v, ok := d.GetOk("main_template"); ok {
+			payload.Properties.MainTemplate = pointer.To(v)
+		} else {
+			payload.Properties.MainTemplate = nil
+		}
 	}
 
 	if d.HasChange("package_file_uri") {

--- a/internal/services/managedapplications/managed_application_definition_resource_test.go
+++ b/internal/services/managedapplications/managed_application_definition_resource_test.go
@@ -162,7 +162,7 @@ resource "azurerm_managed_application_definition" "test" {
   name                = "acctestAppDef%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  lock_level          = "ReadOnly"
+  lock_level          = "None"
   display_name        = "UpdatedTestManagedApplicationDefinition"
   description         = "Updated Test Managed Application Definition"
   package_enabled     = true

--- a/internal/services/managedapplications/managed_application_resource_test.go
+++ b/internal/services/managedapplications/managed_application_resource_test.go
@@ -195,12 +195,11 @@ func TestAccManagedApplication_plan(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.empty(),
-			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, plan)),
-			),
-		},
-		{
+			PreConfig: func() {
+				if err := r.cancelExistingAgreement(publisher, offer, plan); err != nil {
+					t.Fatalf("Failed to cancel existing agreement with error: %+v", err)
+				}
+			},
 			Config: r.plan(data, publisher, offer, plan),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -699,14 +698,6 @@ resource "azurerm_managed_application_definition" "test" {
   }
 }
 `, data.Locations.Primary, data.RandomInteger, parameters)
-}
-
-func (ManagedApplicationResource) empty() string {
-	return `
-provider "azurerm" {
-  features {}
-}
-`
 }
 
 func (ManagedApplicationResource) cancelExistingAgreement(publisher string, offer string, plan string) acceptance.ClientCheckFunc {

--- a/internal/services/managedapplications/managed_application_resource_test.go
+++ b/internal/services/managedapplications/managed_application_resource_test.go
@@ -712,7 +712,11 @@ func (ManagedApplicationResource) cancelExistingAgreement(publisher string, offe
 
 		existing, err := client.MarketplaceAgreementsGet(ctx, idGet)
 		if err != nil {
-			return err
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("retrieving %s: %s", idGet, err)
+				}
+			}
 		}
 
 		if model := existing.Model; model != nil {

--- a/internal/services/managedapplications/managed_application_resource_test.go
+++ b/internal/services/managedapplications/managed_application_resource_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -196,7 +197,7 @@ func TestAccManagedApplication_plan(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			PreConfig: func() {
-				if err := r.cancelExistingAgreement(publisher, offer, plan); err != nil {
+				if err := r.cancelExistingAgreement(t, publisher, offer, plan); err != nil {
 					t.Fatalf("Failed to cancel existing agreement with error: %+v", err)
 				}
 			},
@@ -700,39 +701,39 @@ resource "azurerm_managed_application_definition" "test" {
 `, data.Locations.Primary, data.RandomInteger, parameters)
 }
 
-func (ManagedApplicationResource) cancelExistingAgreement(publisher string, offer string, plan string) acceptance.ClientCheckFunc {
-	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-		client := clients.Compute.MarketplaceAgreementsClient
-		subscriptionId := clients.Account.SubscriptionId
-		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(15*time.Minute))
-		defer cancel()
-
-		idGet := agreements.NewOfferPlanID(subscriptionId, publisher, offer, plan)
-		idCancel := agreements.NewPlanID(subscriptionId, publisher, offer, plan)
-
-		existing, err := client.MarketplaceAgreementsGet(ctx, idGet)
-		if err != nil {
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("retrieving %s: %s", idGet, err)
-				}
-			}
-		}
-
-		if model := existing.Model; model != nil {
-			if props := model.Properties; props != nil {
-				if accepted := props.Accepted; accepted != nil && *accepted {
-					resp, err := client.MarketplaceAgreementsCancel(ctx, idCancel)
-					if err != nil {
-						if response.WasNotFound(resp.HttpResponse) {
-							return fmt.Errorf("marketplace agreement %q does not exist", idGet)
-						}
-						return fmt.Errorf("canceling %s: %+v", idGet, err)
-					}
-				}
-			}
-		}
-
-		return nil
+func (ManagedApplicationResource) cancelExistingAgreement(t *testing.T, publisher string, offer string, plan string) error {
+	clientManager, err := testclient.Build()
+	if err != nil {
+		t.Fatalf("building client: %+v", err)
 	}
+
+	ctx, cancel := context.WithDeadline(clientManager.StopContext, time.Now().Add(15*time.Minute))
+	defer cancel()
+
+	client := clientManager.Compute.MarketplaceAgreementsClient
+	subscriptionId := clientManager.Account.SubscriptionId
+
+	idGet := agreements.NewOfferPlanID(subscriptionId, publisher, offer, plan)
+	idCancel := agreements.NewPlanID(subscriptionId, publisher, offer, plan)
+
+	existing, err := client.MarketplaceAgreementsGet(ctx, idGet)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %s", idGet, err)
+	}
+
+	if model := existing.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.MarketplaceAgreementsCancel(ctx, idCancel)
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return fmt.Errorf("marketplace agreement %q does not exist", idGet)
+					}
+					return fmt.Errorf("canceling %s: %+v", idGet, err)
+				}
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
fail: 
```
------- Stdout: -------
=== RUN   TestAccManagedApplicationDefinition_update
=== PAUSE TestAccManagedApplicationDefinition_update
=== CONT  TestAccManagedApplicationDefinition_update
    testcase.go:173: Step 4/9 error: Pre-apply plan check(s) failed:
        'azurerm_managed_application_definition.test' - expected action to not be Replace
--- FAIL: TestAccManagedApplicationDefinition_update (114.66s)
FAIL
```
```
------- Stdout: -------
=== RUN   TestAccManagedApplication_plan
=== PAUSE TestAccManagedApplication_plan
=== CONT  TestAccManagedApplication_plan
    testcase.go:173: Step 1/4 error: Pre-apply plan check(s) failed:
        azurerm_managed_application.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccManagedApplication_plan (14.27s)
FAIL
```
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
