### PR TITLE
`azurerm_kubernetes_cluster` -  support for`daemonset_eviction_for_empty_nodes_enabled`, `daemonset_eviction_for_occupied_nodes_enabled` and `ignore_daemonsets_utilization_enabled` properties

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -189,16 +189,19 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							Default:  false,
 						},
+
 						"daemonset_eviction_for_empty_nodes_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
 						},
+
 						"daemonset_eviction_for_occupied_nodes_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  true,
 						},
+
 						"expander": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
@@ -210,91 +213,107 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 								string(managedclusters.ExpanderRandom),
 							}, false),
 						},
+
 						"ignore_daemonsets_utilization_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
 						},
+
 						"max_graceful_termination_sec": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							Computed: true,
 						},
+
 						"max_node_provisioning_time": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Default:      "15m",
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"max_unready_nodes": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Default:      3,
 							ValidateFunc: validation.IntAtLeast(0),
 						},
+
 						"max_unready_percentage": {
 							Type:         pluginsdk.TypeFloat,
 							Optional:     true,
 							Default:      45,
 							ValidateFunc: validation.FloatBetween(0, 100),
 						},
+
 						"new_pod_scale_up_delay": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scan_interval": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_delay_after_add": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_delay_after_delete": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_delay_after_failure": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_unneeded": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_unready": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: containerValidate.Duration,
 						},
+
 						"scale_down_utilization_threshold": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							Computed: true,
 						},
+
 						"empty_bulk_delete_max": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							Computed: true,
 						},
+
 						"skip_nodes_with_local_storage": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  !features.FourPointOhBeta(),
 						},
+
 						"skip_nodes_with_system_pods": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,

--- a/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -1137,26 +1137,26 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   auto_scaler_profile {
-    balance_similar_node_groups      = true
-	daemonset_eviction_for_empty_nodes_enabled = true
-	daemonset_eviction_for_occupied_nodes_enabled = false
-    expander                         = "least-waste"
-	ignore_daemonsets_utilization_enabled = true
-    max_graceful_termination_sec     = 15
-    max_node_provisioning_time       = "10m"
-    max_unready_nodes                = 5
-    max_unready_percentage           = 50
-    new_pod_scale_up_delay           = "10s"
-    scan_interval                    = "10s"
-    scale_down_delay_after_add       = "10m"
-    scale_down_delay_after_delete    = "10s"
-    scale_down_delay_after_failure   = "15m"
-    scale_down_unneeded              = "15m"
-    scale_down_unready               = "15m"
-    scale_down_utilization_threshold = "0.5"
-    empty_bulk_delete_max            = "50"
-    skip_nodes_with_local_storage    = false
-    skip_nodes_with_system_pods      = false
+    balance_similar_node_groups                   = true
+    daemonset_eviction_for_empty_nodes_enabled    = true
+    daemonset_eviction_for_occupied_nodes_enabled = false
+    expander                                      = "least-waste"
+    ignore_daemonsets_utilization_enabled         = true
+    max_graceful_termination_sec                  = 15
+    max_node_provisioning_time                    = "10m"
+    max_unready_nodes                             = 5
+    max_unready_percentage                        = 50
+    new_pod_scale_up_delay                        = "10s"
+    scan_interval                                 = "10s"
+    scale_down_delay_after_add                    = "10m"
+    scale_down_delay_after_delete                 = "10s"
+    scale_down_delay_after_failure                = "15m"
+    scale_down_unneeded                           = "15m"
+    scale_down_unready                            = "15m"
+    scale_down_utilization_threshold              = "0.5"
+    empty_bulk_delete_max                         = "50"
+    skip_nodes_with_local_storage                 = false
+    skip_nodes_with_system_pods                   = false
   }
 
   identity {

--- a/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -1138,7 +1138,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   auto_scaler_profile {
     balance_similar_node_groups      = true
+	daemonset_eviction_for_empty_nodes_enabled = true
+	daemonset_eviction_for_occupied_nodes_enabled = false
     expander                         = "least-waste"
+	ignore_daemonsets_utilization_enabled = true
     max_graceful_termination_sec     = 15
     max_node_provisioning_time       = "10m"
     max_unready_nodes                = 5

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -286,7 +286,13 @@ An `auto_scaler_profile` block supports the following:
 
 * `balance_similar_node_groups` - (Optional) Detect similar node groups and balance the number of nodes between them. Defaults to `false`.
 
+* `daemonset_eviction_for_empty_nodes_enabled` - (Optional) Whether DaemonSet pods will be gracefully terminated from empty nodes. Defaults to `false`.
+
+* `daemonset_eviction_for_occupied_nodes_enabled` - (Optional) Whether DaemonSet pods will be gracefully terminated from non-empty nodes. Defaults to `true`.
+
 * `expander` - (Optional) Expander to use. Possible values are `least-waste`, `priority`, `most-pods` and `random`. Defaults to `random`.
+
+* `ignore_daemonsets_utilization_enabled` - (Optional) Whether DaemonSet pods will be ignored when calculating resource utilization for scale down. Defaults to `false`.
 
 * `max_graceful_termination_sec` - (Optional) Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to `600`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_kubernetes_cluster` - `auto_scaler_profile` support `daemonset_eviction_for_empty_nodes_enabled`, `daemonset_eviction_for_occupied_nodes_enabled` and `ignore_daemonsets_utilization_enabled` properties

Doc describing the meaning of the properties & their default value: https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler?tabs=azure-cli
![image](https://github.com/user-attachments/assets/4da9b321-44b9-42e8-bad5-0d28cec1c7b7)
![image](https://github.com/user-attachments/assets/6b3391ad-d459-45d7-adc2-eb590a033dd3)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="964" alt="image" src="https://github.com/user-attachments/assets/e8a3eaa3-af9c-45f7-89a9-a786265effd3">



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster` - `auto_scaler_profile` support `daemonset_eviction_for_empty_nodes_enabled`, `daemonset_eviction_for_occupied_nodes_enabled` and `ignore_daemonsets_utilization_enabled` properties


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
