### PR TITLE
`azurerm_cdn_endpoint_custom_domain` - `cdn_managed_https.tls_version` and `user_managed_https.tls_version` no longer accept `None` or `TLS10` as a value in 5.0

### DIFF
--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	keyvaultClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
@@ -74,9 +75,7 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						ValidateFunc: validation.StringInSlice([]string{
-							string(cdn.MinimumTLSVersionTLS10),
 							string(cdn.MinimumTLSVersionTLS12),
-							string(cdn.MinimumTLSVersionNone),
 						}, false),
 						Default: string(cdn.MinimumTLSVersionTLS12),
 					},
@@ -96,9 +95,7 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						ValidateFunc: validation.StringInSlice([]string{
-							string(cdn.MinimumTLSVersionTLS10),
 							string(cdn.MinimumTLSVersionTLS12),
-							string(cdn.MinimumTLSVersionNone),
 						}, false),
 						Default: string(cdn.MinimumTLSVersionTLS12),
 					},
@@ -114,6 +111,28 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 		ValidateFunc: keyvaultValidate.NestedItemIdWithOptionalVersion,
 	}
 
+	if !features.FivePointOhBeta() {
+		schema["cdn_managed_https"].Elem.(*pluginsdk.Resource).Schema["tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.MinimumTLSVersionNone),
+				string(cdn.MinimumTLSVersionTLS10),
+				string(cdn.MinimumTLSVersionTLS12),
+			}, false),
+			Default: string(cdn.MinimumTLSVersionTLS12),
+		}
+		schema["user_managed_https"].Elem.(*pluginsdk.Resource).Schema["tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.MinimumTLSVersionNone),
+				string(cdn.MinimumTLSVersionTLS10),
+				string(cdn.MinimumTLSVersionTLS12),
+			}, false),
+			Default: string(cdn.MinimumTLSVersionTLS12),
+		}
+	}
 	return &pluginsdk.Resource{
 		Create: resourceArmCdnEndpointCustomDomainCreate,
 		Read:   resourceArmCdnEndpointCustomDomainRead,

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -66,8 +66,8 @@ Please follow the format in the example below for listing breaking changes in re
 
 ### `azurerm_cdn_endpoint_custom_domain`
 
-* The `cdn_managed_https.tls_version` property no langer accepts `None` or `TLS10` as a value.
-* The `user_managed_https.tls_version` property no langer accepts `None` or `TLS10` as a value.
+* The `cdn_managed_https.tls_version` property no longer accepts `None` or `TLS10` as a value.
+* The `user_managed_https.tls_version` property no longer accepts `None` or `TLS10` as a value.
 
 ### `azurerm_cdn_frontdoor_custom_domain`
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -64,6 +64,11 @@ Please follow the format in the example below for listing breaking changes in re
 * The `example_property_with_changed_default` property now defaults to `NewDefault`.
 ```
 
+### `azurerm_cdn_endpoint_custom_domain`
+
+* The `cdn_managed_https.tls_version` property no langer accepts `None` or `TLS10` as a value.
+* The `user_managed_https.tls_version` property no langer accepts `None` or `TLS10` as a value.
+
 ### `azurerm_cdn_frontdoor_custom_domain`
 
 * The `tls.minimum_tls_version` property no longer accepts `TLS10` as a value.

--- a/website/docs/r/cdn_endpoint_custom_domain.html.markdown
+++ b/website/docs/r/cdn_endpoint_custom_domain.html.markdown
@@ -91,6 +91,8 @@ A `cdn_managed_https` block supports the following:
 
 * `tls_version` - (Optional) The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
 
+~> **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+
 ---
 
 A `user_managed_https` block supports the following:
@@ -98,6 +100,8 @@ A `user_managed_https` block supports the following:
 * `key_vault_secret_id` - (Required) The ID of the Key Vault Secret that contains the HTTPS certificate.
 
 * `tls_version` - (Optional) The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+~> **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

To deprecate non-tls and tls1.0 per the [announcement](https://azure.microsoft.com/en-us/updates?id=update-retirement-tls1-0-tls1-1-versions-azure-services)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

These tests require setting up domain and certificate on testing subscriptions, while, it's not allowed in our subscriptions now due to security. As these are schema changes, there is no logic change, can we continue without the testing results?

<!--Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_endpoint_custom_domain` - `cdn_managed_https.tls_version` and `user_managed_https.tls_version` no longer accept `None` or `TLS10` as a value in 5.0 [GH-28157]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
