### PR TITLE
container apps - support for additional settings in container apps probes

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -2223,7 +2223,6 @@ resource "azurerm_container_app" "test" {
         initial_delay           = 5
         timeout                 = 2
         failure_count_threshold = 3
-        success_count_threshold = 1
       }
 
       startup_probe {
@@ -2232,7 +2231,6 @@ resource "azurerm_container_app" "test" {
         initial_delay           = 5
         timeout                 = 5
         failure_count_threshold = 1
-        success_count_threshold = 1
       }
 
       volume_mounts {

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -2199,6 +2199,7 @@ resource "azurerm_container_app" "test" {
         transport               = "HTTP"
         port                    = 5000
         path                    = "/uptime"
+        initial_delay           = 5
         timeout                 = 2
         failure_count_threshold = 1
         success_count_threshold = 1
@@ -2222,13 +2223,16 @@ resource "azurerm_container_app" "test" {
         initial_delay           = 5
         timeout                 = 2
         failure_count_threshold = 3
+        success_count_threshold = 1
       }
 
       startup_probe {
         transport               = "TCP"
         port                    = 5000
+        initial_delay           = 5
         timeout                 = 5
         failure_count_threshold = 1
+        success_count_threshold = 1
       }
 
       volume_mounts {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1931,11 +1931,12 @@ func ContainerAppReadinessProbeSchemaComputed() *pluginsdk.Schema {
 func expandContainerAppReadinessProbe(input ContainerAppReadinessProbe) containerapps.ContainerAppProbe {
 	probeType := containerapps.TypeReadiness
 	result := containerapps.ContainerAppProbe{
-		Type:             &probeType,
-		PeriodSeconds:    pointer.To(input.Interval),
-		TimeoutSeconds:   pointer.To(input.Timeout),
-		FailureThreshold: pointer.To(input.FailureThreshold),
-		SuccessThreshold: pointer.To(input.SuccessThreshold),
+		Type:                &probeType,
+		InitialDelaySeconds: pointer.To(input.InitialDelay),
+		PeriodSeconds:       pointer.To(input.Interval),
+		TimeoutSeconds:      pointer.To(input.Timeout),
+		FailureThreshold:    pointer.To(input.FailureThreshold),
+		SuccessThreshold:    pointer.To(input.SuccessThreshold),
 	}
 
 	switch p := strings.ToUpper(input.Transport); p {
@@ -1972,6 +1973,7 @@ func expandContainerAppReadinessProbe(input ContainerAppReadinessProbe) containe
 func flattenContainerAppReadinessProbe(input containerapps.ContainerAppProbe) []ContainerAppReadinessProbe {
 	result := make([]ContainerAppReadinessProbe, 0)
 	probe := ContainerAppReadinessProbe{
+		InitialDelay:     pointer.From(input.InitialDelay),
 		Interval:         pointer.From(input.PeriodSeconds),
 		Timeout:          pointer.From(input.TimeoutSeconds),
 		FailureThreshold: pointer.From(input.FailureThreshold),
@@ -2230,6 +2232,7 @@ func expandContainerAppLivenessProbe(input ContainerAppLivenessProbe) containera
 		PeriodSeconds:       pointer.To(input.Interval),
 		TimeoutSeconds:      pointer.To(input.Timeout),
 		FailureThreshold:    pointer.To(input.FailureThreshold),
+		SuccessThreshold:    pointer.To(input.SuccessThreshold),
 	}
 
 	switch p := strings.ToUpper(input.Transport); p {
@@ -2270,6 +2273,7 @@ func flattenContainerAppLivenessProbe(input containerapps.ContainerAppProbe) []C
 		Interval:               pointer.From(input.PeriodSeconds),
 		Timeout:                pointer.From(input.TimeoutSeconds),
 		FailureThreshold:       pointer.From(input.FailureThreshold),
+		SuccessThreshold:       pointer.From(input.SuccessThreshold),
 		TerminationGracePeriod: pointer.From(input.TerminationGracePeriodSeconds),
 	}
 	if httpGet := input.HTTPGet; httpGet != nil {
@@ -2515,10 +2519,12 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 func expandContainerAppStartupProbe(input ContainerAppStartupProbe) containerapps.ContainerAppProbe {
 	probeType := containerapps.TypeStartup
 	result := containerapps.ContainerAppProbe{
-		Type:             &probeType,
-		PeriodSeconds:    pointer.To(input.Interval),
-		TimeoutSeconds:   pointer.To(input.Timeout),
-		FailureThreshold: pointer.To(input.FailureThreshold),
+		Type:                &probeType,
+		InitialDelaySeconds: pointer.To(input.InitialDelay),
+		PeriodSeconds:       pointer.To(input.Interval),
+		TimeoutSeconds:      pointer.To(input.Timeout),
+		FailureThreshold:    pointer.To(input.FailureThreshold),
+		SuccessThreshold:    pointer.To(input.SuccessThreshold),
 	}
 
 	switch p := strings.ToUpper(input.Transport); p {
@@ -2555,9 +2561,11 @@ func expandContainerAppStartupProbe(input ContainerAppStartupProbe) containerapp
 func flattenContainerAppStartupProbe(input containerapps.ContainerAppProbe) []ContainerAppStartupProbe {
 	result := make([]ContainerAppStartupProbe, 0)
 	probe := ContainerAppStartupProbe{
+		InitialDelay:           pointer.From(input.InitialDelaySeconds),
 		Interval:               pointer.From(input.PeriodSeconds),
 		Timeout:                pointer.From(input.TimeoutSeconds),
 		FailureThreshold:       pointer.From(input.FailureThreshold),
+		SuccessThreshold:       pointer.From(input.SuccessThreshold),
 		TerminationGracePeriod: pointer.From(input.TerminationGracePeriodSeconds),
 	}
 

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1973,7 +1973,7 @@ func expandContainerAppReadinessProbe(input ContainerAppReadinessProbe) containe
 func flattenContainerAppReadinessProbe(input containerapps.ContainerAppProbe) []ContainerAppReadinessProbe {
 	result := make([]ContainerAppReadinessProbe, 0)
 	probe := ContainerAppReadinessProbe{
-		InitialDelay:     pointer.From(input.InitialDelay),
+		InitialDelay:     pointer.From(input.InitialDelaySeconds),
 		Interval:         pointer.From(input.PeriodSeconds),
 		Timeout:          pointer.From(input.TimeoutSeconds),
 		FailureThreshold: pointer.From(input.FailureThreshold),

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1734,6 +1734,7 @@ type ContainerAppReadinessProbe struct {
 	Port             int64        `tfschema:"port"`
 	Path             string       `tfschema:"path"`
 	Headers          []HttpHeader `tfschema:"header"`
+	InitialDelay     int64        `tfschema:"initial_delay"`
 	Interval         int64        `tfschema:"interval_seconds"`
 	Timeout          int64        `tfschema:"timeout"`
 	FailureThreshold int64        `tfschema:"failure_count_threshold"`
@@ -1799,6 +1800,14 @@ func ContainerAppReadinessProbeSchema() *pluginsdk.Schema {
 					},
 				},
 
+				"initial_delay": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntBetween(0, 60),
+					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+				},
+
 				"interval_seconds": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
@@ -1819,8 +1828,8 @@ func ContainerAppReadinessProbeSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      3,
-					ValidateFunc: validation.IntBetween(1, 10),
-					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					ValidateFunc: validation.IntBetween(1, 30),
+					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
 				"success_count_threshold": {
@@ -1885,6 +1894,12 @@ func ContainerAppReadinessProbeSchemaComputed() *pluginsdk.Schema {
 					},
 				},
 
+				"initial_delay": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+				},
+
 				"interval_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -1900,7 +1915,7 @@ func ContainerAppReadinessProbeSchemaComputed() *pluginsdk.Schema {
 				"failure_count_threshold": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
 				"success_count_threshold": {
@@ -2004,6 +2019,7 @@ type ContainerAppLivenessProbe struct {
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
+	SuccessThreshold       int64        `tfschema:"success_count_threshold"`
 	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
 }
 
@@ -2070,8 +2086,8 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      1,
-					ValidateFunc: validation.IntBetween(1, 60),
-					Description:  "The time in seconds to wait after the container has started before the probe is started.",
+					ValidateFunc: validation.IntBetween(0, 60),
+					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2094,8 +2110,16 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      3,
-					ValidateFunc: validation.IntBetween(1, 10),
-					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					ValidateFunc: validation.IntBetween(1, 30),
+					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
+				},
+
+				"success_count_threshold": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      1,
+					ValidateFunc: validation.IntBetween(1, 1),
+					Description:  "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to `1`. Must be `1` for liveness and startup Probes. Minimum value is `1`.",
 				},
 
 				"termination_grace_period_seconds": {
@@ -2161,7 +2185,7 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 				"initial_delay": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The time in seconds to wait after the container has started before the probe is started.",
+					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2179,7 +2203,13 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 				"failure_count_threshold": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
+				},
+
+				"success_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to `1`. Must be `1` for liveness and startup Probes. Minimum value is `1`.",
 				},
 
 				"termination_grace_period_seconds": {
@@ -2279,9 +2309,11 @@ type ContainerAppStartupProbe struct {
 	Port                   int64        `tfschema:"port"`
 	Path                   string       `tfschema:"path"`
 	Headers                []HttpHeader `tfschema:"header"`
+	InitialDelay           int64        `tfschema:"initial_delay"`
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
+	SuccessThreshold       int64        `tfschema:"success_count_threshold"`
 	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
 }
 
@@ -2344,6 +2376,14 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					},
 				},
 
+				"initial_delay": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntBetween(0, 60),
+					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+				},
+
 				"interval_seconds": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
@@ -2364,8 +2404,16 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      3,
-					ValidateFunc: validation.IntBetween(1, 10),
-					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					ValidateFunc: validation.IntBetween(1, 30),
+					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
+				},
+
+				"success_count_threshold": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      1,
+					ValidateFunc: validation.IntBetween(1, 1),
+					Description:  "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.",
 				},
 
 				"termination_grace_period_seconds": {
@@ -2424,6 +2472,12 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 					},
 				},
 
+				"initial_delay": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+				},
+
 				"interval_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -2439,7 +2493,13 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 				"failure_count_threshold": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
+				},
+
+				"success_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.",
 				},
 
 				"termination_grace_period_seconds": {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1805,7 +1805,7 @@ func ContainerAppReadinessProbeSchema() *pluginsdk.Schema {
 					Optional:     true,
 					Default:      0,
 					ValidateFunc: validation.IntBetween(0, 60),
-					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+					Description:  "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
 				},
 
 				"interval_seconds": {
@@ -1897,7 +1897,7 @@ func ContainerAppReadinessProbeSchemaComputed() *pluginsdk.Schema {
 				"initial_delay": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+					Description: "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2088,7 +2088,7 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 					Optional:     true,
 					Default:      1,
 					ValidateFunc: validation.IntBetween(0, 60),
-					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
+					Description:  "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2178,7 +2178,7 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 				"initial_delay": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
+					Description: "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2367,7 +2367,7 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					Optional:     true,
 					Default:      0,
 					ValidateFunc: validation.IntBetween(0, 60),
-					Description:  "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+					Description:  "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
 				},
 
 				"interval_seconds": {
@@ -2453,7 +2453,7 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 				"initial_delay": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
-					Description: "The number of seconds elapsed after the container has started before liveness or readiness probes are initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
+					Description: "The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.",
 				},
 
 				"interval_seconds": {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -2021,7 +2021,6 @@ type ContainerAppLivenessProbe struct {
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
-	SuccessThreshold       int64        `tfschema:"success_count_threshold"`
 	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
 }
 
@@ -2116,14 +2115,6 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
-				"success_count_threshold": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Default:      1,
-					ValidateFunc: validation.IntBetween(1, 1),
-					Description:  "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to `1`. Must be `1` for liveness and startup Probes. Minimum value is `1`.",
-				},
-
 				"termination_grace_period_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -2208,12 +2199,6 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
-				"success_count_threshold": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to `1`. Must be `1` for liveness and startup Probes. Minimum value is `1`.",
-				},
-
 				"termination_grace_period_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -2232,7 +2217,6 @@ func expandContainerAppLivenessProbe(input ContainerAppLivenessProbe) containera
 		PeriodSeconds:       pointer.To(input.Interval),
 		TimeoutSeconds:      pointer.To(input.Timeout),
 		FailureThreshold:    pointer.To(input.FailureThreshold),
-		SuccessThreshold:    pointer.To(input.SuccessThreshold),
 	}
 
 	switch p := strings.ToUpper(input.Transport); p {
@@ -2273,7 +2257,6 @@ func flattenContainerAppLivenessProbe(input containerapps.ContainerAppProbe) []C
 		Interval:               pointer.From(input.PeriodSeconds),
 		Timeout:                pointer.From(input.TimeoutSeconds),
 		FailureThreshold:       pointer.From(input.FailureThreshold),
-		SuccessThreshold:       pointer.From(input.SuccessThreshold),
 		TerminationGracePeriod: pointer.From(input.TerminationGracePeriodSeconds),
 	}
 	if httpGet := input.HTTPGet; httpGet != nil {
@@ -2317,7 +2300,6 @@ type ContainerAppStartupProbe struct {
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
-	SuccessThreshold       int64        `tfschema:"success_count_threshold"`
 	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
 }
 
@@ -2412,14 +2394,6 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
-				"success_count_threshold": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Default:      1,
-					ValidateFunc: validation.IntBetween(1, 1),
-					Description:  "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.",
-				},
-
 				"termination_grace_period_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -2500,12 +2474,6 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
 
-				"success_count_threshold": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The minimum consecutive successes for the probe to be considered healthy after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.",
-				},
-
 				"termination_grace_period_seconds": {
 					Type:        pluginsdk.TypeInt,
 					Computed:    true,
@@ -2524,7 +2492,6 @@ func expandContainerAppStartupProbe(input ContainerAppStartupProbe) containerapp
 		PeriodSeconds:       pointer.To(input.Interval),
 		TimeoutSeconds:      pointer.To(input.Timeout),
 		FailureThreshold:    pointer.To(input.FailureThreshold),
-		SuccessThreshold:    pointer.To(input.SuccessThreshold),
 	}
 
 	switch p := strings.ToUpper(input.Transport); p {
@@ -2565,7 +2532,6 @@ func flattenContainerAppStartupProbe(input containerapps.ContainerAppProbe) []Co
 		Interval:               pointer.From(input.PeriodSeconds),
 		Timeout:                pointer.From(input.TimeoutSeconds),
 		FailureThreshold:       pointer.From(input.FailureThreshold),
-		SuccessThreshold:       pointer.From(input.SuccessThreshold),
 		TerminationGracePeriod: pointer.From(input.TerminationGracePeriodSeconds),
 	}
 

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -151,7 +151,7 @@ A `liveness_probe` block supports the following:
 
 * `host` - The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
 
-* `initial_delay` - The time in seconds to wait after the container has started before the probe is started.
+* `initial_delay` - The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.
 
 * `interval_seconds` - How often, in seconds, the probe should run. Possible values are in the range `1` - `240`. Defaults to `10`.
 
@@ -187,11 +187,13 @@ An `env` block supports the following:
 
 A `readiness_probe` block supports the following:
 
-* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.
 
 * `header` - A `header` block as detailed below.
 
 * `host` - The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `initial_delay` - The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.
 
 * `interval_seconds` - How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
 
@@ -217,11 +219,13 @@ A `header` block supports the following:
 
 A `startup_probe` block supports the following:
 
-* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.
 
 * `header` - A `header` block as detailed below.
 
 * `host` - The value for the host header which should be sent with this probe. If unspecified, the IP Address of the Pod is used as the host header. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `initial_delay` - The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.
 
 * `interval_seconds` - How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -260,7 +260,7 @@ A `liveness_probe` block supports the following:
 
 * `host` - (Optional) The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
 
-* `initial_delay` - (Optional) The time in seconds to wait after the container has started before the probe is started.
+* `initial_delay` - (Optional) The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `1` seconds.
 
 * `interval_seconds` - (Optional) How often, in seconds, the probe should run. Possible values are in the range `1` - `240`. Defaults to `10`.
 
@@ -298,11 +298,13 @@ An `env` block supports the following:
 
 A `readiness_probe` block supports the following:
 
-* `failure_count_threshold` - (Optional) The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+* `failure_count_threshold` - (Optional) The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.
 
 * `header` - (Optional) A `header` block as detailed below.
 
 * `host` - (Optional) The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `initial_delay` - (Optional) The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.
 
 * `interval_seconds` - (Optional) How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
 
@@ -328,11 +330,13 @@ A `header` block supports the following:
 
 A `startup_probe` block supports the following:
 
-* `failure_count_threshold` - (Optional) The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+* `failure_count_threshold` - (Optional) The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.
 
 * `header` - (Optional) A `header` block as detailed below.
 
 * `host` - (Optional) The value for the host header which should be sent with this probe. If unspecified, the IP Address of the Pod is used as the host header. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `initial_delay` - (Optional) The number of seconds elapsed after the container has started before the probe is initiated. Possible values are between `0` and `60`. Defaults to `0` seconds.
 
 * `interval_seconds` - (Optional) How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The available settings for the configuration of the liveness, readiness and startup probes in Azure Container Apps are lacking a few details.

FYI, There are some defaults for existing probe settings which are different between Azure and Terraform, I left them intact.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app ` - added missing settings in liveness_probe, startup_probe and readiness_probe [GH-25457]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Enhancement


## Related Issue(s)
Fixes  #25457, fixes #24845