### PR TITLE
`azurerm_storage_share` - Fix a bug that using `storage_account_id` accidentally leaks to the wrong branch for creation

### DIFF
--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -196,7 +196,11 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if model := share.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("quota", props.ShareQuota)
-			d.Set("acl", flattenStorageShareACLs(pointer.From(props.SignedIdentifiers)))
+			acl, err := flattenStorageShareACLs(pointer.From(props.SignedIdentifiers))
+			if err != nil {
+				return err
+			}
+			d.Set("acl", acl)
 			d.Set("metadata", FlattenMetaData(pointer.From(props.Metadata)))
 		}
 	}

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -660,8 +660,8 @@ resource "azurerm_storage_share" "test" {
 
     access_policy {
       permissions = "rwd"
-      start       = "2019-07-02T09:38:21Z"
-      expiry      = "2019-07-02T10:38:21Z"
+      start       = "2019-07-02T09:38:21.0000000Z"
+      expiry      = "2019-07-02T10:38:21.0000000Z"
     }
   }
 
@@ -781,8 +781,8 @@ resource "azurerm_storage_share" "test" {
 
     access_policy {
       permissions = "rwd"
-      start       = "2019-07-02T09:38:21Z"
-      expiry      = "2019-07-02T10:38:21Z"
+      start       = "2019-07-02T09:38:21.0000000Z"
+      expiry      = "2019-07-02T10:38:21.0000000Z"
     }
   }
 }
@@ -876,8 +876,8 @@ resource "azurerm_storage_share" "test" {
 
     access_policy {
       permissions = "rwd"
-      start       = "2019-07-02T09:38:21Z"
-      expiry      = "2019-07-02T10:38:21Z"
+      start       = "2019-07-02T09:38:21.0000000Z"
+      expiry      = "2019-07-02T10:38:21.0000000Z"
     }
   }
   acl {
@@ -885,8 +885,8 @@ resource "azurerm_storage_share" "test" {
 
     access_policy {
       permissions = "rwd"
-      start       = "2019-07-02T09:38:21Z"
-      expiry      = "2019-07-02T10:38:21Z"
+      start       = "2019-07-02T09:38:21.0000000Z"
+      expiry      = "2019-07-02T10:38:21.0000000Z"
     }
   }
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

With the introduction of `storage_account_id` on the `azurerm_storage_share` in https://github.com/hashicorp/terraform-provider-azurerm/pull/27733, there is one bug in the creation code, that if users specify the new `storage_account_id` property (with `storage_account_name` omitted, as they are in conflict), the logic _leaks_ to the v5 part, which is causing issues like https://github.com/hashicorp/terraform-provider-azurerm/issues/28032.

This PR fixes that part by:

- Removing the `storage_account_name` check, but infer the account name from the id if `storage_account_id` is used
- Mark the `storage_account_[id|name]` as Computed, per the breaking change guideline
- Removing the confusing/likely redundent check: `&& !strings.HasPrefix(d.Id(), "/subscriptions/")`

Additionally, I've reverted the changes on the acctest config, for the acl timestamp format, for the compatibility purpose. Note that the format is different between data plane and mgmt plane APIs. Meanwhile, I've modified the `flattenStorageShareACLs` to convert the timestamp format back to the data plane version.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<details>
<summary>Without v5 toggle</summary>
<pre>
$ TF_ACC=1 go test -v -timeout=20h -run=TestAccStorageShare_ ./internal/services/storage
=== RUN   TestAccStorageShare_basicDeprecated
=== PAUSE TestAccStorageShare_basicDeprecated
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== RUN   TestAccStorageShare_complete
=== PAUSE TestAccStorageShare_complete
=== RUN   TestAccStorageShare_requiresImportDeprecated
=== PAUSE TestAccStorageShare_requiresImportDeprecated
=== RUN   TestAccStorageShare_requiresImport
=== PAUSE TestAccStorageShare_requiresImport
=== RUN   TestAccStorageShare_disappearsDeprecated
=== PAUSE TestAccStorageShare_disappearsDeprecated
=== RUN   TestAccStorageShare_deleteAndRecreateDeprecated
=== PAUSE TestAccStorageShare_deleteAndRecreateDeprecated
=== RUN   TestAccStorageShare_metaDataDeprecated
=== PAUSE TestAccStorageShare_metaDataDeprecated
=== RUN   TestAccStorageShare_metaData
=== PAUSE TestAccStorageShare_metaData
=== RUN   TestAccStorageShare_aclDeprecated
=== PAUSE TestAccStorageShare_aclDeprecated
=== RUN   TestAccStorageShare_acl
=== PAUSE TestAccStorageShare_acl
=== RUN   TestAccStorageShare_aclGhostedRecallDeprecated
=== PAUSE TestAccStorageShare_aclGhostedRecallDeprecated
=== RUN   TestAccStorageShare_aclGhostedRecall
=== PAUSE TestAccStorageShare_aclGhostedRecall
=== RUN   TestAccStorageShare_updateQuotaDeprecated
=== PAUSE TestAccStorageShare_updateQuotaDeprecated
=== RUN   TestAccStorageShare_updateQuota
=== PAUSE TestAccStorageShare_updateQuota
=== RUN   TestAccStorageShare_largeQuotaDeprecated
=== PAUSE TestAccStorageShare_largeQuotaDeprecated
=== RUN   TestAccStorageShare_largeQuota
=== PAUSE TestAccStorageShare_largeQuota
=== RUN   TestAccStorageShare_accessTierStandardDeprecated
=== PAUSE TestAccStorageShare_accessTierStandardDeprecated
=== RUN   TestAccStorageShare_accessTierStandard
=== PAUSE TestAccStorageShare_accessTierStandard
=== RUN   TestAccStorageShare_accessTierPremiumDeprecated
=== PAUSE TestAccStorageShare_accessTierPremiumDeprecated
=== RUN   TestAccStorageShare_accessTierPremium
=== PAUSE TestAccStorageShare_accessTierPremium
=== RUN   TestAccStorageShare_nfsProtocolDeprecated
=== PAUSE TestAccStorageShare_nfsProtocolDeprecated
=== RUN   TestAccStorageShare_nfsProtocol
=== PAUSE TestAccStorageShare_nfsProtocol
=== RUN   TestAccStorageShare_protocolUpdateDeprecated
=== PAUSE TestAccStorageShare_protocolUpdateDeprecated
=== RUN   TestAccStorageShare_protocolUpdate
=== PAUSE TestAccStorageShare_protocolUpdate
=== CONT  TestAccStorageShare_basicDeprecated
=== CONT  TestAccStorageShare_protocolUpdateDeprecated
=== CONT  TestAccStorageShare_aclGhostedRecall
=== CONT  TestAccStorageShare_acl
=== CONT  TestAccStorageShare_metaData
=== CONT  TestAccStorageShare_aclDeprecated
=== CONT  TestAccStorageShare_accessTierStandardDeprecated
=== CONT  TestAccStorageShare_deleteAndRecreateDeprecated
=== CONT  TestAccStorageShare_disappearsDeprecated
=== CONT  TestAccStorageShare_requiresImport
=== CONT  TestAccStorageShare_requiresImportDeprecated
=== CONT  TestAccStorageShare_complete
=== CONT  TestAccStorageShare_basic
=== CONT  TestAccStorageShare_metaDataDeprecated
=== CONT  TestAccStorageShare_updateQuota
=== CONT  TestAccStorageShare_protocolUpdate
--- PASS: TestAccStorageShare_disappearsDeprecated (145.53s)
=== CONT  TestAccStorageShare_largeQuota
--- PASS: TestAccStorageShare_requiresImport (217.11s)
=== CONT  TestAccStorageShare_largeQuotaDeprecated
--- PASS: TestAccStorageShare_requiresImportDeprecated (218.71s)
=== CONT  TestAccStorageShare_updateQuotaDeprecated
--- PASS: TestAccStorageShare_updateQuota (240.98s)
=== CONT  TestAccStorageShare_accessTierPremium
--- PASS: TestAccStorageShare_basicDeprecated (242.37s)
=== CONT  TestAccStorageShare_nfsProtocol
--- PASS: TestAccStorageShare_basic (244.21s)
=== CONT  TestAccStorageShare_nfsProtocolDeprecated
--- PASS: TestAccStorageShare_protocolUpdate (245.54s)
=== CONT  TestAccStorageShare_accessTierPremiumDeprecated
--- PASS: TestAccStorageShare_protocolUpdateDeprecated (246.55s)
=== CONT  TestAccStorageShare_accessTierStandard
--- PASS: TestAccStorageShare_aclGhostedRecall (247.91s)
=== CONT  TestAccStorageShare_aclGhostedRecallDeprecated
--- PASS: TestAccStorageShare_complete (255.45s)
--- PASS: TestAccStorageShare_metaDataDeprecated (276.71s)
--- PASS: TestAccStorageShare_largeQuota (156.07s)
--- PASS: TestAccStorageShare_metaData (305.02s)
--- PASS: TestAccStorageShare_aclDeprecated (306.36s)
--- PASS: TestAccStorageShare_accessTierStandardDeprecated (317.48s)
--- PASS: TestAccStorageShare_deleteAndRecreateDeprecated (322.63s)
--- PASS: TestAccStorageShare_accessTierPremium (122.25s)
--- PASS: TestAccStorageShare_nfsProtocol (122.26s)
--- PASS: TestAccStorageShare_nfsProtocolDeprecated (122.13s)
--- PASS: TestAccStorageShare_accessTierPremiumDeprecated (122.42s)
--- PASS: TestAccStorageShare_largeQuotaDeprecated (152.35s)
--- PASS: TestAccStorageShare_updateQuotaDeprecated (163.19s)
--- PASS: TestAccStorageShare_acl (404.99s)
--- PASS: TestAccStorageShare_aclGhostedRecallDeprecated (163.45s)
--- PASS: TestAccStorageShare_accessTierStandard (237.37s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       483.953s
</pre>
</details>

<details>
<summary>With v5 toggle</summary>
<pre>
$ ARM_FIVEPOINTZERO_BETA=true TF_ACC=1 go test -v -timeout=20h -run=TestAccStorageShare_ ./internal/services/storage
=== RUN   TestAccStorageShare_basicDeprecated
    storage_share_resource_test.go:26: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_basicDeprecated (0.00s)
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== RUN   TestAccStorageShare_complete
=== PAUSE TestAccStorageShare_complete
=== RUN   TestAccStorageShare_requiresImportDeprecated
    storage_share_resource_test.go:75: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_requiresImportDeprecated (0.00s)
=== RUN   TestAccStorageShare_requiresImport
=== PAUSE TestAccStorageShare_requiresImport
=== RUN   TestAccStorageShare_disappearsDeprecated
    storage_share_resource_test.go:109: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_disappearsDeprecated (0.00s)
=== RUN   TestAccStorageShare_deleteAndRecreateDeprecated
    storage_share_resource_test.go:124: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_deleteAndRecreateDeprecated (0.00s)
=== RUN   TestAccStorageShare_metaDataDeprecated
    storage_share_resource_test.go:153: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_metaDataDeprecated (0.00s)
=== RUN   TestAccStorageShare_metaData
=== PAUSE TestAccStorageShare_metaData
=== RUN   TestAccStorageShare_aclDeprecated
    storage_share_resource_test.go:201: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_aclDeprecated (0.00s)
=== RUN   TestAccStorageShare_acl
=== PAUSE TestAccStorageShare_acl
=== RUN   TestAccStorageShare_aclGhostedRecallDeprecated
    storage_share_resource_test.go:263: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_aclGhostedRecallDeprecated (0.00s)
=== RUN   TestAccStorageShare_aclGhostedRecall
=== PAUSE TestAccStorageShare_aclGhostedRecall
=== RUN   TestAccStorageShare_updateQuotaDeprecated
    storage_share_resource_test.go:297: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_updateQuotaDeprecated (0.00s)
=== RUN   TestAccStorageShare_updateQuota
=== PAUSE TestAccStorageShare_updateQuota
=== RUN   TestAccStorageShare_largeQuotaDeprecated
    storage_share_resource_test.go:343: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_largeQuotaDeprecated (0.00s)
=== RUN   TestAccStorageShare_largeQuota
=== PAUSE TestAccStorageShare_largeQuota
=== RUN   TestAccStorageShare_accessTierStandardDeprecated
    storage_share_resource_test.go:391: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_accessTierStandardDeprecated (0.00s)
=== RUN   TestAccStorageShare_accessTierStandard
=== PAUSE TestAccStorageShare_accessTierStandard
=== RUN   TestAccStorageShare_accessTierPremiumDeprecated
    storage_share_resource_test.go:439: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_accessTierPremiumDeprecated (0.00s)
=== RUN   TestAccStorageShare_accessTierPremium
=== PAUSE TestAccStorageShare_accessTierPremium
=== RUN   TestAccStorageShare_nfsProtocolDeprecated
    storage_share_resource_test.go:473: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_nfsProtocolDeprecated (0.00s)
=== RUN   TestAccStorageShare_nfsProtocol
=== PAUSE TestAccStorageShare_nfsProtocol
=== RUN   TestAccStorageShare_protocolUpdateDeprecated
    storage_share_resource_test.go:508: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_protocolUpdateDeprecated (0.00s)
=== RUN   TestAccStorageShare_protocolUpdate
=== PAUSE TestAccStorageShare_protocolUpdate
=== CONT  TestAccStorageShare_accessTierStandard
=== CONT  TestAccStorageShare_basic
=== CONT  TestAccStorageShare_largeQuota
=== CONT  TestAccStorageShare_nfsProtocol
=== CONT  TestAccStorageShare_accessTierPremium
=== CONT  TestAccStorageShare_metaData
=== CONT  TestAccStorageShare_aclGhostedRecall
=== CONT  TestAccStorageShare_requiresImport
=== CONT  TestAccStorageShare_complete
=== CONT  TestAccStorageShare_protocolUpdate
=== CONT  TestAccStorageShare_acl
=== CONT  TestAccStorageShare_updateQuota
--- PASS: TestAccStorageShare_requiresImport (104.31s)
--- PASS: TestAccStorageShare_basic (105.14s)
--- PASS: TestAccStorageShare_aclGhostedRecall (105.25s)
--- PASS: TestAccStorageShare_nfsProtocol (105.77s)
--- PASS: TestAccStorageShare_accessTierPremium (105.82s)
--- PASS: TestAccStorageShare_complete (106.34s)
--- PASS: TestAccStorageShare_updateQuota (109.27s)
--- PASS: TestAccStorageShare_metaData (130.78s)
--- PASS: TestAccStorageShare_accessTierStandard (133.63s)
--- PASS: TestAccStorageShare_largeQuota (134.36s)
--- PASS: TestAccStorageShare_protocolUpdate (233.51s)
--- PASS: TestAccStorageShare_acl (260.46s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       260.500s

</pre>
</details>


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share` - Fix a bug that using `storage_account_id` accidentally leaks to the wrong branch for creation [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28032


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
