### PR TITLE
`azurerm_web_application_firewall_policy` - add support for `policy_settings.0.file_upload_enforcement`

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -396,6 +396,22 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 							Default:  true,
 						},
 
+						"file_upload_enforcement": {
+							Type: pluginsdk.TypeBool,
+							/*
+								NOTE: O+C: This value defaults to true but is only available under certain conditions (i.e. when version is 3.2)
+									managed_rules {
+										managed_rule_set {
+										  type    = "OWASP"
+										  version = "3.2"
+										}
+									  }
+							*/
+							Optional: true,
+							// We'll remove computed in 5.0 so we don't break existing configurations
+							Computed: !features.FivePointOhBeta(),
+						},
+
 						"max_request_body_size_in_kb": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
@@ -727,12 +743,14 @@ func expandWebApplicationFirewallPolicyPolicySettings(input []interface{}) *weba
 	mode := v["mode"].(string)
 	requestBodyCheck := v["request_body_check"].(bool)
 	requestBodyEnforcement := v["request_body_enforcement"].(bool)
+	fileUploadEnforcement := v["file_upload_enforcement"].(bool)
 	maxRequestBodySizeInKb := v["max_request_body_size_in_kb"].(int)
 	fileUploadLimitInMb := v["file_upload_limit_in_mb"].(int)
 
 	result := webapplicationfirewallpolicies.PolicySettings{
 		State:                             pointer.To(enabled),
 		Mode:                              pointer.To(webapplicationfirewallpolicies.WebApplicationFirewallMode(mode)),
+		FileUploadEnforcement:             pointer.To(fileUploadEnforcement),
 		RequestBodyCheck:                  pointer.To(requestBodyCheck),
 		RequestBodyEnforcement:            pointer.To(requestBodyEnforcement),
 		MaxRequestBodySizeInKb:            pointer.To(int64(maxRequestBodySizeInKb)),
@@ -1088,6 +1106,7 @@ func flattenWebApplicationFirewallPolicyPolicySettings(input *webapplicationfire
 	result["mode"] = string(pointer.From(input.Mode))
 	result["request_body_check"] = input.RequestBodyCheck
 	result["request_body_enforcement"] = input.RequestBodyEnforcement
+	result["file_upload_enforcement"] = input.FileUploadEnforcement
 	result["max_request_body_size_in_kb"] = int(pointer.From(input.MaxRequestBodySizeInKb))
 	result["file_upload_limit_in_mb"] = int(pointer.From(input.FileUploadLimitInMb))
 	result["log_scrubbing"] = flattenWebApplicationFirewallPolicyLogScrubbing(input.LogScrubbing)

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -405,6 +405,35 @@ func TestAccWebApplicationFirewallPolicy_BotManager(t *testing.T) {
 	})
 }
 
+func TestAccWebApplicationFirewallPolicy_fileUploadEnforcement(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_application_firewall_policy", "test")
+	r := WebApplicationFirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fileUploadEnforcement(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadEnforcement(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadEnforcement(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t WebApplicationFirewallResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := webapplicationfirewallpolicies.ParseApplicationGatewayWebApplicationFirewallPolicyID(state.ID)
 	if err != nil {
@@ -2034,4 +2063,41 @@ resource "azurerm_web_application_firewall_policy" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (WebApplicationFirewallResource) fileUploadEnforcement(data acceptance.TestData, enforcement bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctestwafpolicy-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled                     = true
+    mode                        = "Prevention"
+    request_body_check          = false
+    request_body_enforcement    = true
+    file_upload_limit_in_mb     = 128
+    max_request_body_size_in_kb = 128
+    file_upload_enforcement     = %t
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enforcement)
 }

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -196,6 +196,8 @@ The `policy_settings` block supports the following:
 
 * `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie validity lifetime in minutes. The user is challenged after the lifetime expires. Accepted values are in the range `5` to `1440`. Defaults to `30`.
 
+* `file_upload_enforcement` - (Optional)  - Whether the firewall should block a request with upload size greater then `file_upload_limit_in_mb`.
+
 ---
 
 The `managed_rules` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for `policy_settings.0.file_upload_enforcement`. It is odd because the value is defaulted when using a specific configuration which could cause issues if it was not Optional/Computed. I've made it so that we remove computed with 5.0 but am happy to take that out if it'll cause issues down the road

```
--- PASS: TestAccWebApplicationFirewallPolicy_fileUploadEnforcement (309.12s)
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_web_application_firewall_policy` - add support for `policy_settings.0.file_upload_enforcement` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
