### PR TITLE
`automation`: remove or updat acctests contains replace cases

### DIFF
--- a/internal/services/automation/automation_job_schedule_resource_test.go
+++ b/internal/services/automation/automation_job_schedule_resource_test.go
@@ -51,33 +51,6 @@ func TestAccAutomationJobSchedule_complete(t *testing.T) {
 	})
 }
 
-func TestAccAutomationJobSchedule_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_automation_job_schedule", "test")
-	r := AutomationJobScheduleResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccAutomationJobSchedule_updateRunbook(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_job_schedule", "test")
 	r := AutomationJobScheduleResource{}

--- a/internal/services/automation/automation_python3_package_resource_test.go
+++ b/internal/services/automation/automation_python3_package_resource_test.go
@@ -45,19 +45,12 @@ func TestAccPython3Package_basic(t *testing.T) {
 	})
 }
 
-func TestAccPython3Package_update(t *testing.T) {
+func TestAccPython3Package_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.Python3PackageResource{}.ResourceType(), "test")
 	r := Python3PackageResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("content_uri", "content_version"),
-		{
-			Config: r.update(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -84,7 +77,7 @@ resource "azurerm_automation_python3_package" "test" {
 `, a.template(data), data.RandomInteger)
 }
 
-func (a Python3PackageResource) update(data acceptance.TestData) string {
+func (a Python3PackageResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 %s

--- a/internal/services/automation/automation_runbook_resource_test.go
+++ b/internal/services/automation/automation_runbook_resource_test.go
@@ -392,7 +392,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
+  name     = "acctestRG-auto-%[1]d"
   location = "%[2]s"
 }
 
@@ -441,7 +441,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
+  name     = "acctestRG-auto-%[1]d"
   location = "%[2]s"
 }
 
@@ -499,7 +499,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
+  name     = "acctestRG-auto-%[1]d"
   location = "%[2]s"
 }
 

--- a/internal/services/automation/automation_watcher_resource_test.go
+++ b/internal/services/automation/automation_watcher_resource_test.go
@@ -118,7 +118,7 @@ resource "azurerm_automation_watcher" "test" {
     param_foo = "arg_bar"
   }
 
-  etag                           = "etag example-update"
+  etag                           = "etag example"
   execution_frequency_in_seconds = 20
   script_name                    = azurerm_automation_runbook.test.name
   script_run_on                  = azurerm_automation_hybrid_runbook_worker_group.test.name

--- a/internal/services/automation/automation_watcher_resource_test.go
+++ b/internal/services/automation/automation_watcher_resource_test.go
@@ -36,6 +36,7 @@ func TestAccWatcher_basic(t *testing.T) {
 }
 
 func TestAccWatcher_update(t *testing.T) {
+	t.Skip("Watcher Must be stopped before updating, so Skip this test")
 	data := acceptance.BuildTestData(t, automation.WatcherResource{}.ResourceType(), "test")
 	r := WatcherResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -110,7 +111,7 @@ resource "azurerm_automation_watcher" "test" {
   location              = "%[3]s"
 
   tags = {
-    "foo" = "bar-update"
+    "foo" = "bar"
   }
 
   script_parameters = {
@@ -121,7 +122,7 @@ resource "azurerm_automation_watcher" "test" {
   execution_frequency_in_seconds = 20
   script_name                    = azurerm_automation_runbook.test.name
   script_run_on                  = azurerm_automation_hybrid_runbook_worker_group.test.name
-  description                    = "example-watcher desc update"
+  description                    = "example-watcher desc"
 }
 `, a.template(data), data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/automation/automation_watcher_resource_test.go
+++ b/internal/services/automation/automation_watcher_resource_test.go
@@ -36,7 +36,6 @@ func TestAccWatcher_basic(t *testing.T) {
 }
 
 func TestAccWatcher_update(t *testing.T) {
-	t.Skip("Watcher Must be stopped before updating, so Skip this test")
 	data := acceptance.BuildTestData(t, automation.WatcherResource{}.ResourceType(), "test")
 	r := WatcherResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -115,7 +114,7 @@ resource "azurerm_automation_watcher" "test" {
   }
 
   script_parameters = {
-    param_foo = "arg_bar"
+    foo = "bar"
   }
 
   etag                           = "etag example"

--- a/internal/services/automation/automation_watcher_resource_test.go
+++ b/internal/services/automation/automation_watcher_resource_test.go
@@ -110,18 +110,18 @@ resource "azurerm_automation_watcher" "test" {
   location              = "%[3]s"
 
   tags = {
-    "foo" = "bar"
+    "foo" = "bar-update"
   }
 
   script_parameters = {
-    foo = "bar"
+    param_foo = "arg_bar"
   }
 
-  etag                           = "etag example"
+  etag                           = "etag example-update"
   execution_frequency_in_seconds = 20
   script_name                    = azurerm_automation_runbook.test.name
   script_run_on                  = azurerm_automation_hybrid_runbook_worker_group.test.name
-  description                    = "example-watcher desc"
+  description                    = "example-watcher desc update"
 }
 `, a.template(data), data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Remove or update acctests contains replace cases of automation.
![image](https://github.com/user-attachments/assets/1686e70b-bbd8-451c-b70e-881e56b74e46)



To update the Watcher, it must first be stopped; otherwise, the server will return an error as below. The original `TestAccWatcher_update` was a replacement rather than an actual update, which is why it appeared successful. I'm skipping the update case for now due to other issues and will create another PR to address it.

```
        Watcher Name: "acctest-watcher-241018110129761686"): unexpected status 400
        (400 Bad Request) with response:
        {"code":"BadRequest","message":"{\"Message\":\"Watcher must be stopped before
        updating.\"}"}
```


Test Result:


```
--- PASS: TestAccAutomationRunbook_withJobSchedule (298.70s)
--- PASS: TestAccPython3Package_complete (249.26s)
```
