### PR TITLE
`azurerm_container_app` - adding property `max_inactive_revisions`

### DIFF
--- a/internal/services/containerapps/container_app_data_source.go
+++ b/internal/services/containerapps/container_app_data_source.go
@@ -30,6 +30,7 @@ type ContainerAppDataSourceModel struct {
 	ManagedEnvironmentId       string                                     `tfschema:"container_app_environment_id"`
 	Location                   string                                     `tfschema:"location"`
 	RevisionMode               string                                     `tfschema:"revision_mode"`
+	MaxInactiveRevisions       int64                                      `tfschema:"max_inactive_revisions"`
 	Ingress                    []helpers.Ingress                          `tfschema:"ingress"`
 	Registries                 []helpers.Registry                         `tfschema:"registry"`
 	Secrets                    []helpers.Secret                           `tfschema:"secret"`
@@ -117,6 +118,11 @@ func (r ContainerAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
+
+		"max_inactive_revisions": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
 	}
 }
 
@@ -172,6 +178,7 @@ func (r ContainerAppDataSource) Read() sdk.ResourceFunc {
 							containerApp.Ingress = helpers.FlattenContainerAppIngress(config.Ingress, id.ContainerAppName)
 							containerApp.Registries = helpers.FlattenContainerAppRegistries(config.Registries)
 							containerApp.Dapr = helpers.FlattenContainerAppDapr(config.Dapr)
+							containerApp.MaxInactiveRevisions = pointer.ToInt64(config.MaxInactiveRevisions)
 						}
 					}
 					containerApp.LatestRevisionName = pointer.From(props.LatestRevisionName)

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -39,9 +39,10 @@ type ContainerAppModel struct {
 	Dapr         []helpers.Dapr              `tfschema:"dapr"`
 	Template     []helpers.ContainerTemplate `tfschema:"template"`
 
-	Identity            []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	WorkloadProfileName string                                     `tfschema:"workload_profile_name"`
-	Tags                map[string]interface{}                     `tfschema:"tags"`
+	Identity             []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	WorkloadProfileName  string                                     `tfschema:"workload_profile_name"`
+	MaxInactiveRevisions int64                                      `tfschema:"max_inactive_revisions"`
+	Tags                 map[string]interface{}                     `tfschema:"tags"`
 
 	OutboundIpAddresses        []string `tfschema:"outbound_ip_addresses"`
 	LatestRevisionName         string   `tfschema:"latest_revision_name"`
@@ -110,6 +111,12 @@ func (r ContainerAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"max_inactive_revisions": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
 		},
 
 		"tags": commonschema.Tags(),
@@ -199,10 +206,11 @@ func (r ContainerAppResource) Create() sdk.ResourceFunc {
 				Location: location.Normalize(env.Model.Location),
 				Properties: &containerapps.ContainerAppProperties{
 					Configuration: &containerapps.Configuration{
-						Ingress:    helpers.ExpandContainerAppIngress(app.Ingress, id.ContainerAppName),
-						Dapr:       helpers.ExpandContainerAppDapr(app.Dapr),
-						Secrets:    secrets,
-						Registries: registries,
+						Ingress:              helpers.ExpandContainerAppIngress(app.Ingress, id.ContainerAppName),
+						Dapr:                 helpers.ExpandContainerAppDapr(app.Dapr),
+						Secrets:              secrets,
+						Registries:           registries,
+						MaxInactiveRevisions: pointer.FromInt64(app.MaxInactiveRevisions),
 					},
 					ManagedEnvironmentId: pointer.To(app.ManagedEnvironmentId),
 					Template:             helpers.ExpandContainerAppTemplate(app.Template, metadata),
@@ -279,6 +287,7 @@ func (r ContainerAppResource) Read() sdk.ResourceFunc {
 						state.Ingress = helpers.FlattenContainerAppIngress(config.Ingress, id.ContainerAppName)
 						state.Registries = helpers.FlattenContainerAppRegistries(config.Registries)
 						state.Dapr = helpers.FlattenContainerAppDapr(config.Dapr)
+						state.MaxInactiveRevisions = pointer.ToInt64(config.MaxInactiveRevisions)
 					}
 					state.LatestRevisionName = pointer.From(props.LatestRevisionName)
 					state.LatestRevisionFqdn = pointer.From(props.LatestRevisionFqdn)
@@ -373,6 +382,10 @@ func (r ContainerAppResource) Update() sdk.ResourceFunc {
 				if err != nil {
 					return fmt.Errorf("invalid registry config for %s: %+v", id, err)
 				}
+			}
+
+			if metadata.ResourceData.HasChange("max_inactive_revisions") {
+				model.Properties.Configuration.MaxInactiveRevisions = pointer.FromInt64(state.MaxInactiveRevisions)
 			}
 
 			if metadata.ResourceData.HasChange("dapr") {

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -576,22 +576,6 @@ func TestAccContainerAppResource_ingressTrafficValidation(t *testing.T) {
 	})
 }
 
-func TestAccContainerAppResource_maxInactiveRevisionsValidation(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
-	r := ContainerAppResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.maxInactiveRevisionsValidation(data, -1),
-			ExpectError: regexp.MustCompile("max_inactive_revisions must be between 0 and 100"),
-		},
-		{
-			Config:      r.maxInactiveRevisionsValidation(data, 101),
-			ExpectError: regexp.MustCompile("max_inactive_revisions must be between 0 and 100"),
-		},
-	})
-}
-
 func TestAccContainerAppResource_maxInactiveRevisionsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -2893,18 +2877,4 @@ resource "azurerm_container_app" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
-}
-
-func (r ContainerAppResource) maxInactiveRevisionsValidation(data acceptance.TestData, maxInactiveResivions int) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_container_app" "test" {
-  name                         = "acctest-capp-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  container_app_environment_id = azurerm_container_app_environment.test.id
-  revision_mode                = "Single"
-  max_inactive_revisions       = %d
-}
-`, r.template(data), data.RandomInteger, maxInactiveResivions)
 }

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -49,6 +49,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `workload_profile_name` - The name of the Workload Profile in the Container App Environment in which this Container App is running.
 
+* `max_inactive_revisions` - The max inactive revisions for this Container App.
+
 * `tags` - A mapping of tags to assign to the Container App.
 
 ---

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -32,6 +32,7 @@ resource "azurerm_container_app_environment" "example" {
   resource_group_name        = azurerm_resource_group.example.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
 }
+
 resource "azurerm_container_app" "example" {
   name                         = "example-app"
   container_app_environment_id = azurerm_container_app_environment.example.id
@@ -78,6 +79,8 @@ The following arguments are supported:
 * `workload_profile_name` - (Optional) The name of the Workload Profile in the Container App Environment to place this Container App.
 
 ~> **Note:** Omit this value to use the default `Consumption` Workload Profile.
+
+* `max_inactive_revisions` - (Optional) The maximum of inactive revisions allowed for this Container App.
 
 * `tags` - (Optional) A mapping of tags to assign to the Container App.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The property `max_inactive_revisions` is not available into the `azurerm_container_app`

https://learn.microsoft.com/en-us/rest/api/containerapps/container-apps/create-or-update?view=rest-containerapps-2024-03-01&tabs=HTTP#configuration

This property is available with bicep / terraform azapi but not with azurerm.

The value should be optional and between `0;100` according the REST API.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` - support for the `max_inactive_revisions` property [GH-27598]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27140


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
