### PR TITLE
`search` - fix TestAccSearchService_freeSku

### DIFF
--- a/internal/services/search/search_service_resource_test.go
+++ b/internal/services/search/search_service_resource_test.go
@@ -44,7 +44,7 @@ func TestAccSearchService_freeSku(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "free"),
+			Config: r.semanticSearchBasic(data, "free"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("semantic_search_sku").HasValue(""),


### PR DESCRIPTION
This test was failing due to a ForceNew being trigged because of a location difference between the two test steps. The two test steps are the same except one is locked to `westus` so we'll just use that basic step that is locked to `westus` to get the test to pass


```
--- PASS: TestAccSearchService_freeSku (91.29s)
```