### PR TITLE
`azurerm_databricks_workspace`: fix acceptance test of replace

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -245,13 +245,6 @@ func TestAccDatabricksWorkspace_updateSKU(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.basic(data, "trial"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

SKU can only be upgraded from `trial` to `standard`, not downgraded.
https://github.com/hashicorp/terraform-provider-azurerm/blob/8da4254d313a733d1c15f27d9b91929ea2381cff/internal/services/databricks/databricks_workspace_resource.go#L367-L369

```
=== CONT  TestAccDatabricksWorkspace_updateSKU
    testcase.go:173: Step 7/9 error: Pre-apply plan check(s) failed:
        'azurerm_databricks_workspace.test' - expected action to not be Replace, path: [[sku]]
--- FAIL: TestAccDatabricksWorkspace_updateSKU (625.83s)
```

![image](https://github.com/user-attachments/assets/9101a8c0-2f33-4227-8b03-d2437eabe63a)
