### PR TITLE
azurerm_subnet: Remove ForceNew from `default_outbound_access_enabled` property.

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -204,7 +204,6 @@ func resourceSubnet() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Default:  true,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"private_endpoint_network_policies": {
@@ -512,6 +511,10 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			props.AddressPrefixes = utils.ExpandStringSlice(addressPrefixesRaw)
 			props.AddressPrefix = nil
 		}
+	}
+
+	if d.HasChange("default_outbound_access_enabled") {
+		props.DefaultOutboundAccess = pointer.To(d.Get("default_outbound_access_enabled").(bool))
 	}
 
 	if d.HasChange("delegation") {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -127,20 +127,25 @@ func TestAccSubnet_disappears(t *testing.T) {
 }
 
 func TestAccSubnet_defaultOutbound(t *testing.T) {
-	dataInternal := acceptance.BuildTestData(t, "azurerm_subnet", "internal")
-	dataPublic := acceptance.BuildTestData(t, "azurerm_subnet", "public")
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "internal")
 	r := SubnetResource{}
 
-	dataInternal.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.defaultOutbound(dataInternal),
+			Config: r.defaultOutbound(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(dataInternal.ResourceName).ExistsInAzure(r),
-				check.That(dataInternal.ResourceName).Key("default_outbound_access_enabled").HasValue("false"),
-				check.That(dataPublic.ResourceName).ExistsInAzure(r),
-				check.That(dataPublic.ResourceName).Key("default_outbound_access_enabled").HasValue("true"),
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_outbound_access_enabled").HasValue("true"),
 			),
 		},
+		data.ImportStep(),
+		{
+			Config: r.defaultOutbound(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("default_outbound_access_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -839,7 +844,7 @@ resource "azurerm_subnet" "test" {
 `, r.template(data))
 }
 
-func (r SubnetResource) defaultOutbound(data acceptance.TestData) string {
+func (r SubnetResource) defaultOutbound(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
 resource "azurerm_subnet" "internal" {
@@ -847,16 +852,9 @@ resource "azurerm_subnet" "internal" {
   resource_group_name             = azurerm_resource_group.test.name
   virtual_network_name            = azurerm_virtual_network.test.name
   address_prefixes                = ["10.0.2.0/24"]
-  default_outbound_access_enabled = false
+  default_outbound_access_enabled = %t
 }
-resource "azurerm_subnet" "public" {
-  name                            = "public"
-  resource_group_name             = azurerm_resource_group.test.name
-  virtual_network_name            = azurerm_virtual_network.test.name
-  address_prefixes                = ["10.0.3.0/24"]
-  default_outbound_access_enabled = true
-}
-`, r.template(data))
+`, r.template(data), enabled)
 }
 
 func (r SubnetResource) delegationUpdated(data acceptance.TestData) string {


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removed ForceNew flag from default_outbound_access_enabled property.
Updated TestAccSubnet_defaultOutbound to evaluate the update on the property.

Notes:
- The documentation has not been updated as it does not describe the property as Force Recreation.
- This change is not required in `azurerm_virtual_network` resource, since it is already supporting the update without recreation.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
make acctests  SERVICE='network' TESTARGS='-run=TestAccSubnet_defaultOutbound'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccSubnet_defaultOutbound -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSubnet_defaultOutbound
=== PAUSE TestAccSubnet_defaultOutbound
=== CONT  TestAccSubnet_defaultOutbound
--- PASS: TestAccSubnet_defaultOutbound (312.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       312.871s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_subnet` -  `default_outbound_access_enabled` property can be updated without recreate the resource [GH-27848]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27848


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
