### PR TITLE
add bug/enhancement/etc labels in tools/generator-service

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -7,15 +7,15 @@ dependencies:
     - vendor/**/*
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - website/**/*
 tooling:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - internal/tools/**/*
 state-migration:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - internal/services/**/migration/**/*
 service/aadb2c:
 - changed-files:

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -152,7 +152,6 @@ func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) e
 	}
 
 	output += `
-
 bug:
   - '- \[ ?X ?\] Bug Fix'
 

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -66,15 +66,15 @@ dependencies:
     - vendor/**/*
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - website/**/*
 tooling:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - internal/tools/**/*
 state-migration:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - internal/services/**/migration/**/*
 `
 
@@ -150,6 +150,18 @@ func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) e
 		out = append(out, "")
 		output += fmt.Sprintf("\n%s", strings.Join(out, "\n"))
 	}
+
+	output += `
+
+bug:
+  - '- \[ ?X ?\] Bug Fix'
+
+enhancement:
+  - '- \[ ?X ?\] Enhancement'
+
+breaking-change:
+  - '- \[ ?X ?\] Breaking Change'
+`
 
 	return writeToFile(outputFileName, output)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

**THIS PR CANNOT FIX THE LABLER ACTION FAILURE, SEEMS THE LABELER ACTION DOES NOT SUPPORT SUCH CONFIGURATION**

The `labeler-pull-request-triage.yml` file was generated by go:generate in https://github.com/hashicorp/terraform-provider-azurerm/blob/e3fd32d69b4a6f6d593493a6cb9c654e72dbdae9/internal/provider/services.go#L134

superseds #27795

This PR is fo fix the action failure of `Generation Check / gencheck (pull_request)`:

```
make[1]: Entering directory '/home/runner/work/terraform-provider-azurerm/terraform-provider-azurerm'
go generate ./internal/services/...
go generate ./internal/provider/
make[1]: Leaving directory '/home/runner/work/terraform-provider-azurerm/terraform-provider-azurerm'
==> Comparing generated code to committed code...
 .github/labeler-pull-request-triage.yml | 9 ---------
 1 file changed, 9 deletions(-)

Unexpected difference in generated code. Run 'make generate' to update the generated code and commit.
make: *** [GNUmakefile:[7](https://github.com/hashicorp/terraform-provider-azurerm/actions/runs/11606840664/job/32319432692?pr=27827#step:5:8)3: gencheck] Error 1
Error: Process completed with exit code 2.
```
