### PR TITLE
`azurerm_linux_web_app`, `azurerm_windows_web_app`: allow to set auth_settings_v2.custom_oidc_v2.client_secret_setting_name property

### DIFF
--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -1214,6 +1214,7 @@ func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
 
 				"client_secret_setting_name": {
 					Type:        pluginsdk.TypeString,
+					Optional:    true,
 					Computed:    true,
 					Description: "The App Setting name that contains the secret for this Custom OIDC Client.",
 				},
@@ -1334,13 +1335,20 @@ func expandCustomOIDCAuthV2Settings(input []CustomOIDCAuthV2Settings) map[string
 		if v.Name == "" {
 			continue
 		}
+
+		// For backward compatibility, stablish the generated name is the incomming value is empty
+		clientSecretSettingName := ""
+		if clientSecretSettingName = v.ClientSecretSettingName; clientSecretSettingName == "" {
+			clientSecretSettingName = fmt.Sprintf("%s_PROVIDER_AUTHENTICATION_SECRET", strings.ToUpper(v.Name))
+		}
+
 		provider := webapps.CustomOpenIdConnectProvider{
 			Enabled: pointer.To(true),
 			Registration: &webapps.OpenIdConnectRegistration{
 				ClientId: pointer.To(v.ClientId),
 				ClientCredential: &webapps.OpenIdConnectClientCredential{
 					Method:                  pointer.To(webapps.ClientCredentialMethodClientSecretPost),
-					ClientSecretSettingName: pointer.To(fmt.Sprintf("%s_PROVIDER_AUTHENTICATION_SECRET", strings.ToUpper(v.Name))),
+					ClientSecretSettingName: pointer.To(clientSecretSettingName),
 				},
 				OpenIdConnectConfiguration: &webapps.OpenIdConnectConfig{
 					WellKnownOpenIdConfiguration: pointer.To(v.OpenIDConfigurationEndpoint),

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -89,6 +89,14 @@ func TestAccLinuxWebApp_authV2CustomOIDC(t *testing.T) {
 			),
 		},
 		data.ImportStep("site_credential.0.password"),
+		{
+			Config: r.authV2CustomOIDCWithSecretName(data, "CustomSecretName"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc_v2.0.client_secret_setting_name").HasValue("CustomSecretName"),
+			),
+		},
+		data.ImportStep("site_credential.0.password"),
 	})
 }
 
@@ -436,6 +444,50 @@ resource "azurerm_linux_web_app" "test" {
       name                          = "testcustom"
       client_id                     = "testCustomID"
       openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+func (r LinuxWebAppResource) authV2CustomOIDCWithSecretName(data acceptance.TestData, secretSettingName string) string {
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_settings_v2 {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    custom_oidc_v2 {
+      name                          = "testcustom"
+      client_id                     = "testCustomID"
+      openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
+      client_secret_setting_name    = "%[3]s"
     }
 
     login {}

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -350,7 +350,7 @@ A `custom_oidc_v2` block supports the following:
 
 * `client_credential_method` - The Client Credential Method used.
 
-* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the secret for this Custom OIDC Client. Defaults to `name` above (in capital) and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
 
 * `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
 
@@ -732,7 +732,7 @@ A `site_config` block supports the following:
 
 * `scm_ip_restriction_default_action` - (Optional) The Default action for traffic that does not match any `scm_ip_restriction` rule. possible values include `Allow` and `Deny`. Defaults to `Allow`.
 
-* `scm_minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests to the SCM site Possible values include: `1.0`, `1.1`, and `1.2`. Defaults to `1.2`.
+* `scm_minimum_tls_version` - (Optional) This configures the minimum version of TLS required for SSL requests to the SCM site. Possible values are `1.0`, `1.1`, `1.2` and `1.3`. Defaults to `1.2`.
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Linux Web App `ip_restriction` configuration be used for the SCM also.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -352,7 +352,7 @@ A `custom_oidc_v2` block supports the following:
 
 * `client_credential_method` - The Client Credential Method used.
 
-* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the secret for this Custom OIDC Client. Defaults to `name` above (in capital) and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
 
 * `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
 
@@ -736,7 +736,7 @@ A `site_config` block supports the following:
 
 * `scm_ip_restriction_default_action` - (Optional) The Default action for traffic that does not match any `scm_ip_restriction` rule. possible values include `Allow` and `Deny`. Defaults to `Allow`.
 
-* `scm_minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests to the SCM site Possible values include: `1.0`, `1.1`, and `1.2`. Defaults to `1.2`.
+* `scm_minimum_tls_version` - (Optional) This configures the minimum version of TLS required for SSL requests to the SCM site. Possible values are `1.0`, `1.1`, `1.2` and `1.3`. Defaults to `1.2`.
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Linux Web App `ip_restriction` configuration be used for the SCM also.
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -361,7 +361,7 @@ A `custom_oidc_v2` block supports the following:
 
 * `client_credential_method` - The Client Credential Method used.
 
-* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the secret for this Custom OIDC Client. Defaults to `name` above (in capital) and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
 
 * `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
 
@@ -751,7 +751,7 @@ A `site_config` block supports the following:
 
 * `scm_ip_restriction_default_action` - (Optional) The Default action for traffic that does not match any `scm_ip_restriction` rule. possible values include `Allow` and `Deny`. Defaults to `Allow`.
 
-* `scm_minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests to the SCM site Possible values include: `1.0`, `1.1`, and `1.2`. Defaults to `1.2`.
+* `scm_minimum_tls_version` - (Optional) This configures the minimum version of TLS required for SSL requests to the SCM site. Possible values are `1.0`, `1.1`, `1.2` and `1.3`. Defaults to `1.2`.
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Windows Web App `ip_restriction` configuration be used for the SCM also.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -356,7 +356,7 @@ A `custom_oidc_v2` block supports the following:
 
 * `client_credential_method` - The Client Credential Method used.
 
-* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the secret for this Custom OIDC Client. Defaults to `name` above (in capital) and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
 
 * `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
 
@@ -748,7 +748,7 @@ A `site_config` block supports the following:
 
 * `scm_ip_restriction_default_action` - (Optional) The Default action for traffic that does not match any `scm_ip_restriction` rule. possible values include `Allow` and `Deny`. Defaults to `Allow`.
 
-* `scm_minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests to the SCM site Possible values include: `1.0`, `1.1`, and `1.2`. Defaults to `1.2`.
+* `scm_minimum_tls_version` - (Optional) This configures the minimum version of TLS required for SSL requests to the SCM site. Possible values are `1.0`, `1.1`, `1.2` and `1.3`. Defaults to `1.2`.
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Windows Web App Slot `ip_restriction` configuration be used for the SCM also.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Updated web app to accept a value for `client_secret_setting_name`. The change is valid for both Windows and Linux, as well as the related slot resources.
  - For backward compatibility, if the property is not defined it will use as default the generated name.
- Updated the relevant Test cases to include verification of the value.
- Updated docs (as bonus, fixed some linting errors).

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_web_app` - `auth_settings_v2.custom_oidc_v2.client_secret_setting_name` property now can be defined [GH-27988]
*  `azurerm_linux_web_app_slot` - `auth_settings_v2.custom_oidc_v2.client_secret_setting_name` property now can be defined [GH-27988]
*  `azurerm_windows_web_app` - `auth_settings_v2.custom_oidc_v2.client_secret_setting_name` property now can be defined [GH-27988]
*  `azurerm_windows_web_app_slot` - `auth_settings_v2.custom_oidc_v2.client_secret_setting_name` property now can be defined [GH-27988]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27988


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
