### PR TITLE
`azurerm_security_center_subscription_pricing` - correctly type assert additional properties 

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -290,10 +290,16 @@ func expandSecurityCenterSubscriptionPricingExtensions(inputList []interface{}, 
 			isEnabled = pricings_v2023_01_01.IsEnabledTrue
 		}
 		output := pricings_v2023_01_01.Extension{
-			Name:                          extensionName,
-			IsEnabled:                     isEnabled,
-			AdditionalExtensionProperties: pointer.To(extensionProperties),
+			Name:      extensionName,
+			IsEnabled: isEnabled,
 		}
+
+		if vAdditional, ok := extensionProperties[extensionName]; ok {
+			props, _ := vAdditional.(*interface{})
+			p := (*props).(map[string]interface{})
+			output.AdditionalExtensionProperties = pointer.To(p)
+		}
+
 		outputList = append(outputList, output)
 	}
 

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -60,6 +60,16 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPosture(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterSubscriptionPricing_storage(t *testing.T) {
+	// These tests will change pricing tier of cloud posture
+	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"securityCenterSubscriptionPricing": {
+			"subplan":  testAccSecurityCenterSubscriptionPricing_storageAccountSubplan,
+			"defender": testAccSecurityCenterSubscriptionPricing_storageAccountDefender,
+		},
+	})
+}
+
 func TestAccSecurityCenterSubscriptionPricing_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}
@@ -92,7 +102,7 @@ func TestAccSecurityCenterSubscriptionPricing_cosmosDbs(t *testing.T) {
 	})
 }
 
-func TestAccSecurityCenterSubscriptionPricing_storageAccountSubplan(t *testing.T) {
+func testAccSecurityCenterSubscriptionPricing_storageAccountSubplan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}
 
@@ -109,7 +119,7 @@ func TestAccSecurityCenterSubscriptionPricing_storageAccountSubplan(t *testing.T
 	})
 }
 
-func TestAccSecurityCenterSubscriptionPricing_storageAccountDefender(t *testing.T) {
+func testAccSecurityCenterSubscriptionPricing_storageAccountDefender(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}
 

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -109,6 +109,21 @@ func TestAccSecurityCenterSubscriptionPricing_storageAccountSubplan(t *testing.T
 	})
 }
 
+func TestAccSecurityCenterSubscriptionPricing_storageAccountDefender(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
+	r := SecurityCenterSubscriptionPricingResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageAccountDefender(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func testAccSecurityCenterSubscriptionPricing_cloudPostureExtension(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}
@@ -238,6 +253,31 @@ resource "azurerm_security_center_subscription_pricing" "test" {
   tier          = "Standard"
   resource_type = "StorageAccounts"
   subplan       = "PerStorageAccount"
+}
+`
+}
+
+func (SecurityCenterSubscriptionPricingResource) storageAccountDefender() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_security_center_subscription_pricing" "test" {
+  tier          = "Standard"
+  resource_type = "StorageAccounts"
+  subplan       = "DefenderForStorageV2"
+
+  extension {
+    additional_extension_properties = {
+      "CapGBPerMonthPerStorageAccount" = "5000"
+    }
+    name = "OnUploadMalwareScanning"
+  }
+
+  extension {
+    name = "SensitiveDataDiscovery"
+  }
 }
 `
 }

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -61,7 +61,6 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPosture(t *testing.T) {
 }
 
 func TestAccSecurityCenterSubscriptionPricing_storage(t *testing.T) {
-	// These tests will change pricing tier of cloud posture
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"securityCenterSubscriptionPricing": {
 			"subplan":  testAccSecurityCenterSubscriptionPricing_storageAccountSubplan,


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The type of `additionalProperties` changed in the SDK which meant we were not type asserting and transforming this properly before setting it into the payload.


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

## Testing 

Test results in TC are flaky since these tests don't appear to be run sequentially, test results are from a local run.
```
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPosture
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/standardToFree
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/freeToStandard
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/basic
--- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPosture (179.41s)
    --- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing (179.41s)
        --- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/standardToFree (58.99s)
        --- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/freeToStandard (47.69s)
        --- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPosture/securityCenterSubscriptionPricing/basic (72.74s)
=== RUN   TestAccSecurityCenterSubscriptionPricing_storage
=== RUN   TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing
=== RUN   TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing/subplan
=== RUN   TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing/defender
--- PASS: TestAccSecurityCenterSubscriptionPricing_storage (65.66s)
    --- PASS: TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing (65.66s)
        --- PASS: TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing/subplan (32.71s)
        --- PASS: TestAccSecurityCenterSubscriptionPricing_storage/securityCenterSubscriptionPricing/defender (32.95s)
=== RUN   TestAccSecurityCenterSubscriptionPricing_update
--- PASS: TestAccSecurityCenterSubscriptionPricing_update (23.57s)
=== RUN   TestAccSecurityCenterSubscriptionPricing_cosmosDbs
--- PASS: TestAccSecurityCenterSubscriptionPricing_cosmosDbs (25.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter        296.531s

```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_security_center_subscription_pricing` - correctly type assert `additional_extension_properties` before setting it into the payload [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27704

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
