### PR TITLE
azurerm_bastion_host: Adding `zones` property to resource and data source.

### DIFF
--- a/internal/services/network/bastion_host_data_source.go
+++ b/internal/services/network/bastion_host_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-01-01/bastionhosts"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -104,6 +105,8 @@ func dataSourceBastionHost() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
 			"tags": commonschema.TagsDataSource(),
+
+			"zones": commonschema.ZonesMultipleComputed(),
 		},
 	}
 }
@@ -133,6 +136,7 @@ func dataSourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			skuName = string(*sku.Name)
 		}
 		d.Set("sku", skuName)
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		if props := model.Properties; props != nil {
 			d.Set("dns_name", props.DnsName)

--- a/internal/services/network/bastion_host_data_source_test.go
+++ b/internal/services/network/bastion_host_data_source_test.go
@@ -13,14 +13,15 @@ import (
 
 type BastionHostDataSource struct{}
 
-func TestAccBastionHostDataSource_basic(t *testing.T) {
+func TestAccBastionHostDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_bastion_host", "test")
 	r := BastionHostDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("copy_paste_enabled").Exists(),
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("location").Exists(),
 				check.That(data.ResourceName).Key("sku").Exists(),
@@ -33,13 +34,15 @@ func TestAccBastionHostDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_configuration.0.name").Exists(),
 				check.That(data.ResourceName).Key("ip_configuration.0.subnet_id").Exists(),
 				check.That(data.ResourceName).Key("ip_configuration.0.public_ip_address_id").Exists(),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.environment").HasValue("production"),
 				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 	})
 }
 
-func (BastionHostDataSource) basic(data acceptance.TestData) string {
+func (BastionHostDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -47,5 +50,5 @@ data "azurerm_bastion_host" "test" {
   name                = azurerm_bastion_host.test.name
   resource_group_name = azurerm_bastion_host.test.resource_group_name
 }
-`, BastionHostResource{}.basic(data))
+`, BastionHostResource{}.complete(data))
 }

--- a/internal/services/network/bastion_host_data_source_test.go
+++ b/internal/services/network/bastion_host_data_source_test.go
@@ -33,6 +33,7 @@ func TestAccBastionHostDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_configuration.0.name").Exists(),
 				check.That(data.ResourceName).Key("ip_configuration.0.subnet_id").Exists(),
 				check.That(data.ResourceName).Key("ip_configuration.0.public_ip_address_id").Exists(),
+				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 	})

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -27,7 +27,6 @@ func TestAccBastionHost_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 	})
@@ -58,6 +57,7 @@ func TestAccBastionHost_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.environment").HasValue("production"),
+				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -199,14 +199,12 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_bastion_host" "test" {
   name                = "acctestBastion%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  zones               = azurerm_public_ip.test.zones
 
   ip_configuration {
     name                 = "ip-configuration"
@@ -301,6 +299,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_bastion_host" "test" {
@@ -308,6 +307,7 @@ resource "azurerm_bastion_host" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   copy_paste_enabled  = false
+  zones               = azurerm_public_ip.test.zones
 
   ip_configuration {
     name                 = "ip-configuration"

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -27,6 +27,7 @@ func TestAccBastionHost_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 	})
@@ -198,12 +199,14 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_bastion_host" "test" {
   name                = "acctestBastion%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  zones               = azurerm_public_ip.test.zones
 
   ip_configuration {
     name                 = "ip-configuration"

--- a/website/docs/d/bastion_host.html.markdown
+++ b/website/docs/d/bastion_host.html.markdown
@@ -62,6 +62,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `tags` - A mapping of tags assigned to the Bastion Host.
 
+* `zones` - A list of Availability Zones in which this Bastion Host is located.
+
 ---
 
 A `ip_configuration` block supports the following:

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -106,6 +106,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+* `zones` - (Optional) Specifies a list of Availability Zones in which this Public Bastion Host should be located. Changing this forces a new resource to be created.
+
 ---
 
 A `ip_configuration` block supports the following:


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
- Added `zones` property to resource and data source.
- Updated Complete Test to include zones.
- Updated Data Source test to use Complete config.
- Updated docs.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

```
make acctests SERVICE='network' TESTARGS='-run=TestAccBastionHost_'
=== RUN   TestAccBastionHost_basic
=== PAUSE TestAccBastionHost_basic
=== RUN   TestAccBastionHost_standardSku
=== PAUSE TestAccBastionHost_standardSku
=== RUN   TestAccBastionHost_complete
=== PAUSE TestAccBastionHost_complete
=== RUN   TestAccBastionHost_requiresImport
=== PAUSE TestAccBastionHost_requiresImport
=== RUN   TestAccBastionHost_scaleUnits
=== PAUSE TestAccBastionHost_scaleUnits
=== RUN   TestAccBastionHost_sku
=== PAUSE TestAccBastionHost_sku
=== RUN   TestAccBastionHost_developerSku
=== PAUSE TestAccBastionHost_developerSku
=== RUN   TestAccBastionHost_premiumSku
=== PAUSE TestAccBastionHost_premiumSku
=== CONT  TestAccBastionHost_basic
=== CONT  TestAccBastionHost_scaleUnits
=== CONT  TestAccBastionHost_developerSku
=== CONT  TestAccBastionHost_sku
=== CONT  TestAccBastionHost_complete
=== CONT  TestAccBastionHost_standardSku
=== CONT  TestAccBastionHost_requiresImport
=== CONT  TestAccBastionHost_premiumSku
--- PASS: TestAccBastionHost_developerSku (390.34s)
--- PASS: TestAccBastionHost_standardSku (1164.83s)
--- PASS: TestAccBastionHost_requiresImport (1178.79s)
--- PASS: TestAccBastionHost_complete (1207.11s)
--- PASS: TestAccBastionHost_premiumSku (1325.62s)
--- PASS: TestAccBastionHost_basic (1353.50s)
--- PASS: TestAccBastionHost_sku (1688.30s)
--- PASS: TestAccBastionHost_scaleUnits (1881.51s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1881.726s
```

```
make acctests SERVICE='network' TESTARGS='-run=TestAccBastionHostDataSource_'

=== RUN   TestAccBastionHostDataSource_complete
=== PAUSE TestAccBastionHostDataSource_complete
=== CONT  TestAccBastionHostDataSource_complete
--- PASS: TestAccBastionHostDataSource_complete (1052.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1052.699s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_bastion_host` - support for the `zones` property [GH-27783]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27783


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
