### PR TITLE
feature: `azurerm_kubernetes_cluster` data source output workload prefixed attributes

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -723,7 +723,7 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
-						vertical_pod_autoscaler_enabled : {
+						vertical_pod_autoscaler_enabled: {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -719,11 +719,11 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						keda_enabled: {
+						"keda_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
-						vertical_pod_autoscaler_enabled: {
+						"vertical_pod_autoscaler_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
@@ -731,7 +731,7 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
-			"workload_autoscaler_enabled": {
+			"workload_identity_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
@@ -978,6 +978,18 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			if err := d.Set("kube_admin_config", adminKubeConfig); err != nil {
 				return fmt.Errorf("setting `kube_admin_config`: %+v", err)
 			}
+
+			if err := d.Set("workload_autoscaler_profile", props.WorkloadAutoScalerProfile); err != nil {
+				return fmt.Errorf("setting `workload_autoscaler_profile`: %+v", err)
+			}
+
+			// if err = d.set("workload_autoscaler_profile_keda", props.WorkloadAutoScalerProfile); err != nil {
+			// 	return fmt.Errorf("setting `workload_autoscaler_profile`: %+v", err)
+			// }
+
+			if err := d.Set("workload_identity_enabled", props.WorkloadIdentityEnabled); err != nil {
+				return fmt.Errorf("setting `workload_identity_enabled`: %+v", err)
+			}
 		}
 
 		identity, err := flattenClusterDataSourceIdentity(model.Identity)
@@ -993,16 +1005,6 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("kube_config_raw", kubeConfigRaw)
 		if err := d.Set("kube_config", kubeConfig); err != nil {
 			return fmt.Errorf("setting `kube_config`: %+v", err)
-		}
-
-		workloadAutoscalerProfile := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(props.WorkloadAutoscalerProfile)
-		if err := d.Set("workload_autoscaler_profile", workloadAutoscalerProfile); err != nil {
-			return fmt.Errorf("setting `workload_autoscaler_profile`: %+v", err)
-		}
-
-		workloadAutoscalerEnabled := false
-		if props.WorkloadIdentity != nil {
-			workloadAutoscalerEnabled = *props.WorkloadIdentity
 		}
 
 		d.Set("tags", tags.Flatten(model.Tags))
@@ -1594,15 +1596,15 @@ func flattenKubernetesClusterDataSourceUpgradeSettings(input *managedclusters.Ag
 	return []interface{}{values}
 }
 
-func flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input *managedclusters.ManagedClusterPropertiesWorkloadAutoscalerProfile) []interface{} {
-	values := make(map[string]interface{})
+// func flattenKubernetesClusterDataSourceWorkloadAutoScalerProfile(input *managedclusters.ManagedClusterWorkloadAutoScalerProfile) []interface{} {
+// 	values := make(map[string]interface{})
 
-	if input == nil {
-		return []interface{}{values}
-	}
+// 	if input == nil {
+// 		return []interface{}{values}
+// 	}
 
-	values[keda_enabled] = input.KedaEnabled
-	values[vertical_pod_autoscaler_enabled] = input.VerticalPodAutoscalerEnabled
+// 	values["keda_enabled"] = input.KedaEnabled
+// 	values["vertical_pod_autoscaler_enabled"] = input.VerticalPodAutoscalerEnabled
 
-	return []interface{}{values}
-}
+// 	return []interface{}{values}
+// }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -679,39 +679,39 @@ func TestAccDataSourceKubernetesCluster_serviceMeshRevisions(t *testing.T) {
 }
 
 func TestFlattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(t *testing.T) {
-    input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
-        KedaEnabled:                to.BoolPtr(true),
-        VerticalPodAutoscalerEnabled: to.BoolPtr(false),
-    }
+	input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
+		KedaEnabled:                  toBoolPtr(true),
+		VerticalPodAutoscalerEnabled: toBoolPtr(false),
+	}
 
-    expected := []interface{}{
-        map[string]interface{}{
-            "keda_enabled":                      true,
-            "vertical_pod_autoscaler_enabled":   false,
-        },
-    }
+	expected := []interface{}{
+		map[string]interface{}{
+			"keda_enabled":                    true,
+			"vertical_pod_autoscaler_enabled": false,
+		},
+	}
 
-    output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
-    assert.Equal(t, expected, output)
+	output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
+	assert.Equal(t, expected, output)
 }
 
 func TestFlattenKubernetesClusterDataSourceWorkloadAutoscalerProfile_WorkflowIdentityEnabled(t *testing.T) {
-    input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
-        WorkflowIdentityEnabled: to.BoolPtr(true),
-    }
+	input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
+		WorkflowIdentityEnabled: toBoolPtr(true),
+	}
 
-    expected := []interface{}{
-        map[string]interface{}{
-            "workflow_identity_enabled": true,
-        },
-    }
+	expected := []interface{}{
+		map[string]interface{}{
+			"workflow_identity_enabled": true,
+		},
+	}
 
-    output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
-    assert.Equal(t, expected, output)
+	output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
+	assert.Equal(t, expected, output)
 }
 
-func to.BoolPtr(value bool) *bool {
-    return &value
+func toBoolPtr(value bool) *bool {
+	return &value
 }
 
 func (KubernetesClusterDataSource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -678,6 +678,42 @@ func TestAccDataSourceKubernetesCluster_serviceMeshRevisions(t *testing.T) {
 	})
 }
 
+func TestFlattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(t *testing.T) {
+    input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
+        KedaEnabled:                to.BoolPtr(true),
+        VerticalPodAutoscalerEnabled: to.BoolPtr(false),
+    }
+
+    expected := []interface{}{
+        map[string]interface{}{
+            "keda_enabled":                      true,
+            "vertical_pod_autoscaler_enabled":   false,
+        },
+    }
+
+    output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
+    assert.Equal(t, expected, output)
+}
+
+func TestFlattenKubernetesClusterDataSourceWorkloadAutoscalerProfile_WorkflowIdentityEnabled(t *testing.T) {
+    input := &containerservice.ManagedClusterPropertiesWorkloadAutoscalerProfile{
+        WorkflowIdentityEnabled: to.BoolPtr(true),
+    }
+
+    expected := []interface{}{
+        map[string]interface{}{
+            "workflow_identity_enabled": true,
+        },
+    }
+
+    output := flattenKubernetesClusterDataSourceWorkloadAutoscalerProfile(input)
+    assert.Equal(t, expected, output)
+}
+
+func to.BoolPtr(value bool) *bool {
+    return &value
+}
+
 func (KubernetesClusterDataSource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-05-01/managedclusters/model_managedclusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-05-01/managedclusters/model_managedclusterproperties.go
@@ -45,4 +45,5 @@ type ManagedClusterProperties struct {
 	UpgradeSettings           *ClusterUpgradeSettings                    `json:"upgradeSettings,omitempty"`
 	WindowsProfile            *ManagedClusterWindowsProfile              `json:"windowsProfile,omitempty"`
 	WorkloadAutoScalerProfile *ManagedClusterWorkloadAutoScalerProfile   `json:"workloadAutoScalerProfile,omitempty"`
+	WorkloadIdentityEnabled   *bool                                      `json:"workloadIdentityEnabled,omitempty"`
 }


### PR DESCRIPTION
Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/27761.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster ` - data source support for the `workload_autoscaler_profile` property. [#27761]
* `azurerm_kubernetes_cluster ` - data source support for the `workload_identity_enabled` property. [#27761]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27761.


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
