### PR TITLE
Acctest: Add back the missing provider config

### DIFF
--- a/internal/services/authorization/client_config_data_source_test.go
+++ b/internal/services/authorization/client_config_data_source_test.go
@@ -36,6 +36,10 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 
 func (d ClientConfigDataSource) basic() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_client_config" "current" {
 }
 `

--- a/internal/services/authorization/pim_active_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource_test.go
@@ -174,6 +174,10 @@ resource "azuread_group" "test" {
 
 func (r PimActiveRoleAssignmentResource) noExpiration(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -201,6 +205,10 @@ resource "azurerm_pim_active_role_assignment" "test" {
 
 func (PimActiveRoleAssignmentResource) expirationByDurationHours(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -240,6 +248,10 @@ resource "azurerm_pim_active_role_assignment" "test" {
 
 func (PimActiveRoleAssignmentResource) expirationByDurationDays(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -285,6 +297,10 @@ resource "azurerm_pim_active_role_assignment" "test" {
 
 func (PimActiveRoleAssignmentResource) importSetup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -339,6 +355,10 @@ resource "azurerm_pim_active_role_assignment" "import" {
 
 func (PimActiveRoleAssignmentResource) expirationByDate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -384,6 +404,10 @@ resource "azurerm_pim_active_role_assignment" "test" {
 
 func (PimActiveRoleAssignmentResource) pending(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -155,6 +155,10 @@ func (r PimEligibleRoleAssignmentResource) Exists(ctx context.Context, client *c
 
 func (PimEligibleRoleAssignmentResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azuread_domains" "test" {
   only_initial = true
 }

--- a/internal/services/authorization/role_assignment_marketplace_resource_test.go
+++ b/internal/services/authorization/role_assignment_marketplace_resource_test.go
@@ -205,6 +205,10 @@ data "azurerm_role_definition" "test" {
   name = "%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_marketplace_role_assignment" "test" {
   role_definition_id = "${data.azurerm_role_definition.test.id}"
   principal_id       = "${data.azurerm_client_config.test.object_id}"
@@ -222,6 +226,10 @@ resource "azurerm_marketplace_role_assignment" "test" {
 
 func (RoleAssignmentMarketplaceResource) roleNameConfig(id string, roleName string) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_client_config" "test" {
 }
 
@@ -259,6 +267,10 @@ resource "azurerm_marketplace_role_assignment" "import" {
 
 func (RoleAssignmentMarketplaceResource) builtinConfig(id string, roleName string) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_client_config" "test" {
 }
 
@@ -292,6 +304,10 @@ resource "azuread_service_principal" "test" {
   application_id = azuread_application.test.application_id
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_marketplace_role_assignment" "test" {
   name                 = "%s"
   role_definition_name = "%s"
@@ -318,6 +334,10 @@ resource "azuread_service_principal" "test" {
   application_id = azuread_application.test.application_id
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_marketplace_role_assignment" "test" {
   name                             = "%s"
   role_definition_name             = "%s"
@@ -340,6 +360,10 @@ provider "azuread" {}
 resource "azuread_group" "test" {
   display_name     = "acctestspa-%d"
   security_enabled = true
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_marketplace_role_assignment" "test" {

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -281,6 +281,10 @@ func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Clie
 
 func (RoleAssignmentResource) emptyNameConfig() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -2017,6 +2017,10 @@ resource "azurerm_batch_pool" "test" {
 
 func (BatchPoolResource) networkConfiguration(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d-batchpool"
   location = "%[2]s"

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -1197,5 +1197,5 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
   object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString)
 }

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -137,6 +137,10 @@ locals {
   admin_password    = "Password1234!%[1]d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"

--- a/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
@@ -700,6 +700,10 @@ locals {
   vm_name = "acctestvm%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1611,6 +1611,10 @@ func (r LinuxVirtualMachineResource) otherEdgeZone(data acceptance.TestData) str
 	return fmt.Sprintf(`
 %[1]s
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[3]d"
   location = "%[2]s"
@@ -1977,7 +1981,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWithOutProvider(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) otherLicenseType(data acceptance.TestData) string {
@@ -2333,7 +2337,7 @@ resource "azurerm_key_vault_certificate" "second" {
     }
   }
 }
-`, r.template(data), data.RandomString)
+`, r.templateWithOutProvider(data), data.RandomString)
 }
 
 func (r LinuxVirtualMachineResource) otherSecret(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_test.go
@@ -45,6 +45,35 @@ func (r LinuxVirtualMachineResource) templateBase(data acceptance.TestData) stri
 	return fmt.Sprintf(`
 %s
 
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, r.templateBasePublicKey(), data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) templateBaseWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -82,4 +111,22 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, r.templateBase(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) templateWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+`, r.templateBaseWithOutProvider(data), data.RandomInteger)
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_disk_os_test.go
@@ -812,5 +812,5 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
   object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString)
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_extensions_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_extensions_test.go
@@ -420,10 +420,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionOnlySettings(data acceptan
 	return fmt.Sprintf(`
 %[1]s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -481,10 +477,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
@@ -548,10 +540,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionForceUpdateTag(data accept
 	return fmt.Sprintf(`
 %[1]s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -613,10 +601,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionMultiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
@@ -694,10 +678,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionUpdate(data acceptance.Tes
 	return fmt.Sprintf(`
 %[1]s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -754,9 +734,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionsRollingUpgradeWithHealthExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-provider "azurerm" {
-  features {}
-}
+
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                            = "acctestvmss-%d"
   resource_group_name             = azurerm_resource_group.test.name
@@ -813,9 +791,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionsWithHealthExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-provider "azurerm" {
-  features {}
-}
+
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                            = "acctestvmss-%d"
   resource_group_name             = azurerm_resource_group.test.name
@@ -867,9 +843,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionsAutomaticUpgradeWithHealthExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-provider "azurerm" {
-  features {}
-}
+
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                            = "acctestvmss-%d"
   resource_group_name             = azurerm_resource_group.test.name
@@ -932,10 +906,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionWithTimeBudget(data accept
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -996,10 +966,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionTimeBudgetWithoutExtension
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1043,10 +1009,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionsAutomaticUpgradeWithServi
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_service_fabric_cluster" "test" {
   name                = "acctest-%d"
@@ -1137,10 +1099,6 @@ func (r LinuxVirtualMachineScaleSetResource) extensionAutomaticUpgradeEnabled(da
 	return fmt.Sprintf(`
 %[1]s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1194,10 +1152,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionOperationsEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
@@ -1262,10 +1216,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) extensionOperationsDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
@@ -1411,5 +1361,5 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomString, index)
+`, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString, index)
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_images_test.go
@@ -593,7 +593,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, offer, sku)
+`, r.templateWithOutProvider(data), data.RandomInteger, offer, sku)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) imagesRollingUpdate(data acceptance.TestData, offer, sku string) string {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -1232,6 +1232,10 @@ func (r LinuxVirtualMachineScaleSetResource) otherEdgeZone(data acceptance.TestD
 	return fmt.Sprintf(`
 %[1]s
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[3]d"
   location = "%[2]s"
@@ -1342,7 +1346,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWithOutProvider(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) otherPrioritySpot(data acceptance.TestData, evictionPolicy string) string {
@@ -2705,10 +2709,6 @@ func (r LinuxVirtualMachineScaleSetResource) otherEncryptionAtHost(data acceptan
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -3142,10 +3142,6 @@ func (r LinuxVirtualMachineScaleSetResource) otherSecureBootEnabled(data accepta
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -3188,10 +3184,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (r LinuxVirtualMachineScaleSetResource) otherVTpmEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
@@ -3445,5 +3437,5 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, sku)
+`, r.templateWithOutProvider(data), data.RandomInteger, sku)
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -45,6 +45,35 @@ func (r LinuxVirtualMachineScaleSetResource) template(data acceptance.TestData) 
 	return fmt.Sprintf(`
 %s
 
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vmss-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, r.templatePublicKey(), data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) templateWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-vmss-%d"
   location = "%s"
@@ -69,6 +98,10 @@ resource "azurerm_subnet" "test" {
 func (r LinuxVirtualMachineScaleSetResource) templateWithLocation(data acceptance.TestData, location string) string {
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-vmss-%d"

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -817,5 +817,5 @@ resource "azurerm_virtual_machine_extension" "test" {
     source_vault_id = azurerm_key_vault.test[%[4]d].id
   }
 }
-`, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomString, index)
+`, LinuxVirtualMachineResource{}.templateWithOutProvider(data), data.RandomInteger, data.RandomString, index)
 }

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -1139,5 +1139,5 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
   object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString)
 }

--- a/internal/services/compute/windows_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_images_test.go
@@ -130,6 +130,10 @@ locals {
   vm_name = "acctvm-%[1]s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[2]d"
   location = "%[3]s"

--- a/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
@@ -690,6 +690,10 @@ locals {
   vm_name = "acctestvm%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1973,6 +1973,10 @@ func (r WindowsVirtualMachineResource) otherEdgeZone(data acceptance.TestData) s
 	data.Locations.Primary = "westus"
 
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[2]d"
   location = "%[1]s"
@@ -2342,7 +2346,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data))
+`, r.templateWithOutProvider(data))
 }
 
 func (r WindowsVirtualMachineResource) otherLicenseTypeDefault(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_test.go
@@ -32,6 +32,37 @@ func (t WindowsVirtualMachineResource) Exists(ctx context.Context, clients *clie
 
 func (WindowsVirtualMachineResource) templateBase(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  vm_name = "acctestvm%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (WindowsVirtualMachineResource) templateBaseWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
 locals {
   vm_name = "acctestvm%s"
 }
@@ -73,4 +104,22 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, r.templateBase(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) templateWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+`, r.templateBaseWithOutProvider(data), data.RandomInteger)
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_disk_os_test.go
@@ -844,5 +844,5 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
   object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString)
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_extensions_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_extensions_test.go
@@ -427,10 +427,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionBasic(data acceptance.Te
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -485,10 +481,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionForceUpdateTag(data acceptance.TestData, updateTag string) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -545,10 +537,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionMultiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -615,10 +603,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionOnlySettings(data accept
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -670,10 +654,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionUpdate(data acceptance.T
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -724,10 +704,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionsRollingUpgradeWithHealthExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -788,10 +764,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionsWithHealthExtension(dat
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                     = local.vm_name
   resource_group_name      = azurerm_resource_group.test.name
@@ -844,10 +816,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionsAutomaticUpgradeWithHealthExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                     = local.vm_name
@@ -915,10 +883,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionWithTimeBudget(data acce
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -977,10 +941,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionTimeBudgetWithoutExtensi
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -1021,10 +981,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionsAutomaticUpgradeWithServiceFabricExtension(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_service_fabric_cluster" "test" {
   name                = local.vm_name
@@ -1114,10 +1070,6 @@ func (r WindowsVirtualMachineScaleSetResource) extensionAutomaticUpgradeEnabled(
 	return fmt.Sprintf(`
 %s
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -1165,10 +1117,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionOperationsEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -1226,10 +1174,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 func (r WindowsVirtualMachineScaleSetResource) extensionOperationsDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -1367,5 +1311,5 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomString, index)
+`, r.templateWithOutProvider(data), data.RandomString, index)
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_images_test.go
@@ -601,7 +601,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), version)
+`, r.templateWithOutProvider(data), version)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) imagesRollingUpdate(data acceptance.TestData, version string) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -1373,6 +1373,10 @@ locals {
   vm_name = "%[1]s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[3]d"
   location = "%[2]s"
@@ -1517,7 +1521,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data))
+`, r.templateWithOutProvider(data))
 }
 
 func (r WindowsVirtualMachineScaleSetResource) otherEnableAutomaticUpdatesDisabled(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
@@ -37,6 +37,37 @@ func (WindowsVirtualMachineScaleSetResource) vmName(data acceptance.TestData) st
 
 func (r WindowsVirtualMachineScaleSetResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  vm_name = "%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, r.vmName(data), data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) templateWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
 locals {
   vm_name = "%s"
 }

--- a/internal/services/containers/kubernetes_cluster_auth_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_auth_resource_test.go
@@ -864,6 +864,10 @@ variable "tenant_id" {
   default = "%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -908,6 +912,10 @@ func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigOlderKube
 	return fmt.Sprintf(`
 variable "tenant_id" {
   default = "%[1]s"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -957,6 +965,10 @@ variable "tenant_id" {
   default = "%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -1002,6 +1014,10 @@ func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigScale(dat
 	return fmt.Sprintf(`
 variable "tenant_id" {
   default = "%s"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -1095,6 +1111,10 @@ func (KubernetesClusterResource) roleBasedAccessControlAzureConfig(data acceptan
 	return fmt.Sprintf(`
 variable "tenant_id" {
   default = "%s"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -2336,6 +2336,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) podCidrs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -2370,6 +2374,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) podCidrsDualStack(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -2405,6 +2413,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) serviceCidrs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -2440,6 +2452,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) serviceCidrsDualStack(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"
@@ -2962,6 +2978,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) changingLoadBalancerProfileConfigIPPrefix(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -3037,6 +3057,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) changingLoadBalancerProfileConfigManagedIPs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -3112,6 +3136,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) changingLoadBalancerProfileConfigIPIds(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -3187,6 +3215,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) unsetLoadBalancerProfileConfigIPIds(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -3778,6 +3810,10 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) httpProxyConfigWithSubnet(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1741,6 +1741,10 @@ func (KubernetesClusterResource) nodeLabelsConfig(data acceptance.TestData, labe
 	}
 	labelsStr := strings.Join(labelsSlice, "\n")
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-aks-%d"
   location = "%s"

--- a/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
+++ b/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
@@ -633,6 +633,10 @@ variable "prefix" {
   default = "acctest%s"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2034,7 +2034,9 @@ resource "azurerm_app_service_plan" "test" {
 
 func (LogicAppStandardResource) vNetIntegration_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
@@ -2115,7 +2117,9 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (LogicAppStandardResource) vNetIntegration_subnet1(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
@@ -2197,7 +2201,9 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (LogicAppStandardResource) vNetIntegration_subnet2(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -1214,6 +1214,10 @@ resource "azurerm_machine_learning_workspace" "test" {
 func (r WorkspaceResource) serverlessCompute(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_virtual_network" "test" {
@@ -1253,6 +1257,10 @@ resource "azurerm_machine_learning_workspace" "test" {
 func (r WorkspaceResource) serverlessComputeWithoutSubnet(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_virtual_network" "test" {

--- a/internal/services/maintenance/public_maintenance_configurations_data_source_test.go
+++ b/internal/services/maintenance/public_maintenance_configurations_data_source_test.go
@@ -60,6 +60,10 @@ func TestAccDataSourcePublicMaintenanceConfigurations_recurEvery(t *testing.T) {
 
 func (PublicMaintenanceConfigurationsDataSource) allFilters() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_public_maintenance_configurations" "test" {
   location    = "West Europe"
   scope       = "SQLManagedInstance"
@@ -70,6 +74,10 @@ data "azurerm_public_maintenance_configurations" "test" {
 
 func (PublicMaintenanceConfigurationsDataSource) noFilters() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_public_maintenance_configurations" "test" {
 
 }
@@ -78,6 +86,10 @@ data "azurerm_public_maintenance_configurations" "test" {
 
 func (PublicMaintenanceConfigurationsDataSource) recurEvery() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_public_maintenance_configurations" "test" {
   scope       = "SQLManagedInstance"
   recur_every = "Friday-Sunday"

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
@@ -136,6 +136,10 @@ func TestAccMonitorScheduledQueryRules_AutoMitigate(t *testing.T) {
 
 func (MonitorScheduledQueryRulesResource) AlertingActionAutoMitigate(data acceptance.TestData, ts string, autoMitigate bool) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -176,6 +180,10 @@ QUERY
 
 func (MonitorScheduledQueryRulesResource) AlertingActionQueryTypeNumber(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -219,6 +227,10 @@ QUERY
 
 func (MonitorScheduledQueryRulesResource) AlertingActionConfigBasic(data acceptance.TestData, ts string) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -266,6 +278,10 @@ QUERY
 
 func (MonitorScheduledQueryRulesResource) AlertingActionConfigUpdate(data acceptance.TestData, ts string) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -318,6 +334,10 @@ func (MonitorScheduledQueryRulesResource) AlertingActionConfigComplete(data acce
 	ts := time.Now().Format(time.RFC3339)
 
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -378,6 +398,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "test" {
 
 func (MonitorScheduledQueryRulesResource) AlertingActionCrossResourceConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"

--- a/internal/services/monitor/monitor_scheduled_query_rules_log_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_log_resource_test.go
@@ -72,6 +72,10 @@ func TestAccMonitorScheduledQueryRules_LogToMetricActionComplete(t *testing.T) {
 
 func (MonitorScheduledQueryRulesLogResource) LogToMetricActionConfigBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -106,6 +110,10 @@ resource "azurerm_monitor_scheduled_query_rules_log" "test" {
 
 func (MonitorScheduledQueryRulesLogResource) LogToMetricActionConfigUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%d"
   location = "%s"
@@ -142,6 +150,10 @@ resource "azurerm_monitor_scheduled_query_rules_log" "test" {
 
 func (MonitorScheduledQueryRulesLogResource) LogToMetricActionConfigComplete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-monitor-%[1]d"
   location = "%[2]s"

--- a/internal/services/mssql/mssql_virtual_machine_group_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_group_resource_test.go
@@ -140,6 +140,10 @@ func (MsSqlVirtualMachineGroupResource) Exists(ctx context.Context, client *clie
 
 func (MsSqlVirtualMachineGroupResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"
@@ -324,6 +328,10 @@ resource "azurerm_mssql_virtual_machine_group" "test" {
 
 func (MsSqlVirtualMachineGroupResource) tags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"
@@ -351,6 +359,10 @@ resource "azurerm_mssql_virtual_machine_group" "test" {
 
 func (MsSqlVirtualMachineGroupResource) tagsUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"

--- a/internal/services/network/network_service_tags_data_source_test.go
+++ b/internal/services/network/network_service_tags_data_source_test.go
@@ -132,52 +132,59 @@ func TestAccDataSourceAzureRMServiceTags_AzureFrontDoorFirstParty(t *testing.T) 
 	})
 }
 
-func (NetworkServiceTagsDataSource) basic() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (NetworkServiceTagsDataSource) template() string {
+	return `provider "azurerm" {
+  features {}
+}
+`
+}
+
+func (d NetworkServiceTagsDataSource) basic() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location = "westcentralus"
   service  = "AzureKeyVault"
 }`
 }
 
-func (NetworkServiceTagsDataSource) region() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) region() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location        = "westcentralus"
   service         = "AzureKeyVault"
   location_filter = "australiacentral"
 }`
 }
 
-func (NetworkServiceTagsDataSource) tagName() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) tagName() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location        = "westus2"
   service         = "Storage"
   location_filter = "westus2"
 }`
 }
 
-func (NetworkServiceTagsDataSource) azureFrontDoor() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) azureFrontDoor() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location = "northeurope"
   service  = "AzureFrontDoor"
 }`
 }
 
-func (NetworkServiceTagsDataSource) azureFrontDoorBackend() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) azureFrontDoorBackend() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location = "northeurope"
   service  = "AzureFrontDoor.Backend"
 }`
 }
 
-func (NetworkServiceTagsDataSource) azureFrontDoorFrontend() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) azureFrontDoorFrontend() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location = "northeurope"
   service  = "AzureFrontDoor.Frontend"
 }`
 }
 
-func (NetworkServiceTagsDataSource) azureFrontDoorFirstParty() string {
-	return `data "azurerm_network_service_tags" "test" {
+func (d NetworkServiceTagsDataSource) azureFrontDoorFirstParty() string {
+	return d.template() + `data "azurerm_network_service_tags" "test" {
   location = "northeurope"
   service  = "AzureFrontDoor.FirstParty"
 }`

--- a/internal/services/network/virtual_network_gateway_connection_data_source_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_data_source_test.go
@@ -81,6 +81,10 @@ variable "random" {
   default = "%d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-${var.random}"
   location = "%s"
@@ -161,6 +165,10 @@ variable "random2" {
 
 variable "shared_key" {
   default = "%s"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test_1" {
@@ -291,6 +299,10 @@ func (VirtualNetworkGatewayConnectionDataSource) ipsecPolicy(data acceptance.Tes
 	return fmt.Sprintf(`
 variable "random" {
   default = "%d"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -339,6 +339,10 @@ variable "random" {
   default = "%d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-${var.random}"
   location = "%s"
@@ -417,6 +421,10 @@ variable "random" {
   default = "%d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-${var.random}"
   location = "%s"
@@ -486,6 +494,10 @@ func (VirtualNetworkGatewayConnectionResource) expressRoute(data acceptance.Test
 	return fmt.Sprintf(`
 variable "random" {
   default = "%d"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -593,6 +605,10 @@ func (VirtualNetworkGatewayConnectionResource) expressRouteWithFastPath(data acc
 	return fmt.Sprintf(`
 variable "random" {
   default = "%d"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -717,6 +733,10 @@ resource "azurerm_virtual_network_gateway_connection" "import" {
 
 func (VirtualNetworkGatewayConnectionResource) vnetToVnet(data acceptance.TestData, rInt1 int, rInt2 int, sharedKey string) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 variable "random1" {
   default = "%d"
 }
@@ -849,6 +869,10 @@ variable "random" {
   default = "%d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-${var.random}"
   location = "%s"
@@ -935,6 +959,10 @@ variable "random" {
   default = "%d"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-${var.random}"
   location = "%s"
@@ -1017,6 +1045,10 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 
 func (VirtualNetworkGatewayConnectionResource) connectionProtocol(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 variable "random" {
   default = "%d"
 }
@@ -1105,6 +1137,10 @@ func (VirtualNetworkGatewayConnectionResource) trafficSelectorPolicy(data accept
 	return fmt.Sprintf(`
 variable "random" {
   default = "%d"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -1198,6 +1234,10 @@ func (VirtualNetworkGatewayConnectionResource) trafficSelectorPolicyMultiple(dat
 	return fmt.Sprintf(`
 variable "random" {
   default = "%d"
+}
+
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
@@ -1294,6 +1334,10 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 
 func (VirtualNetworkGatewayConnectionResource) useLocalAzureIpAddressEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -1365,6 +1409,10 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 
 func (VirtualNetworkGatewayConnectionResource) useLocalAzureIpAddressEnabledUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -1436,6 +1484,10 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 
 func (VirtualNetworkGatewayConnectionResource) useCustomBgpAddresses(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -1263,6 +1263,10 @@ resource "azurerm_virtual_network_gateway" "test" {
 
 func (VirtualNetworkGatewayResource) privateIpAddressEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -1319,6 +1323,10 @@ resource "azurerm_virtual_network_gateway" "test" {
 
 func (VirtualNetworkGatewayResource) privateIpAddressEnabledUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -1375,6 +1383,10 @@ resource "azurerm_virtual_network_gateway" "test" {
 
 func (VirtualNetworkGatewayResource) customRoute(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -1431,6 +1443,10 @@ resource "azurerm_virtual_network_gateway" "test" {
 
 func (VirtualNetworkGatewayResource) customRouteUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -302,6 +302,154 @@ func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.
 
 func (BackupProtectedVmResource) base(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-backup-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "vnet"
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest_subnet"
+  virtual_network_name = azurerm_virtual_network.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  address_prefixes     = ["10.0.10.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctest_nic"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "acctestipconfig"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-ip"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+  allocation_method   = "Dynamic"
+  domain_name_label   = "acctestip%d"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctest%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctest-datadisk"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1023"
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctestvm"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  vm_size               = "Standard_D1_v2"
+  network_interface_ids = [azurerm_network_interface.test.id]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "acctest-osdisk"
+    managed_disk_type = "Standard_LRS"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+  }
+
+  storage_data_disk {
+    name              = "acctest-datadisk"
+    managed_disk_id   = azurerm_managed_disk.test.id
+    managed_disk_type = "Standard_LRS"
+    disk_size_gb      = azurerm_managed_disk.test.disk_size_gb
+    create_option     = "Attach"
+    lun               = 0
+  }
+
+  storage_data_disk {
+    name              = "acctest-another-datadisk"
+    create_option     = "Empty"
+    disk_size_gb      = "1"
+    lun               = 1
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "acctest"
+    admin_username = "vmadmin"
+    admin_password = "Password123!@#"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  boot_diagnostics {
+    enabled     = true
+    storage_uri = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  soft_delete_enabled = false
+}
+
+resource "azurerm_backup_policy_vm" "test" {
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 10
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (BackupProtectedVmResource) baseWithOutProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d"
   location = "%s"
@@ -446,6 +594,10 @@ resource "azurerm_backup_policy_vm" "test" {
 
 func (BackupProtectedVmResource) baseWithoutVM(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d"
   location = "%s"
@@ -670,10 +822,6 @@ resource "azurerm_backup_policy_vm" "test" {
 
 func (r BackupProtectedVmResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -689,10 +837,6 @@ resource "azurerm_backup_protected_vm" "test" {
 
 func (r BackupProtectedVmResource) updateDiskExclusion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -709,6 +853,10 @@ resource "azurerm_backup_protected_vm" "test" {
 // For update backup policy id test
 func (BackupProtectedVmResource) basePolicyTest(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-backup-%d-1"
   location = "%s"
@@ -772,10 +920,6 @@ resource "azurerm_managed_disk" "test" {
 // For update backup policy id test
 func (r BackupProtectedVmResource) withBasePolicy(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_policy_vm" "test_change_backup" {
@@ -838,10 +982,6 @@ resource "azurerm_backup_protected_vm" "import" {
 
 func (r BackupProtectedVmResource) additionalVault(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_resource_group" "test2" {
@@ -930,10 +1070,6 @@ resource "azurerm_backup_protected_vm" "test" {
 
 func (r BackupProtectedVmResource) protectionStopped(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_backup_protected_vm" "test" {
@@ -959,7 +1095,7 @@ provider "azurerm" {
 }
 
 %s
-`, r.base(data))
+`, r.baseWithOutProvider(data))
 }
 
 func (r BackupProtectedVmResource) basicWithSoftDelete(data acceptance.TestData, deleted bool) string {

--- a/internal/services/servicebus/servicebus_subscription_data_source_test.go
+++ b/internal/services/servicebus/servicebus_subscription_data_source_test.go
@@ -29,6 +29,10 @@ func TestAccDataSourceServiceBusSubscription_basic(t *testing.T) {
 
 func (ServiceBusSubscriptionDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -245,6 +245,10 @@ func (t ServiceBusSubscriptionResource) Exists(ctx context.Context, clients *cli
 }
 
 const testAccServiceBusSubscription_tfTemplate = `
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -276,6 +280,10 @@ func (ServiceBusSubscriptionResource) basic(data acceptance.TestData) string {
 
 func (ServiceBusSubscriptionResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
@@ -384,6 +392,10 @@ func (ServiceBusSubscriptionResource) updateDeadLetteringOnFilterEvaluationExcep
 
 func (ServiceBusSubscriptionResource) clientScopedSubscriptionEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"

--- a/internal/services/storage/storage_account_static_website_data_plane_resource_test.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource_test.go
@@ -166,6 +166,10 @@ resource "azurerm_storage_account_static_website" "test" {
 
 func (r AccountStaticWebsiteResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-storage-%d"

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource_test.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource_test.go
@@ -122,6 +122,10 @@ resource "azurerm_storage_sync_cloud_endpoint" "import" {
 
 func (r StorageSyncCloudEndpointResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-StorageSync-%[1]d"
   location = "%[2]s"

--- a/internal/services/storage/storage_sync_resource_test.go
+++ b/internal/services/storage/storage_sync_resource_test.go
@@ -107,6 +107,10 @@ func (r StorageSyncResource) Exists(ctx context.Context, client *clients.Client,
 
 func (r StorageSyncResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-ss-%d"
   location = "%s"
@@ -138,6 +142,10 @@ resource "azurerm_storage_sync" "import" {
 
 func (r StorageSyncResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-ss-%d"
   location = "%s"

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
@@ -189,6 +189,10 @@ func (t AppServiceSlotVirtualNetworkSwiftConnectionResource) disappears(ctx cont
 
 func (AppServiceSlotVirtualNetworkSwiftConnectionResource) app_base(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-appservice-%d"
   location = "%s"
@@ -302,6 +306,10 @@ resource "azurerm_app_service_slot_virtual_network_swift_connection" "import" {
 
 func (AppServiceSlotVirtualNetworkSwiftConnectionResource) function_base(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-functionapp-%d"
   location = "%s"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to add back the missing provider config for the acctests, which is now required as a result of the PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/27936.

This PR is constructed via the following procedures:

- I've forked and modified the terraform-plugin-testing, to make it only write out configurations to a output directory in the form of:

```
.
├── TestAccAadB2cDirectoryDataSource_basic
│   └── 0
│       └── terraform_plugin_test.tf
├── TestAccAadB2cDirectoryResource_basic
│   └── 0
│       └── terraform_plugin_test.tf
├── TestAccAadB2cDirectoryResource_domainNameUnavailable
│   └── 0
│       └── terraform_plugin_test.tf
├── TestAccAadB2cDirectoryResource_requiresImport
│   └── 0
│       └── terraform_plugin_test.tf
├── TestAccAadB2cDirectoryResource_update
│   ├── 0
│   │   └── terraform_plugin_test.tf
│   ├── 3
│   │   └── terraform_plugin_test.tf
│   └── 6
│       └── terraform_plugin_test.tf
...
```

Note that the following test case and steps are _not_ exported:
- The test case is ignored due to some environment variables are not set, or some other reasons. As these test cases are manually triggerd, should be fine to leave them as is.
- The import step (and the corresponding refresh step). Since these steps not have valid config at all.

(The branch is at: https://github.com/magodo/terraform-plugin-testing/tree/config_print)

I then replace the module with my fork above, `go mod tidy && go mod vendor`, then run the command below:

```
$ TF_OUTDIR=/tmp/test TF_ACC=1 go test -v -timeout=20h -run=. ./internal/services/*
```

This exports the test cases/steps into */tmp/test* with above folder structure, where each file represents the effective config for each test step.

Next thing is to run `grep` (too lazy to write a HCL parsing tool for this case) in the */tmp/test* folder:

1. `grep -rL "provider .*azurerm.* {" .`: This returns the ones that has no provider config defined at all.
2. `grep -r "provider .*azurerm.* {" . | awk -F: '{count[$1]++} END {for (file in count) print file, count[file]}' | awk '$2 != 1'`: This returns the ones have provider config defined multiple times

With the change of this PR, there is no entry for the 1st case. For the 2nd case, I get the followings:

- ./TestAccDataSourceNetAppVolume_basic/0/terraform_plugin_test.tf 2
- ./TestAccDataSourceNetAppVolume_backupPolicy/0/terraform_plugin_test.tf 2
- ./TestAccStorageAccountCustomerManagedKey_remoteKeyVault/0/terraform_plugin_test.tf 2
- ./TestAccStorageAccount_customerManagedKeyRemoteKeyVault/0/terraform_plugin_test.tf 2
- ./TestAccNetAppVolume_volEncryptionCmkSystemAssigned/0/terraform_plugin_test.tf 2
- ./TestAccNetAppVolume_volEncryptionCmkUserAssigned/0/terraform_plugin_test.tf 2

The `TestAccDataSourceNetAppVolume` and `TestAccStorageAccountCustomerManagedKey` ones are due to there is the `azurerm-alt` provider defined. While the `TestAccNetAppVolume` ones are existing errors, introduced in https://github.com/hashicorp/terraform-provider-azurerm/pull/27188 (TC: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETAPP/266596?buildTab=tests&status=failed), and I'd rather leave them untouched.

Finally, I created a root main.tf, and reference all the folders as submodules. With some reasonable modifications, the `terraform init` succeeded, which at least proves there is no duplicate provider configurations. To ensure each one has the valid provider configuration, things become challenging, as some of the existing configurations themselves are problematic. I don't know the exact number of them (there are >10000 modules). Up to this point, it should be good to go/test for a couple of big RPs.

Regarding the fixes, I'd like to mention the principle I've been following:
- Add the provider config at the base/template ones
- Sometimes, the base/template is injected to a function, which has the provider config defined already. In this case, I'll duplicate the base/template (transitively) with the name `WithOutProvider`, and remove the provider config inside the original base/template. Then use this new variation function instead
 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
