### PR TITLE
`azurerm_load_test` - fix test failure of `TestAccLoadTest_update`

### DIFF
--- a/internal/services/loadtestservice/load_test_resource.go
+++ b/internal/services/loadtestservice/load_test_resource.go
@@ -67,7 +67,6 @@ func (r LoadTestResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 		"resource_group_name": commonschema.ResourceGroupName(),
 		"description": {
-			ForceNew: true,
 			Optional: true,
 			Type:     pluginsdk.TypeString,
 		},
@@ -184,6 +183,9 @@ func (r LoadTestResource) Read() sdk.ResourceFunc {
 				schema.ResourceGroupName = id.ResourceGroupName
 				if err := r.mapLoadTestResourceToLoadTestResourceSchema(*model, &schema); err != nil {
 					return fmt.Errorf("flattening model: %+v", err)
+				}
+				if property := model.Properties; property != nil {
+					schema.Description = pointer.From(property.Description)
 				}
 			}
 
@@ -344,6 +346,10 @@ func (r LoadTestResource) mapLoadTestResourceSchemaToLoadTestResourceUpdate(inpu
 	output.Identity = identity
 
 	output.Tags = tags.Expand(input.Tags)
+
+	output.Properties = &loadtests.LoadTestResourceUpdateProperties{
+		Description: pointer.To(input.Description),
+	}
 	return nil
 }
 

--- a/website/docs/r/load_test.html.markdown
+++ b/website/docs/r/load_test.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group within which this Load Test should exist. Changing this forces a new Load Test to be created.
 
-* `description` - (Optional) Description of the resource. Changing this forces a new Load Test to be created.
+* `description` - (Optional) Description of the resource.
 
 * `identity` - (Optional) An `identity` block as defined below. Specifies the Managed Identity which should be assigned to this Load Test.
 


### PR DESCRIPTION
Test `TestAccLoadTest_update` failed with the following error. After verifying the behavior of the API , it was found that the `description` is updateable. So the `description` should not be marked as a `ForceNew`. Remove `ForceNew` to fix the following test failure.

![image](https://github.com/user-attachments/assets/8261e73c-5d31-4d2d-a1d0-e8361c551161)

Test Result:
PASS: TestAccLoadTest_update (693.85s)
 