### PR TITLE
`azurerm_synapse_workspace_aad_admin` - fix dependency issue when removing `azurerm_synapse_workspace_aad_admin` for `azurerm_synapse_workspace` 

### DIFF
--- a/internal/services/synapse/synapse_workspace_aad_admin_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_aad_admin_resource_test.go
@@ -102,6 +102,7 @@ resource "azurerm_synapse_workspace" "test" {
   storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
+  azuread_authentication_only          = true
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When deleting resource `azurerm_synapse_workspace_aad_admin`, if `azuread_authentication_only` is enabled for `azurerm_synapse_workspace`, the API returns the following error. 

`User tried to delete Azure Active Directory admin when AzureADOnlyAuthentication is set, please use azureADOnlyAuthentications API first.`

Since the API requires that `azurerm_synapse_workspace_aad_admin` can be deleted only if `azuread_authentication_only` is disabled, submit this PR to disable `azuread_authentication_only` (if it is enabled) before deleting `azurerm_synapse_workspace_aad_admin` to fix the dependency issue.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Before applying this PR, after enabling `azuread_authentication_only` in the test case `TestAccSynapseWorkspaceAADAdmin_basic`, the error occurred as follows.

```
=== RUN   TestAccSynapseWorkspaceAADAdmin_basic
=== PAUSE TestAccSynapseWorkspaceAADAdmin_basic
=== CONT  TestAccSynapseWorkspaceAADAdmin_basic
    testcase.go:173: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: setting empty Synapse Workspace "acctestsw241010110304534387" AAD Admin (Resource Group "acctestRG-synapse-241010110304534387"): synapse.WorkspaceAadAdminsClient#Delete: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidAzureADAdminDeleteOperation" Message="User tried to delete Azure Active Directory admin when AzureADOnlyAuthentication is set, please use azureADOnlyAuthentications API first."       
--- FAIL: TestAccSynapseWorkspaceAADAdmin_basic (824.73s)
```

After applying this PR, the test case passes.
` PASS: TestAccSynapseWorkspaceAADAdmin_basic (1040.62s)
`

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_synapse_workspace_aad_admin` - fix dependency issue when deleting `azurerm_synapse_workspace_aad_admin` 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change




