### PR TITLE
`azurerm_sentinel_alert_rule_anomaly_duplicate` - fix acctest

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -76,34 +76,14 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccSentinelAlertRuleAnomalyDuplicate_withCustomObservation(t *testing.T) {
+func TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
 	r := SentinelAlertRuleAnomalyDuplicateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+
 			Config: r.basicWithThresholdObservation(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basicWithMultiSelectObservation(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basicWithSingleSelectObservation(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basicWithPrioritizeExcludeObservation(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -112,13 +92,56 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_withCustomObservation(t *testing.T
 	})
 }
 
+func TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
+	r := SentinelAlertRuleAnomalyDuplicateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithMultiSelectObservation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
+	r := SentinelAlertRuleAnomalyDuplicateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithSingleSelectObservation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
+	r := SentinelAlertRuleAnomalyDuplicateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithPrioritizeExcludeObservation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+
+}
+
 func (SentinelAlertRuleAnomalyDuplicateResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "Potential data staging"
+  display_name               = "Anomalous Azure operations"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
@@ -162,19 +185,29 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithSingleSelectObservatio
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "Unusual web traffic detected with IP in URL path"
+  display_name               = "Anomalous W3CIIS logs activity"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
-  display_name               = "acctest duplicate Unusual web traffic detected with IP in URL path"
+  display_name               = "acctest duplicate Anomalous W3CIIS logs activity"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   built_in_rule_id           = data.azurerm_sentinel_alert_rule_anomaly.test.id
   enabled                    = true
   mode                       = "Flighting"
 
   single_select_observation {
-    name  = "Device vendor"
-    value = "Zscaler"
+    name  = "Number of reasons for anomalous activity"
+    value = "1"
+  }
+
+  single_select_observation {
+    name  = "Display anomalies for a specific top reason"
+    value = "None"
+  }
+
+  single_select_observation {
+    name  = "Display anomalies for public, private, or all IPs"
+    value = "Public IPs"
   }
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
@@ -209,24 +242,19 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithPrioritizeExcludeObser
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "Anomalous web request activity"
+  display_name               = "Potential domain generation algorithm (DGA) on next-level DNS Domains"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
-  display_name               = "acctest duplicate Anomalous web request activity"
+  display_name               = "acctest Potential domain generation algorithm (DGA) on next-level DNS Domains"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   built_in_rule_id           = data.azurerm_sentinel_alert_rule_anomaly.test.id
   enabled                    = true
   mode                       = "Flighting"
 
   prioritized_exclude_observation {
-    name       = "Prioritize script suffixes of the URI stems"
-    prioritize = ".asp, .aspx, .armx, .asax, .ashz"
-  }
-
-  prioritized_exclude_observation {
-    name    = "Exclude noisy URI stems"
-    exclude = "test.com"
+    name    = "Domain suffixes"
+    exclude = ".lan, .home, .test"
   }
 
 }

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -76,13 +76,12 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation(t *testing.T) {
+func TestAccSentinelAlertRuleAnomalyDuplicate_thresholdWithCustomObservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
 	r := SentinelAlertRuleAnomalyDuplicateResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-
 			Config: r.basicWithThresholdObservation(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -92,7 +91,7 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation(t *
 	})
 }
 
-func TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation(t *testing.T) {
+func TestAccSentinelAlertRuleAnomalyDuplicate_multiSelectWithCustomObservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
 	r := SentinelAlertRuleAnomalyDuplicateResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -106,7 +105,7 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation(t
 	})
 }
 
-func TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation(t *testing.T) {
+func TestAccSentinelAlertRuleAnomalyDuplicate_singleSelectWithCustomObservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
 	r := SentinelAlertRuleAnomalyDuplicateResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -120,7 +119,7 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation(
 	})
 }
 
-func TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation(t *testing.T) {
+func TestAccSentinelAlertRuleAnomalyDuplicate_prioritizeExcludeWithCustomObservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_anomaly_duplicate", "test")
 	r := SentinelAlertRuleAnomalyDuplicateResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -132,7 +131,6 @@ func TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObserva
 		},
 		data.ImportStep(),
 	})
-
 }
 
 func (SentinelAlertRuleAnomalyDuplicateResource) basic(data acceptance.TestData) string {
@@ -236,6 +234,7 @@ resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }
+
 func (SentinelAlertRuleAnomalyDuplicateResource) basicWithPrioritizeExcludeObservation(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

the old test case was kind of out of date and failing, so update the testing config.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
❯❯ tftest sentinel TestAccSentinelAlertRuleAnomalyDuplicate_
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_basic
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_basic
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation
=== RUN   TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation
=== PAUSE TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_basic
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation
=== CONT  TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_PrioritizeExcludeWithCustomObservation (198.71s)
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_requiresImport (243.28s)
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_MultiSelectWithCustomObservation (248.70s)
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_ThresholdWithCustomObservation (258.97s)
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_SingleSelectWithCustomObservation (269.69s)
--- PASS: TestAccSentinelAlertRuleAnomalyDuplicate_basic (270.62s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      272.607s
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_sentinel_alert_rule_anomaly_duplicate` - fix acctest [GH-27635]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
