### PR TITLE
New Resource: azurerm_storage_share_rm

### DIFF
--- a/internal/services/storage/registration.go
+++ b/internal/services/storage/registration.go
@@ -62,6 +62,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_storage_object_replication":           resourceStorageObjectReplication(),
 		"azurerm_storage_queue":                        resourceStorageQueue(),
 		"azurerm_storage_share":                        resourceStorageShare(),
+		"azurerm_storage_share_rm":                     resourceStorageShareRm(),
 		"azurerm_storage_share_file":                   resourceStorageShareFile(),
 		"azurerm_storage_share_directory":              resourceStorageShareDirectory(),
 		"azurerm_storage_table":                        resourceStorageTable(),

--- a/internal/services/storage/storage_share_rm_resource.go
+++ b/internal/services/storage/storage_share_rm_resource.go
@@ -1,0 +1,436 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storage
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileshares"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func resourceStorageShareRm() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceStorageShareRmCreate,
+		Read:   resourceStorageShareRmRead,
+		Update: resourceStorageShareRmUpdate,
+		Delete: resourceStorageShareRmDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := fileshares.ParseShareID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageShareName,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"storage_account_name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"quota": {
+				Type:         pluginsdk.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 102400),
+			},
+
+			"metadata": MetaDataComputedSchema(),
+
+			"acl": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"id": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 64),
+						},
+						"access_policy": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"start_time": {
+										Type:             pluginsdk.TypeString,
+										Optional:         true,
+										DiffSuppressFunc: suppress.RFC3339Time,
+										ValidateFunc:     validation.IsRFC3339Time,
+									},
+									"expiry_time": {
+										Type:             pluginsdk.TypeString,
+										Optional:         true,
+										DiffSuppressFunc: suppress.RFC3339Time,
+										ValidateFunc:     validation.IsRFC3339Time,
+									},
+									"permission": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"enabled_protocol": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(fileshares.EnabledProtocolsSMB),
+					string(fileshares.EnabledProtocolsNFS),
+				}, false),
+				Default: string(fileshares.EnabledProtocolsSMB),
+			},
+
+			"root_squash": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(fileshares.RootSquashTypeAllSquash),
+					string(fileshares.RootSquashTypeNoRootSquash),
+					string(fileshares.RootSquashTypeRootSquash),
+				}, false),
+			},
+
+			"access_tier": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(fileshares.ShareAccessTierPremium),
+						string(fileshares.ShareAccessTierHot),
+						string(fileshares.ShareAccessTierCool),
+						string(fileshares.ShareAccessTierTransactionOptimized),
+					}, false),
+			},
+		},
+	}
+}
+
+func resourceStorageShareRmCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	storageClient := meta.(*clients.Client).Storage
+	fileSharesClient := meta.(*clients.Client).Storage.ResourceManager.FileShares
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	accountName := d.Get("storage_account_name").(string)
+	shareName := d.Get("name").(string)
+	quota := d.Get("quota").(int)
+
+	metaDataRaw := d.Get("metadata").(map[string]interface{})
+	metaData := ExpandMetaData(metaDataRaw)
+
+	aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
+	acls := expandStorageShareRmACLs(aclsRaw)
+
+	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
+	if err != nil {
+		return fmt.Errorf("retrieving Account %q for Share %q: %v", accountName, shareName, err)
+	}
+	if account == nil {
+		return fmt.Errorf("locating Storage Account %q", accountName)
+	}
+
+	shareId := fileshares.NewShareID(subscriptionId, resourceGroupName, accountName, shareName)
+	existing, err := fileSharesClient.Get(ctx, shareId, fileshares.DefaultGetOperationOptions())
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("could not get fileshare")
+
+		}
+	}
+
+	log.Printf("[INFO] Creating Share %q in Storage Account %q", shareName, accountName)
+
+	fileShare := fileshares.FileShare{
+		Name: pointer.To(shareName),
+		Properties: &fileshares.FileShareProperties{
+			SignedIdentifiers: pointer.To(acls),
+			Metadata:          &metaData,
+			ShareQuota:        pointer.To(int64(quota)),
+		},
+	}
+
+	if protocol := d.Get("enabled_protocol").(string); protocol != "" {
+		enabledProtocol := parseProtocol(protocol)
+		if enabledProtocol == fileshares.EnabledProtocolsNFS {
+			// Only FileStorage (whose sku tier is Premium only) storage account is able to have NFS file shares.
+			// See: https://learn.microsoft.com/en-us/azure/storage/files/storage-files-quick-create-use-linux#applies-to
+			if account.Kind != storageaccounts.KindFileStorage {
+				return fmt.Errorf("NFS File Share is only supported for Storage Account with kind %q but got `%s`", string(storageaccounts.KindFileStorage), account.Kind)
+			}
+
+			if rootSquash := d.Get("root_squash").(string); rootSquash != "" {
+				fileShare.Properties.RootSquash = pointer.To(parseRootSquashType(rootSquash))
+			}
+
+			if quota < 100 {
+				return fmt.Errorf("NFS File Share required a quota of 100 at least but got %d", quota)
+			}
+		}
+
+		fileShare.Properties.EnabledProtocols = pointer.To(enabledProtocol)
+	}
+
+	if accessTier := d.Get("access_tier").(string); accessTier != "" {
+		fileShare.Properties.AccessTier = pointer.To(parseAccessTier(accessTier))
+	}
+
+	createResp, err := fileSharesClient.Create(ctx, shareId, fileShare, fileshares.DefaultCreateOperationOptions())
+	if err != nil {
+		return fmt.Errorf("creating %s: %v", shareId.ID(), err)
+	}
+
+	id, err := fileshares.ParseShareID(pointer.From(createResp.Model.Id))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
+
+	return resourceStorageShareRmRead(d, meta)
+}
+
+func resourceStorageShareRmRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	fileSharesClient := meta.(*clients.Client).Storage.ResourceManager.FileShares
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := fileshares.ParseShareID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := fileSharesClient.Get(ctx, *id, fileshares.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("name", id.ShareName)
+	d.Set("storage_account_name", id.StorageAccountName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	d.Set("quota", int(pointer.From(resp.Model.Properties.ShareQuota)))
+
+	if resp.Model.Properties.EnabledProtocols != nil {
+		d.Set("enabled_protocol", string(*resp.Model.Properties.EnabledProtocols))
+	}
+
+	accessTier := ""
+	if resp.Model.Properties.AccessTier != nil {
+		accessTier = string(pointer.From(resp.Model.Properties.AccessTier))
+	}
+	d.Set("access_tier", accessTier)
+
+	if resp.Model.Properties.SignedIdentifiers != nil {
+		if err := d.Set("acl", flattenStorageShareRmACLs(pointer.From(resp.Model.Properties.SignedIdentifiers))); err != nil {
+			return fmt.Errorf("flattening `acl`: %+v", err)
+		}
+	}
+
+	metadata := make(map[string]interface{})
+	if resp.Model.Properties.Metadata != nil {
+		metadata = FlattenMetaData(pointer.From(resp.Model.Properties.Metadata))
+	}
+
+	d.Set("root_squash", string(pointer.From(resp.Model.Properties.RootSquash)))
+
+	d.Set("metadata", metadata)
+
+	return nil
+}
+
+func resourceStorageShareRmUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	fileSharesClient := meta.(*clients.Client).Storage.ResourceManager.FileShares
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := fileshares.ParseShareID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	fileShare := fileshares.FileShare{
+		Properties: &fileshares.FileShareProperties{},
+	}
+
+	if d.HasChange("quota") {
+		log.Printf("[DEBUG] Updating the Quota for %s", id)
+		quota := int64(d.Get("quota").(int))
+
+		fileShare.Properties.ShareQuota = pointer.To(quota)
+	}
+
+	if d.HasChange("metadata") {
+		log.Printf("[DEBUG] Updating the MetaData for %s", id)
+
+		metaDataRaw := d.Get("metadata").(map[string]interface{})
+		metaData := ExpandMetaData(metaDataRaw)
+
+		fileShare.Properties.Metadata = &metaData
+	}
+
+	if d.HasChange("acl") {
+		log.Printf("[DEBUG] Updating the ACLs for %s", id)
+
+		aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
+		acls := expandStorageShareRmACLs(aclsRaw)
+
+		fileShare.Properties.SignedIdentifiers = pointer.To(acls)
+	}
+
+	if d.HasChange("access_tier") {
+		log.Printf("[DEBUG] Updating Access Tier for %s", id)
+
+		accessTier := d.Get("access_tier").(string)
+		fileShare.Properties.AccessTier = pointer.To(parseAccessTier(accessTier))
+	}
+
+	if d.HasChange("root_squash") {
+		log.Printf("[DEBUG] Updating Root Squash for %s", id)
+
+		rootSquash := d.Get("root_squash").(string)
+		fileShare.Properties.RootSquash = pointer.To(parseRootSquashType(rootSquash))
+	}
+
+	if _, err = fileSharesClient.Update(ctx, *id, fileShare); err != nil {
+		return fmt.Errorf("could not update storage share %v", err)
+	}
+
+	return resourceStorageShareRmRead(d, meta)
+}
+
+func resourceStorageShareRmDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	fileSharesClient := meta.(*clients.Client).Storage.ResourceManager.FileShares
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := fileshares.ParseShareID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err = fileSharesClient.Delete(ctx, *id, fileshares.DefaultDeleteOperationOptions()); err != nil {
+		if strings.Contains(err.Error(), "The specified share does not exist") {
+			return nil
+		}
+		return fmt.Errorf("deleting %s: %v", id, err)
+	}
+
+	return nil
+}
+
+func parseProtocol(input string) fileshares.EnabledProtocols {
+	vals := map[string]fileshares.EnabledProtocols{
+		"nfs": fileshares.EnabledProtocolsNFS,
+		"smb": fileshares.EnabledProtocolsSMB,
+	}
+
+	return vals[strings.ToLower(input)]
+}
+
+func parseAccessTier(input string) fileshares.ShareAccessTier {
+	vals := map[string]fileshares.ShareAccessTier{
+		"cool":                 fileshares.ShareAccessTierCool,
+		"hot":                  fileshares.ShareAccessTierHot,
+		"premium":              fileshares.ShareAccessTierPremium,
+		"transactionoptimized": fileshares.ShareAccessTierTransactionOptimized,
+	}
+
+	return vals[strings.ToLower(input)]
+}
+
+func parseRootSquashType(input string) fileshares.RootSquashType {
+	vals := map[string]fileshares.RootSquashType{
+		"allsquash":    fileshares.RootSquashTypeAllSquash,
+		"norootsquash": fileshares.RootSquashTypeNoRootSquash,
+		"rootsquash":   fileshares.RootSquashTypeRootSquash,
+	}
+
+	return vals[strings.ToLower(input)]
+}
+
+func expandStorageShareRmACLs(input []interface{}) []fileshares.SignedIdentifier {
+	results := make([]fileshares.SignedIdentifier, 0)
+
+	for _, v := range input {
+		vals := v.(map[string]interface{})
+
+		policies := vals["access_policy"].([]interface{})
+		policy := policies[0].(map[string]interface{})
+
+		identifier := fileshares.SignedIdentifier{
+			Id: pointer.To(vals["id"].(string)),
+			AccessPolicy: &fileshares.AccessPolicy{
+				StartTime:  pointer.To(policy["start_time"].(string)),
+				ExpiryTime: pointer.To(policy["expiry_time"].(string)),
+				Permission: pointer.To(policy["permission"].(string)),
+			},
+		}
+		results = append(results, identifier)
+	}
+
+	return results
+}
+
+func flattenStorageShareRmACLs(input []fileshares.SignedIdentifier) []interface{} {
+	result := make([]interface{}, 0)
+
+	for _, v := range input {
+		output := map[string]interface{}{
+			"id": v.Id,
+			"access_policy": []interface{}{
+				map[string]interface{}{
+					"start_time":  v.AccessPolicy.StartTime,
+					"expiry_time": v.AccessPolicy.ExpiryTime,
+					"permission":  v.AccessPolicy.Permission,
+				},
+			},
+		}
+
+		result = append(result, output)
+	}
+
+	return result
+}

--- a/internal/services/storage/storage_share_rm_resource_test.go
+++ b/internal/services/storage/storage_share_rm_resource_test.go
@@ -1,0 +1,641 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/fileshares"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type StorageShareResourceRm struct{}
+
+func TestAccStorageShareRm_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enabled_protocol").HasValue("SMB"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccStorageShareRm_disappears(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
+	})
+}
+
+func TestAccStorageShareRm_deleteAndRecreate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.template(data),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_metaData(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.metaData(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.metaDataUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_acl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.acl(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.aclUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_aclGhostedRecall(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.aclGhostedRecall(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_updateQuota(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updateQuota(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("quota").HasValue("5"),
+			),
+		},
+	})
+}
+
+func TestAccStorageShareRm_largeQuota(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.largeQuota(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.largeQuotaUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_accessTierStandard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.accessTierStandard(data, "Cool"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.accessTierStandard(data, "Hot"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_accessTierPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.accessTierPremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShareRm_nfsProtocol(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.protocol(data, "NFS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// TestAccStorageShare_protocolUpdate is to ensure destroy-then-create of the storage share can tolerant the "ShareBeingDeleted" issue.
+func TestAccStorageShareRm_protocolUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_rm", "test")
+	r := StorageShareResourceRm{}
+
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+		{
+			Config: r.protocol(data, "NFS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.protocol(data, "SMB"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r StorageShareResourceRm) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := fileshares.ParseShareID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := client.Storage.ResourceManager.FileShares.Get(ctx, *id, fileshares.DefaultGetOperationOptions())
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r StorageShareResourceRm) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := fileshares.ParseShareID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = client.Storage.ResourceManager.FileShares.Delete(ctx, *id, fileshares.DefaultDeleteOperationOptions()); err != nil {
+		return nil, fmt.Errorf("deleting File Share %q in %s: %+v", id.ShareName, id.StorageAccountName, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r StorageShareResourceRm) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) metaData(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+
+  metadata = {
+    hello = "world"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) metaDataUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+
+  metadata = {
+    hello = "world"
+    happy = "birthday"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) acl(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permission  = "rwd"
+      start_time  = "2019-07-02T09:38:21.0000000Z"
+      expiry_time = "2019-07-02T10:38:21.0000000Z"
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) aclGhostedRecall(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+
+  acl {
+    id = "GhostedRecall"
+    access_policy {
+      permission = "r"
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) aclUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+
+  acl {
+    id = "AAAANDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permission  = "rwd"
+      start_time  = "2019-07-02T09:38:21.0000000Z"
+      expiry_time = "2019-07-02T10:38:21.0000000Z"
+    }
+  }
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permission  = "rwd"
+      start_time  = "2019-07-02T09:38:21.0000000Z"
+      expiry_time = "2019-07-02T10:38:21.0000000Z"
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "import" {
+  name                 = azurerm_storage_share_rm.test.name
+  storage_account_name = azurerm_storage_share_rm.test.storage_account_name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+}
+`, template)
+}
+
+func (r StorageShareResourceRm) updateQuota(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 5
+}
+`, template, data.RandomString)
+}
+
+func (r StorageShareResourceRm) largeQuota(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storageshare-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestshare%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Premium"
+  account_replication_type        = "LRS"
+  account_kind                    = "FileStorage"
+  allow_nested_items_to_be_public = false
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 6000
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (r StorageShareResourceRm) largeQuotaUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storageshare-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestshare%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Premium"
+  account_replication_type        = "LRS"
+  account_kind                    = "FileStorage"
+  allow_nested_items_to_be_public = false
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 10000
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (r StorageShareResourceRm) accessTierStandard(data acceptance.TestData, tier string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestacc%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  allow_nested_items_to_be_public = false
+}
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 100
+  enabled_protocol     = "SMB"
+  access_tier          = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, tier)
+}
+
+func (r StorageShareResourceRm) accessTierPremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestacc%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Premium"
+  account_replication_type        = "LRS"
+  account_kind                    = "FileStorage"
+  allow_nested_items_to_be_public = false
+}
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  quota                = 100
+  enabled_protocol     = "SMB"
+  access_tier          = "Premium"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (r StorageShareResourceRm) protocol(data acceptance.TestData, protocol string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestacc%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_kind                    = "FileStorage"
+  account_tier                    = "Premium"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
+}
+
+resource "azurerm_storage_share_rm" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  enabled_protocol     = "%s"
+  quota                = 100
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, protocol)
+}
+
+func (r StorageShareResourceRm) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                            = "acctestacc%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
+
+  tags = {
+    environment = "staging"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/docs/r/storage_share_rm.html.markdown
+++ b/website/docs/r/storage_share_rm.html.markdown
@@ -1,0 +1,123 @@
+---
+subcategory: "Storage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_share_rm"
+description: |-
+  Manages a File Share within Azure Storage.
+---
+
+# azurerm_storage_share_rm
+
+Manages a File Share within Azure Storage.
+
+~> **Note** The storage share supports two storage tiers: premium and standard. Standard file shares are created in general purpose (GPv1 or GPv2) storage accounts and premium file shares are created in FileStorage storage accounts. For further information, refer to the section "What storage tiers are supported in Azure Files?" of [documentation](https://docs.microsoft.com/azure/storage/files/storage-files-faq#general).
+
+~> **Note on Authentication** Shared Keys will not be used to authenticate the requests.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "azuretest"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "azureteststorage"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share_rm" "example" {
+  name                 = "sharename"
+  resource_group_name  = azurerm_resource_group.example.name
+  storage_account_name = azurerm_storage_account.example.name
+  quota                = 50
+
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permission  = "rwdl"
+      start_time  = "2019-07-02T09:38:21.0000000Z"
+      expiry_time = "2019-07-02T10:38:21.0000000Z"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the share. Must be unique within the storage account where the share is located. Changing this forces a new resource to be created.
+
+* `storage_account_name` - (Required) Specifies the storage account in which to create the share. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Storage Account is located in.
+
+* `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`, `Premium`.
+
+~>**NOTE:** The `FileStorage` `account_kind` of the `azurerm_storage_account` requires `Premium` `access_tier`.
+
+* `acl` - (Optional) One or more `acl` blocks as defined below.
+
+* `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. The `SMB` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. The `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `SMB`. Changing this forces a new resource to be created.
+
+~>**NOTE:** The `FileStorage` `account_kind` of the `azurerm_storage_account` is required for the `NFS` protocol.
+
+* `quota` - (Required) The maximum size of the share, in gigabytes.
+
+~>**NOTE:** For Standard storage accounts, by default this must be `1` GB (or higher) and at most `5120` GB (`5` TB). This can be set to a value larger than `5120` GB if `large_file_share_enabled` is set to `true` in the parent `azurerm_storage_account`.
+
+~>**NOTE:** For Premium FileStorage storage accounts, this must be greater than `100` GB and at most `102400` GB (`100` TB).
+
+* `root_squash` - (Optional) The root squash of the File Share. Possible values are `AllSquash`, `RootSquash` and `NoRootSquash` the setting is only working for `NFS`. Defaults to  `NoRootSquash`.
+
+* `metadata` - (Optional) A mapping of MetaData for this File Share.
+
+---
+
+A `acl` block supports the following:
+
+* `id` - (Required) The ID which should be used for this Shared Identifier.
+
+* `access_policy` - (Optional) An `access_policy` block as defined below.
+
+---
+
+A `access_policy` block supports the following:
+
+* `permission` - (Required) The permission which should be associated with this Shared Identifier. Possible value is combination of `r` (read), `w` (write), `d` (delete), and `l` (list).
+
+~> **Note:** Permission order is strict at the service side, and permissions need to be listed in the order above.
+
+* `start_time` - (Optional) The time at which this Access Policy should be valid from, in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+
+* `expiry_time` - (Optional) The time at which this Access Policy should be valid until, in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the File Share.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Storage Share.
+* `update` - (Defaults to 30 minutes) Used when updating the Storage Share.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Storage Share.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Storage Share.
+
+## Import
+
+Storage Shares can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_share_rm.exampleShare /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.Storage/storageAccounts/examplestorageaccountname/fileServices/default/shares/eyamplesharename
+
+```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is the first of multiple PR's that adds support for control plane api to interact with Storage Accounts.
The new resource adds ad new resource for storage share

Example:
```
resource "azurerm_storage_share_rm" "example" {
  name                 = "sharename"
  resource_group_name                 = azurerm_resource_group.example.name
  storage_account_name  = azurerm_storage_account.test-storage-acct.name
  quota                =  20
  acl {
    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"

    access_policy {
      permission = "rwdl"
      start_time       = "2019-07-02T10:38:21Z"
      expiry_time      = "2019-07-02T10:38:21Z"
    }
  }
}
```

API reference: https://learn.microsoft.com/en-us/rest/api/storagerp/file-shares/create?view=rest-storagerp-2023-05-01&tabs=HTTP#accesspolicy

The new resource is called "rm" like we do at the azure cli:
https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/storage/docs/Azure%20Storage%20File%20Share.md#overview

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Resource `azurerm_storage_share_rm`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
