### PR TITLE
`azurerm_virtual_desktop_workspace` - fix test failure of `TestAccAzureRMDesktopVirtualizationWorkspace_update`

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_resource_test.go
@@ -121,7 +121,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_desktop_workspace" "test" {
-  name                = "acctWS%d"
+  name                = "acctestWS%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
@@ -147,7 +147,7 @@ resource "azurerm_virtual_desktop_workspace" "test" {
   description                   = "Acceptance Test by creating acctws%d"
   public_network_access_enabled = false
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomInteger)
+`, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.RandomInteger)
 }
 
 func (r AzureRMDesktopVirtualizationWorkspaceResource) requiresImport(data acceptance.TestData) string {


### PR DESCRIPTION
Fix the following issue where the resource name changed during update, causing the test to fail.

![image](https://github.com/user-attachments/assets/a68a32cf-25e2-40b9-8edb-c993191d7654)
