### PR TITLE
`azurerm_sentinel_alert_rule_fusion` - deprecate `name` and `alert_rule_template_id`

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -84,21 +84,6 @@ func TestAccSentinelAlertRuleFusion_sourceSetting(t *testing.T) {
 	})
 }
 
-func TestAccSentinelAlertRuleFusion_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_fusion", "test")
-	r := SentinelAlertRuleFusionResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.RequiresImportErrorStep(r.requiresImport),
-	})
-}
-
 func (r SentinelAlertRuleFusionResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	alertRuleClient := client.Sentinel.AlertRulesClient
 	id, err := alertrules.ParseAlertRuleID(state.ID)
@@ -130,50 +115,32 @@ func (r SentinelAlertRuleFusionResource) basic(data acceptance.TestData) string 
 	return fmt.Sprintf(`
 %s
 
-data "azurerm_sentinel_alert_rule_template" "test" {
-  display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+resource "azurerm_sentinel_alert_rule_fusion" "test" {
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 
-resource "azurerm_sentinel_alert_rule_fusion" "test" {
-  name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
-}
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r SentinelAlertRuleFusionResource) disabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-data "azurerm_sentinel_alert_rule_template" "test" {
-  display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-}
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
-  name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   enabled                    = false
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r SentinelAlertRuleFusionResource) sourceSetting(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "azurerm_sentinel_alert_rule_template" "test" {
-  display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-}
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
-  name                       = "acctest-SentinelAlertRule-Fusion-%[2]d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   source {
     name    = "Anomalies"
     enabled = %[3]t
@@ -236,18 +203,6 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
 `, r.template(data), data.RandomInteger, enabled)
 }
 
-func (r SentinelAlertRuleFusionResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_sentinel_alert_rule_fusion" "import" {
-  name                       = azurerm_sentinel_alert_rule_fusion.test.name
-  log_analytics_workspace_id = azurerm_sentinel_alert_rule_fusion.test.log_analytics_workspace_id
-  alert_rule_template_guid   = azurerm_sentinel_alert_rule_fusion.test.alert_rule_template_guid
-}
-`, r.basic(data))
-}
-
 func (r SentinelAlertRuleFusionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -266,17 +221,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
+
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Sentinel Fusion Alert Rule.
 
+~> **Note:** The fusion alert rule (multistage attack detection) is enabled by default, for more details please check the [document](https://learn.microsoft.com/en-us/azure/sentinel/configure-fusion-rules#configure-fusion-rules)
+
 ## Example Usage
 
 ```hcl
@@ -25,22 +27,13 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "example" {
   name                       = "example-fusion-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   alert_rule_template_guid   = "f71aba3d-28fb-450b-b192-4e76a83015c8"
 }
 ```
@@ -49,11 +42,13 @@ resource "azurerm_sentinel_alert_rule_fusion" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Sentinel Fusion Alert Rule. Changing this forces a new Sentinel Fusion Alert Rule to be created.
-
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace this Sentinel Fusion Alert Rule belongs to. Changing this forces a new Sentinel Fusion Alert Rule to be created.
 
-* `alert_rule_template_guid` - (Required) The GUID of the alert rule template which is used for this Sentinel Fusion Alert Rule. Changing this forces a new Sentinel Fusion Alert Rule to be created.
+* `name` - (Optional) The name which should be used for this Sentinel Fusion Alert Rule. Changing this forces a new Sentinel Fusion Alert Rule to be created.
+~> **Note:** This property has been deprecated and will be removed in version 5.0.
+
+* `alert_rule_template_guid` - (Optional) The GUID of the alert rule template which is used for this Sentinel Fusion Alert Rule. Changing this forces a new Sentinel Fusion Alert Rule to be created.
+~> **Note:** This property has been deprecated and will be removed in version 5.0.
 
 * `enabled` - (Optional) Should this Sentinel Fusion Alert Rule be enabled? Defaults to `true`.
 


### PR DESCRIPTION
The fusion alert rule is enabled by default (https://learn.microsoft.com/en-us/azure/sentinel/configure-fusion-rules#configure-scheduled-analytics-rules-for-fusion-detections) with the name `BuiltInFusion` now, so there is no need to specify `name` and `alert_rule_template_id`.
However there might be existing alert rules created before the "enable by default" event, so kept the `name` and `alert_rule_template_id` to avoid breaking these configs.
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
❯❯ tftest sentinel TestAccSentinelAlertRuleFusion_
=== RUN   TestAccSentinelAlertRuleFusion_basic
=== PAUSE TestAccSentinelAlertRuleFusion_basic
=== RUN   TestAccSentinelAlertRuleFusion_disable
=== PAUSE TestAccSentinelAlertRuleFusion_disable
=== RUN   TestAccSentinelAlertRuleFusion_sourceSetting
=== PAUSE TestAccSentinelAlertRuleFusion_sourceSetting
=== CONT  TestAccSentinelAlertRuleFusion_basic
=== CONT  TestAccSentinelAlertRuleFusion_sourceSetting
=== CONT  TestAccSentinelAlertRuleFusion_disable
--- PASS: TestAccSentinelAlertRuleFusion_basic (336.17s)
--- PASS: TestAccSentinelAlertRuleFusion_sourceSetting (393.83s)
--- PASS: TestAccSentinelAlertRuleFusion_disable (600.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel	600.305s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_sentinel_alert_rule_fusion` - deprecate `name` and `alert_rule_template_id` [GH-27642]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
