### PR TITLE
`azurerm_container_group` - Fix update error with `diagnostics.log_analytics` defined

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -875,6 +875,11 @@ func resourceContainerGroupUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		model.Properties.Volumes = pointer.To(containerGroupVolumes)
 
+		// As API doesn't return the value of WorkspaceKey, so it has to get the value from tf config and set it to request payload. Otherwise, the Update API call would fail
+		if diagnostics := expandContainerGroupDiagnostics(d.Get("diagnostics").([]interface{})); diagnostics != nil && diagnostics.LogAnalytics != nil {
+			model.Properties.Diagnostics.LogAnalytics.WorkspaceKey = diagnostics.LogAnalytics.WorkspaceKey
+		}
+
 		// As Update API doesn't support to update identity, so it has to use CreateOrUpdate API to update identity
 		if err := client.ContainerGroupsCreateOrUpdateThenPoll(ctx, *id, model); err != nil {
 			return fmt.Errorf("updating %s: %+v", *id, err)

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -266,6 +266,26 @@ func TestAccContainerGroup_logTypeUnset(t *testing.T) {
 	})
 }
 
+func TestAccContainerGroup_AssignedIdentityUpdateWithLogWorkspace(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.SystemAssignedIdentityWithLogWorkspace(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.UserAssignedIdentityWithLogWorkspace(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccContainerGroup_linuxBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
 	r := ContainerGroupResource{}
@@ -326,20 +346,13 @@ func TestAccContainerGroup_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccContainerGroup_linuxBasicUpdate(t *testing.T) {
+func TestAccContainerGroup_linuxBasicMultipleContainers(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
 	r := ContainerGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.linuxBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("container.#").HasValue("1"),
-			),
-		},
-		{
-			Config: r.linuxBasicUpdated(data),
+			Config: r.linuxBasicMultipleContainers(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("container.#").HasValue("2"),
@@ -813,7 +826,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -853,7 +866,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -904,7 +917,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     liveness_probe {
@@ -947,7 +960,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
   }
@@ -983,7 +996,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
   }
@@ -1028,7 +1041,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1098,7 +1111,7 @@ resource "azurerm_container_group" "test" {
   os_type             = "Linux"
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1148,7 +1161,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1191,7 +1204,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1232,7 +1245,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1272,7 +1285,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1302,7 +1315,7 @@ resource "azurerm_container_group" "import" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1338,7 +1351,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1361,7 +1374,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "sidecar"
-    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
   }
@@ -1393,7 +1406,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
 
@@ -1410,7 +1423,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "sidecar"
-    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
   }
@@ -1449,7 +1462,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1471,7 +1484,7 @@ resource "azurerm_container_group" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (ContainerGroupResource) linuxBasicUpdated(data acceptance.TestData) string {
+func (ContainerGroupResource) linuxBasicMultipleContainers(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1491,7 +1504,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
 
@@ -1507,7 +1520,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "sidecar"
-    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
   }
@@ -1562,7 +1575,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1630,7 +1643,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1684,7 +1697,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -1932,7 +1945,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hf"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "1"
     memory = "1.5"
 
@@ -2183,7 +2196,7 @@ resource "azurerm_container_group" "test" {
 
   init_container {
     name     = "init"
-    image    = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image    = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     commands = ["touch", "/sharedempty/file.txt"]
 
     volume {
@@ -2196,7 +2209,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "reader"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "1"
     memory = "1.5"
 
@@ -2234,7 +2247,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name     = "writer"
-    image    = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image    = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu      = "1"
     memory   = "1.5"
     commands = ["touch", "/sharedempty/file.txt"]
@@ -2249,7 +2262,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "reader"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "1"
     memory = "1.5"
 
@@ -2287,7 +2300,7 @@ resource "azurerm_container_group" "test" {
 
   init_container {
     name     = "init"
-    image    = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image    = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     commands = ["echo", "hello from init"]
     secure_environment_variables = {
       PASSWORD = "something_very_secure_for_init"
@@ -2296,7 +2309,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "1"
     memory = "1.5"
 
@@ -2329,7 +2342,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -2394,7 +2407,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hello-world"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 
@@ -2503,7 +2516,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -2604,7 +2617,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -2644,7 +2657,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -2679,7 +2692,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "hw"
-    image  = "mcr.microsoft.com/quantum/linux-selfcontained:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "0.5"
     ports {
@@ -2796,4 +2809,120 @@ resource "azurerm_container_group" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (ContainerGroupResource) SystemAssignedIdentityWithLogWorkspace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+
+  container {
+    name   = "hw"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+    cpu    = "0.5"
+    memory = "0.5"
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+  }
+
+  diagnostics {
+    log_analytics {
+      workspace_id  = azurerm_log_analytics_workspace.test.workspace_id
+      workspace_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    environment = "Testing"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (ContainerGroupResource) UserAssignedIdentityWithLogWorkspace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  name = "acctest%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+
+  container {
+    name   = "hw"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+    cpu    = "0.5"
+    memory = "0.5"
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+  }
+
+  diagnostics {
+    log_analytics {
+      workspace_id  = azurerm_log_analytics_workspace.test.workspace_id
+      workspace_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    }
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  tags = {
+    environment = "Testing"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes an issue where updating the `identity.type` argument for the `azurerm_container_group` resource throws an error when `diagnostics.log_analytics` is defined due to the workspace key is not in the PUT request body (see: https://github.com/hashicorp/terraform-provider-azurerm/issues/27999).

Meanwhile, to pass the test cases, I did the following updates to the tests:

- Changing the `TestAccContainerGroup_linuxBasicUpdate` to be `TestAccContainerGroup_linuxBasicMultipleContainers`, as the previous one introduces a recreate (as the `container` block is force new).
- Changing the image value, as the previous ones are non-existed anymore. E.g. the TC has a lot of failures regarding this:

```
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        Error: creating Container Group (Subscription: "*******"
        Resource Group Name: "acctestRG-241113234136602111"
        Container Group Name: "acctestcontainergroup-241113234136602111"): performing ContainerGroupsCreateOrUpdate: unexpected status 400 (400 Bad Request) with error: InaccessibleImage: The image 'mcr.microsoft.com/quantum/linux-selfcontained:latest' in container group 'acctestcontainergroup-241113234136602111' is not accessible. Please check the image and registry credential.
          with azurerm_container_group.test,
          on terraform_plugin_test.tf line 33, in resource "azurerm_container_group" "test":
          33: resource "azurerm_container_group" "test" {
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
$ TF_ACC=1 go test -v -timeout=20h -run='TestAccContainerGroup_(linuxBasic|AssignedIdentityUpdate)' ./internal/services/containers
=== RUN   TestAccContainerGroup_AssignedIdentityUpdate
=== PAUSE TestAccContainerGroup_AssignedIdentityUpdate
=== RUN   TestAccContainerGroup_AssignedIdentityUpdateWithLogWorkspace
=== PAUSE TestAccContainerGroup_AssignedIdentityUpdateWithLogWorkspace
=== RUN   TestAccContainerGroup_linuxBasic
=== PAUSE TestAccContainerGroup_linuxBasic
=== RUN   TestAccContainerGroup_linuxBasicMultipleContainers
=== PAUSE TestAccContainerGroup_linuxBasicMultipleContainers
=== RUN   TestAccContainerGroup_linuxBasicTagsUpdate
=== PAUSE TestAccContainerGroup_linuxBasicTagsUpdate
=== CONT  TestAccContainerGroup_AssignedIdentityUpdate
=== CONT  TestAccContainerGroup_linuxBasicTagsUpdate
=== CONT  TestAccContainerGroup_linuxBasicMultipleContainers
=== CONT  TestAccContainerGroup_linuxBasic
=== CONT  TestAccContainerGroup_AssignedIdentityUpdateWithLogWorkspace
--- PASS: TestAccContainerGroup_linuxBasic (99.34s)
--- PASS: TestAccContainerGroup_linuxBasicTagsUpdate (103.30s)
--- PASS: TestAccContainerGroup_linuxBasicMultipleContainers (150.62s)
--- PASS: TestAccContainerGroup_AssignedIdentityUpdate (154.40s)
--- PASS: TestAccContainerGroup_AssignedIdentityUpdateWithLogWorkspace (185.62s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    185.652s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_group` - Fix update error with `diagnostics.log_analytics` defined [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27999


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
