### PR TITLE
`azurerm_log_analytics_data_export_rule` - wait for state after creation

### DIFF
--- a/internal/services/loganalytics/custompollers/log_analytics_data_export_poller.go
+++ b/internal/services/loganalytics/custompollers/log_analytics_data_export_poller.go
@@ -1,0 +1,47 @@
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &LogAnalyticsDataExportPoller{}
+
+type LogAnalyticsDataExportPoller struct {
+	client *dataexport.DataExportClient
+	id     dataexport.DataExportId
+}
+
+var (
+	pollingSuccess = pollers.PollResult{
+		Status:       pollers.PollingStatusSucceeded,
+		PollInterval: 10 * time.Second,
+	}
+	pollingInProgress = pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}
+)
+
+func NewLogAnalyticsDataExportPoller(client *dataexport.DataExportClient, id dataexport.DataExportId) *LogAnalyticsDataExportPoller {
+	return &LogAnalyticsDataExportPoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (p LogAnalyticsDataExportPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.Get(ctx, p.id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return &pollingInProgress, nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+	return &pollingSuccess, nil
+}

--- a/internal/services/loganalytics/log_analytics_data_export_resource.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource.go
@@ -171,7 +171,7 @@ func resourceOperationalinsightsDataExportCreateUpdate(d *pluginsdk.ResourceData
 	}
 
 	// Tracked on https://github.com/Azure/azure-rest-api-specs/issues/31399
-	log.Printf("[DEBUG] Waiting for Log Analytics Workspace Data Export %q to become ready", id.ID())
+	log.Printf("[DEBUG] Waiting for Log Analytics Workspace Data Export Rule %q to become ready", id.ID())
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:                   []string{"NotFound"},
 		Target:                    []string{"Exists"},
@@ -182,7 +182,7 @@ func resourceOperationalinsightsDataExportCreateUpdate(d *pluginsdk.ResourceData
 	}
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for Log Analytics Workspace Data Export %q to become ready: %+v", id.ID(), err)
+		return fmt.Errorf("waiting for Log Analytics Workspace Data Export Rule %q to become ready: %+v", id.ID(), err)
 	}
 
 	d.SetId(id.ID())


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The service might return 404 for newly created `azurerm_log_analytics_data_export_rule`, and it requires an additional polling to make sure we do not get 404 response. tracked on https://github.com/Azure/azure-rest-api-specs/issues/31399
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="634" alt="image" src="https://github.com/user-attachments/assets/3ec6e033-adca-42c8-9d92-425af61ba824">
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_data_export_rule` - wait for state after creation [GH-27876]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
