### PR TITLE
`azurerm_arc_machine` - support `identity` and `tags` properties

### DIFF
--- a/internal/services/hybridcompute/arc_machine_resource.go
+++ b/internal/services/hybridcompute/arc_machine_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2024-07-10/machines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -19,10 +20,12 @@ import (
 )
 
 type ArcMachineResourceModel struct {
-	Name              string `tfschema:"name"`
-	ResourceGroupName string `tfschema:"resource_group_name"`
-	Location          string `tfschema:"location"`
-	Kind              string `tfschema:"kind"`
+	Name              string                         `tfschema:"name"`
+	ResourceGroupName string                         `tfschema:"resource_group_name"`
+	Location          string                         `tfschema:"location"`
+	Kind              string                         `tfschema:"kind"`
+	Identity          []identity.ModelSystemAssigned `tfschema:"identity"`
+	Tags              map[string]string              `tfschema:"tags"`
 }
 
 type ArcMachineResource struct{}
@@ -58,6 +61,10 @@ func (r ArcMachineResource) Arguments() map[string]*pluginsdk.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(machines.PossibleValuesForArcKindEnum(), false),
 		},
+
+		"identity": commonschema.SystemAssignedIdentityOptional(),
+
+		"tags": commonschema.Tags(),
 	}
 }
 
@@ -92,6 +99,12 @@ func (r ArcMachineResource) Create() sdk.ResourceFunc {
 			parameters := machines.Machine{
 				Location: location.Normalize(model.Location),
 				Kind:     pointer.To(machines.ArcKindEnum(model.Kind)),
+				Tags:     pointer.To(model.Tags),
+			}
+
+			parameters.Identity, err = identity.ExpandSystemAssignedFromModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
 
 			if _, err := client.CreateOrUpdate(ctx, id, parameters, machines.DefaultCreateOrUpdateOperationOptions()); err != nil {
@@ -130,9 +143,56 @@ func (r ArcMachineResource) Read() sdk.ResourceFunc {
 			if model := resp.Model; model != nil {
 				state.Location = location.Normalize(model.Location)
 				state.Kind = string(pointer.From(model.Kind))
+				state.Identity = identity.FlattenSystemAssignedToModel(model.Identity)
+				state.Tags = pointer.From(model.Tags)
 			}
 
 			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ArcMachineResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.HybridCompute.HybridComputeClient_v2024_07_10.Machines
+
+			var model ArcMachineResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := machines.ParseMachineID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id, machines.DefaultGetOperationOptions())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+			existing := resp.Model
+
+			if metadata.ResourceData.HasChange("identity") {
+				existing.Identity, err = identity.ExpandSystemAssignedFromModel(model.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				existing.Tags = pointer.To(model.Tags)
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, *id, *existing, machines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			return nil
 		},
 	}
 }

--- a/internal/services/hybridcompute/arc_machine_resource_test.go
+++ b/internal/services/hybridcompute/arc_machine_resource_test.go
@@ -48,6 +48,50 @@ func TestAccArcMachineResource_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccArcMachineResource_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_machine", "test")
+	r := ArcMachineResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.identity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccArcMachineResource_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_machine", "test")
+	r := ArcMachineResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r ArcMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := machines.ParseMachineID(state.ID)
 	if err != nil {
@@ -90,6 +134,52 @@ resource "azurerm_arc_machine" "import" {
   kind                = azurerm_arc_machine.test.kind
 }
 `, r.basic(data))
+}
+
+func (r ArcMachineResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_arc_machine" "test" {
+  name                = "acctest-hcm-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  kind                = "SCVMM"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ArcMachineResource) identity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_arc_machine" "test" {
+  name                = "acctest-hcm-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  kind                = "SCVMM"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r ArcMachineResource) template(data acceptance.TestData) string {

--- a/website/docs/r/arc_machine.html.markdown
+++ b/website/docs/r/arc_machine.html.markdown
@@ -23,6 +23,14 @@ resource "azurerm_arc_machine" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   kind                = "SCVMM"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    environment = "example"
+  }
 }
 ```
 
@@ -38,11 +46,31 @@ The following arguments are supported:
 
 * `kind` - (Required) The kind of the Arc Machine. Possible values are `AVS`, `AWS`, `EPS`, `GCP`, `HCI`, `SCVMM` and `VMware`. Changing this forces a new resource to be created.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+* An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity assigned to this Arc Machine. At this time the only possible value is `SystemAssigned`. Changing this forces a new resource to be created.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Arc Machine.
+
+* `identity` - An `identity` block as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID associated with this Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
 ## Timeouts
 
@@ -50,6 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating this Arc Machine.
 * `read` - (Defaults to 5 minutes) Used when retrieving this Arc Machine.
+* `update` - (Defaults to 30 minutes) Used when updating this Arc Machine.
 * `delete` - (Defaults to 30 minutes) Used when deleting this Arc Machine.
 
 ## Import


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

swagger:https://github.com/Azure/azure-rest-api-specs/blob/20f765ef6dfb1b649a69b808bc0053e3e91150f1/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/stable/2024-07-10/HybridCompute.json#L2314


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
-> % make acctests SERVICE="hybridcompute" TESTARGS="-parallel 5 -run TestAccArcMachineResource_" TESTTIMEOUT='2h'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/hybridcompute -parallel 5 -run TestAccArcMachineResource_ -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccArcMachineResource_basic
--- PASS: TestAccArcMachineResource_basic (62.11s)
=== RUN   TestAccArcMachineResource_requiresImport
--- PASS: TestAccArcMachineResource_requiresImport (57.97s)
=== RUN   TestAccArcMachineResource_identity
--- PASS: TestAccArcMachineResource_identity (58.90s)
=== RUN   TestAccArcMachineResource_update
--- PASS: TestAccArcMachineResource_update (99.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/hybridcompute 278.181s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
