### PR TITLE
`postgresql`: fix replace acctests

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -604,28 +604,6 @@ func TestAccPostgresqlFlexibleServer_publicNetworkAccessEnabled(t *testing.T) {
 	})
 }
 
-func TestAccPostgresqlFlexibleServer_recreateWithLowerStorageMb(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
-	r := PostgresqlFlexibleServerResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.recreateWithLowerStorageMb(data, data.RandomInteger, "65536"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_password", "create_mode"),
-		{
-			Config: r.recreateWithLowerStorageMb(data, data.RandomInteger+1, "32768"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_password", "create_mode"),
-	})
-}
-
 func (PostgresqlFlexibleServerResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := servers.ParseFlexibleServerID(state.ID)
 	if err != nil {
@@ -1439,22 +1417,4 @@ resource "azurerm_postgresql_flexible_server" "test" {
   public_network_access_enabled = %t
 }
 `, r.template(data), data.RandomInteger, publicNetworkAccessEnabled)
-}
-
-func (r PostgresqlFlexibleServerResource) recreateWithLowerStorageMb(data acceptance.TestData, nameSuffix int, storageMb string) string {
-	return fmt.Sprintf(`
-%s
-resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  storage_mb             = %s
-  storage_tier           = "P6"
-  version                = "12"
-  sku_name               = "GP_Standard_D2s_v3"
-  zone                   = "2"
-}
-`, r.template(data), nameSuffix, storageMb)
 }

--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -534,7 +534,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acct%[1]d"
+  name                     = "accsa%[1]d"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -593,12 +593,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                            = "accsa%[1]d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  account_tier                    = "Standard"
-  account_replication_type        = "GRS"
-  allow_nested_items_to_be_public = false
+  name                     = "accsa%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 }
 
 resource "azurerm_postgresql_server" "test" {

--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -539,7 +539,6 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
-  allow_nested_items_to_be_public = false
 
   tags = {
     environment = "staging"
@@ -594,11 +593,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "accsa%[1]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
+  name                            = "accsa%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
   allow_nested_items_to_be_public = false
 }
 
@@ -615,10 +614,10 @@ resource "azurerm_postgresql_server" "test" {
   storage_mb = 640000
 
   backup_retention_days        = 14
-  geo_redundant_backup_enabled = false
+  geo_redundant_backup_enabled = true
   auto_grow_enabled            = false
 
-  infrastructure_encryption_enabled = false
+  infrastructure_encryption_enabled = true
   public_network_access_enabled     = true
   ssl_enforcement_enabled           = false
   ssl_minimal_tls_version_enforced  = "TLSEnforcementDisabled"

--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -615,7 +615,7 @@ resource "azurerm_postgresql_server" "test" {
 
   backup_retention_days        = 14
   geo_redundant_backup_enabled = true
-  auto_grow_enabled            = false
+  auto_grow_enabled            = true
 
   infrastructure_encryption_enabled = true
   public_network_access_enabled     = true

--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -173,13 +173,6 @@ func TestAccPostgreSQLServer_updated(t *testing.T) {
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.gp(data, "9.6"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_login_password"),
-		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -208,13 +201,6 @@ func TestAccPostgreSQLServer_updateSKU(t *testing.T) {
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.sku(data, "10.0", "B_Gen5_2"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_login_password"),
-		{
 			Config: r.sku(data, "10.0", "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -222,7 +208,7 @@ func TestAccPostgreSQLServer_updateSKU(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.sku(data, "10.0", "MO_Gen5_16"),
+			Config: r.sku(data, "10.0", "GP_Gen5_4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -553,6 +539,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 
   tags = {
     environment = "staging"
@@ -612,6 +599,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_postgresql_server" "test" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

To fix these tests:
```
=== CONT  TestAccPostgresqlFlexibleServer_recreateWithLowerStorageMb
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_postgresql_flexible_server.test' - expected action to not be Replace, path: [[name]]
--- FAIL: TestAccPostgresqlFlexibleServer_recreateWithLowerStorageMb (401.14s)

=== CONT  TestAccPostgreSQLServer_updated
    testcase.go:173: Step 4/12 error: Pre-apply plan check(s) failed:
        'azurerm_postgresql_server.test' - expected action to not be Replace, path: [[infrastructure_encryption_enabled] [geo_redundant_backup_enabled]]
--- FAIL: TestAccPostgreSQLServer_updated (262.81s)

=== CONT  TestAccPostgreSQLServer_updateSKU
    testcase.go:173: Step 4/9 error: Pre-apply plan check(s) failed:
        'azurerm_postgresql_server.test' - expected action to not be Replace, path: [[sku_name]]
--- FAIL: TestAccPostgreSQLServer_updateSKU (321.31s)
```

![image](https://github.com/user-attachments/assets/67dd5328-0b20-42de-8f91-2c03fadba01e)

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change