### PR TITLE
`azurerm_cdn_frontdoor_custom_domain` - update documents for TLS 1.0 retirement

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -119,8 +119,7 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 	}
 
 	if !features.FivePointOhBeta() {
-		tlsElem := resource.Schema["tls"].Elem.(*pluginsdk.Resource)
-		tlsElem.Schema["minimum_tls_version"] = &pluginsdk.Schema{
+		resource.Schema["tls"].Elem.(*pluginsdk.Resource).Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  string(cdn.AfdMinimumTLSVersionTLS12),
@@ -129,7 +128,6 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 				string(cdn.AfdMinimumTLSVersionTLS10),
 			}, false),
 		}
-		resource.Schema["tls"].Elem = tlsElem
 	}
 
 	return resource

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -11,6 +11,7 @@ import (
 	dnsValidate "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -90,10 +91,17 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							Default:  string(cdn.AfdMinimumTLSVersionTLS12),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(cdn.AfdMinimumTLSVersionTLS10),
-								string(cdn.AfdMinimumTLSVersionTLS12),
-							}, false),
+							ValidateFunc: validation.StringInSlice(func() []string {
+								if !features.FivePointOhBeta() {
+									return []string{
+										string(cdn.AfdMinimumTLSVersionTLS10),
+										string(cdn.AfdMinimumTLSVersionTLS12),
+									}
+								}
+								return []string{
+									string(cdn.AfdMinimumTLSVersionTLS12),
+								}
+							}(), false),
 						},
 
 						// NOTE: If the secret is managed by FrontDoor this will cause a perpetual diff,

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -41,94 +41,105 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 			return err
 		}),
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.FrontDoorCustomDomainName,
-			},
-
-			// NOTE: I need this fake field because I need the profile name during the create operation
-			"cdn_frontdoor_profile_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.FrontDoorProfileID,
-			},
-
-			"dns_zone_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: dnsValidate.ValidateDnsZoneID,
-			},
-
-			"host_name": {
-				Type:     pluginsdk.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-
-			"tls": {
-				Type:     pluginsdk.TypeList,
-				Required: true,
-				MaxItems: 1,
-
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-
-						"certificate_type": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(cdn.AfdCertificateTypeManagedCertificate),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(cdn.AfdCertificateTypeCustomerCertificate),
-								string(cdn.AfdCertificateTypeManagedCertificate),
-							}, false),
-						},
-
-						"minimum_tls_version": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(cdn.AfdMinimumTLSVersionTLS12),
-							ValidateFunc: validation.StringInSlice(func() []string {
-								if !features.FivePointOhBeta() {
-									return []string{
-										string(cdn.AfdMinimumTLSVersionTLS10),
-										string(cdn.AfdMinimumTLSVersionTLS12),
-									}
-								}
-								return []string{
-									string(cdn.AfdMinimumTLSVersionTLS12),
-								}
-							}(), false),
-						},
-
-						// NOTE: If the secret is managed by FrontDoor this will cause a perpetual diff,
-						// so this has to be an optional computed field.
-						"cdn_frontdoor_secret_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validate.FrontDoorSecretID,
-						},
-					},
-				},
-			},
-
-			"expiration_date": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"validation_token": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-		},
+		Schema: resourceCdnFrontDoorCustomDomainSchema(),
 	}
 
 	return resource
+}
+
+func resourceCdnFrontDoorCustomDomainSchema() map[string]*pluginsdk.Schema {
+	result := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.FrontDoorCustomDomainName,
+		},
+
+		// NOTE: I need this fake field because I need the profile name during the create operation
+		"cdn_frontdoor_profile_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.FrontDoorProfileID,
+		},
+
+		"dns_zone_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: dnsValidate.ValidateDnsZoneID,
+		},
+
+		"host_name": {
+			Type:     pluginsdk.TypeString,
+			ForceNew: true,
+			Required: true,
+		},
+
+		"tls": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+
+					"certificate_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  string(cdn.AfdCertificateTypeManagedCertificate),
+						ValidateFunc: validation.StringInSlice([]string{
+							string(cdn.AfdCertificateTypeCustomerCertificate),
+							string(cdn.AfdCertificateTypeManagedCertificate),
+						}, false),
+					},
+
+					"minimum_tls_version": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  string(cdn.AfdMinimumTLSVersionTLS12),
+						ValidateFunc: validation.StringInSlice([]string{
+							string(cdn.AfdMinimumTLSVersionTLS12),
+						}, false),
+					},
+
+					// NOTE: If the secret is managed by FrontDoor this will cause a perpetual diff,
+					// so this has to be an optional computed field.
+					"cdn_frontdoor_secret_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validate.FrontDoorSecretID,
+					},
+				},
+			},
+		},
+
+		"expiration_date": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"validation_token": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+
+	if !features.FivePointOhBeta() {
+		tlsElem := result["tls"].Elem.(*pluginsdk.Resource)
+		tlsElem.Schema["minimum_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(cdn.AfdMinimumTLSVersionTLS12),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.AfdMinimumTLSVersionTLS12),
+				string(cdn.AfdMinimumTLSVersionTLS10),
+			}, false),
+		}
+		result["tls"].Elem = tlsElem
+	}
+
+	return result
 }
 
 func resourceCdnFrontDoorCustomDomainCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -155,7 +155,11 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 
   tls {
     certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS10"
+    minimum_tls_version = "TLS12"
+  }
+
+  tags {
+	test = "acctest"
   }
 }
 `, template, data.RandomInteger, data.RandomStringOfLength(8))
@@ -174,7 +178,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 
   tls {
     certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS10"
+    minimum_tls_version = "TLS12"
   }
 }
 `, template, data.RandomInteger, data.RandomStringOfLength(8))

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type CdnFrontDoorCustomDomainResource struct {
-}
+type CdnFrontDoorCustomDomainResource struct{}
 
 func TestAccCdnFrontDoorCustomDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
@@ -159,7 +158,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   }
 
   tags {
-	test = "acctest"
+    test = "acctest"
   }
 }
 `, template, data.RandomInteger, data.RandomStringOfLength(8))

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -51,7 +51,7 @@ func TestAccCdnFrontDoorCustomDomain_requiresImport(t *testing.T) {
 
 func TestAccCdnFrontDoorCustomDomain_update(t *testing.T) {
 	if features.FivePointOhBeta() {
-		t.Skipf("There is no avaliable `tls_version` to test update, to test CMK, it requires an official certificate from approved provider list instead of testing cert.")
+		t.Skipf("There is no available `tls_version` to test update, to test CMK, it requires an official certificate from approved provider list instead of testing cert.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
 	r := CdnFrontDoorCustomDomainResource{}

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -49,6 +50,9 @@ func TestAccCdnFrontDoorCustomDomain_requiresImport(t *testing.T) {
 }
 
 func TestAccCdnFrontDoorCustomDomain_update(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("There is no avaliable `tls_version` to test update, to test CMK, it requires an official certificate from approved provider list instead of testing cert.")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
 	r := CdnFrontDoorCustomDomainResource{}
 
@@ -119,7 +123,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     minimum_tls_version = "TLS12"
   }
 }
-`, template, data.RandomInteger, data.RandomStringOfLength(8))
+`, template, data.RandomInteger, data.RandomString)
 }
 
 func (r CdnFrontDoorCustomDomainResource) requiresImport(data acceptance.TestData) string {
@@ -150,18 +154,15 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   name                     = "acctestcustomdomain-%[2]d"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
   dns_zone_id              = azurerm_dns_zone.test.id
-  host_name                = join(".", ["sub-%[3]s", azurerm_dns_zone.test.name])
+  host_name                = join(".", ["%s", azurerm_dns_zone.test.name])
 
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"
   }
 
-  tags {
-    test = "acctest"
-  }
 }
-`, template, data.RandomInteger, data.RandomStringOfLength(8))
+`, template, data.RandomInteger, data.RandomString)
 }
 
 func (r CdnFrontDoorCustomDomainResource) complete(data acceptance.TestData) string {
@@ -180,7 +181,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     minimum_tls_version = "TLS12"
   }
 }
-`, template, data.RandomInteger, data.RandomStringOfLength(8))
+`, template, data.RandomInteger, data.RandomString)
 }
 
 // TODO: Add test case that uses pre_validated_custom_domain_resource_id

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -72,6 +72,10 @@ Please follow the format in the example below for listing breaking changes in re
 * The deprecated `storage_account_name` property has been removed in favour of the `storage_account_id` property.
 * The deprecated `resource_manager_id` property has been removed in favour of the `id` property.
 
+### `azurerm_cdn_frontdoor_custom_domain`
+
+* The `tls.minimum_tls_version` property no longer accept `TLS10` value.
+  
 ## Breaking Changes in Data Sources
 
 Please follow the format in the example below for listing breaking changes in data sources:

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -74,7 +74,7 @@ Please follow the format in the example below for listing breaking changes in re
 
 ### `azurerm_cdn_frontdoor_custom_domain`
 
-* The `tls.minimum_tls_version` property no longer accept `TLS10` value.
+* The `tls.minimum_tls_version` property no longer accepts `TLS10` as a value.
   
 ## Breaking Changes in Data Sources
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -104,6 +104,8 @@ A `tls` block supports the following:
 ->**NOTE:** It may take up to 15 minutes for the Front Door Service to validate the state and Domain ownership of the Custom Domain.
 
 * `minimum_tls_version` - (Optional) TLS protocol version that will be used for Https. Possible values include `TLS10` and `TLS12`. Defaults to `TLS12`.
+  
+~> **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more details.
 
 * `cdn_frontdoor_secret_id` - (Optional) Resource ID of the Front Door Secret.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

As the [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/), update the documents and deprecate tls 1.0 and tls 1.1 in v5.0
 
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

For 4.0
```
❯❯ tftest cdn TestAccCdnFrontDoorCustomDomain_      
=== RUN   TestAccCdnFrontDoorCustomDomain_basic
=== PAUSE TestAccCdnFrontDoorCustomDomain_basic
=== RUN   TestAccCdnFrontDoorCustomDomain_requiresImport
=== PAUSE TestAccCdnFrontDoorCustomDomain_requiresImport
=== RUN   TestAccCdnFrontDoorCustomDomain_update
=== PAUSE TestAccCdnFrontDoorCustomDomain_update
=== RUN   TestAccCdnFrontDoorCustomDomain_complete
=== PAUSE TestAccCdnFrontDoorCustomDomain_complete
=== CONT  TestAccCdnFrontDoorCustomDomain_basic
=== CONT  TestAccCdnFrontDoorCustomDomain_update
=== CONT  TestAccCdnFrontDoorCustomDomain_requiresImport
=== CONT  TestAccCdnFrontDoorCustomDomain_complete
--- PASS: TestAccCdnFrontDoorCustomDomain_requiresImport (394.52s)
--- PASS: TestAccCdnFrontDoorCustomDomain_complete (394.75s)
--- PASS: TestAccCdnFrontDoorCustomDomain_basic (420.94s)
--- PASS: TestAccCdnFrontDoorCustomDomain_update (476.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn	476.717s
```

For 5.0
```
❯❯ ARM_FIVEPOINTZERO_BETA=true tftest cdn TestAccCdnFrontDoorCustomDomain_
=== RUN   TestAccCdnFrontDoorCustomDomain_basic
=== PAUSE TestAccCdnFrontDoorCustomDomain_basic
=== RUN   TestAccCdnFrontDoorCustomDomain_requiresImport
=== PAUSE TestAccCdnFrontDoorCustomDomain_requiresImport
=== RUN   TestAccCdnFrontDoorCustomDomain_update
    cdn_frontdoor_custom_domain_resource_test.go:54: There is no avaliable `tls_version` to test update, to test CMK, it requires an official certificate from approved provider list instead of testing cert.
--- SKIP: TestAccCdnFrontDoorCustomDomain_update (0.00s)
=== RUN   TestAccCdnFrontDoorCustomDomain_complete
=== PAUSE TestAccCdnFrontDoorCustomDomain_complete
=== CONT  TestAccCdnFrontDoorCustomDomain_basic
=== CONT  TestAccCdnFrontDoorCustomDomain_complete
=== CONT  TestAccCdnFrontDoorCustomDomain_requiresImport
--- PASS: TestAccCdnFrontDoorCustomDomain_requiresImport (335.68s)
--- PASS: TestAccCdnFrontDoorCustomDomain_complete (420.09s)
--- PASS: TestAccCdnFrontDoorCustomDomain_basic (421.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn	421.673s
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_custom_domain` - update documents for TLS 1.0 retirement [GH-27912]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
