### PR TITLE
Docs: Removed enabled property from encryption block in the example

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -63,7 +63,6 @@ resource "azurerm_container_registry" "acr" {
   }
 
   encryption {
-    enabled            = true
     key_vault_key_id   = data.azurerm_key_vault_key.example.id
     identity_client_id = azurerm_user_assigned_identity.example.client_id
   }
@@ -139,7 +138,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. 
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `sku` - (Required) The SKU name of the container registry. Possible values are `Basic`, `Standard` and `Premium`.
 
@@ -165,7 +164,7 @@ The following arguments are supported:
 
 * `trust_policy_enabled` - (Optional) Boolean value that indicated whether trust policy is enabled. Defaults to `false`.
 
-* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`. 
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`.
 
 * `export_policy_enabled` - (Optional) Boolean value that indicates whether export policy is enabled. Defaults to `true`. In order to set it to `false`, make sure the `public_network_access_enabled` is also set to `false`.
 
@@ -187,7 +186,7 @@ The `georeplications` block supports the following:
 
 * `location` - (Required) A location where the container registry should be geo-replicated.
 
-* `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? 
+* `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry?
 
 * `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication location? Defaults to `false`.
 


### PR DESCRIPTION
Oneliner: removed "enabled = true" in the encryption block from the example code.
This line change should have been included in commit a585719e4c3dfad9382916bbc9b2a65ccba14c96 
Cc: @stephybun 