### PR TITLE
`azurerm_batch_pool` - support for new block `security_profile`

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -791,11 +791,44 @@ func expandBatchPoolVirtualMachineConfig(d *pluginsdk.ResourceData) (*pool.Virtu
 		result.OsDisk = expandBatchPoolOSDisk(v)
 	}
 
+	if v, ok := d.GetOk("security_profile"); ok {
+		result.SecurityProfile = expandBatchPoolSecurityProfile(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("windows"); ok {
 		result.WindowsConfiguration = expandBatchPoolWindowsConfiguration(v.([]interface{}))
 	}
 
 	return &result, nil
+}
+
+func expandBatchPoolSecurityProfile(profile []interface{}) *pool.SecurityProfile {
+	if len(profile) == 0 {
+		return nil
+	}
+
+	item := profile[0].(map[string]interface{})
+	securityProfile := &pool.SecurityProfile{
+		UefiSettings: &pool.UefiSettings{},
+	}
+
+	if v, ok := item["host_encryption_enabled"]; ok {
+		securityProfile.EncryptionAtHost = pointer.FromBool(v.(bool))
+	}
+
+	if v, ok := item["security_type"]; ok {
+		securityProfile.SecurityType = pointer.To(pool.SecurityTypes(v.(string)))
+	}
+
+	if v, ok := item["secure_boot_enabled"]; ok {
+		securityProfile.UefiSettings.SecureBootEnabled = pointer.FromBool(v.(bool))
+	}
+
+	if v, ok := item["vtpm_enabled"]; ok {
+		securityProfile.UefiSettings.VTpmEnabled = pointer.FromBool(v.(bool))
+	}
+
+	return securityProfile
 }
 
 func expandBatchPoolOSDisk(ref interface{}) *pool.OSDisk {

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -411,6 +411,31 @@ func flattenBatchPoolIdentityReferenceToIdentityID(ref *pool.ComputeNodeIdentity
 	return ""
 }
 
+func flattenBatchPoolSecurityProfile(configProfile *pool.SecurityProfile) []interface{} {
+	securityProfile := make([]interface{}, 0)
+	securityConfig := make(map[string]interface{})
+
+	if configProfile.EncryptionAtHost != nil {
+		securityConfig["host_encryption_enabled"] = *configProfile.EncryptionAtHost
+	}
+
+	if configProfile.SecurityType != nil {
+		securityConfig["security_type"] = string(*configProfile.SecurityType)
+	}
+
+	if configProfile.UefiSettings != nil {
+		if configProfile.UefiSettings.SecureBootEnabled != nil {
+			securityConfig["secure_boot_enabled"] = pointer.ToBool(configProfile.UefiSettings.SecureBootEnabled)
+		}
+		if configProfile.UefiSettings.VTpmEnabled != nil {
+			securityConfig["vtpm_enabled"] = pointer.ToBool(configProfile.UefiSettings.VTpmEnabled)
+		}
+	}
+
+	securityProfile = append(securityProfile, securityConfig)
+	return securityProfile
+}
+
 func flattenBatchPoolUserAccount(d *pluginsdk.ResourceData, account *pool.UserAccount) map[string]interface{} {
 	userAccount := make(map[string]interface{})
 	userAccount["name"] = account.Name

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -415,21 +415,12 @@ func flattenBatchPoolSecurityProfile(configProfile *pool.SecurityProfile) []inte
 	securityProfile := make([]interface{}, 0)
 	securityConfig := make(map[string]interface{})
 
-	if configProfile.EncryptionAtHost != nil {
-		securityConfig["host_encryption_enabled"] = *configProfile.EncryptionAtHost
-	}
-
-	if configProfile.SecurityType != nil {
-		securityConfig["security_type"] = string(*configProfile.SecurityType)
-	}
+	securityConfig["host_encryption_enabled"] = pointer.From(configProfile.EncryptionAtHost)
+	securityConfig["security_type"] = string(pointer.From(configProfile.SecurityType))
 
 	if configProfile.UefiSettings != nil {
-		if configProfile.UefiSettings.SecureBootEnabled != nil {
-			securityConfig["secure_boot_enabled"] = pointer.ToBool(configProfile.UefiSettings.SecureBootEnabled)
-		}
-		if configProfile.UefiSettings.VTpmEnabled != nil {
-			securityConfig["vtpm_enabled"] = pointer.ToBool(configProfile.UefiSettings.VTpmEnabled)
-		}
+		securityConfig["secure_boot_enabled"] = pointer.From(configProfile.UefiSettings.SecureBootEnabled)
+		securityConfig["vtpm_enabled"] = pointer.From(configProfile.UefiSettings.VTpmEnabled)
 	}
 
 	securityProfile = append(securityProfile, securityConfig)
@@ -838,7 +829,7 @@ func expandBatchPoolSecurityProfile(profile []interface{}) *pool.SecurityProfile
 	}
 
 	if v, ok := item["host_encryption_enabled"]; ok {
-		securityProfile.EncryptionAtHost = pointer.FromBool(v.(bool))
+		securityProfile.EncryptionAtHost = pointer.To(v.(bool))
 	}
 
 	if v, ok := item["security_type"]; ok {
@@ -846,11 +837,11 @@ func expandBatchPoolSecurityProfile(profile []interface{}) *pool.SecurityProfile
 	}
 
 	if v, ok := item["secure_boot_enabled"]; ok {
-		securityProfile.UefiSettings.SecureBootEnabled = pointer.FromBool(v.(bool))
+		securityProfile.UefiSettings.SecureBootEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := item["vtpm_enabled"]; ok {
-		securityProfile.UefiSettings.VTpmEnabled = pointer.FromBool(v.(bool))
+		securityProfile.UefiSettings.VTpmEnabled = pointer.To(v.(bool))
 	}
 
 	return securityProfile

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -727,6 +727,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 			"security_profile": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -1275,25 +1276,17 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 						nodePlacementConfiguration = append(nodePlacementConfiguration, nodePlacementConfig)
 						d.Set("node_placement", nodePlacementConfiguration)
 					}
+
 					osDiskPlacement := ""
 					if config.OsDisk != nil && config.OsDisk.EphemeralOSDiskSettings != nil && config.OsDisk.EphemeralOSDiskSettings.Placement != nil {
 						osDiskPlacement = string(*config.OsDisk.EphemeralOSDiskSettings.Placement)
 					}
 					d.Set("os_disk_placement", osDiskPlacement)
+
 					if config.SecurityProfile != nil {
-						securityProfile := make([]interface{}, 0)
-						securityConfig := make(map[string]interface{})
-						securityConfig["host_encryption_enabled"] = pointer.ToBool(config.SecurityProfile.EncryptionAtHost)
-						if config.SecurityProfile.SecurityType != nil {
-							securityConfig["security_type"] = string(*config.SecurityProfile.SecurityType)
-						}
-						if config.SecurityProfile.UefiSettings != nil {
-							securityConfig["secure_boot_enabled"] = pointer.ToBool(config.SecurityProfile.UefiSettings.SecureBootEnabled)
-							securityConfig["vtpm_enabled"] = pointer.ToBool(config.SecurityProfile.UefiSettings.VTpmEnabled)
-						}
-						securityProfile = append(securityProfile, securityConfig)
-						d.Set("security_profile", securityProfile)
+						d.Set("security_profile", flattenBatchPoolSecurityProfile(config.SecurityProfile))
 					}
+
 					if config.WindowsConfiguration != nil {
 						windowsConfig := []interface{}{
 							map[string]interface{}{

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -733,21 +733,25 @@ func resourceBatchPool() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"host_encryption_enabled": {
 							Type:     pluginsdk.TypeBool,
+							ForceNew: true,
 							Optional: true,
 						},
 						"security_type": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(pool.PossibleValuesForSecurityTypes(), false),
 						},
 						"secure_boot_enabled": {
 							Type:         pluginsdk.TypeBool,
 							Optional:     true,
+							ForceNew:     true,
 							RequiredWith: []string{"security_profile.0.security_type"},
 						},
 						"vtpm_enabled": {
 							Type:         pluginsdk.TypeBool,
 							Optional:     true,
+							ForceNew:     true,
 							RequiredWith: []string{"security_profile.0.security_type"},
 						},
 					},

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -2677,12 +2677,12 @@ func (BatchPoolResource) securityProfileWithUEFISettings(data acceptance.TestDat
 	return fmt.Sprintf(`
 %s
 resource "azurerm_batch_account" "test" {
-  name                = "testaccbatch%s"
+  name                = "acctestbatch%s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 resource "azurerm_batch_pool" "test" {
-  name                = "testaccpool%s"
+  name                = "acctestpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
   node_agent_sku_id   = "batch.node.ubuntu 22.04"

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -2692,7 +2692,7 @@ resource "azurerm_batch_pool" "test" {
   }
   security_profile {
     host_encryption_enabled = false
-    security_type		   = "trustedLaunch"
+    security_type           = "trustedLaunch"
     secure_boot_enabled     = true
     vtpm_enabled            = false
   }

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -740,6 +740,24 @@ func TestAccBatchPool_interNodeCommunicationWithTaskSchedulingPolicy(t *testing.
 	})
 }
 
+func TestAccBatchPool_securityProfileWithUEFISettings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.securityProfileWithUEFISettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("security_profile.0.host_encryption_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("security_profile.0.security_type").HasValue("trustedLaunch"),
+				check.That(data.ResourceName).Key("security_profile.0.secure_boot_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("security_profile.0.vtpm_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep("stop_pending_resize_operation"),
+	})
+}
+
 func TestAccBatchPool_linuxUserAccounts(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 	r := BatchPoolResource{}
@@ -2652,4 +2670,38 @@ resource "azurerm_subnet_network_security_group_association" "test" {
   network_security_group_id = azurerm_network_security_group.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) securityProfileWithUEFISettings(data acceptance.TestData) string {
+	template := BatchPoolResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 22.04"
+  vm_size             = "Standard_A1"
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+  security_profile {
+    host_encryption_enabled = false
+    security_type		   = "trustedLaunch"
+    secure_boot_enabled     = true
+    vtpm_enabled            = false
+  }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+`, template, data.RandomString, data.RandomString)
 }

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -165,6 +165,8 @@ The following arguments are supported:
 
 * `os_disk_placement` - (Optional) Specifies the ephemeral disk placement for operating system disk for all VMs in the pool. This property can be used by user in the request to choose which location the operating system should be in. e.g., cache disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer to Ephemeral OS disk size requirements for Windows VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements> and Linux VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements>. The only possible value is `CacheDisk`.
 
+* `security_profile` - (Optional) A `security_profile` block that describes the security settings for the Batch pool as defined below.
+
 * `target_node_communication_mode` - (Optional) The desired node communication mode for the pool. Possible values are `Classic`, `Default` and `Simplified`.
 
 * `task_scheduling_policy` - (Optional) A `task_scheduling_policy` block that describes how tasks are distributed across compute nodes in a pool as defined below. If not specified, the default is spread as defined below.
@@ -501,6 +503,19 @@ A `network_security_group_rules` block supports the following:
 A `task_scheduling_policy` block supports the following:
 
 * `node_fill_type` - (Optional) Supported values are "Pack" and "Spread". "Pack" means as many tasks as possible (taskSlotsPerNode) should be assigned to each node in the pool before any tasks are assigned to the next node in the pool. "Spread" means that tasks should be assigned evenly across all nodes in the pool.
+
+---
+A `security_profile` block supports the following:
+
+* `host_encryption_enabled` - (Optional) Whether to enable host encryption for the virtual machine or virtual machine scale set. This will enable the encryption for all the disks including Resource/Temp disk at host itself. Possible values are `true` and `false`.
+
+* `security_type` - (Optional) The security type of the virtual machine. Possible values are `confidentialVM` and `trustedLaunch`.
+
+* `secure_boot_enabled` - (Optional) Whether to enable secure boot for the virtual machine or virtual machine scale set. Possible values are `true` and `false`.
+
+* `vtpm_enabled` - (Optional) Whether to enable virtual trusted platform module (vTPM) for the virtual machine or virtual machine scale set. Possible values are `true` and `false`.
+
+~> **NOTE:** `security_type` must be specified to set UEFI related properties including `secure_boot_enabled` and `vtpm_enabled`.
 
 ---
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -507,13 +507,15 @@ A `task_scheduling_policy` block supports the following:
 ---
 A `security_profile` block supports the following:
 
-* `host_encryption_enabled` - (Optional) Whether to enable host encryption for the Virtual Machine or Virtual Machine Scale Set. This will enable the encryption for all the disks including Resource/Temp disk at host itself. Possible values are `true` and `false`.
+* `host_encryption_enabled` - (Optional) Whether to enable host encryption for the Virtual Machine or Virtual Machine Scale Set. This will enable the encryption for all the disks including Resource/Temp disk at host itself. Possible values are `true` and `false`. Changing this forces a new resource to be created.
 
-* `security_type` - (Optional) The security type of the Virtual Machine. Possible values are `confidentialVM` and `trustedLaunch`.
+* `security_type` - (Optional) The security type of the Virtual Machine. Possible values are `confidentialVM` and `trustedLaunch`. Changing this forces a new resource to be created.
 
-* `secure_boot_enabled` - (Optional) Whether to enable secure boot for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`.
+* `secure_boot_enabled` - (Optional) Whether to enable secure boot for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`. Changing this forces a new resource to be created.
 
-* `vtpm_enabled` - (Optional) Whether to enable virtual trusted platform module (vTPM) for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`.
+* `vtpm_enabled` - (Optional) Whether to enable virtual trusted platform module (vTPM) for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`. Changing this forces a new resource to be created.
+
+~> **NOTE:** `security_profile` block can only be specified during creation and does not support updates.
 
 ~> **NOTE:** `security_type` must be specified to set UEFI related properties including `secure_boot_enabled` and `vtpm_enabled`.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -507,13 +507,13 @@ A `task_scheduling_policy` block supports the following:
 ---
 A `security_profile` block supports the following:
 
-* `host_encryption_enabled` - (Optional) Whether to enable host encryption for the virtual machine or virtual machine scale set. This will enable the encryption for all the disks including Resource/Temp disk at host itself. Possible values are `true` and `false`.
+* `host_encryption_enabled` - (Optional) Whether to enable host encryption for the Virtual Machine or Virtual Machine Scale Set. This will enable the encryption for all the disks including Resource/Temp disk at host itself. Possible values are `true` and `false`.
 
-* `security_type` - (Optional) The security type of the virtual machine. Possible values are `confidentialVM` and `trustedLaunch`.
+* `security_type` - (Optional) The security type of the Virtual Machine. Possible values are `confidentialVM` and `trustedLaunch`.
 
-* `secure_boot_enabled` - (Optional) Whether to enable secure boot for the virtual machine or virtual machine scale set. Possible values are `true` and `false`.
+* `secure_boot_enabled` - (Optional) Whether to enable secure boot for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`.
 
-* `vtpm_enabled` - (Optional) Whether to enable virtual trusted platform module (vTPM) for the virtual machine or virtual machine scale set. Possible values are `true` and `false`.
+* `vtpm_enabled` - (Optional) Whether to enable virtual trusted platform module (vTPM) for the Virtual Machine or Virtual Machine Scale Set. Possible values are `true` and `false`.
 
 ~> **NOTE:** `security_type` must be specified to set UEFI related properties including `secure_boot_enabled` and `vtpm_enabled`.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -165,7 +165,7 @@ The following arguments are supported:
 
 * `os_disk_placement` - (Optional) Specifies the ephemeral disk placement for operating system disk for all VMs in the pool. This property can be used by user in the request to choose which location the operating system should be in. e.g., cache disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer to Ephemeral OS disk size requirements for Windows VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements> and Linux VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements>. The only possible value is `CacheDisk`.
 
-* `security_profile` - (Optional) A `security_profile` block that describes the security settings for the Batch pool as defined below.
+* `security_profile` - (Optional) A `security_profile` block that describes the security settings for the Batch pool as defined below. Changing this forces a new resource to be created.
 
 * `target_node_communication_mode` - (Optional) The desired node communication mode for the pool. Possible values are `Classic`, `Default` and `Simplified`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
For resource `azurerm_batch_pool` 
- support new block `security_profile`
- add documentation for `security_profile`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.



## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![image](https://github.com/user-attachments/assets/4fe47028-a5ed-473d-bfe5-cbc273834a47)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_batch_pool` - support for new block `security_profile` [GH-28069]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27952
