### PR TITLE
azurerm_web_application_firewall_policy: Adding 1.1 value as allowed in managed_rules.managed_rule_set.version

### DIFF
--- a/internal/services/network/validate/web_application_firewall_policy.go
+++ b/internal/services/network/validate/web_application_firewall_policy.go
@@ -60,6 +60,7 @@ var ValidateWebApplicationFirewallPolicyRuleGroupName = validation.StringInSlice
 var ValidateWebApplicationFirewallPolicyRuleSetVersion = validation.StringInSlice([]string{
 	"0.1",
 	"1.0",
+	"1.1",
 	"2.1",
 	"2.2.9",
 	"3.0",
@@ -75,6 +76,7 @@ var ValidateWebApplicationFirewallPolicyRuleSetType = validation.StringInSlice([
 
 var ValidateWebApplicationFirewallPolicyExclusionRuleSetVersion = validation.StringInSlice([]string{
 	"1.0",
+	"1.1",
 	"2.1",
 	"3.2",
 }, false)

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -1987,7 +1987,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
 
       excluded_rule_set {
         type    = "Microsoft_BotManagerRuleSet"
-        version = "1.0"
+        version = "1.1"
         rule_group {
           rule_group_name = "UnknownBots"
           excluded_rules = [
@@ -2036,7 +2036,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
 
     managed_rule_set {
       type    = "Microsoft_BotManagerRuleSet"
-      version = "1.0"
+      version = "1.1"
     }
 
     exclusion {
@@ -2046,7 +2046,7 @@ resource "azurerm_web_application_firewall_policy" "test" {
 
       excluded_rule_set {
         type    = "Microsoft_BotManagerRuleSet"
-        version = "1.0"
+        version = "1.1"
         rule_group {
           rule_group_name = "GoodBots"
           excluded_rules = [


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description
- Adding 1.1 value as allowed in managed_rules.managed_rule_set.version.
- Adding 1.1 value as allowed in managed_rules.exclusion.version.excluded_rule_set.version.
- Updated Test to use this version.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/network -run=TestAccWebApplicationFirewallPolicy_BotManager -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWebApplicationFirewallPolicy_BotManager
=== PAUSE TestAccWebApplicationFirewallPolicy_BotManager
=== CONT  TestAccWebApplicationFirewallPolicy_BotManager
--- PASS: TestAccWebApplicationFirewallPolicy_BotManager (348.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       349.000s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_web_application_firewall_policy` - support for the `1.1` value on `managed_rules.managed_rule_set.version` property [GH-28036]
* `azurerm_web_application_firewall_policy` - support for the `1.1` value on `managed_rules.exclusion.version.excluded_rule_set.version` property [GH-28036]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28036


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
