### PR TITLE
azurerm_public_ip_prefix: adding `sku_tier` property

### DIFF
--- a/internal/services/network/public_ip_prefix_data_source.go
+++ b/internal/services/network/public_ip_prefix_data_source.go
@@ -42,6 +42,11 @@ func dataSourcePublicIpPrefix() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"sku_tier": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"prefix_length": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -82,6 +87,7 @@ func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 		if sku := model.Sku; sku != nil {
 			d.Set("sku", string(pointer.From(sku.Name)))
+			d.Set("sku_tier", string(pointer.From(sku.Tier)))
 		}
 		if props := model.Properties; props != nil {
 			d.Set("prefix_length", props.PrefixLength)

--- a/internal/services/network/public_ip_prefix_data_source_test.go
+++ b/internal/services/network/public_ip_prefix_data_source_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-03-01/publicipprefixes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -27,6 +28,7 @@ func TestAccDataSourcePublicIPPrefix_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("resource_group_name").HasValue(resourceGroupName),
 				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
 				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(string(publicipprefixes.PublicIPPrefixSkuTierRegional)),
 				check.That(data.ResourceName).Key("prefix_length").HasValue("31"),
 				check.That(data.ResourceName).Key("ip_prefix").Exists(),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -63,6 +63,17 @@ func resourcePublicIpPrefix() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"sku_tier": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(publicipprefixes.PublicIPPrefixSkuTierRegional),
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(publicipprefixes.PublicIPPrefixSkuTierGlobal),
+					string(publicipprefixes.PublicIPPrefixSkuTierRegional),
+				}, false),
+			},
+
 			"prefix_length": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
@@ -118,6 +129,7 @@ func resourcePublicIpPrefixCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Sku: &publicipprefixes.PublicIPPrefixSku{
 			Name: pointer.To(publicipprefixes.PublicIPPrefixSkuName(d.Get("sku").(string))),
+			Tier: pointer.To(publicipprefixes.PublicIPPrefixSkuTier(d.Get("sku_tier").(string))),
 		},
 		Properties: &publicipprefixes.PublicIPPrefixPropertiesFormat{
 			PrefixLength:           pointer.To(int64(d.Get("prefix_length").(int))),
@@ -190,11 +202,10 @@ func resourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
 		d.Set("zones", zones.FlattenUntyped(model.Zones))
-		skuName := ""
 		if sku := model.Sku; sku != nil {
-			skuName = string(pointer.From(sku.Name))
+			d.Set("sku", string(pointer.From(sku.Name)))
+			d.Set("sku_tier", string(pointer.From(sku.Tier)))
 		}
-		d.Set("sku", skuName)
 		if props := model.Properties; props != nil {
 			d.Set("prefix_length", props.PrefixLength)
 			d.Set("ip_prefix", props.IPPrefix)

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -64,14 +64,11 @@ func resourcePublicIpPrefix() *pluginsdk.Resource {
 			},
 
 			"sku_tier": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(publicipprefixes.PublicIPPrefixSkuTierRegional),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipprefixes.PublicIPPrefixSkuTierGlobal),
-					string(publicipprefixes.PublicIPPrefixSkuTierRegional),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(publicipprefixes.PublicIPPrefixSkuTierRegional),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(publicipprefixes.PossibleValuesForPublicIPPrefixSkuTier(), false),
 			},
 
 			"prefix_length": {

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -389,7 +389,7 @@ resource "azurerm_public_ip_prefix" "test" {
   resource_group_name = azurerm_resource_group.test.name
   name                = "acctestpublicipprefix-%d"
   location            = azurerm_resource_group.test.location
-	sku_tier            = "%s"
+  sku_tier            = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, tier)
 }

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -63,6 +63,38 @@ func TestAccPublicIpPrefix_basic(t *testing.T) {
 	})
 }
 
+func TestAccPublicIpPrefix_globalTier(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+	r := PublicIPPrefixResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sku_tier(data, string(publicipprefixes.PublicIPPrefixSkuTierGlobal)),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(string(publicipprefixes.PublicIPPrefixSkuTierGlobal)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccPublicIpPrefix_regionalTier(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+	r := PublicIPPrefixResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sku_tier(data, string(publicipprefixes.PublicIPPrefixSkuTierRegional)),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(string(publicipprefixes.PublicIPPrefixSkuTierRegional)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccPublicIpPrefix_ipv6(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixResource{}
@@ -340,6 +372,26 @@ resource "azurerm_public_ip_prefix" "test" {
   prefix_length = 24
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (PublicIPPrefixResource) sku_tier(data acceptance.TestData, tier string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+	sku_tier            = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, tier)
 }
 
 func (PublicIPPrefixResource) zonesSingle(data acceptance.TestData) string {

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -35,6 +35,7 @@ output "public_ip_prefix" {
 * `ip_prefix` - The Public IP address range, in CIDR notation.
 * `location` - The supported Azure location where the resource exists.
 * `sku` - The SKU of the Public IP Prefix.
+* `sku_tier` - The SKU Tier of the Public IP.
 * `prefix_length` - The number of bits of the prefix.
 * `tags` - A mapping of tags to assigned to the resource.
 * `zones` - A list of Availability Zones in which this Public IP Prefix is located.

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 -> **Note:** Public IP Prefix can only be created with Standard SKUs at this time.
 
+* `sku_tier` - (Optional) The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.
+
 * `ip_version` - (Optional) The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.
 
 * `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 31 (2 addresses). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
- Added `sku_tier` to the resource and the data source.
- Updated `TestAccDataSourcePublicIPPrefix_basic` to validate the output value.
- Added `TestAccPublicIpPrefix_globalTier` and `TestAccPublicIpPrefix_regionalTier` to test both possible values.
- Updated docs.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
make acctests SERVICE='network' TESTARGS='-run=TestAccDataSourcePublicIPPrefix_'

=== RUN   TestAccDataSourcePublicIPPrefix_basic
=== PAUSE TestAccDataSourcePublicIPPrefix_basic
=== CONT  TestAccDataSourcePublicIPPrefix_basic
--- PASS: TestAccDataSourcePublicIPPrefix_basic (167.14s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       167.429s
```

```
make acctests SERVICE='network' TESTARGS='-run=TestAccPublicIpPrefix_'

=== RUN   TestAccPublicIpPrefix_basic
=== PAUSE TestAccPublicIpPrefix_basic
=== RUN   TestAccPublicIpPrefix_globalTier
=== PAUSE TestAccPublicIpPrefix_globalTier
=== RUN   TestAccPublicIpPrefix_regionalTier
=== PAUSE TestAccPublicIpPrefix_regionalTier
=== RUN   TestAccPublicIpPrefix_ipv6
=== PAUSE TestAccPublicIpPrefix_ipv6
=== RUN   TestAccPublicIpPrefix_requiresImport
=== PAUSE TestAccPublicIpPrefix_requiresImport
=== RUN   TestAccPublicIpPrefix_prefixLength31
=== PAUSE TestAccPublicIpPrefix_prefixLength31
=== RUN   TestAccPublicIpPrefix_prefixLength24
=== PAUSE TestAccPublicIpPrefix_prefixLength24
=== RUN   TestAccPublicIpPrefix_update
=== PAUSE TestAccPublicIpPrefix_update
=== RUN   TestAccPublicIpPrefix_disappears
=== PAUSE TestAccPublicIpPrefix_disappears
=== RUN   TestAccPublicIpPrefix_zonesSingle
=== PAUSE TestAccPublicIpPrefix_zonesSingle
=== RUN   TestAccPublicIpPrefix_zonesMultiple
=== PAUSE TestAccPublicIpPrefix_zonesMultiple
=== CONT  TestAccPublicIpPrefix_basic
=== CONT  TestAccPublicIpPrefix_zonesSingle
=== CONT  TestAccPublicIpPrefix_prefixLength24
=== CONT  TestAccPublicIpPrefix_disappears
=== CONT  TestAccPublicIpPrefix_zonesMultiple
=== CONT  TestAccPublicIpPrefix_ipv6
=== CONT  TestAccPublicIpPrefix_prefixLength31
=== CONT  TestAccPublicIpPrefix_requiresImport
=== CONT  TestAccPublicIpPrefix_regionalTier
--- PASS: TestAccPublicIpPrefix_disappears (475.63s)
=== CONT  TestAccPublicIpPrefix_globalTier
--- PASS: TestAccPublicIpPrefix_requiresImport (484.94s)
=== CONT  TestAccPublicIpPrefix_update
--- PASS: TestAccPublicIpPrefix_zonesSingle (489.34s)
--- PASS: TestAccPublicIpPrefix_ipv6 (497.96s)
--- PASS: TestAccPublicIpPrefix_zonesMultiple (517.30s)
--- PASS: TestAccPublicIpPrefix_prefixLength31 (519.51s)
--- PASS: TestAccPublicIpPrefix_basic (589.28s)
--- PASS: TestAccPublicIpPrefix_regionalTier (293.36s)
--- PASS: TestAccPublicIpPrefix_update (193.22s)
--- PASS: TestAccPublicIpPrefix_globalTier (236.70s)
```

Note: Missing `TestAccPublicIpPrefix_prefixLength24 ` because is not accepted in my working subscription.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_public_ip_prefix` - support for the `sku_tier` property [GH-27877]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27877


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
