### PR TITLE
`azurerm_key_vault_key` - `expiration_date` only recreates the resource when it is removed from the config file

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -265,21 +265,12 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 					return false // If old or new values are not strings, don't force new
 				}
 
-				// Parse old and new expiration dates
-				oldDate, err1 := time.Parse(time.RFC3339, oldDateStr)
-				newDate, err2 := time.Parse(time.RFC3339, newDateStr)
-				if err1 != nil || err2 != nil {
-					return false // If there are parsing errors, don't force new
+				// There isn't a way to remove the expiration date from a key so we'll recreate the resource when it's removed from config
+				if oldDateStr != "" && newDateStr == "" {
+					return true
 				}
 
-				// Compare old and new expiration dates
-				if newDate.After(oldDate) {
-					// If the new expiration date is further in the future, allow update
-					return false
-				}
-
-				// If the new expiration date is not further, force recreation
-				return true
+				return false
 			}),
 		),
 	}

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -111,7 +111,9 @@ The following arguments are supported:
 
 ~> **Note:** Once `expiration_date` is set, it's not possible to unset the key even if it is deleted & recreated as underlying Azure API uses the restore of the purged key.
 
-* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
+* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
+
+~> **Note:** Removing this field from the config forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Key Vault Key expiration dates can be updated but not removed and this PR adds that functionality into the provider.

```
--- PASS: TestAccKeyVaultKey_updateExpirationDate (1264.03s)
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_key` - `expiration_date` only recreates the resource when it is removed from the config file [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
