### PR TITLE
`azurerm_traffic_manager_external_endpoint` - revert `priority` back to O+C since API increments the default value

### DIFF
--- a/internal/services/trafficmanager/azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource.go
@@ -109,9 +109,10 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      1,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				// NOTE: O+C the API dynamically increments the default value for priority depending on the number of endpoints
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/external_endpoint_resource.go
+++ b/internal/services/trafficmanager/external_endpoint_resource.go
@@ -109,9 +109,10 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      1,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				// NOTE: O+C the API dynamically increments the default value for priority depending on the number of endpoints
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/external_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/external_endpoint_resource_test.go
@@ -108,6 +108,21 @@ func TestAccExternalEndpoint_subnets(t *testing.T) {
 	})
 }
 
+func TestAccExternalEndpoint_multipleEndpointsWithDynamicPriority(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_external_endpoint", "test")
+	r := ExternalEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccExternalEndpoint_performancePolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_external_endpoint", "test")
 	r := ExternalEndpointResource{}
@@ -228,6 +243,32 @@ resource "azurerm_traffic_manager_external_endpoint" "test" {
     name  = "header"
     value = "www.bing.com"
   }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ExternalEndpointResource) multiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_traffic_manager_external_endpoint" "test" {
+  name              = "acctestend-azure%[2]d"
+  target            = "www.example.com"
+  weight            = 5
+  profile_id        = azurerm_traffic_manager_profile.test.id
+  endpoint_location = azurerm_resource_group.test.location
+}
+
+resource "azurerm_traffic_manager_external_endpoint" "test2" {
+  name              = "acctestend-azure2%[2]d"
+  target            = "www.pandas.com"
+  weight            = 5
+  profile_id        = azurerm_traffic_manager_profile.test.id
+  endpoint_location = azurerm_resource_group.test.location
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/traffic_manager_azure_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_azure_endpoint.html.markdown
@@ -72,8 +72,6 @@ The following arguments are supported:
 
 * `weight` - (Optional) Specifies how much traffic should be distributed to this endpoint, this must be specified for Profiles using the Weighted traffic routing method. Valid values are between `1` and `1000`. Defaults to `1`.
 
----
-
 * `always_serve_enabled` - (Optional) If Always Serve is enabled, probing for endpoint health will be disabled and endpoints will be included in the traffic routing method. Defaults to `false`.
 
 * `custom_header` - (Optional) One or more `custom_header` blocks as defined below.
@@ -82,7 +80,7 @@ The following arguments are supported:
 
 * `geo_mappings` - (Optional) A list of Geographic Regions used to distribute traffic, such as `WORLD`, `UK` or `DE`. The same location can't be specified in two endpoints. [See the Geographic Hierarchies documentation for more information](https://docs.microsoft.com/rest/api/trafficmanager/geographichierarchies/getdefault).
 
-* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation. Defaults to `1`.
+* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation.
 
 * `subnet` - (Optional) One or more `subnet` blocks as defined below. Changing this forces a new resource to be created.
 

--- a/website/docs/r/traffic_manager_external_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_external_endpoint.html.markdown
@@ -65,8 +65,6 @@ The following arguments are supported:
 
 * `endpoint_location` - (Optional) Specifies the Azure location of the Endpoint, this must be specified for Profiles using the `Performance` routing method.
 
----
-
 * `always_serve_enabled` - (Optional) If Always Serve is enabled, probing for endpoint health will be disabled and endpoints will be included in the traffic routing method. Defaults to `false`.
 
 * `custom_header` - (Optional) One or more `custom_header` blocks as defined below.
@@ -75,7 +73,7 @@ The following arguments are supported:
 
 * `geo_mappings` - (Optional) A list of Geographic Regions used to distribute traffic, such as `WORLD`, `UK` or `DE`. The same location can't be specified in two endpoints. [See the Geographic Hierarchies documentation for more information](https://docs.microsoft.com/rest/api/trafficmanager/geographichierarchies/getdefault).
 
-* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation. Defaults to `1`.
+* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation.
 
 * `subnet` - (Optional) One or more `subnet` blocks as defined below. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removed default and set `priority` back to O+C
- Added a test case to ensure we catch any regression around expected behaviour of the `priority` field

## Testing 

![image](https://github.com/user-attachments/assets/e9efe67f-f99d-4a4c-983a-e87039a8f322)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_traffic_manager_external_endpoint` - the value for `priority` will be dynamically assigned by the API  [GH-00000]
* `azurerm_traffic_manager_azure_endpoint` - the value for `priority` will be dynamically assigned by the API   [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27275


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
