### PR TITLE
`azurerm_policy_definition`: fix acceptance test of removing forcenew `paramters` steps

### DIFF
--- a/internal/services/policy/policy_definition_resource_test.go
+++ b/internal/services/policy/policy_definition_resource_test.go
@@ -158,13 +158,6 @@ func TestAccAzureRMPolicyDefinition_removeParameter(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

https://github.com/hashicorp/terraform-provider-azurerm/blob/6454ea9769d45fc7b42667113081e7dc963477b6/internal/services/policy/policy_definition_resource.go#L47-L53



```
=== CONT  TestAccAzureRMPolicyDefinition_removeParameter
    testcase.go:173: Step 7/9 error: Pre-apply plan check(s) failed:
        'azurerm_policy_definition.test' - expected action to not be Replace, path: [[parameters]]
--- FAIL: TestAccAzureRMPolicyDefinition_removeParameter (385.15s)
```

