### PR TITLE
`data.azurerm_sentinel_alert_rule_anomaly` - fix acctest

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_data_source_test.go
@@ -56,12 +56,12 @@ func TestAccSentinelAlertRuleAnomalyDataSource_basicWithSingleSelect(t *testing.
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("enabled").Exists(),
 				check.That(data.ResourceName).Key("frequency").Exists(),
-				check.That(data.ResourceName).Key("required_data_connector.#").HasValue("1"),
+				check.That(data.ResourceName).Key("required_data_connector.#").HasValue("5"),
 				check.That(data.ResourceName).Key("mode").Exists(),
 				check.That(data.ResourceName).Key("settings_definition_id").Exists(),
 				check.That(data.ResourceName).Key("tactics.#").HasValue("1"),
-				check.That(data.ResourceName).Key("techniques.#").HasValue("2"),
-				check.That(data.ResourceName).Key("single_select_observation.#").HasValue("2"),
+				check.That(data.ResourceName).Key("techniques.#").HasValue("1"),
+				check.That(data.ResourceName).Key("single_select_observation.#").HasValue("1"),
 			),
 		},
 	})
@@ -138,7 +138,7 @@ func (SentinelAlertRuleAnomalyDataSource) basic_withSingleSelect(data acceptance
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "Suspicious geography change in Palo Alto GlobalProtect account logins"
+  display_name               = "Unusual network volume anomaly"
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
update the target rule to fix acctest
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
❯❯ tftest sentinel TestAccSentinelAlertRuleAnomalyDataSource_basicWithSin
gleSelect
=== RUN   TestAccSentinelAlertRuleAnomalyDataSource_basicWithSingleSelect
=== PAUSE TestAccSentinelAlertRuleAnomalyDataSource_basicWithSingleSelect
=== CONT  TestAccSentinelAlertRuleAnomalyDataSource_basicWithSingleSelect
--- PASS: TestAccSentinelAlertRuleAnomalyDataSource_basicWithSingleSelect
 (258.85s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services
/sentinel       260.864s

```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `data.azurerm_sentinel_alert_rule_anomaly` - fix acctest [GH-27625]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
