### PR TITLE
Docs - updated `cdn_frontdoor_origin_group` docs to reflect valid health probe intervals

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
@@ -114,7 +114,7 @@ func resourceCdnFrontDoorOriginGroup() *pluginsdk.Resource {
 						"interval_in_seconds": {
 							Type:         pluginsdk.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(5, 31536000),
+							ValidateFunc: validation.IntBetween(1, 255),
 						},
 
 						"path": {

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -72,7 +72,7 @@ A `health_probe` block supports the following:
 
 * `protocol` - (Required) Specifies the protocol to use for health probe. Possible values are `Http` and `Https`.
 
-* `interval_in_seconds` - (Required) Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+* `interval_in_seconds` - (Required) Specifies the number of seconds between health probes. Possible values are between `5` and `255` seconds (inclusive).
 
 * `request_type` - (Optional) Specifies the type of health probe request that is made. Possible values are `GET` and `HEAD`. Defaults to `HEAD`.
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -72,7 +72,7 @@ A `health_probe` block supports the following:
 
 * `protocol` - (Required) Specifies the protocol to use for health probe. Possible values are `Http` and `Https`.
 
-* `interval_in_seconds` - (Required) Specifies the number of seconds between health probes. Possible values are between `5` and `255` seconds (inclusive).
+* `interval_in_seconds` - (Required) Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
 
 * `request_type` - (Optional) Specifies the type of health probe request that is made. Possible values are `GET` and `HEAD`. Defaults to `HEAD`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Docs - updated `cdn_frontdoor_origin_group` docs to reflect valid health probe intervals. Specifying a value larger than 255 gives the error

```
│ Error: creating Front Door Origin Group: (Origin Group Name "<name>" / Profile Name "<name>" / Resource Group "<name>"): cdn.AFDOriginGroupsClient#Create: Failure sending request: StatusCode=400 -- Original Error: Code="BadRequest" Message="Property 'AfdOriginGroup.HealthProbeSettings.ProbeIntervalInSeconds' cannot be set to '300'. Acceptable values are within range [1, 255]"
```



## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `cdn_frontdoor_origin_group` - updated docs to reflect valid values for `interval_in_seconds` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
- [x] Documentation 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
