### PR TITLE
azurerm_api_management_api_diagnostic & azurerm_api_management_diagnostic - error out when operation_name_format is set with identity not applicationinsights

### DIFF
--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -128,7 +128,7 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
 			if _, n := d.GetChange("operation_name_format"); n != "" {
 				if d.Get("identifier") != "applicationinsights" {
-					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
+					return fmt.Errorf("`operation_name_format` cannot be set when `identifier` is not `applicationinsights`")
 				}
 			}
 

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -126,11 +126,12 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
-			if _, ok := d.GetOk("operation_name_format"); ok {
+			if _, n := d.GetChange("operation_name_format"); n != "" {
 				if d.Get("identifier") != "applicationinsights" {
 					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
 				}
 			}
+
 			return nil
 		},
 	}

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -4,6 +4,7 @@
 package apimanagement
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -123,6 +124,15 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 				}, false),
 			},
 		},
+
+		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
+			if _, ok := d.GetOk("operation_name_format"); ok {
+				if d.Get("identifier") != "applicationinsights" {
+					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
+				}
+			}
+			return nil
+		},
 	}
 }
 
@@ -194,8 +204,6 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 	if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
 		if d.Get("identifier") == "applicationinsights" {
 			parameters.Properties.OperationNameFormat = pointer.To(apidiagnostic.OperationNameFormat(operationNameFormat.(string)))
-		} else {
-			return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights on %s", id)
 		}
 	}
 

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -191,8 +191,12 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 		},
 	}
 
-	if d.Get("identifier") == "applicationinsights" {
-		parameters.Properties.OperationNameFormat = pointer.To(apidiagnostic.OperationNameFormat(d.Get("operation_name_format").(string)))
+	if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+		if d.Get("identifier") == "applicationinsights" {
+			parameters.Properties.OperationNameFormat = pointer.To(apidiagnostic.OperationNameFormat(operationNameFormat.(string)))
+		} else {
+			return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights on %s", id)
+		}
 	}
 
 	samplingPercentage := d.GetRawConfig().AsValueMap()["sampling_percentage"]

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -123,11 +123,12 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
-			if _, ok := d.GetOk("operation_name_format"); ok {
+			if _, n := d.GetChange("operation_name_format"); n != "" {
 				if d.Get("identifier") != "applicationinsights" {
 					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
 				}
 			}
+
 			return nil
 		},
 	}

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -150,9 +150,11 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	if d.Get("identifier") == "applicationinsights" {
-		if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+	if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+		if d.Get("identifier") == "" {
 			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
+		} else {
+			return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights on %s", id)
 		}
 	}
 

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -4,6 +4,7 @@
 package apimanagement
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -120,6 +121,15 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 				}, false),
 			},
 		},
+
+		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
+			if _, ok := d.GetOk("operation_name_format"); ok {
+				if d.Get("identifier") != "applicationinsights" {
+					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
+				}
+			}
+			return nil
+		},
 	}
 }
 
@@ -151,10 +161,8 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 	}
 
 	if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
-		if d.Get("identifier") == "" {
+		if d.Get("identifier") == "applicationinsights" {
 			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
-		} else {
-			return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights on %s", id)
 		}
 	}
 

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -125,7 +125,7 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
 			if _, n := d.GetChange("operation_name_format"); n != "" {
 				if d.Get("identifier") != "applicationinsights" {
-					return fmt.Errorf("operation_name_format cannot be set when identifier is not applicationinsights")
+					return fmt.Errorf("`operation_name_format` cannot be set when `identifier` is not `applicationinsights`")
 				}
 			}
 


### PR DESCRIPTION
improve on #27456

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change