### PR TITLE
Docs: Update servicebus_subscription - auto_delete_on_idle

### DIFF
--- a/website/docs/d/servicebus_subscription.html.markdown
+++ b/website/docs/d/servicebus_subscription.html.markdown
@@ -33,7 +33,7 @@ output "servicebus_subscription" {
 
 * `max_delivery_count` - The maximum number of deliveries.
 
-* `auto_delete_on_idle` - The idle interval after which the topic is automatically deleted.
+* `auto_delete_on_idle` - The idle interval after which the Subscription is automatically deleted.
 
 * `default_message_ttl` - The Default message timespan to live. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 


### PR DESCRIPTION
Fixes typo in the "auto_delete_on_idle" description;

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
I do not believe a setting on the subscription will cause the topic to be deleted. This looks to be like a copy paste typo.

## PR Checklist

- [ x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”