### PR TITLE
azurerm_subnet: Fixed and removed deprecated Tests.

### DIFF
--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -185,40 +185,6 @@ func TestAccSubnet_delegation(t *testing.T) {
 	})
 }
 
-// TODO 4.0: Remove test
-func TestAccSubnet_enablePrivateEndpointNetworkPolicies(t *testing.T) {
-	if !features.FourPointOhBeta() {
-		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-		r := SubnetResource{}
-
-		data.ResourceTest(t, r, []acceptance.TestStep{
-			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-		})
-	} else {
-		t.Skip("skipping due to deprecation of the 'private_endpoint_network_policies_enabled' fields in 4.0")
-	}
-}
-
 func TestAccSubnet_privateEndpointNetworkPolicies(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
@@ -282,232 +248,6 @@ func TestAccSubnet_enablePrivateLinkServiceNetworkPolicies(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
-}
-
-// TODO 4.0: Remove test
-func TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies(t *testing.T) {
-	if !features.FourPointOhBeta() {
-		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-		r := SubnetResource{}
-
-		data.ResourceTest(t, r, []acceptance.TestStep{
-			{
-				Config: r.enforcePrivateLinkEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkEndpointNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-		})
-	} else {
-		t.Skip("@WodansSon: skipping due to deprecation of the 'enforce_private_link_endpoint_network_policies' field in 4.0")
-	}
-}
-
-// TODO 4.0: Remove test
-func TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies(t *testing.T) {
-	if !features.FourPointOhBeta() {
-		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-		r := SubnetResource{}
-
-		data.ResourceTest(t, r, []acceptance.TestStep{
-			{
-				Config: r.enforcePrivateLinkServiceNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkServiceNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkServiceNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-				),
-			},
-			data.ImportStep(),
-		})
-	} else {
-		t.Skip("@WodansSon: skipping due to deprecation of the 'enforce_private_link_service_network_policies' field in 4.0")
-	}
-}
-
-// TODO 4.0: Remove test
-func TestAccSubnet_PrivateLinkPoliciesToggleWithEnforceFirst(t *testing.T) {
-	if !features.FourPointOhBeta() {
-		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-		r := SubnetResource{}
-
-		data.ResourceTest(t, r, []acceptance.TestStep{
-			{
-				Config: r.enforcePrivateLinkEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("true"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkServiceNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateLinkServiceNetworkPolicies(data, true),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.privateEndpointNetworkPolicies(data, "Enabled"),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-		})
-	} else {
-		t.Skip("@WodansSon: skipping due to deprecation of the 'enforce_private_link_endpoint_network_policies' and 'enforce_private_link_service_network_policies' fields in 4.0")
-	}
-}
-
-// TODO 4.0: Remove test
-func TestAccSubnet_PrivateLinkPoliciesToggleWithEnabledFirst(t *testing.T) {
-	if !features.FourPointOhBeta() {
-		data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-		r := SubnetResource{}
-
-		data.ResourceTest(t, r, []acceptance.TestStep{
-			{
-				Config: r.privateEndpointNetworkPolicies(data, "Disabled"),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("true"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateEndpointNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("true"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Disabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkEndpointNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enablePrivateLinkServiceNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: r.enforcePrivateLinkServiceNetworkPolicies(data, false),
-				Check: acceptance.ComposeTestCheckFunc(
-					check.That(data.ResourceName).ExistsInAzure(r),
-					check.That(data.ResourceName).Key("enforce_private_link_endpoint_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("enforce_private_link_service_network_policies").HasValue("false"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_link_service_network_policies_enabled").HasValue("true"),
-					check.That(data.ResourceName).Key("private_endpoint_network_policies").HasValue("Enabled"),
-				),
-			},
-			data.ImportStep(),
-		})
-	} else {
-		t.Skip("@WodansSon: skipping due to deprecation of the 'enforce_private_link_endpoint_network_policies' and 'enforce_private_link_service_network_policies' fields in 4.0")
-	}
 }
 
 func TestAccSubnet_serviceEndpoints(t *testing.T) {
@@ -883,31 +623,15 @@ resource "azurerm_subnet" "test" {
 `, r.template(data))
 }
 
-// TODO 4.0: Remove test
-func (r SubnetResource) enablePrivateEndpointNetworkPolicies(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  private_endpoint_network_policies = %t
-}
-`, r.template(data), enabled)
-}
-
 func (r SubnetResource) privateEndpointNetworkPolicies(data acceptance.TestData, enabled string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_subnet" "test" {
   name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
+  resource_group_name  = azurerm_virtual_network.test.resource_group_name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  address_prefixes     = azurerm_virtual_network.test.address_space
 
   private_endpoint_network_policies = "%s"
 }
@@ -915,38 +639,6 @@ resource "azurerm_subnet" "test" {
 }
 
 func (r SubnetResource) enablePrivateLinkServiceNetworkPolicies(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  private_link_service_network_policies_enabled = %t
-}
-`, r.template(data), enabled)
-}
-
-// TODO 4.0: Remove test
-func (r SubnetResource) enforcePrivateLinkEndpointNetworkPolicies(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  private_endpoint_network_policies = %t
-}
-`, r.template(data), enabled)
-}
-
-// TODO 4.0: Remove test
-func (r SubnetResource) enforcePrivateLinkServiceNetworkPolicies(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -976,6 +668,9 @@ resource "azurerm_subnet" "test" {
 
 func (SubnetResource) basic_addressPrefixes(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+	features {}
+}
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-n-%d"
   location = "%s"
@@ -997,6 +692,9 @@ resource "azurerm_subnet" "test" {
 
 func (SubnetResource) complete_addressPrefixes(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+	features {}
+}
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-n-%d"
   location = "%s"


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
- Removed Tests marked as deprecated since version 4.0.
Fixed errors on `TestAccSubnet_basic_addressPrefixes`, `TestAccSubnet_update_addressPrefixes` and `TestAccSubnet_complete_addressPrefixes` tests.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/network -run=TestAccSubnet_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSubnet_basic
=== PAUSE TestAccSubnet_basic
=== RUN   TestAccSubnet_basic_addressPrefixes
=== PAUSE TestAccSubnet_basic_addressPrefixes
=== RUN   TestAccSubnet_complete_addressPrefixes
=== PAUSE TestAccSubnet_complete_addressPrefixes
=== RUN   TestAccSubnet_update_addressPrefixes
=== PAUSE TestAccSubnet_update_addressPrefixes
=== RUN   TestAccSubnet_requiresImport
=== PAUSE TestAccSubnet_requiresImport
=== RUN   TestAccSubnet_disappears
=== PAUSE TestAccSubnet_disappears
=== RUN   TestAccSubnet_defaultOutbound
=== PAUSE TestAccSubnet_defaultOutbound
=== RUN   TestAccSubnet_delegation
=== PAUSE TestAccSubnet_delegation
=== RUN   TestAccSubnet_privateEndpointNetworkPolicies
=== PAUSE TestAccSubnet_privateEndpointNetworkPolicies
=== RUN   TestAccSubnet_enablePrivateLinkServiceNetworkPolicies
=== PAUSE TestAccSubnet_enablePrivateLinkServiceNetworkPolicies
=== RUN   TestAccSubnet_serviceEndpoints
=== PAUSE TestAccSubnet_serviceEndpoints
=== RUN   TestAccSubnet_serviceEndpointPolicy
=== PAUSE TestAccSubnet_serviceEndpointPolicy
=== RUN   TestAccSubnet_updateAddressPrefix
=== PAUSE TestAccSubnet_updateAddressPrefix
=== RUN   TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues
=== PAUSE TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues
=== RUN   TestAccSubnet_updateServiceDelegation
=== PAUSE TestAccSubnet_updateServiceDelegation
=== CONT  TestAccSubnet_basic
=== CONT  TestAccSubnet_privateEndpointNetworkPolicies
=== CONT  TestAccSubnet_requiresImport
=== CONT  TestAccSubnet_delegation
=== CONT  TestAccSubnet_update_addressPrefixes
=== CONT  TestAccSubnet_complete_addressPrefixes
=== CONT  TestAccSubnet_basic_addressPrefixes
=== CONT  TestAccSubnet_defaultOutbound
--- PASS: TestAccSubnet_requiresImport (475.91s)
=== CONT  TestAccSubnet_disappears
--- PASS: TestAccSubnet_complete_addressPrefixes (585.08s)
=== CONT  TestAccSubnet_updateAddressPrefix
--- PASS: TestAccSubnet_basic_addressPrefixes (627.86s)
=== CONT  TestAccSubnet_updateServiceDelegation
--- PASS: TestAccSubnet_basic (657.34s)
=== CONT  TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues
--- PASS: TestAccSubnet_defaultOutbound (697.23s)
=== CONT  TestAccSubnet_serviceEndpoints
--- PASS: TestAccSubnet_disappears (306.50s)
=== CONT  TestAccSubnet_serviceEndpointPolicy
--- PASS: TestAccSubnet_privateLinkEndpointNetworkPoliciesValidateDefaultValues (380.55s)
=== CONT  TestAccSubnet_enablePrivateLinkServiceNetworkPolicies
--- PASS: TestAccSubnet_update_addressPrefixes (1123.39s)
--- PASS: TestAccSubnet_updateAddressPrefix (648.62s)
--- PASS: TestAccSubnet_privateEndpointNetworkPolicies (1331.95s)
--- PASS: TestAccSubnet_delegation (1439.47s)
--- PASS: TestAccSubnet_serviceEndpointPolicy (727.95s)
--- PASS: TestAccSubnet_updateServiceDelegation (1007.58s)
--- PASS: TestAccSubnet_serviceEndpoints (1032.79s)
--- PASS: TestAccSubnet_enablePrivateLinkServiceNetworkPolicies (735.75s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1775.088s
```

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
