### PR TITLE
azurerm_backup_protected_vm - protection can now be suspended during destroy

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -75,8 +75,9 @@ func Default() UserFeatures {
 			PurgeSoftDeletedWorkspaceOnDestroy: false,
 		},
 		RecoveryService: RecoveryServiceFeatures{
-			VMBackupStopProtectionAndRetainDataOnDestroy: false,
-			PurgeProtectedItemsFromVaultOnDestroy:        false,
+			VMBackupStopProtectionAndRetainDataOnDestroy:    false,
+			VMBackupSuspendProtectionAndRetainDataOnDestroy: false,
+			PurgeProtectedItemsFromVaultOnDestroy:           false,
 		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -106,6 +106,7 @@ type MachineLearningFeatures struct {
 }
 
 type RecoveryServiceFeatures struct {
-	VMBackupStopProtectionAndRetainDataOnDestroy bool
-	PurgeProtectedItemsFromVaultOnDestroy        bool
+	VMBackupStopProtectionAndRetainDataOnDestroy    bool
+	VMBackupSuspendProtectionAndRetainDataOnDestroy bool
+	PurgeProtectedItemsFromVaultOnDestroy           bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -375,9 +375,16 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"vm_backup_stop_protection_and_retain_data_on_destroy": {
-						Type:     pluginsdk.TypeBool,
-						Optional: true,
-						Default:  false,
+						Type:         pluginsdk.TypeBool,
+						Optional:     true,
+						Default:      false,
+						ExactlyOneOf: []string{"vm_backup_stop_protection_and_retain_data_on_destroy", "vm_backup_suspend_protection_and_retain_data_on_destroy"},
+					},
+					"vm_backup_suspend_protection_and_retain_data_on_destroy": {
+						Type:         pluginsdk.TypeBool,
+						Optional:     true,
+						Default:      false,
+						ExactlyOneOf: []string{"vm_backup_stop_protection_and_retain_data_on_destroy", "vm_backup_suspend_protection_and_retain_data_on_destroy"},
 					},
 					"purge_protected_items_from_vault_on_destroy": {
 						Type:     pluginsdk.TypeBool,
@@ -641,6 +648,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			recoveryServicesRaw := items[0].(map[string]interface{})
 			if v, ok := recoveryServicesRaw["vm_backup_stop_protection_and_retain_data_on_destroy"]; ok {
 				featuresMap.RecoveryService.VMBackupStopProtectionAndRetainDataOnDestroy = v.(bool)
+			}
+			if v, ok := recoveryServicesRaw["vm_backup_suspend_protection_and_retain_data_on_destroy"]; ok {
+				featuresMap.RecoveryService.VMBackupSuspendProtectionAndRetainDataOnDestroy = v.(bool)
 			}
 			if v, ok := recoveryServicesRaw["purge_protected_items_from_vault_on_destroy"]; ok {
 				featuresMap.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy = v.(bool)

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -88,8 +88,9 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeletedWorkspaceOnDestroy: false,
 				},
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: false,
-					PurgeProtectedItemsFromVaultOnDestroy:        false,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    false,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:           false,
 				},
 			},
 		},
@@ -197,8 +198,9 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"recovery_service": []interface{}{
 						map[string]interface{}{
-							"vm_backup_stop_protection_and_retain_data_on_destroy": true,
-							"purge_protected_items_from_vault_on_destroy":          true,
+							"vm_backup_stop_protection_and_retain_data_on_destroy":    true,
+							"vm_backup_suspend_protection_and_retain_data_on_destroy": true,
+							"purge_protected_items_from_vault_on_destroy":             true,
 						},
 					},
 				},
@@ -271,8 +273,9 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeletedWorkspaceOnDestroy: true,
 				},
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: true,
-					PurgeProtectedItemsFromVaultOnDestroy:        true,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    true,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: true,
+					PurgeProtectedItemsFromVaultOnDestroy:           true,
 				},
 			},
 		},
@@ -380,8 +383,9 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"recovery_service": []interface{}{
 						map[string]interface{}{
-							"vm_backup_stop_protection_and_retain_data_on_destroy": false,
-							"purge_protected_items_from_vault_on_destroy":          false,
+							"vm_backup_stop_protection_and_retain_data_on_destroy":    false,
+							"vm_backup_suspend_protection_and_retain_data_on_destroy": false,
+							"purge_protected_items_from_vault_on_destroy":             false,
 						},
 					},
 				},
@@ -454,8 +458,9 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeletedWorkspaceOnDestroy: false,
 				},
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: false,
-					PurgeProtectedItemsFromVaultOnDestroy:        false,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    false,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:           false,
 				},
 			},
 		},
@@ -1692,8 +1697,9 @@ func TestExpandFeaturesRecoveryService(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: false,
-					PurgeProtectedItemsFromVaultOnDestroy:        false,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    false,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:           false,
 				},
 			},
 		},
@@ -1703,16 +1709,18 @@ func TestExpandFeaturesRecoveryService(t *testing.T) {
 				map[string]interface{}{
 					"recovery_service": []interface{}{
 						map[string]interface{}{
-							"vm_backup_stop_protection_and_retain_data_on_destroy": true,
-							"purge_protected_items_from_vault_on_destroy":          true,
+							"vm_backup_stop_protection_and_retain_data_on_destroy":    true,
+							"vm_backup_suspend_protection_and_retain_data_on_destroy": true,
+							"purge_protected_items_from_vault_on_destroy":             true,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: true,
-					PurgeProtectedItemsFromVaultOnDestroy:        true,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    true,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: true,
+					PurgeProtectedItemsFromVaultOnDestroy:           true,
 				},
 			},
 		},
@@ -1722,16 +1730,18 @@ func TestExpandFeaturesRecoveryService(t *testing.T) {
 				map[string]interface{}{
 					"recovery_service": []interface{}{
 						map[string]interface{}{
-							"vm_backup_stop_protection_and_retain_data_on_destroy": false,
-							"purge_protected_items_from_vault_on_destroy":          false,
+							"vm_backup_stop_protection_and_retain_data_on_destroy":    false,
+							"vm_backup_suspend_protection_and_retain_data_on_destroy": false,
+							"purge_protected_items_from_vault_on_destroy":             false,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				RecoveryService: features.RecoveryServiceFeatures{
-					VMBackupStopProtectionAndRetainDataOnDestroy: false,
-					PurgeProtectedItemsFromVaultOnDestroy:        false,
+					VMBackupStopProtectionAndRetainDataOnDestroy:    false,
+					VMBackupSuspendProtectionAndRetainDataOnDestroy: false,
+					PurgeProtectedItemsFromVaultOnDestroy:           false,
 				},
 			},
 		},

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -473,6 +473,11 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 				f.RecoveryService.VMBackupStopProtectionAndRetainDataOnDestroy = feature[0].VMBackupStopProtectionAndRetainDataOnDestroy.ValueBool()
 			}
 
+			f.RecoveryService.VMBackupSuspendProtectionAndRetainDataOnDestroy = false
+			if !feature[0].VMBackupSuspendProtectionAndRetainDataOnDestroy.IsNull() && !feature[0].VMBackupSuspendProtectionAndRetainDataOnDestroy.IsUnknown() {
+				f.RecoveryService.VMBackupSuspendProtectionAndRetainDataOnDestroy = feature[0].VMBackupSuspendProtectionAndRetainDataOnDestroy.ValueBool()
+			}
+
 			f.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy = false
 			if !feature[0].PurgeProtectedItemsFromVaultOnDestroy.IsNull() && !feature[0].PurgeProtectedItemsFromVaultOnDestroy.IsUnknown() {
 				f.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy = feature[0].PurgeProtectedItemsFromVaultOnDestroy.ValueBool()

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -197,6 +197,10 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected recver_services.vm_backup_stop_protection_and_retain_data_on_destroy to be false")
 	}
 
+	if features.RecoveryService.VMBackupSuspendProtectionAndRetainDataOnDestroy {
+		t.Errorf("expected recver_services.vm_backup_suspend_protection_and_retain_data_on_destroy to be false")
+	}
+
 	if features.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy {
 		t.Errorf("expected recovery_service.PurgeProtectedItemsFromVaultOnDestroy to be false")
 	}
@@ -296,14 +300,16 @@ func defaultFeaturesList() types.List {
 	machineLearningList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(MachineLearningAttributes), []attr.Value{machineLearning})
 
 	recoveryServices, _ := basetypes.NewObjectValueFrom(context.Background(), RecoveryServiceAttributes, map[string]attr.Value{
-		"vm_backup_stop_protection_and_retain_data_on_destroy": basetypes.NewBoolNull(),
-		"purge_protected_items_from_vault_on_destroy":          basetypes.NewBoolNull(),
+		"vm_backup_stop_protection_and_retain_data_on_destroy":    basetypes.NewBoolNull(),
+		"vm_backup_suspend_protection_and_retain_data_on_destroy": basetypes.NewBoolNull(),
+		"purge_protected_items_from_vault_on_destroy":             basetypes.NewBoolNull(),
 	})
 	recoveryServicesList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes), []attr.Value{recoveryServices})
 
 	recoveryServicesVaults, _ := basetypes.NewObjectValueFrom(context.Background(), RecoveryServiceVaultsAttributes, map[string]attr.Value{
-		"vm_backup_stop_protection_and_retain_data_on_destroy": basetypes.NewBoolNull(),
-		"purge_protected_items_from_vault_on_destroy":          basetypes.NewBoolNull(),
+		"vm_backup_stop_protection_and_retain_data_on_destroy":    basetypes.NewBoolNull(),
+		"vm_backup_suspend_protection_and_retain_data_on_destroy": basetypes.NewBoolNull(),
+		"purge_protected_items_from_vault_on_destroy":             basetypes.NewBoolNull(),
 	})
 	recoveryServicesVaultsList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(RecoveryServiceVaultsAttributes), []attr.Value{recoveryServicesVaults})
 

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -239,13 +239,15 @@ var MachineLearningAttributes = map[string]attr.Type{
 }
 
 type RecoveryService struct {
-	VMBackupStopProtectionAndRetainDataOnDestroy types.Bool `tfsdk:"vm_backup_stop_protection_and_retain_data_on_destroy"`
-	PurgeProtectedItemsFromVaultOnDestroy        types.Bool `tfsdk:"purge_protected_items_from_vault_on_destroy"`
+	VMBackupStopProtectionAndRetainDataOnDestroy    types.Bool `tfsdk:"vm_backup_stop_protection_and_retain_data_on_destroy"`
+	VMBackupSuspendProtectionAndRetainDataOnDestroy types.Bool `tfsdk:"vm_backup_suspend_protection_and_retain_data_on_destroy"`
+	PurgeProtectedItemsFromVaultOnDestroy           types.Bool `tfsdk:"purge_protected_items_from_vault_on_destroy"`
 }
 
 var RecoveryServiceAttributes = map[string]attr.Type{
-	"vm_backup_stop_protection_and_retain_data_on_destroy": types.BoolType,
-	"purge_protected_items_from_vault_on_destroy":          types.BoolType,
+	"vm_backup_stop_protection_and_retain_data_on_destroy":    types.BoolType,
+	"vm_backup_suspend_protection_and_retain_data_on_destroy": types.BoolType,
+	"purge_protected_items_from_vault_on_destroy":             types.BoolType,
 }
 
 type RecoveryServiceVaults struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -448,6 +448,9 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 									"vm_backup_stop_protection_and_retain_data_on_destroy": schema.BoolAttribute{
 										Optional: true,
 									},
+									"vm_backup_suspend_protection_and_retain_data_on_destroy": schema.BoolAttribute{
+										Optional: true,
+									},
 									"purge_protected_items_from_vault_on_destroy": schema.BoolAttribute{
 										Optional: true,
 									},

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -356,7 +356,9 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	if meta.(*clients.Client).Features.RecoveryService.VMBackupStopProtectionAndRetainDataOnDestroy {
+	features := meta.(*clients.Client).Features.RecoveryService
+
+	if features.VMBackupStopProtectionAndRetainDataOnDestroy || features.VMBackupSuspendProtectionAndRetainDataOnDestroy {
 		log.Printf("[DEBUG] Retaining Data and Stopping Protection for %s", id)
 
 		existing, err := client.Get(ctx, *id, protecteditems.GetOperationOptions{})
@@ -369,19 +371,24 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 			return fmt.Errorf("making Read request on %s: %+v", id, err)
 		}
 
+		desiredState := protecteditems.ProtectionStateProtectionStopped
+		if features.VMBackupSuspendProtectionAndRetainDataOnDestroy {
+			desiredState = protecteditems.ProtectionStateBackupsSuspended
+		}
+
 		if model := existing.Model; model != nil {
 			if properties := model.Properties; properties != nil {
 				if vm, ok := properties.(protecteditems.AzureIaaSComputeVMProtectedItem); ok {
 					updateInput := protecteditems.ProtectedItemResource{
 						Properties: &protecteditems.AzureIaaSComputeVMProtectedItem{
-							ProtectionState:  pointer.To(protecteditems.ProtectionStateProtectionStopped),
+							ProtectionState:  pointer.To(desiredState),
 							SourceResourceId: vm.SourceResourceId,
 						},
 					}
 
 					resp, err := client.CreateOrUpdate(ctx, *id, updateInput)
 					if err != nil {
-						return fmt.Errorf("stopping protection and retaining data for %s: %+v", id, err)
+						return fmt.Errorf("setting protection to %s and retaining data for %s: %+v", desiredState, id, err)
 					}
 
 					operationId, err := parseBackupOperationId(resp.HttpResponse)
@@ -414,7 +421,7 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 	}
 
 	if err = resourceRecoveryServicesBackupProtectedVMWaitForDeletion(ctx, client, opResultClient, *id, operationId); err != nil {
-		return err
+		return fmt.Errorf("waiting for deleting %s: %+v", id, err)
 	}
 
 	return nil
@@ -441,8 +448,7 @@ func resourceRecoveryServicesBackupProtectedVMWaitForStateCreateUpdate(ctx conte
 		},
 	}
 
-	_, err := state.WaitForStateContext(ctx)
-	if err != nil {
+	if _, err := state.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to provision: %+v", id, err)
 	}
 

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -251,6 +251,25 @@ func TestAccBackupProtectedVm_protectionStoppedOnDestroy(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedVm_protectionSuspendedOnDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
+	r := BackupProtectedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.protectionSuspendOnDestroy(data),
+		},
+	})
+}
+
 func TestAccBackupProtectedVm_recoverSoftDeletedVM(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
 	r := BackupProtectedVmResource{}
@@ -953,6 +972,21 @@ provider "azurerm" {
   features {
     recovery_service {
       vm_backup_stop_protection_and_retain_data_on_destroy = true
+      purge_protected_items_from_vault_on_destroy          = true
+    }
+  }
+}
+
+%s
+`, r.base(data))
+}
+
+func (r BackupProtectedVmResource) protectionSuspendOnDestroy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    recovery_service {
+      vm_backup_suspend_protection_and_retain_data_on_destroy = true
       purge_protected_items_from_vault_on_destroy          = true
     }
   }

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -67,8 +67,9 @@ provider "azurerm" {
     }
 
     recovery_service {
-      vm_backup_stop_protection_and_retain_data_on_destroy = true
-      purge_protected_items_from_vault_on_destroy          = true
+      vm_backup_stop_protection_and_retain_data_on_destroy    = true
+      vm_backup_suspend_protection_and_retain_data_on_destroy = true
+      purge_protected_items_from_vault_on_destroy             = true
     }
 
     resource_group {
@@ -226,6 +227,8 @@ The `postgresql_flexible_server` block supports the following:
 The `recovery_service` block supports the following:
 
 * `vm_backup_stop_protection_and_retain_data_on_destroy` - (Optional) Should we retain the data and stop protection instead of destroying the backup protected vm? Defaults to `false`.
+
+* `vm_backup_suspend_protection_and_retain_data_on_destroy` - (Optional) Should we retain the data and suspend protection instead of destroying the backup protected vm? Defaults to `false`.
 
 * `purge_protected_items_from_vault_on_destroy` - (Optional) Should we purge all protected items when destroying the vault. Defaults to `false`.
 


### PR DESCRIPTION

## Description

add provider feature vm_backup_suspend_protection_and_retain_data_on_destroy

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `provider` - support for the `vm_backup_suspend_protection_and_retain_data_on_destroy` feature [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
