### PR TITLE
`linux_function_app` making it easier for beginners to upload code into

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -79,6 +79,10 @@ The following arguments are supported:
 
 ~> **Note:** Please create a predefined share if you are restricting your storage account to a virtual network by setting `WEBSITE_CONTENTOVERVNET` to 1 in app_setting.
 
+~> **Note:** For runtime related settings, please use `node_version` in `site_config` to set the node version and use `functions_extension_version` to set the function runtime version, terraform will assign the values to the key `WEBSITE_NODE_DEFAULT_VERSION` and `FUNCTIONS_EXTENSION_VERSION` in app setting.
+
+~> **Note:** By default, Terraform does not assign a value to `WEBSITE_RUN_FROM_PACKAGE`. This allows you to publish an unzipped code package using tools like [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local). Alternatively, you can publish a zipped package by setting `WEBSITE_RUN_FROM_PACKAGE=1` and specifying `zip_deploy_file` with your zipped file. You may also set `WEBSITE_RUN_FROM_PACKAGE=URL`, ensuring the URL ends with .zip. Regardless of the option you choose, ensure that your zipped package has the correct structure. For more information, refer to the [Azure documentation](https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package).
+
 * `auth_settings` - (Optional) A `auth_settings` block as defined below.
 
 * `auth_settings_v2` - (Optional) An `auth_settings_v2` block as defined below.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

For beginners, it's a bit challenging to start publishing their  code into function app. There are different tools and techniques, each having their own quirks which can lead to confusing error. In particular, making sense of `WEBSITE_RUN_FROM_PACKAGE` is challenging and understanding that parameter is essential before publishing the code. Azure doc for that page is confusing and has several inconsistencies which makes it hard to grasp. I remember I had issue with this few years ago. Every time, I had to spend few days to figure out what to do with  `WEBSITE_RUN_FROM_PACKAGE`. I've already created [a long PR](https://github.com/MicrosoftDocs/azure-docs/pull/124746) on Azure doc to help readers. But that doc page isn't very dynamic, to put it politely.

I want beginner users of Terraform to be able to start publishing their code easily without struggling with `WEBSITE_RUN_FROM_PACKAGE` parameter; because that concept is rather simple, just that it has been badly presented by Azure, and good information about it is scattered around the web or is on outdated pages. It's too much work for a beginner. That's why I've made an easy-to-understand note to inform readers. Also, I've added an easy way to publish code. So beginners can start publishing their code with minimal confusing. Feel free to modify the note.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
