### PR TITLE
`docs`: fix resource type name typo and aks rename field

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -103,7 +103,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. More information [can be found in the documentation](https://docs.microsoft.com/azure/aks/azure-disk-customer-managed-keys). Changing this forces a new resource to be created.
 
-* `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Managed Kubernetes Cluster should exist. Changing this forces a new resource to be created.
+* `edge_zone` - (Optional) Specifies the Extended Zone (formerly called Edge Zone) within the Azure Region where this Managed Kubernetes Cluster should exist. Changing this forces a new resource to be created.
 
 * `http_application_routing_enabled` - (Optional) Should HTTP Application Routing be enabled?
 

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Orbital"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_orbital_contact_profile"
+page_title: "Azure Resource Manager: azurerm_orbital_contact"
 description: |-
   Manages an orbital contact resource.
 ---


### PR DESCRIPTION
Fix a typo in page title field of the orbital contact resource, and update the field description with the new term of aks cluster extended zones.

## Related Issue(s)
Fixes #27613

