### PR TITLE
azurerm_api_management - prevent panic

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -2184,7 +2184,7 @@ func flattenApiManagementPolicies(d *pluginsdk.ResourceData, input *policy.Polic
 	// as such we need to retrieve this value from the state if it's present
 	if existing, ok := d.GetOk("policy"); ok {
 		existingVs := existing.([]interface{})
-		if len(existingVs) > 0 {
+		if len(existingVs) > 0 && existingVs[0] != nil {
 			existingV := existingVs[0].(map[string]interface{})
 			output["xml_link"] = existingV["xml_link"].(string)
 		}


### PR DESCRIPTION
fix 
```
Stack trace from the terraform-provider-azurerm_v3.112.0_x5 plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 800 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement.flattenApiManagementPolicies(0xc002e20380?, 0x82a89c5?)
github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/api_management_resource.go:2188 +0x275
github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement.resourceApiManagementServiceRead(0xc002e20380, {0x728b120?, 0xc00116d680})
github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/api_management_resource.go:1347 +0x137a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(Resource).read(0x8aa7800?, {0x8aa7800?, 0xc002881110?}, 0xd?, {0x728b120?, 0xc00116d680?}) github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:783 +0x163 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(Resource).RefreshWithoutUpgrade(0xc000b7cd20, {0x8aa7800, 0xc002881110}, 0xc0013292b0, {0x728b120, 0xc00116d680})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:1089 +0x552
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(GRPCProviderServer).ReadResource(0xc00042ba40, {0x8aa7800?, 0xc002881020?}, 0xc0002f7b80) github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/grpc_provider.go:649 +0x48a github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(server).ReadResource(0xc001f54960, {0x8aa7800?, 0xc0028804b0?}, 0xc00133a000)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/tf5server/server.go:789 +0x48b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x7f25080?, 0xc001f54960}, {0x8aa7800, 0xc0028804b0}, 0xc00046c070, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:431 +0x169
google.golang.org/grpc.(Server).processUnaryRPC(0xc000526000, {0x8ad24a0, 0xc002082340}, 0xc002d839e0, 0xc002001bc0, 0xe103448, 0x0) google.golang.org/grpc@v1.58.3/server.go:1374 +0xde7 google.golang.org/grpc.(Server).handleStream(0xc000526000, {0x8ad24a0, 0xc002082340}, 0xc002d839e0, 0x0)
google.golang.org/grpc@v1.58.3/server.go:1751 +0x9e7
google.golang.org/grpc.(Server).serveStreams.func1.1() google.golang.org/grpc@v1.58.3/server.go:986 +0xbb created by google.golang.org/grpc.(Server).serveStreams.func1 in goroutine 22
google.golang.org/grpc@v1.58.3/server.go:997 +0x145

Error: The terraform-provider-azurerm_v3.112.0_x5 plugin crashed!
```