### PR TITLE
Updated no longer supported code blocks

### DIFF
--- a/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
+++ b/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
   target_resource_id         = "${azurerm_mssql_server.example.id}/databases/master"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
 
-  enable_log {
+  enabled_log {
     category = "SQLSecurityAuditEvents"
   }
 

--- a/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
+++ b/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
@@ -32,25 +32,16 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
   target_resource_id         = "${azurerm_mssql_server.example.id}/databases/master"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
 
-  log {
+  enable_log {
     category = "SQLSecurityAuditEvents"
-    enabled  = true
-
-    retention_policy {
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-    }
   }
 
   lifecycle {
-    ignore_changes = [log, metric]
+    ignore_changes = [enable_log, metric]
   }
 }
 

--- a/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
+++ b/examples/sql-azure/sql_server_auditing_log_analytics/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
   }
 
   lifecycle {
-    ignore_changes = [enable_log, metric]
+    ignore_changes = [enabled_log, metric]
   }
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The log block is no longer supported, it changed to enabled_log, the current supported block. The enabled string is no longer needed and the retention_policy function is deprecated.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”