### PR TITLE
`hdinsight_spark_cluster_resource`: Add support for `availability_zones`

### DIFF
--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -6,7 +6,6 @@ package hdinsight
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/extensions"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hdinsight/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"time"
 
@@ -401,6 +402,16 @@ func flattenHDInsightAzureMonitor(input *extensions.AzureMonitorResponse) []inte
 		})
 	}
 
+	return output
+}
+
+func expandHDInsightAvailabilityZones(input interface{}) []string {
+	output := make([]string, 0)
+
+	v := input.(*schema.Set)
+	for _, az := range v.List() {
+		output = append(output, az.(string))
+	}
 	return output
 }
 

--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/extensions"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hdinsight/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -402,16 +401,6 @@ func flattenHDInsightAzureMonitor(input *extensions.AzureMonitorResponse) []inte
 		})
 	}
 
-	return output
-}
-
-func expandHDInsightAvailabilityZones(input interface{}) []string {
-	output := make([]string, 0)
-
-	v := input.(*schema.Set)
-	for _, az := range v.List() {
-		output = append(output, az.(string))
-	}
 	return output
 }
 

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -150,6 +150,8 @@ func resourceHDInsightSparkCluster() *pluginsdk.Resource {
 			"monitor": SchemaHDInsightsMonitor(),
 
 			"extension": SchemaHDInsightsExtension(),
+
+			"availability_zones": commonschema.ZonesMultipleOptional(),
 		},
 	}
 }
@@ -272,6 +274,10 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if v, ok := d.GetOk("availability_zones"); ok {
+		payload.Zones = pointer.To(expandHDInsightAvailabilityZones(v))
+	}
+
 	if err := client.CreateThenPoll(ctx, id, payload); err != nil {
 		return fmt.Errorf("creating Spark %s: %+v", id, err)
 	}
@@ -382,6 +388,10 @@ func resourceHDInsightSparkClusterRead(d *pluginsdk.ResourceData, meta interface
 			}
 			if err := d.Set("disk_encryption", diskEncryptionProps); err != nil {
 				return fmt.Errorf("flattening setting `disk_encryption`: %+v", err)
+			}
+
+			if model.Zones != nil {
+				d.Set("availability_zones", pointer.From(model.Zones))
 			}
 
 			if err := d.Set("network", flattenHDInsightsNetwork(props.NetworkProperties)); err != nil {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -153,7 +153,7 @@ func resourceHDInsightSparkCluster() *pluginsdk.Resource {
 
 			"extension": SchemaHDInsightsExtension(),
 
-			"zones": commonschema.ZonesMultipleOptional(),
+			"zones": commonschema.ZonesMultipleOptionalForceNew(),
 		},
 	}
 }

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -5,8 +5,6 @@ package hdinsight
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"time"
 
@@ -17,7 +15,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -841,17 +841,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     is_default                   = true
   }
 
-  private_link_configuration {
-    name     = "testconfig"
-    group_id = "headnode"
-    ip_configuration {
-      name                         = "testipconfig"
-      primary                      = false
-      private_ip_allocation_method = "dynamic"
-      subnet_id                    = azurerm_subnet.test.id
-    }
-  }
-
   roles {
     head_node {
       vm_size            = "Standard_A4_V2"

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -40,6 +40,26 @@ func TestAccHDInsightSparkCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightSparkCluster_availabilityZones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	r := HDInsightSparkClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.availabilityZones(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightSparkCluster_roleScriptActions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
 	r := HDInsightSparkClusterResource{}
@@ -740,6 +760,146 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightSparkClusterResource) availabilityZones(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctestsql-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  administrator_login          = "sql_admin"
+  administrator_login_password = "TerrAform123!"
+  version                      = "12.0"
+}
+
+resource "azurerm_mssql_database" "hive" {
+  name        = "hive"
+  server_id   = azurerm_mssql_server.test.id
+  collation   = "SQL_Latin1_General_CP1_CI_AS"
+  create_mode = "Default"
+}
+
+resource "azurerm_mssql_database" "oozie" {
+  name        = "oozie"
+  server_id   = azurerm_mssql_server.test.id
+  collation   = "SQL_Latin1_General_CP1_CI_AS"
+  create_mode = "Default"
+}
+
+resource "azurerm_mssql_database" "ambari" {
+  name        = "ambari"
+  server_id   = azurerm_mssql_server.test.id
+  collation   = "SQL_Latin1_General_CP1_CI_AS"
+  create_mode = "Default"
+}
+
+resource "azurerm_mssql_firewall_rule" "AzureServices" {
+  name             = "allow-azure-services"
+  server_id        = azurerm_mssql_server.test.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.16.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.16.11.0/26"]
+}
+
+resource "azurerm_hdinsight_spark_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+  availability_zones  = ["1"]
+
+  component_version {
+    spark = "2.4"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account_gen2 {
+    storage_resource_id          = azurerm_storage_account.gen2test.id
+    filesystem_id                = azurerm_storage_data_lake_gen2_filesystem.gen2test.id
+    managed_identity_resource_id = azurerm_user_assigned_identity.test.id
+    is_default                   = true
+  }
+
+  private_link_configuration {
+    name     = "testconfig"
+    group_id = "headnode"
+    ip_configuration {
+      name                         = "testipconfig"
+      primary                      = false
+      private_ip_allocation_method = "dynamic"
+      subnet_id                    = azurerm_subnet.test.id
+    }
+  }
+
+  roles {
+    head_node {
+      vm_size            = "Standard_A4_V2"
+      username           = "acctestusrvm"
+      password           = "AccTestvdSC4daf986!"
+      subnet_id          = azurerm_subnet.test.id
+      virtual_network_id = azurerm_virtual_network.test.id
+    }
+
+    worker_node {
+      vm_size               = "Standard_A4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+      subnet_id             = azurerm_subnet.test.id
+      virtual_network_id    = azurerm_virtual_network.test.id
+    }
+
+    zookeeper_node {
+      vm_size            = "Medium"
+      username           = "acctestusrvm"
+      password           = "AccTestvdSC4daf986!"
+      subnet_id          = azurerm_subnet.test.id
+      virtual_network_id = azurerm_virtual_network.test.id
+    }
+  }
+  metastores {
+    hive {
+      server        = azurerm_mssql_server.test.fully_qualified_domain_name
+      database_name = azurerm_mssql_database.hive.name
+      username      = azurerm_mssql_server.test.administrator_login
+      password      = azurerm_mssql_server.test.administrator_login_password
+    }
+    oozie {
+      server        = azurerm_mssql_server.test.fully_qualified_domain_name
+      database_name = azurerm_mssql_database.oozie.name
+      username      = azurerm_mssql_server.test.administrator_login
+      password      = azurerm_mssql_server.test.administrator_login_password
+    }
+    ambari {
+      server        = azurerm_mssql_server.test.fully_qualified_domain_name
+      database_name = azurerm_mssql_database.ambari.name
+      username      = azurerm_mssql_server.test.administrator_login
+      password      = azurerm_mssql_server.test.administrator_login_password
+    }
+  }
+}
+`, r.gen2template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r HDInsightSparkClusterResource) gen2basic(data acceptance.TestData) string {

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -127,6 +127,8 @@ The following arguments are supported:
 
 * `security_profile` - (Optional) A `security_profile` block as defined below. Changing this forces a new resource to be created.
 
+* `availability_zones` - (Optional) A list of Availability Zones which should be used for this HDInsight Spark Cluster.
+
 ---
 
 A `component_version` block supports the following:

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -127,7 +127,7 @@ The following arguments are supported:
 
 * `security_profile` - (Optional) A `security_profile` block as defined below. Changing this forces a new resource to be created.
 
-* `availability_zones` - (Optional) A list of Availability Zones which should be used for this HDInsight Spark Cluster.
+* `zones` - (Optional) A list of Availability Zones which should be used for this HDInsight Spark Cluster. Chaning this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
