### PR TITLE
`resource` - fix `TestAccResourceManagementPrivateLinkAssociation_requiresImport` 

### DIFF
--- a/internal/services/resource/resource_management_private_link_association_resource_test.go
+++ b/internal/services/resource/resource_management_private_link_association_resource_test.go
@@ -17,11 +17,16 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type ResourceManagementPrivateLinkAssociationTestResource struct{}
+type ResourceManagementPrivateLinkAssociationTestResource struct {
+	uuid string
+}
 
 func TestAccResourceManagementPrivateLinkAssociation_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_resource_management_private_link_association", "test")
-	r := ResourceManagementPrivateLinkAssociationTestResource{}
+	randomUUID, _ := uuid.GenerateUUID()
+	r := ResourceManagementPrivateLinkAssociationTestResource{
+		uuid: randomUUID,
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +41,10 @@ func TestAccResourceManagementPrivateLinkAssociation_basic(t *testing.T) {
 
 func TestAccResourceManagementPrivateLinkAssociation_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_resource_management_private_link_association", "test")
-	r := ResourceManagementPrivateLinkAssociationTestResource{}
+	randomUUID, _ := uuid.GenerateUUID()
+	r := ResourceManagementPrivateLinkAssociationTestResource{
+		uuid: randomUUID,
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -79,7 +87,6 @@ func (r ResourceManagementPrivateLinkAssociationTestResource) Exists(ctx context
 }
 
 func (r ResourceManagementPrivateLinkAssociationTestResource) basic(data acceptance.TestData) string {
-	randomUUID, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -93,7 +100,7 @@ resource "azurerm_resource_management_private_link_association" "test" {
   resource_management_private_link_id = azurerm_resource_management_private_link.test.id
   public_network_access_enabled       = true
 }
-`, r.template(data), randomUUID)
+`, r.template(data), r.uuid, data.RandomInteger)
 }
 
 func (r ResourceManagementPrivateLinkAssociationTestResource) generateName(data acceptance.TestData) string {

--- a/internal/services/resource/resource_management_private_link_association_resource_test.go
+++ b/internal/services/resource/resource_management_private_link_association_resource_test.go
@@ -100,7 +100,7 @@ resource "azurerm_resource_management_private_link_association" "test" {
   resource_management_private_link_id = azurerm_resource_management_private_link.test.id
   public_network_access_enabled       = true
 }
-`, r.template(data), r.uuid, data.RandomInteger)
+    `, r.template(data), r.uuid)
 }
 
 func (r ResourceManagementPrivateLinkAssociationTestResource) generateName(data acceptance.TestData) string {

--- a/internal/services/resource/resource_management_private_link_association_resource_test.go
+++ b/internal/services/resource/resource_management_private_link_association_resource_test.go
@@ -100,7 +100,7 @@ resource "azurerm_resource_management_private_link_association" "test" {
   resource_management_private_link_id = azurerm_resource_management_private_link.test.id
   public_network_access_enabled       = true
 }
-    `, r.template(data), r.uuid)
+`, r.template(data), r.uuid)
 }
 
 func (r ResourceManagementPrivateLinkAssociationTestResource) generateName(data acceptance.TestData) string {


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
`resource` - fix `TestAccResourceManagementPrivateLinkAssociation_requiresImport`  recreate caused by uuid generation
```
------- Stdout: -------
=== RUN   TestAccResourceManagementPrivateLinkAssociation_requiresImport
=== PAUSE TestAccResourceManagementPrivateLinkAssociation_requiresImport
=== CONT  TestAccResourceManagementPrivateLinkAssociation_requiresImport
    testcase.go:173: Step 2/2, expected an error with pattern, no match on: Pre-apply plan check(s) failed:
        'azurerm_resource_management_private_link_association.test' - expected action to not be Replace
--- FAIL: TestAccResourceManagementPrivateLinkAssociation_requiresImport (193.90s)
FAIL
```

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
