### PR TITLE
azurerm_recovery_services_vault - introduce soft_delete_status

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -142,9 +142,23 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 			},
 
 			"soft_delete_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:          pluginsdk.TypeBool,
+				Optional:      true,
+				Default:       true,
+				ConflictsWith: []string{"soft_delete_status"},
+				Deprecated:    "use soft_delete_status instead",
+			},
+
+			"soft_delete_status": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Default:       vaults.SoftDeleteStateEnabled,
+				ConflictsWith: []string{"soft_delete_enabled"},
+				ValidateFunc: validation.StringInSlice([]string{
+					string(vaults.SoftDeleteStateEnabled),
+					string(vaults.SoftDeleteStateDisabled),
+					string(vaults.SoftDeleteStateAlwaysON),
+				}, false),
 			},
 
 			"monitoring": {
@@ -310,11 +324,30 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 
 	var StateRefreshPendingStrings []string
 	var StateRefreshTargetStrings []string
+	// old logic via soft_delete_enabled
 	if sd := d.Get("soft_delete_enabled").(bool); sd {
 		state := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
 		cfg.Properties.SoftDeleteFeatureState = &state
 		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
 		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+	} else {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled
+		cfg.Properties.SoftDeleteFeatureState = &state
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+	}
+	// new logic via soft_delete_status, supercedes soft_delete_enabled
+	if sds := d.Get("soft_delete_status").(string); sds == string(vaults.SoftDeleteStateEnabled) {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
+		cfg.Properties.SoftDeleteFeatureState = &state
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+	} else if sds == string(vaults.SoftDeleteStateAlwaysON) {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON
+		cfg.Properties.SoftDeleteFeatureState = &state
+		// does this matter ? shouldn't it just test for the target, it's creation of a vault
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON)}
 	} else {
 		state := backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled
 		cfg.Properties.SoftDeleteFeatureState = &state
@@ -522,11 +555,30 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	// an update on vault will cause the vault config reset to default, so whether the config has change or not, it needs to be updated.
 	var StateRefreshPendingStrings []string
 	var StateRefreshTargetStrings []string
+	// old logic via soft_delete_enabled
 	if sd := d.Get("soft_delete_enabled").(bool); sd {
 		state := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
 		cfg.Properties.SoftDeleteFeatureState = &state
 		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
 		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+	} else {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled
+		cfg.Properties.SoftDeleteFeatureState = &state
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+	}
+	// new logic via soft_delete_status, supercedes soft_delete_enabled
+	if sds := d.Get("soft_delete_status").(string); sds == string(vaults.SoftDeleteStateEnabled) {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
+		cfg.Properties.SoftDeleteFeatureState = &state
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled)}
+	} else if sds == string(vaults.SoftDeleteStateAlwaysON) {
+		state := backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON
+		cfg.Properties.SoftDeleteFeatureState = &state
+		// does this matter ? shouldn't it just test for the target
+		StateRefreshPendingStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)}
+		StateRefreshTargetStrings = []string{string(backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON)}
 	} else {
 		state := backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled
 		cfg.Properties.SoftDeleteFeatureState = &state
@@ -622,12 +674,25 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("retrieving %s: %+v", cfgId, err)
 		}
 
+		// old soft_delete_enabled
 		softDeleteEnabled := false
 		if cfg.Model != nil && cfg.Model.Properties != nil && cfg.Model.Properties.SoftDeleteFeatureState != nil {
-			softDeleteEnabled = *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
+			// true if Enabled or AlawysON - both represent true here
+			if *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled || *cfg.Model.Properties.SoftDeleteFeatureState == backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON {
+				softDeleteEnabled = true
+			}
+
 		}
 
 		d.Set("soft_delete_enabled", softDeleteEnabled)
+
+		// new soft_delete_status
+		softDeleteStatus := string(backupresourcevaultconfigs.SoftDeleteFeatureStateDisabled)
+		if cfg.Model != nil && cfg.Model.Properties != nil && cfg.Model.Properties.SoftDeleteFeatureState != nil {
+			softDeleteStatus = string(*cfg.Model.Properties.SoftDeleteFeatureState)
+		}
+
+		d.Set("soft_delete_status", softDeleteStatus)
 
 		flattenIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -288,6 +288,13 @@ func TestAccRecoveryServicesVault_softDelete(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.softDeleteAlwaysON(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.softDeleteDisabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -612,7 +619,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -635,7 +642,7 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                           = "Standard"
   public_network_access_enabled = %t
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
 }
@@ -659,7 +666,7 @@ resource "azurerm_recovery_services_vault" "test" {
 
   cross_region_restore_enabled = %t
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enable)
 }
@@ -685,7 +692,7 @@ resource "azurerm_recovery_services_vault" "test" {
 
   cross_region_restore_enabled = true
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -711,7 +718,7 @@ resource "azurerm_recovery_services_vault" "test" {
     type = "SystemAssigned"
   }
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -747,7 +754,7 @@ resource "azurerm_recovery_services_vault" "test" {
     ]
   }
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -782,7 +789,7 @@ resource "azurerm_recovery_services_vault" "test" {
     ]
   }
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -805,7 +812,7 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                 = "Standard"
   immutability        = "%s"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, immutability)
 }
@@ -832,7 +839,7 @@ resource "azurerm_recovery_services_vault" "test" {
     alerts_for_critical_operation_failures_enabled = false
   }
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -854,7 +861,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
   storage_mode_type   = "LocallyRedundant"
   tags = {
     ENV = "test"
@@ -902,7 +909,7 @@ resource "azurerm_recovery_services_vault" "test" {
     type = "SystemAssigned"
   }
 
-  soft_delete_enabled = true
+  soft_delete_status = "Enabled"
 
   encryption {
     key_id                            = azurerm_key_vault_key.test[%[5]d].id
@@ -994,7 +1001,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = true
+  soft_delete_status = "Enabled"
 
   identity {
     type         = "UserAssigned"
@@ -1094,7 +1101,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
   storage_mode_type   = "ZoneRedundant"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -1116,6 +1123,28 @@ resource "azurerm_recovery_services_vault" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) softDeleteAlwaysON(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  soft_delete_status = "AlwaysON"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1194,7 +1223,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 
   encryption {
     key_id                            = azurerm_key_vault_key.test.id
@@ -1225,7 +1254,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_status = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1545,7 +1574,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name                = azurerm_resource_group.test.name
   sku                                = "Standard"
   classic_vmware_replication_enabled = true
-  soft_delete_enabled                = false
+  soft_delete_status                 = "Disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -56,7 +56,9 @@ The following arguments are supported:
 
 -> **Note:** Once `cross_region_restore_enabled` is set to `true`, changing it back to `false` forces a new Recovery Service Vault to be created.
 
-* `soft_delete_enabled` - (Optional) Is soft delete enable for this Vault? Defaults to `true`.
+* `soft_delete_enabled` - (Optional) Is soft delete enable for this Vault? Defaults to `true`. **Deprecated** Superseded by `soft_delete_status`
+
+* `soft_delete_status` - (Optional) Is soft delete enable for this Vault? Defaults to `Enabled`. Possible values `Enabled`, `AlwaysON`, `Disabled`. Changing this from `AlwaysON` to `Disabled` or `Enabled` is not possible. You will need to destroy and recreate the resource.
 
 * `encryption` - (Optional) An `encryption` block as defined below. Required with `identity`.
 


### PR DESCRIPTION
introduce soft_delete_status for azurerm_recovery_services_vault

Supersede soft_delete_state (boolean) by soft_delete_status (String)

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
I am trying to fix #23557 , Azure did a bad thing here, it changed a previous boolean value to a something with 4 states. So I think this needs to be addressed in a backwards compatible way by introducing a new attribute for it.

I do have a problem that I have not yet solved, I think within 
https://github.com/Klaas-/terraform-provider-azurerm/blob/3227a9bbd9dee25c8b41cfeb10452d5327b69a5a/internal/services/recoveryservices/recovery_services_vault_resource.go#L351-L356
I need to tell tf that the value of soft_delete_status is not the default true but false.

Also I was unsure if I should update all tests to use the new attribute (which I currently did) or if I should write separate tests. Looking for guidance here. I have not yet run the full tests suite because I noticed the problem described above in my manual tests.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have manually run tests, and I noticed problems that I need help with
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_recovery_services_vault ` - add soft_delete_status property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23557


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
