### PR TITLE
`azurerm_windows_function_app_slot` - fixed panic when planning

### DIFF
--- a/internal/services/appservice/migration/windows_function_app_slot.go
+++ b/internal/services/appservice/migration/windows_function_app_slot.go
@@ -1527,9 +1527,9 @@ func (w WindowsFunctionAppSlotV0toV1) Schema() map[string]*pluginsdk.Schema {
 
 func (w WindowsFunctionAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-		oldId := rawState["service_plan_id"].(string)
+		oldId, ok := rawState["service_plan_id"].(string)
 		// service_plan_id can be empty if it is not in a different Service Plan to the "parent" app
-		if oldId == "" {
+		if !ok || oldId == "" {
 			return rawState, nil
 		}
 		parsedId, err := commonids.ParseAppServicePlanIDInsensitively(oldId)


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Similar to the issue fixed under the linux function app pull request https://github.com/hashicorp/terraform-provider-azurerm/pull/25838, we're seeing the same panic occurring for the Windows function app during the planning phase.

```
Stack trace from the terraform-provider-azurerm_v3.95.0_x5 plugin:

panic: interface conversion: interface {} is nil, not string

goroutine 57 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/migration.(*WindowsFunctionAppSlotV0toV1).UpgradeFunc.WindowsFunctionAppSlotV0toV1.UpgradeFunc.func1({0x0?, 0x0?}, 0x0?, {0x0?, 0x0?})
...
panic: interface conversion: interface {} is nil, not string
```

Just like the linux upgrader, the error is caused by the [type assertion](https://go.dev/ref/spec#Type_assertions) of `service_plan_id`; this PR adds the `ok` validity check on the assertion instead of allowing a fatal panic.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

My test was failing to plan when using azurerm provider version 3.95, and now succeeds with this check during the migration.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_function_app_slot` - fixed error when resource is firstly deployed with provider version <= 3.88.0 and then upgraded


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24894


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
