### PR TITLE
Updates labeler-pull-request-triage for bug, enhancement, and breaking change

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -574,3 +574,9 @@ service/workloads:
 - changed-files:
   - any-glob-to-any-file:
     - internal/services/workloads/**/*
+
+Bug:
+  - '-\s\[X\]\sBug\sFix'
+
+Enhancement:
+  - '-\s\[X\]\sEnhancement'

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -575,10 +575,10 @@ service/workloads:
   - any-glob-to-any-file:
     - internal/services/workloads/**/*
 
-Bug:
+bug:
   - '- \[ ?X ?\] Bug Fix'
 
-Enhancement:
+enhancement:
   - '- \[ ?X ?\] Enhancement'
 
 breaking-change:

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -576,7 +576,10 @@ service/workloads:
     - internal/services/workloads/**/*
 
 Bug:
-  - '-\s\[X\]\sBug\sFix'
+  - '- \[ ?X ?\] Bug Fix'
 
 Enhancement:
-  - '-\s\[X\]\sEnhancement'
+  - '- \[ ?X ?\] Enhancement'
+
+breaking-change:
+  - '- \[ ?X ?\] Breaking Change'


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Updating the labeler to add labels for Bug, Enhancement, and Breaking Change to PRs based on the initial use of the PR template. 
I am working on a future PR to ensure if the check box is ticked sometime after creation it is picked up and labeled. 

New Feature for new-resource and new-data-source not currently included in this automation update.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
