### PR TITLE
`azurerm_iothub` & `azurerm_iothub_certificate`  - fixing acctests

### DIFF
--- a/internal/services/iothub/iothub_certificate_resource_test.go
+++ b/internal/services/iothub/iothub_certificate_resource_test.go
@@ -163,7 +163,7 @@ resource "azurerm_iothub" "test" {
 }
 
 resource "azurerm_iothub_certificate" "test" {
-  name                = "acctestIoTCertificate-%d"
+  name                = "acctestIoTHubCertificate-%d"
   resource_group_name = azurerm_resource_group.test.name
   iothub_name         = azurerm_iothub.test.name
   is_verified         = true

--- a/internal/services/iothub/iothub_certificate_resource_test.go
+++ b/internal/services/iothub/iothub_certificate_resource_test.go
@@ -20,7 +20,7 @@ type IotHubCertificateResource struct{}
 
 func TestAccIotHubCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -37,7 +37,7 @@ func TestAccIotHubCertificate_basic(t *testing.T) {
 
 func TestAccIotHubCertificate_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -56,7 +56,7 @@ func TestAccIotHubCertificate_requiresImport(t *testing.T) {
 
 func TestAccIotHubCertificate_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/iothub/iothub_certificate_resource_test.go
+++ b/internal/services/iothub/iothub_certificate_resource_test.go
@@ -20,6 +20,7 @@ type IotHubCertificateResource struct{}
 
 func TestAccIotHubCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -36,6 +37,7 @@ func TestAccIotHubCertificate_basic(t *testing.T) {
 
 func TestAccIotHubCertificate_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -54,6 +56,7 @@ func TestAccIotHubCertificate_requiresImport(t *testing.T) {
 
 func TestAccIotHubCertificate_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_certificate", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubCertificateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -1560,7 +1560,7 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-`, data.RandomInteger, "eastus", data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (IotHubResource) disableLocalAuth(data acceptance.TestData) string {
@@ -1593,7 +1593,7 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-  `, data.RandomInteger, "eastus", data.RandomInteger)
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (IotHubResource) enableLocalAuth(data acceptance.TestData) string {
@@ -1626,7 +1626,7 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-  `, data.RandomInteger, "eastus", data.RandomInteger)
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (IotHubResource) cloudToDevice(data acceptance.TestData) string {
@@ -2229,12 +2229,12 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "iothub" {
   name     = "acctest-iothub-%[1]d"
-  location = "eastus"
+  location = "%[2]s"
 }
 
 resource "azurerm_resource_group" "endpoint" {
   name     = "acctest-iothub-db-%[1]d"
-  location = "eastus"
+  location = "%[2]s"
 }
 
 resource "azurerm_cosmosdb_account" "test" {
@@ -2278,7 +2278,7 @@ resource "azurerm_iothub" "test" {
     capacity = "1"
   }
 
-  %[2]s
+  %[3]s
 }
 
 resource "azurerm_iothub_endpoint_cosmosdb_account" "test" {
@@ -2303,5 +2303,5 @@ resource "azurerm_iothub_route" "test" {
   enabled        = false
   depends_on     = [azurerm_iothub_endpoint_cosmosdb_account.test]
 }
-`, data.RandomInteger, tagsBlock)
+`, data.RandomInteger, data.Locations.Primary, tagsBlock)
 }

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -20,7 +20,7 @@ type IotHubResource struct{}
 
 func TestAccIotHub_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -36,7 +36,7 @@ func TestAccIotHub_basic(t *testing.T) {
 
 func TestAccIotHub_networkRulesSet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -59,7 +59,7 @@ func TestAccIotHub_networkRulesSet(t *testing.T) {
 
 func TestAccIotHub_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -78,7 +78,7 @@ func TestAccIotHub_requiresImport(t *testing.T) {
 
 func TestAccIotHub_standard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -94,7 +94,7 @@ func TestAccIotHub_standard(t *testing.T) {
 
 func TestAccIotHub_customRoutes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -118,7 +118,7 @@ func TestAccIotHub_customRoutes(t *testing.T) {
 
 func TestAccIotHub_enrichments(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -148,7 +148,7 @@ func TestAccIotHub_enrichments(t *testing.T) {
 
 func TestAccIotHub_removeEndpointsAndRoutes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -171,7 +171,7 @@ func TestAccIotHub_removeEndpointsAndRoutes(t *testing.T) {
 
 func TestAccIotHub_fileUpload(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -199,7 +199,7 @@ func TestAccIotHub_fileUpload(t *testing.T) {
 
 func TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -215,7 +215,7 @@ func TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity(t *testing.T
 
 func TestAccIotHub_fileUploadAuthenticationTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -252,7 +252,7 @@ func TestAccIotHub_fileUploadAuthenticationTypeUpdate(t *testing.T) {
 
 func TestAccIotHub_withDifferentEndpointResourceGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -268,7 +268,7 @@ func TestAccIotHub_withDifferentEndpointResourceGroup(t *testing.T) {
 
 func TestAccIotHub_fallbackRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -287,7 +287,7 @@ func TestAccIotHub_fallbackRoute(t *testing.T) {
 
 func TestAccIotHub_publicAccess(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -324,7 +324,7 @@ func TestAccIotHub_publicAccess(t *testing.T) {
 
 func TestAccIotHub_minTLSVersion(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -340,7 +340,7 @@ func TestAccIotHub_minTLSVersion(t *testing.T) {
 
 func TestAccIotHub_LocalAuth(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -371,7 +371,7 @@ func TestAccIotHub_LocalAuth(t *testing.T) {
 
 func TestAccIotHub_cloudToDevice(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -403,7 +403,7 @@ func TestAccIotHub_cloudToDevice(t *testing.T) {
 
 func TestAccIotHub_identitySystemAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -419,7 +419,7 @@ func TestAccIotHub_identitySystemAssigned(t *testing.T) {
 
 func TestAccIotHub_identitySystemAssignedUserAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -435,7 +435,7 @@ func TestAccIotHub_identitySystemAssignedUserAssigned(t *testing.T) {
 
 func TestAccIotHub_identityUserAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -458,7 +458,7 @@ func TestAccIotHub_identityUserAssigned(t *testing.T) {
 
 func TestAccIotHub_identityUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -502,7 +502,7 @@ func TestAccIotHub_identityUpdate(t *testing.T) {
 
 func TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -518,7 +518,7 @@ func TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity(t *testing.T) 
 
 func TestAccIotHub_endpointAuthenticationTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -555,7 +555,7 @@ func TestAccIotHub_endpointAuthenticationTypeUpdate(t *testing.T) {
 
 func TestAccIotHub_cosmosDBRouteUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
-	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
+	data.Locations.Primary = "eastus" // iothub is only available on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -20,6 +20,7 @@ type IotHubResource struct{}
 
 func TestAccIotHub_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -35,6 +36,7 @@ func TestAccIotHub_basic(t *testing.T) {
 
 func TestAccIotHub_networkRulesSet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -57,6 +59,7 @@ func TestAccIotHub_networkRulesSet(t *testing.T) {
 
 func TestAccIotHub_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -75,6 +78,7 @@ func TestAccIotHub_requiresImport(t *testing.T) {
 
 func TestAccIotHub_standard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -90,6 +94,7 @@ func TestAccIotHub_standard(t *testing.T) {
 
 func TestAccIotHub_customRoutes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -113,6 +118,7 @@ func TestAccIotHub_customRoutes(t *testing.T) {
 
 func TestAccIotHub_enrichments(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -142,6 +148,7 @@ func TestAccIotHub_enrichments(t *testing.T) {
 
 func TestAccIotHub_removeEndpointsAndRoutes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -164,6 +171,7 @@ func TestAccIotHub_removeEndpointsAndRoutes(t *testing.T) {
 
 func TestAccIotHub_fileUpload(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -191,6 +199,7 @@ func TestAccIotHub_fileUpload(t *testing.T) {
 
 func TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -206,6 +215,7 @@ func TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity(t *testing.T
 
 func TestAccIotHub_fileUploadAuthenticationTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -242,6 +252,7 @@ func TestAccIotHub_fileUploadAuthenticationTypeUpdate(t *testing.T) {
 
 func TestAccIotHub_withDifferentEndpointResourceGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -257,6 +268,7 @@ func TestAccIotHub_withDifferentEndpointResourceGroup(t *testing.T) {
 
 func TestAccIotHub_fallbackRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -275,6 +287,7 @@ func TestAccIotHub_fallbackRoute(t *testing.T) {
 
 func TestAccIotHub_publicAccess(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -311,6 +324,7 @@ func TestAccIotHub_publicAccess(t *testing.T) {
 
 func TestAccIotHub_minTLSVersion(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -326,6 +340,7 @@ func TestAccIotHub_minTLSVersion(t *testing.T) {
 
 func TestAccIotHub_LocalAuth(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -356,6 +371,7 @@ func TestAccIotHub_LocalAuth(t *testing.T) {
 
 func TestAccIotHub_cloudToDevice(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -387,6 +403,7 @@ func TestAccIotHub_cloudToDevice(t *testing.T) {
 
 func TestAccIotHub_identitySystemAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -402,6 +419,7 @@ func TestAccIotHub_identitySystemAssigned(t *testing.T) {
 
 func TestAccIotHub_identitySystemAssignedUserAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -417,6 +435,7 @@ func TestAccIotHub_identitySystemAssignedUserAssigned(t *testing.T) {
 
 func TestAccIotHub_identityUserAssigned(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -439,6 +458,7 @@ func TestAccIotHub_identityUserAssigned(t *testing.T) {
 
 func TestAccIotHub_identityUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -482,6 +502,7 @@ func TestAccIotHub_identityUpdate(t *testing.T) {
 
 func TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -497,6 +518,7 @@ func TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity(t *testing.T) 
 
 func TestAccIotHub_endpointAuthenticationTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -533,6 +555,7 @@ func TestAccIotHub_endpointAuthenticationTypeUpdate(t *testing.T) {
 
 func TestAccIotHub_cosmosDBRouteUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	data.Locations.Primary = "eastus" // iothub is only avaliable on limited regions
 	r := IotHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

fixing `TestAccIotHub_LocalAuth` and `TestAccIotHubCertificate_update`, these 2 test cases forced recreate resources before.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="530" alt="image" src="https://github.com/user-attachments/assets/21ec5f5c-d109-4c22-b6ec-04d38e9e16f5">
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_iothub`  - fixing acctests  [GH-27620]
* `azurerm_iothub_certificate` - fixing acctests  [GH-27620]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
