### PR TITLE
`azurerm_web_application_firewall_policy` - support  possible value `Uppercase` for property `transforms`

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -144,15 +144,8 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeSet,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
-											Type: pluginsdk.TypeString,
-											ValidateFunc: validation.StringInSlice([]string{
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformHtmlEntityDecode),
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformLowercase),
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformRemoveNulls),
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformTrim),
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformURLDecode),
-												string(webapplicationfirewallpolicies.WebApplicationFirewallTransformURLEncode),
-											}, false),
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForWebApplicationFirewallTransform(), false),
 										},
 									},
 								},

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -543,7 +543,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
       operator           = "Contains"
       negation_condition = false
       match_values       = ["windows"]
-      transforms         = ["Lowercase"]
+      transforms         = ["Uppercase"]
     }
 
     action = "Block"

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -164,7 +164,7 @@ The `match_conditions` block supports the following:
 
 * `negation_condition` - (Optional) Describes if this is negate condition or not
 
-* `transforms` - (Optional) A list of transformations to do before the match is attempted. Possible values are `HtmlEntityDecode`, `Lowercase`, `RemoveNulls`, `Trim`, `UrlDecode` and `UrlEncode`.
+* `transforms` - (Optional) A list of transformations to do before the match is attempted. Possible values are `HtmlEntityDecode`, `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`.
 
 ---
 


### PR DESCRIPTION
Support  possible value `Uppercase` for property `transforms` to fix #27862.

Test result:
PASS: TestAccWebApplicationFirewallPolicy_complete (379.11s)