### PR TITLE
fix(azurerm_log_analytics_workspace_table): Parse subscriptionId from workspaceId

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -113,7 +113,6 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("decoding %+v", err)
 			}
 			client := metadata.Client.LogAnalytics.TablesClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			tableName := model.Name
 			log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace Table %s update.", tableName)
@@ -123,7 +122,7 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("invalid workspace object ID for table %s: %s", tableName, err)
 			}
 
-			id := tables.NewTableID(subscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, tableName)
+			id := tables.NewTableID(workspaceId.SubscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, tableName)
 
 			updateInput := tables.Table{
 				Properties: &tables.TableProperties{


### PR DESCRIPTION
Subscription ID used to manage tables should be the same as the Log Analytics Workspace.

Fixes #27564

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Resource group for the Log Analytics Workspace should be looked at in correct subscription, as the subscription ID
is present in workspace_id variable, and the table retention should be updated correctly.

When the Log Analytics Workspace has been created previously in another subscription, the Terraform code fails, as explained in #27564.

```
module.diagnostic_settings.azurerm_monitor_diagnostic_setting.diag[0]: Creation complete after 14s [id=/subscriptions/xxxx-xxxx-x7aa/resourceGroups/rg-test-7fc24b/providers/Microsoft.KeyVault/vaults/kv-test-7fc24b|diag-test-7fc24b]
╷
│ Error: failed to update table Usage in workspace log-test-7fc24b in resource group rg-test-csz-7fc24b: performing CreateOrUpdate: unexpected status 404 (404 Not Found) with error: ResourceGroupNotFound: Resource group 'rg-test-csz-7fc24b' could not be found.
│
│   with module.diagnostic_settings.azurerm_log_analytics_workspace_table.table["Usage"],
│   on ../../main.tf line 37, in resource "azurerm_log_analytics_workspace_table" "table":
│   37: resource "azurerm_log_analytics_workspace_table" "table" {
│
│ failed to update table Usage in workspace log-test-7fc24b in resource group rg-test-csz-7fc24b: performing CreateOrUpdate: unexpected status 404 (404 Not Found) with error: ResourceGroupNotFound: Resource group 'rg-test-csz-7fc24b' could not be found.
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_workspace_table` - Correctly parse subscriptionId from workspaceId  [GH-27564]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27564


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
