### PR TITLE
`azurerm_security_center_auto_provisioning` - deprecate resource

### DIFF
--- a/internal/services/securitycenter/registration.go
+++ b/internal/services/securitycenter/registration.go
@@ -4,6 +4,7 @@
 package securitycenter
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -49,9 +50,12 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_security_center_subscription_pricing":                            resourceSecurityCenterSubscriptionPricing(),
 		"azurerm_security_center_workspace":                                       resourceSecurityCenterWorkspace(),
 		"azurerm_security_center_automation":                                      resourceSecurityCenterAutomation(),
-		"azurerm_security_center_auto_provisioning":                               resourceSecurityCenterAutoProvisioning(),
 		"azurerm_security_center_server_vulnerability_assessments_setting":        resourceSecurityCenterServerVulnerabilityAssessmentsSetting(),
 		"azurerm_security_center_server_vulnerability_assessment_virtual_machine": resourceServerVulnerabilityAssessmentVirtualMachine(),
+	}
+
+	if !features.FivePointOhBeta() {
+		resources["azurerm_security_center_auto_provisioning"] = resourceSecurityCenterAutoProvisioning()
 	}
 
 	return resources

--- a/internal/services/securitycenter/security_center_auto_provisioning_resource.go
+++ b/internal/services/securitycenter/security_center_auto_provisioning_resource.go
@@ -42,6 +42,8 @@ func resourceSecurityCenterAutoProvisioning() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
+		DeprecationMessage: "The `azurerm_security_center_auto_provisioning` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider",
+
 		Schema: map[string]*pluginsdk.Schema{
 			"auto_provision": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/securitycenter/security_center_auto_provisioning_resource_test.go
+++ b/internal/services/securitycenter/security_center_auto_provisioning_resource_test.go
@@ -19,6 +19,7 @@ import (
 type SecurityCenterAutoProvisionResource struct{}
 
 func TestAccSecurityCenterAutoProvision_update(t *testing.T) {
+	t.Skipf("Skipping since `azurerm_security_center_auto_provisioning` is deprecated on service side, can no longer be enabled.")
 	data := acceptance.BuildTestData(t, "azurerm_security_center_auto_provisioning", "test")
 	r := SecurityCenterAutoProvisionResource{}
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -36,7 +36,7 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 ### `azurerm_security_center_auto_provisioning`
 
-* This deprecated resource has been removed from the Azure Provider. [Please see the [documention for more details]](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
+* This deprecated resource has been removed from the Azure Provider. Please see the [documention for more details](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
 
 ## Removed Data Sources
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -36,7 +36,7 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 ### `azurerm_security_center_auto_provisioning`
 
-* This deprecated resource has been removed from the Azure Provider. [document](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan)
+* This deprecated resource has been removed from the Azure Provider. [Please see the [documention for more details]](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
 
 ## Removed Data Sources
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -57,6 +57,10 @@ Please follow the format in the example below for listing breaking changes in re
 * The `example_property_with_changed_default` property now defaults to `NewDefault`.
 ```
 
+### `azurerm_security_center_auto_provisioning`
+
+* This deprecated resources has been removed from the Azure Provider.
+
 ### `azurerm_sentinel_alert_rule_fusion`
 
 * The deprecated `name` property has been removed.

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -34,6 +34,9 @@ Please follow the format in the example below for adding removed resources:
 This deprecated resource has been superseded/retired and has been removed from the Azure Provider.
 ```
 
+### `azurerm_security_center_auto_provisioning`
+
+* This deprecated resource has been removed from the Azure Provider. [document](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan)
 
 ## Removed Data Sources
 
@@ -56,10 +59,6 @@ Please follow the format in the example below for listing breaking changes in re
 * The deprecated `example_property_with_no_replacement` property has been removed.
 * The `example_property_with_changed_default` property now defaults to `NewDefault`.
 ```
-
-### `azurerm_security_center_auto_provisioning`
-
-* This deprecated resources has been removed from the Azure Provider.
 
 ### `azurerm_sentinel_alert_rule_fusion`
 

--- a/website/docs/r/security_center_auto_provisioning.html.markdown
+++ b/website/docs/r/security_center_auto_provisioning.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Enables or disables the Security Center Auto Provisioning feature for the subscription
 
+~> **Note:** The `azurerm_security_center_auto_provisioning` resource has been deprecated because [the auto provisioning capability will be deprecated by end of Novemember of 2024](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan) and will be removed in v5.0 of the AzureRM Provider.
+
 ~> **NOTE:** There is no resource name required, it will always be "default"
 
 ## Example Usage


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The capability is deprecated per [the document](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan)
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The resource is deprecated on the service side and the tests can not pass any more with following error:
```
        Error: updating auto-provisioning setting for Auto Provisioning Setting: (Name "default"): security.AutoProvisioningSettingsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="Deprecated" Message="Log Analytics auto provisioning is deprecated and can no longer be enabled."
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_security_center_auto_provisioning` - deprecate resource [GH-28030]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #27670


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
