### PR TITLE
`azurerm_ip_groups` Make IP Group name filter optional

### DIFF
--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -27,7 +27,7 @@ func dataSourceIpGroups() *pluginsdk.Resource {
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
@@ -69,9 +69,17 @@ func dataSourceIpGroupsRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if model := resp.Model; model != nil {
 		for _, group := range *model {
-			if group.Name != nil && strings.Contains(*group.Name, d.Get("name").(string)) {
-				names = append(names, *group.Name)
-				ids = append(ids, *group.Id)
+			if group.Name != nil {
+				// If d.Get("name") is defined, use it for filtering. Else include all groups
+				if d.Get("name") != nil {
+					if strings.Contains(*group.Name, d.Get("name").(string)) {
+						names = append(names, *group.Name)
+						ids = append(ids, *group.Id)
+					}
+				} else {
+					names = append(names, *group.Name)
+					ids = append(ids, *group.Id)
+				}
 			}
 		}
 	}

--- a/internal/services/network/ip_groups_data_source_test.go
+++ b/internal/services/network/ip_groups_data_source_test.go
@@ -58,6 +58,21 @@ func TestAccDataSourceIPGroups_multiple(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceIPGroups_multipleNoFilter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_ip_groups", "test")
+	r := IPGroupsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.multipleNoFilter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("ids.#").HasValue("3"),
+				check.That(data.ResourceName).Key("names.#").HasValue("3"),
+			),
+		},
+	})
+}
+
 // Find IP group which doesn't exist
 func (IPGroupsDataSource) noResults(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -95,6 +110,22 @@ func (IPGroupsDataSource) multiple(data acceptance.TestData) string {
 
 data "azurerm_ip_groups" "test" {
   name                = "acceptanceTestIpGroup"
+  resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_ip_group.test,
+    azurerm_ip_group.test2,
+    azurerm_ip_group.test3,
+  ]
+}
+`, IPGroupResource{}.complete(data))
+}
+
+// Find multiple IP Groups, not filtered by name string
+func (IPGroupsDataSource) multipleNoFilter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_ip_groups" "test" {
   resource_group_name = azurerm_resource_group.test.name
   depends_on = [
     azurerm_ip_group.test,

--- a/website/docs/d/ip_groups.html.markdown
+++ b/website/docs/d/ip_groups.html.markdown
@@ -27,7 +27,7 @@ output "ids" {
 
 The following arguments are supported:
 
-* `name` - (Required) A substring to match some number of IP Groups.
+* `name` - (Optional) A substring to match some number of IP Groups. If no argument provided, all IP groups in the Resource Group are returned.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the IP Groups exist.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This is a minor change that makes the `name` attribute optional for the `azurerm_ip_groups` data call. If `name` is not provided, all IP Groups in a Resource Group are returned. This is useful when there is no name commonality between requested IP Groups in a RG. 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
make acctests SERVICE='network' TESTARGS='-run=TestAccDataSourceIPGroups_' TESTTIMEOUT='15m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccDataSourceIPGroups_ -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceIPGroups_noResults
=== PAUSE TestAccDataSourceIPGroups_noResults
=== RUN   TestAccDataSourceIPGroups_single
=== PAUSE TestAccDataSourceIPGroups_single
=== RUN   TestAccDataSourceIPGroups_multiple
=== PAUSE TestAccDataSourceIPGroups_multiple
=== RUN   TestAccDataSourceIPGroups_multipleNoFilter
=== PAUSE TestAccDataSourceIPGroups_multipleNoFilter
=== CONT  TestAccDataSourceIPGroups_noResults
=== CONT  TestAccDataSourceIPGroups_multipleNoFilter
=== CONT  TestAccDataSourceIPGroups_single
=== CONT  TestAccDataSourceIPGroups_multiple
--- PASS: TestAccDataSourceIPGroups_multipleNoFilter (77.38s)
--- PASS: TestAccDataSourceIPGroups_multiple (136.17s)
--- PASS: TestAccDataSourceIPGroups_noResults (138.84s)
--- PASS: TestAccDataSourceIPGroups_single (141.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/network	149.017s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_ip_groups` - make `name` filter attribute optional [GH-27579]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change