### PR TITLE
`nginx`: fix nginx configuration acc test

### DIFF
--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -237,7 +237,7 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 			}
 
 			var output ConfigurationModel
-			// protected files field not return by API so decode from state
+			// protected files content field not return by API so decode from state
 			if err := meta.Decode(&output); err != nil {
 				return err
 			}
@@ -267,7 +267,7 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 					}
 				}
 
-				// GET does not return protected files
+				// GET returns protected files with virtual_path only without content
 				if files := prop.ProtectedFiles; files != nil {
 					configs := []ProtectedFile{}
 					for _, file := range *files {

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -253,6 +253,7 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 				}
 
 				if files := prop.Files; files != nil {
+					output.ConfigFile = []ConfigFile{}
 					for _, file := range *files {
 						output.ConfigFile = append(output.ConfigFile, ConfigFile{
 							Content:     pointer.ToString(file.Content),
@@ -263,6 +264,7 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 
 				// GET does not return protected files
 				if files := prop.ProtectedFiles; files != nil {
+					output.ProtectedFile = []ProtectedFile{}
 					for _, file := range *files {
 						output.ProtectedFile = append(output.ProtectedFile, ProtectedFile{
 							Content:     pointer.ToString(file.Content),

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -253,23 +253,34 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 				}
 
 				if files := prop.Files; files != nil {
-					output.ConfigFile = []ConfigFile{}
+					configs := []ConfigFile{}
 					for _, file := range *files {
-						output.ConfigFile = append(output.ConfigFile, ConfigFile{
-							Content:     pointer.ToString(file.Content),
-							VirtualPath: pointer.ToString(file.VirtualPath),
-						})
+						if pointer.From(file.Content) != "" {
+							configs = append(configs, ConfigFile{
+								Content:     pointer.ToString(file.Content),
+								VirtualPath: pointer.ToString(file.VirtualPath),
+							})
+						}
+					}
+					if len(configs) > 0 {
+						output.ConfigFile = configs
 					}
 				}
 
 				// GET does not return protected files
 				if files := prop.ProtectedFiles; files != nil {
-					output.ProtectedFile = []ProtectedFile{}
+					configs := []ProtectedFile{}
 					for _, file := range *files {
-						output.ProtectedFile = append(output.ProtectedFile, ProtectedFile{
-							Content:     pointer.ToString(file.Content),
-							VirtualPath: pointer.ToString(file.VirtualPath),
-						})
+						if pointer.From(file.Content) != "" {
+							configs = append(configs, ProtectedFile{
+								Content:     pointer.ToString(file.Content),
+								VirtualPath: pointer.ToString(file.VirtualPath),
+							})
+						}
+					}
+
+					if len(configs) > 0 {
+						output.ProtectedFile = configs
 					}
 				}
 			}

--- a/internal/services/nginx/nginx_configuration_resource_test.go
+++ b/internal/services/nginx/nginx_configuration_resource_test.go
@@ -111,6 +111,10 @@ resource "azurerm_nginx_configuration" "test" {
     content      = local.protected_content
     virtual_path = "/opt/.htpasswd"
   }
+
+  lifecycle {
+    ignore_changes = [protected_file]
+  }
 }
 `, a.template(data))
 }
@@ -193,6 +197,10 @@ resource "azurerm_nginx_configuration" "test" {
   protected_file {
     content      = local.protected_content
     virtual_path = "/opt/.htpasswd"
+  }
+
+  lifecycle {
+    ignore_changes = [protected_file]
   }
 }
 `, a.template(data))

--- a/internal/services/nginx/nginx_configuration_resource_test.go
+++ b/internal/services/nginx/nginx_configuration_resource_test.go
@@ -111,10 +111,6 @@ resource "azurerm_nginx_configuration" "test" {
     content      = local.protected_content
     virtual_path = "/opt/.htpasswd"
   }
-
-  lifecycle {
-    ignore_changes = [protected_file]
-  }
 }
 `, a.template(data))
 }
@@ -197,10 +193,6 @@ resource "azurerm_nginx_configuration" "test" {
   protected_file {
     content      = local.protected_content
     virtual_path = "/opt/.htpasswd"
-  }
-
-  lifecycle {
-    ignore_changes = [protected_file]
   }
 }
 `, a.template(data))


### PR DESCRIPTION
<!--  All Submissions -->

![image](https://github.com/user-attachments/assets/df70af78-90bc-4fb4-8188-6850d4492851)

Fix failure of:
```
=== CONT  TestAccConfiguration_basic
    testcase.go:173: Step 1/3 error: After applying this test step, the refresh plan was not empty.
        stdout
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # azurerm_nginx_configuration.test will be updated in-place
          ~ resource "azurerm_nginx_configuration" "test" {
                id                  = "/subscriptions/*******/resourceGroups/acctestRG-auto-241022231204351629/providers/Nginx.NginxPlus/nginxDeployments/acctest-241022231204351629/configurations/default"
                # (2 unchanged attributes hidden)
              - protected_file {
                  # At least one attribute in this block is (or was) sensitive,
                  # so its contents will not be displayed.
                }
                # (2 unchanged blocks hidden)
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccConfiguration_basic (522.30s)
```