### PR TITLE
[Enhance] -`azurerm_machine_learning_datastore_datalake_gen2` - Support crosse sub storage account

### DIFF
--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
@@ -51,8 +51,8 @@ func TestAccMachineLearningDataStoreDataLakeGen2_spn(t *testing.T) {
 }
 
 func TestAccMachineLearningDataStoreDataLakeGen2_crossSubStorageAccount(t *testing.T) {
-	if os.Getenv("ARM_TEST_ACC_DATASTORE_GEN2_CROSS_SUB_SA_CONTAINER") == "" {
-		t.Skip("ARM_TEST_ACC_DATASTORE_GEN2_CROSS_SUB_SA_CONTAINER not set")
+	if os.Getenv("ARM_SUBSCRIPTION_ID_ALT") == "" {
+		t.Skip("ARM_SUBSCRIPTION_ID_ALT not set")
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_machine_learning_datastore_datalake_gen2", "test")
@@ -193,11 +193,45 @@ resource "azurerm_machine_learning_datastore_datalake_gen2" "test" {
   storage_container_id = azurerm_storage_container.test.resource_manager_id
 }
 
+provider "azurerm-alt" {
+  subscription_id = "%[3]s"
+
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "testalt" {
+  provider = azurerm-alt
+  name     = "acctestRG-alt-%[2]d"
+  location = "%[4]s"
+}
+
+resource "azurerm_storage_account" "testalt" {
+  provider                 = azurerm-alt
+  name                     = "acctestsaalt%[5]d"
+  location                 = azurerm_resource_group.testalt.location
+  resource_group_name      = azurerm_resource_group.testalt.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "testalt" {
+  provider              = azurerm-alt
+  name                  = "acctestcontaineralt%[5]d"
+  storage_account_name  = azurerm_storage_account.testalt.name
+  container_access_type = "private"
+}
+
 resource "azurerm_machine_learning_datastore_datalake_gen2" "crosssub" {
-  name                 = "accdcrosssub%[2]d"
+  name                 = "accdcrosssub%[5]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = "%[3]s"
-}`, template, data.RandomInteger, os.Getenv("ARM_TEST_ACC_DATASTORE_GEN2_CROSS_SUB_SA_CONTAINER"))
+  storage_container_id = azurerm_storage_container.testalt.resource_manager_id
+}
+	`, template, data.RandomInteger, os.Getenv("ARM_SUBSCRIPTION_ID_ALT"), data.Locations.Primary, data.RandomIntOfLength(10))
 }
 
 func (r MachineLearningDataStoreDataLakeGen2) requiresImport(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
@@ -188,7 +188,7 @@ resource "azurerm_storage_container" "test" {
 }
 
 resource "azurerm_machine_learning_datastore_datalake_gen2" "test" {
-  name                 = "accdatastore%[2]d"
+  name                 = "acctestdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
   storage_container_id = azurerm_storage_container.test.resource_manager_id
 }
@@ -227,7 +227,7 @@ resource "azurerm_storage_container" "testalt" {
 }
 
 resource "azurerm_machine_learning_datastore_datalake_gen2" "crosssub" {
-  name                 = "accdcrosssub%[5]d"
+  name                 = "acctestdcrosssub%[5]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
   storage_container_id = azurerm_storage_container.testalt.resource_manager_id
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27254
Relate PR: #27256 

This PR will add the subscription ID and resource group to the service so we know where the storage account located, also works for cross subscription. For the existing resource managed by AzureRM the subscription ID and resource group are null, AzureRM cannot find the storage account if it's not in the same sub as MLW, this PR will fix this.

```log
=== RUN   TestAccMachineLearningDataStoreDataLakeGen2_crossSubStorageAccount
=== PAUSE TestAccMachineLearningDataStoreDataLakeGen2_crossSubStorageAccount
=== CONT  TestAccMachineLearningDataStoreDataLakeGen2_crossSubStorageAccount
--- PASS: TestAccMachineLearningDataStoreDataLakeGen2_crossSubStorageAccount (552.71s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       570.226s
```


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
