### PR TITLE
Changes encryption to customer_managed_key for azurerm_fluid_relay_servers resource

### DIFF
--- a/website/docs/r/fluid_relay_servers.html.markdown
+++ b/website/docs/r/fluid_relay_servers.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `storage_sku` - (Optional) Sku of the storage associated with the resource, Possible values are `standard` and `basic`. Changing this forces a new Fluid Relay Server to be created.
 
-* `encryption` - (Optional) An `encryption` block as defined below. Changing this forces a new resource to be created.
+* `customer_managed_key` - (Optional) A `customer_managed_key` block as defined below. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Fluid Relay Server.
 
@@ -57,7 +57,7 @@ An `identity` block supports the following:
 
 ---
 
-An `encryption` block supports the following:
+An `customer_managed_key` block supports the following:
 
 * `key_vault_key_id` - (Required) The Key Vault Key Id that will be used to encrypt the Fluid Relay Server.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Change the `azurerm_fluid_relay_servers` resource's `encryption` argument to `customer_managed_key` in its documentation. This appears to be the name for the block based on the resource's schema: https://github.com/hashicorp/terraform-provider-azurerm/blob/v4.9.0/internal/services/fluidrelay/fluid_relay_servers_resource.go#L96


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”