### PR TITLE
`acceptance`: add the replace path to the error info

### DIFF
--- a/internal/acceptance/helpers/is_not_resource_action.go
+++ b/internal/acceptance/helpers/is_not_resource_action.go
@@ -64,7 +64,7 @@ func (e isNotResourceAction) CheckPlan(ctx context.Context, req plancheck.CheckP
 			}
 		case plancheck.ResourceActionReplace:
 			if rc.Change.Actions.Replace() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+				resp.Error = fmt.Errorf("'%s' - expected action to not be %s, path: %v", rc.Address, e.actionType, rc.Change.ReplacePaths)
 				return
 			}
 		default:


### PR DESCRIPTION


## Description

Currently, if an acceptance test case includes an update to the ForceNew field, the error log appears as follows:

```
=== CONT  TestAccAutomationRunbook_withJobSchedule
    testcase.go:173: Step 4/12 error: Pre-apply plan check(s) failed:
        'azurerm_automation_runbook.test' - expected action to not be Replace
```

It's sometimes unclear which field triggered the replacement. For example, in `TestAccAutomationRunbook_withJobSchedule` (as above), the `resource_group_name` was changed during the update step. This PR adds the path to the error log so that it will look like this:

```
=== CONT  TestAccAutomationRunbook_withJobSchedule
    testcase.go:173: Step 4/12 error: Pre-apply plan check(s) failed:
        'azurerm_automation_runbook.test' - expected action to not be Replace, path: [[resource_group_name]]
````

