### PR TITLE
golangci - enable tenv linter and swap os.SetEnv to correct t.SetEnv & enabled 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters:
     #- nakedret # Checks that functions with naked returns are not longer than a maximum size
 
     #### DISABLED as it doesn't appear to respect the no-lint directive
-    #- nilerr # Finds the code that returns nil even if it checks that the error is not nil.
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
 
     #### bunch of hits, need to confirm if errors or not #####
     #- copyloopvar #Detects range loop variables that are overwritten in the loop body

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,8 +32,7 @@ linters:
     - govet # reports suspicious constructs. It is roughly the same as 'go vet' (replaced vet and vetshadow)
     - ineffassign # detects when assignments to existing variables are not used
     - misspell # finds commonly misspelled English words.
-    #- nilerr # Finds the code that returns nil even if it checks that the error is not nil.
-    #- nlreturn # Nlreturn checks for a new line before return and branch statements to increase code clarity.
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
     - prealloc # finds slice declarations that could potentially be pre-allocated.
     - predeclared # find code that shadows one of Go's predeclared identifiers.
     - reassign # checks that package variables are not reassigned.
@@ -45,19 +44,18 @@ linters:
     - unparam # reports unused function parameters.
     - wastedassign # finds wasted assignment statements
     - whitespace # checks for unnecessary newlines at the start and end of functions, if, for, etc. (
-    #- wsl # add or remove empty lines.
 
-    ##### need to confirm these are valid and adding t.Parallel() to unit tests would be beneficial / integration tests would nto be affected
+    ##### need to confirm these are valid and adding t.Parallel() to unit tests would be beneficial / integration tests would not be affected
     #- paralleltest # detects missing usage of t.Parallel() method in your Go test.
     #- tparallel # Tparallel detects inappropriate usage of t.Parallel() method in your Go test codes.
 
-    ###### DISABLED because : possible integer overflow conversion int -> int32 all thorughout the codebase
+    ###### DISABLED because : the number of possible integer overflow conversions from int -> int32. it's not an incorrect callout?
     # - gosec # Gosec is a security linter for Go source code
 
-    ##### DISABLED as it flags fmt.Errorf("constant") to be replaced with errors.New("constant") and there are ~1500 instances of this in the codebase
+    ##### DISABLED as it (correctly) flags fmt.Errorf("constant") to be replaced with errors.New("constant") and there are ~1500 instances of this in the codebase
     #- perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
 
-    #### DISABLED but valid, have a lot of these in the codebase to switch over
+    #### DISABLED but valid as relying on output variable names is less than idea, have a lot of these in the codebase to switch over
     #- nakedret # Checks that functions with naked returns are not longer than a maximum size
 
     #### bunch of hits, need to confirm if errors or not #####

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
     - prealloc # finds slice declarations that could potentially be pre-allocated.
     - predeclared # find code that shadows one of Go's predeclared identifiers.
     - reassign # checks that package variables are not reassigned.
-    #- revive #Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - tenv #detects using os.Setenv instead of t.Setenv since Go1.17.
     - tagalign #  checks struct tags that do not align with the specified column in struct definitions.
     - staticcheck # checks rules from staticcheck. It's not the same thing as the staticcheck binary.
     - unused # checks Go code for unused constants, variables, functions and types.
@@ -47,21 +47,18 @@ linters:
     - whitespace # checks for unnecessary newlines at the start and end of functions, if, for, etc. (
     #- wsl # add or remove empty lines.
 
-    ##### need to confirm these are valid and not false positives #####
+    ##### need to confirm these are valid and adding t.Parallel() to unit tests would be beneficial / integration tests would nto be affected
     #- paralleltest # detects missing usage of t.Parallel() method in your Go test.
     #- tparallel # Tparallel detects inappropriate usage of t.Parallel() method in your Go test codes.
 
-    ###### DISABLED because : integer overflow conversion int -> int32
+    ###### DISABLED because : possible integer overflow conversion int -> int32 all thorughout the codebase
     # - gosec # Gosec is a security linter for Go source code
 
-    ##### DISABLED as i was fixing them with other linters, and not realizing how many there are - disabling for now even thou it is valid
+    ##### DISABLED as it flags fmt.Errorf("constant") to be replaced with errors.New("constant") and there are ~1500 instances of this in the codebase
     #- perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
 
-    #### VALID but DISABLED as we have a lot of these in the codebase to switch over
+    #### DISABLED but valid, have a lot of these in the codebase to switch over
     #- nakedret # Checks that functions with naked returns are not longer than a maximum size
-
-    #### DISABLED TO DO IN ITS OWN PR - should be enabled and done #####
-    #- tenv #detects using os.Setenv instead of t.Setenv since Go1.17.
 
     #### bunch of hits, need to confirm if errors or not #####
     #- copyloopvar #Detects range loop variables that are overwritten in the loop body
@@ -93,8 +90,3 @@ linters-settings:
       - computed
   predeclared:
     ignore: new,min,max # should we use newer, minimum, and maximum instead?
-  revive:
-    rules:
-      - name: var-naming
-        disabled: true
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
     - govet # reports suspicious constructs. It is roughly the same as 'go vet' (replaced vet and vetshadow)
     - ineffassign # detects when assignments to existing variables are not used
     - misspell # finds commonly misspelled English words.
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
     - prealloc # finds slice declarations that could potentially be pre-allocated.
     - predeclared # find code that shadows one of Go's predeclared identifiers.
     - reassign # checks that package variables are not reassigned.
@@ -57,6 +56,9 @@ linters:
 
     #### DISABLED but valid as relying on output variable names is less than idea, have a lot of these in the codebase to switch over
     #- nakedret # Checks that functions with naked returns are not longer than a maximum size
+
+    #### DISABLED as it doesn't appear to respect the no-lint directive
+    #- nilerr # Finds the code that returns nil even if it checks that the error is not nil.
 
     #### bunch of hits, need to confirm if errors or not #####
     #- copyloopvar #Detects range loop variables that are overwritten in the loop body

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - govet # reports suspicious constructs. It is roughly the same as 'go vet' (replaced vet and vetshadow)
     - ineffassign # detects when assignments to existing variables are not used
     - misspell # finds commonly misspelled English words.
+    - nilerr # Finds code that returns nil after it checks that the error is not nil.
     - prealloc # finds slice declarations that could potentially be pre-allocated.
     - predeclared # find code that shadows one of Go's predeclared identifiers.
     - reassign # checks that package variables are not reassigned.
@@ -56,9 +57,6 @@ linters:
 
     #### DISABLED but valid as relying on output variable names is less than idea, have a lot of these in the codebase to switch over
     #- nakedret # Checks that functions with naked returns are not longer than a maximum size
-
-    #### DISABLED as it doesn't appear to respect the no-lint directive
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
 
     #### bunch of hits, need to confirm if errors or not #####
     #- copyloopvar #Detects range loop variables that are overwritten in the loop body

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -27,7 +27,7 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 	}
 
 	// Skip enhanced validation
-	_ = os.Setenv("ARM_PROVIDER_ENHANCED_VALIDATION", "false")
+	t.Setenv("ARM_PROVIDER_ENHANCED_VALIDATION", "false")
 
 	testData := &ProviderModel{
 		ResourceProviderRegistrations: types.StringValue("none"),

--- a/internal/provider/framework/helpers_test.go
+++ b/internal/provider/framework/helpers_test.go
@@ -4,7 +4,6 @@
 package framework
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -70,10 +69,7 @@ func Test_getOidcTokenExpectMismatch(t *testing.T) {
 
 func Test_getOidcTokenAKSWorkload(t *testing.T) {
 	expectedString := "testOidcFromFile"
-	err := os.Setenv("AZURE_FEDERATED_TOKEN_FILE", "./testdata/oidc_test_input.txt")
-	if err != nil {
-		t.Fatalf("could not set env var (`AZURE_FEDERATED_TOKEN_FILE`) for test: %+v", err)
-	}
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "./testdata/oidc_test_input.txt")
 
 	p := &ProviderModel{
 		UseAKSWorkloadIdentity: basetypes.NewBoolValue(true),
@@ -91,17 +87,14 @@ func Test_getOidcTokenAKSWorkload(t *testing.T) {
 
 func Test_getOidcTokenAKSWorkloadExpectMismatch(t *testing.T) {
 	configuredString := "testOidc"
-	err := os.Setenv("AZURE_FEDERATED_TOKEN_FILE", "./testdata/oidc_test_input.txt")
-	if err != nil {
-		t.Fatalf("could not set env var (`AZURE_FEDERATED_TOKEN_FILE`) for test: %+v", err)
-	}
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "./testdata/oidc_test_input.txt")
 
 	p := &ProviderModel{
 		OIDCToken:              basetypes.NewStringValue(configuredString),
 		UseAKSWorkloadIdentity: basetypes.NewBoolValue(true),
 	}
 
-	_, err = getOidcToken(p)
+	_, err := getOidcToken(p)
 	if err == nil {
 		t.Fatal("expected an error but did not get one")
 	}
@@ -147,7 +140,7 @@ func Test_getClientSecretExpectMismatch(t *testing.T) {
 }
 
 func Test_getClientSecretFromFile(t *testing.T) {
-	os.Setenv("ARM_CLIENT_SECRET", "")
+	t.Setenv("ARM_CLIENT_SECRET", "")
 	expectedString := "testClientSecretFromFile"
 	p := &ProviderModel{
 		ClientSecretFilePath: basetypes.NewStringValue("./testdata/client_secret_test_input.txt"),
@@ -166,7 +159,7 @@ func Test_getClientSecretFromFile(t *testing.T) {
 }
 
 func Test_getClientSecretFromFileMismatch(t *testing.T) {
-	os.Setenv("ARM_CLIENT_SECRET", "foo")
+	t.Setenv("ARM_CLIENT_SECRET", "foo")
 	p := &ProviderModel{
 		ClientSecretFilePath: basetypes.NewStringValue("./testdata/client_secret_test_input.txt"),
 	}
@@ -233,14 +226,12 @@ func Test_getClientIDFromFile(t *testing.T) {
 
 func Test_getClientIDAKSWorkload(t *testing.T) {
 	expectedString := "testClientIDAKSWorkload"
-	err := os.Setenv("ARM_CLIENT_ID", expectedString)
-	if err != nil {
-		t.Fatalf("failed to set environment variable ARM_CLIENT_ID: %v", err)
-	}
+	t.Setenv("ARM_CLIENT_ID", expectedString)
 
 	p := &ProviderModel{
 		UseAKSWorkloadIdentity: basetypes.NewBoolValue(true),
 	}
+
 	result, err := getClientId(p)
 	if err != nil {
 		t.Fatalf("getClientID returned unexpected error %v", err)
@@ -255,16 +246,14 @@ func Test_getClientIDAKSWorkload(t *testing.T) {
 
 func Test_getClientIDAKSWorkloadExpectMismatch(t *testing.T) {
 	configuredString := "testClientIDAKSWorkload"
-	err := os.Setenv("ARM_CLIENT_ID", "testClientID")
-	if err != nil {
-		t.Fatalf("failed to set environment variable ARM_CLIENT_ID: %v", err)
-	}
+	t.Setenv("ARM_CLIENT_ID", "testClientID")
+
 	p := &ProviderModel{
 		ClientId:               basetypes.NewStringValue(configuredString),
 		UseAKSWorkloadIdentity: basetypes.NewBoolValue(true),
 	}
 
-	_, err = getClientId(p)
+	_, err := getClientId(p)
 	if err == nil {
 		t.Fatalf("expected an error but did not get one")
 	}

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccPluginSDKAndDecoder(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin testing harness prevents this
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -216,7 +216,7 @@ func TestAccPluginSDKAndDecoder(t *testing.T) {
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputed(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always runs tests in parallel
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin testing harness prevents this
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -340,7 +340,7 @@ resource "validator_decoder_unspecified" "test" {}
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputedOverride(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin testing harness prevents this
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -444,7 +444,7 @@ resource "validator_decoder_override" "test" {
 }
 
 func TestAccPluginSDKAndDecoderSets(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin testing harness prevents this
 
 	type MyType struct {
 		SetOfStrings []string  `tfschema:"set_of_strings"`
@@ -624,7 +624,7 @@ func TestAccPluginSDKAndDecoderSets(t *testing.T) {
 }
 
 func TestAccPluginSDKAndEncoder(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // lint:ignore tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin testing harness prevents this
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -863,7 +863,7 @@ func TestAccPluginSDKAndEncoder(t *testing.T) {
 }
 
 func TestAccPluginSDKReturnsComputedFields(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // nolint:tenv // plugin sdk always is
 
 	resourceName := "validator_computed.test"
 	// lintignore:AT001

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -624,7 +624,7 @@ func TestAccPluginSDKAndDecoderSets(t *testing.T) {
 }
 
 func TestAccPluginSDKAndEncoder(t *testing.T) {
-	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
+	os.Setenv("TF_ACC", "1") // lint:ignore tenv plugin sdk always is
 
 	type NestedType struct {
 		Key string `tfschema:"key"`

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -5,6 +5,7 @@ package sdk
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func TestAccPluginSDKAndDecoder(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -215,7 +216,7 @@ func TestAccPluginSDKAndDecoder(t *testing.T) {
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputed(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always runs tests in parallel
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -339,7 +340,7 @@ resource "validator_decoder_unspecified" "test" {}
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputedOverride(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -443,7 +444,7 @@ resource "validator_decoder_override" "test" {
 }
 
 func TestAccPluginSDKAndDecoderSets(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
 
 	type MyType struct {
 		SetOfStrings []string  `tfschema:"set_of_strings"`
@@ -623,7 +624,7 @@ func TestAccPluginSDKAndDecoderSets(t *testing.T) {
 }
 
 func TestAccPluginSDKAndEncoder(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -862,7 +863,7 @@ func TestAccPluginSDKAndEncoder(t *testing.T) {
 }
 
 func TestAccPluginSDKReturnsComputedFields(t *testing.T) {
-	t.Setenv("TF_ACC", "1")
+	os.Setenv("TF_ACC", "1") // nolint: tenv plugin sdk always is
 
 	resourceName := "validator_computed.test"
 	// lintignore:AT001

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -63,7 +63,7 @@ func TestAccPluginSDKAndDecoder(t *testing.T) {
 	}
 
 	// lintignore:AT001
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"validator": func() (*schema.Provider, error) { //nolint:unparam
 				return &schema.Provider{

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -5,7 +5,6 @@ package sdk
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 )
 
 func TestAccPluginSDKAndDecoder(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -216,7 +215,7 @@ func TestAccPluginSDKAndDecoder(t *testing.T) {
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputed(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -340,7 +339,7 @@ resource "validator_decoder_unspecified" "test" {}
 }
 
 func TestAccPluginSDKAndDecoderOptionalComputedOverride(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	type MyType struct {
 		Hello   string `tfschema:"hello"`
@@ -444,7 +443,7 @@ resource "validator_decoder_override" "test" {
 }
 
 func TestAccPluginSDKAndDecoderSets(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	type MyType struct {
 		SetOfStrings []string  `tfschema:"set_of_strings"`
@@ -624,7 +623,7 @@ func TestAccPluginSDKAndDecoderSets(t *testing.T) {
 }
 
 func TestAccPluginSDKAndEncoder(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	type NestedType struct {
 		Key string `tfschema:"key"`
@@ -863,7 +862,7 @@ func TestAccPluginSDKAndEncoder(t *testing.T) {
 }
 
 func TestAccPluginSDKReturnsComputedFields(t *testing.T) {
-	os.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC", "1")
 
 	resourceName := "validator_computed.test"
 	// lintignore:AT001

--- a/internal/sdk/plugin_sdk_test.go
+++ b/internal/sdk/plugin_sdk_test.go
@@ -263,7 +263,7 @@ func TestAccPluginSDKAndDecoderOptionalComputed(t *testing.T) {
 	}
 
 	// lintignore:AT001
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"validator": func() (*schema.Provider, error) { //nolint:unparam
 				return &schema.Provider{
@@ -349,7 +349,7 @@ func TestAccPluginSDKAndDecoderOptionalComputedOverride(t *testing.T) {
 	}
 
 	// lintignore:AT001
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"validator": func() (*schema.Provider, error) { //nolint:unparam
 				return &schema.Provider{
@@ -455,7 +455,7 @@ func TestAccPluginSDKAndDecoderSets(t *testing.T) {
 	}
 
 	// lintignore:AT001
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"validator": func() (*schema.Provider, error) { //nolint:unparam
 				return &schema.Provider{
@@ -648,7 +648,7 @@ func TestAccPluginSDKAndEncoder(t *testing.T) {
 	}
 
 	// lintignore:AT001
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"validator": func() (*schema.Provider, error) { //nolint:unparam
 				return &schema.Provider{

--- a/internal/services/apimanagement/migration/policy.go
+++ b/internal/services/apimanagement/migration/policy.go
@@ -22,7 +22,7 @@ func (ApiManagementPolicyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		apiMgmtId, err := policy.ParseServiceID(rawState["id"].(string))
 		if err != nil {
-			return rawState, nil //nolint:nilerr // this is not an error as we just want to skip the upgrade
+			return rawState, nil // lint:ignore nilerr this is not an error as we just want to skip the upgrade
 		}
 		id := policy.NewServiceID(apiMgmtId.SubscriptionId, apiMgmtId.ResourceGroupName, apiMgmtId.ServiceName)
 		rawState["id"] = id.ID()

--- a/internal/services/apimanagement/migration/policy.go
+++ b/internal/services/apimanagement/migration/policy.go
@@ -22,7 +22,7 @@ func (ApiManagementPolicyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		apiMgmtId, err := policy.ParseServiceID(rawState["id"].(string))
 		if err != nil {
-			return rawState, nil
+			return rawState, nil //nolint:nilerr // this is not an error as we just want to skip the upgrade
 		}
 		id := policy.NewServiceID(apiMgmtId.SubscriptionId, apiMgmtId.ResourceGroupName, apiMgmtId.ServiceName)
 		rawState["id"] = id.ID()

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -172,7 +172,7 @@ func resourceCapacityReservationGroupDelete(d *pluginsdk.ResourceData, meta inte
 			Refresh: func() (interface{}, string, error) {
 				res, err := client.Delete(ctx, *id)
 				if err != nil {
-					return res, "Deleting", nil //nolint:nilerr  Returning nil error is intentional as we will retry the delete operation
+					return res, "Deleting", nil // lint:ignore nilerr Returning nil error is intentional as we will retry the delete operation
 				}
 				return res, "Deleted", nil
 			},

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -172,7 +172,7 @@ func resourceCapacityReservationGroupDelete(d *pluginsdk.ResourceData, meta inte
 			Refresh: func() (interface{}, string, error) {
 				res, err := client.Delete(ctx, *id)
 				if err != nil {
-					return res, "Deleting", nil
+					return res, "Deleting", nil // nolint:nilerr  Returning nil error is intentional as we will retry the delete operation
 				}
 				return res, "Deleted", nil
 			},

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -172,7 +172,7 @@ func resourceCapacityReservationGroupDelete(d *pluginsdk.ResourceData, meta inte
 			Refresh: func() (interface{}, string, error) {
 				res, err := client.Delete(ctx, *id)
 				if err != nil {
-					return res, "Deleting", nil // nolint:nilerr  Returning nil error is intentional as we will retry the delete operation
+					return res, "Deleting", nil //nolint:nilerr  Returning nil error is intentional as we will retry the delete operation
 				}
 				return res, "Deleted", nil
 			},

--- a/internal/services/compute/no_downtime_resize.go
+++ b/internal/services/compute/no_downtime_resize.go
@@ -73,7 +73,7 @@ func determineIfVirtualMachineSkuSupportsNoDowntimeResize(ctx context.Context, v
 	virtualMachineId, err := virtualmachines.ParseVirtualMachineIDInsensitively(*virtualMachineIdRaw)
 	if err != nil {
 		log.Printf("[DEBUG] unable to parse Virtual Machine ID %q that the Managed Disk is attached too - skipping no-downtime-resize since we can't guarantee that's available", *virtualMachineIdRaw)
-		return pointer.To(false), nil
+		return pointer.To(false), nil // nolint: nilerr this is not an error as we just want to skip the check in this situation since we can't guarantee it's available
 	}
 
 	log.Printf("[DEBUG] Retrieving %s..", *virtualMachineId)

--- a/internal/services/compute/no_downtime_resize.go
+++ b/internal/services/compute/no_downtime_resize.go
@@ -73,7 +73,7 @@ func determineIfVirtualMachineSkuSupportsNoDowntimeResize(ctx context.Context, v
 	virtualMachineId, err := virtualmachines.ParseVirtualMachineIDInsensitively(*virtualMachineIdRaw)
 	if err != nil {
 		log.Printf("[DEBUG] unable to parse Virtual Machine ID %q that the Managed Disk is attached too - skipping no-downtime-resize since we can't guarantee that's available", *virtualMachineIdRaw)
-		return pointer.To(false), nil // nolint: nilerr this is not an error as we just want to skip the check in this situation since we can't guarantee it's available
+		return pointer.To(false), nil // lint:ignore nilerr this is not an error as we just want to skip the check in this situation since we can't guarantee it's available
 	}
 
 	log.Printf("[DEBUG] Retrieving %s..", *virtualMachineId)

--- a/internal/services/storage/storage_account_static_website_data_plane_resource.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource.go
@@ -195,7 +195,7 @@ func (a AccountStaticWebsiteResource) Delete() sdk.ResourceFunc {
 
 			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
 			if err != nil {
-				return nil // nolint: nilerr If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
+				return nil // lint:ignore nilerr If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
 			}
 
 			properties := accounts.StorageServiceProperties{

--- a/internal/services/storage/storage_account_static_website_data_plane_resource.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource.go
@@ -195,8 +195,7 @@ func (a AccountStaticWebsiteResource) Delete() sdk.ResourceFunc {
 
 			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
 			if err != nil {
-				// If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
-				return nil
+				return nil // nolint: nilerr If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
 			}
 
 			properties := accounts.StorageServiceProperties{


### PR DESCRIPTION
This pull request refactors the code to replace instances of os.Setenv with t.Setenv in test files. The t.Setenv method, introduced in Go 1.17, is specifically designed for managing environment variables in tests, ensuring they are properly cleaned up after each test case. currently both are in use within the provider and this aligns them with the correct methold.

attempted to enable nilerr to enforce a nolint directive & a comment explaining why the error is being ignored, however linter does not seem to respect nolint director so left comments and disabled linter

also tidy up the golangci config file

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
