### PR TITLE
`azurerm_api_management_api`: add costom poller for `import` openapi

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -409,7 +409,6 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	description := d.Get("description").(string)
 	serviceUrl := d.Get("service_url").(string)
 	subscriptionRequired := d.Get("subscription_required").(bool)
 
@@ -452,8 +451,8 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 		params.Properties.SourceApiId = pointer.To(sourceApiId)
 	}
 
-	if description != "" {
-		params.Properties.Description = pointer.To(description)
+	if description, ok := d.GetOk("description"); ok {
+		params.Properties.Description = pointer.To(description.(string))
 	}
 
 	if displayName != "" {

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -517,6 +517,7 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 	// First we execute import and then updated the other props.
 	if d.HasChange("import") {
 		if vs, hasImport := d.GetOk("import"); hasImport {
+			d.Partial(true)
 			if apiParams := expandApiManagementApiImport(vs.([]interface{}), apiType, soapApiType,
 				path, serviceUrl, version, versionSetId); apiParams != nil {
 				result, err := client.CreateOrUpdate(ctx, *id, *apiParams, api.CreateOrUpdateOperationOptions{})
@@ -531,6 +532,7 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 					}
 				}
 			}
+			d.Partial(false)
 		}
 	}
 

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -1008,6 +1008,7 @@ resource "azurerm_api_management_api" "revision" {
   resource_group_name  = azurerm_resource_group.test.name
   api_management_name  = azurerm_api_management.test.name
   revision             = "18"
+  description          = "What is my purpose? You parse butter."
   source_api_id        = "${azurerm_api_management_api.test.id};rev=3"
   revision_description = "Creating a Revision of an existing API"
   contact {

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -233,19 +233,19 @@ func TestAccApiManagementApi_importOpenapi(t *testing.T) {
 	})
 }
 
-func TestAccApiManagementApi_importOpenapiInvalide(t *testing.T) {
+func TestAccApiManagementApi_importOpenapiInvalid(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.importOpenapiInvalide(data),
+			Config:      r.importOpenapiInvalid(data),
 			ExpectError: regexp.MustCompile("ValidationError"),
 		},
 	})
 }
 
-func TestAccApiManagementApi_updateImportOpenapiInvalide(t *testing.T) {
+func TestAccApiManagementApi_updateImportOpenapiInvalid(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}
 
@@ -258,7 +258,7 @@ func TestAccApiManagementApi_updateImportOpenapiInvalide(t *testing.T) {
 		},
 		data.ImportStep("import"),
 		{
-			Config:      r.importOpenapiInvalide(data),
+			Config:      r.importOpenapiInvalid(data),
 			ExpectError: regexp.MustCompile("ValidationError"),
 		},
 		{
@@ -659,7 +659,7 @@ resource "azurerm_api_management_api" "test" {
 `, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
-func (r ApiManagementApiResource) importOpenapiInvalide(data acceptance.TestData) string {
+func (r ApiManagementApiResource) importOpenapiInvalid(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -673,7 +673,7 @@ resource "azurerm_api_management_api" "test" {
   revision            = "current"
 
   import {
-    content_value  = file("testdata/api_management_api_openapi_invalide.yaml")
+    content_value  = file("testdata/api_management_api_openapi_invalid.yaml")
     content_format = "openapi"
   }
 }

--- a/internal/services/apimanagement/custompollers/api_management_api_poller.go
+++ b/internal/services/apimanagement/custompollers/api_management_api_poller.go
@@ -35,6 +35,8 @@ var (
 	}
 )
 
+// NewAPIManagementAPIPoller - creates a new poller for API Management API operations to handle the case there is a query string
+// parameter "asyncId" in the Location header of the response. This is used to poll the status of the operation.
 func NewAPIManagementAPIPoller(cli *api.ApiClient, id api.ApiId, response *http.Response) *apiManagementAPIPoller {
 	urlStr := response.Header.Get("location")
 	var asyncId string

--- a/internal/services/apimanagement/custompollers/api_management_api_poller.go
+++ b/internal/services/apimanagement/custompollers/api_management_api_poller.go
@@ -1,0 +1,112 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/api"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var _ pollers.PollerType = &apiManagementAPIPoller{}
+
+type apiManagementAPIPoller struct {
+	client  *api.ApiClient
+	id      api.ApiId
+	asyncID string
+}
+
+var (
+	pollingSuccess = pollers.PollResult{
+		Status:       pollers.PollingStatusSucceeded,
+		PollInterval: 10 * time.Second,
+	}
+	pollingInProgress = pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}
+)
+
+func NewAPIManagementAPIPoller(cli *api.ApiClient, id api.ApiId, response *http.Response) *apiManagementAPIPoller {
+	urlStr := response.Header.Get("location")
+	var asyncId string
+	if u, err := url.Parse(urlStr); err == nil {
+		asyncId = u.Query().Get("asyncId")
+	}
+
+	// sometimes the poller is not required as the API directly return 200
+	if asyncId == "" {
+		return nil
+	}
+
+	return &apiManagementAPIPoller{
+		client:  cli,
+		id:      id,
+		asyncID: asyncId,
+	}
+}
+
+type options struct {
+	asyncId string
+}
+
+func (p options) ToHeaders() *client.Headers {
+	return &client.Headers{}
+}
+
+func (p options) ToOData() *odata.Query {
+	return &odata.Query{}
+}
+
+func (p options) ToQuery() *client.QueryParams {
+	q := client.QueryParams{}
+	q.Append("asyncId", p.asyncId)
+	return &q
+}
+
+func (p apiManagementAPIPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	if p.asyncID == "" {
+		return &pollingSuccess, nil
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusAccepted,
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       p.id.ID(),
+		OptionsObject: options{
+			asyncId: p.asyncID,
+		},
+	}
+	req, err := p.client.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %+v", err)
+	}
+
+	resp, err := p.client.Client.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+
+	// the response actually doesn't include a provisioningState property, so we only chech the http status code
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return &pollingSuccess, nil
+	case http.StatusAccepted, http.StatusCreated:
+		return &pollingInProgress, nil
+	}
+
+	return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+}

--- a/internal/services/apimanagement/testdata/api_management_api_openapi_invalid.yaml
+++ b/internal/services/apimanagement/testdata/api_management_api_openapi_invalid.yaml
@@ -21,7 +21,7 @@ paths:
           name: status
           schema:
             type: string
-            default: PRODUCTIVEInvalide
+            default: PRODUCTIVEInvalid
             enum:
               - PRODUCTIVE
               - ARCHIVED

--- a/internal/services/apimanagement/testdata/api_management_api_openapi_invalide.yaml
+++ b/internal/services/apimanagement/testdata/api_management_api_openapi_invalide.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+openapi: 3.0.0
+info:
+  title: api1
+  description: api
+  version: 1.0.0
+servers:
+  - url: "https://terraform.com/test/v1/api1"
+    description: test
+paths:
+  /default:
+    post:
+      operationId: default
+      summary: Default
+      description: Default operation
+      parameters:
+        - description: status
+          in: query
+          name: status
+          schema:
+            type: string
+            default: PRODUCTIVEInvalide
+            enum:
+              - PRODUCTIVE
+              - ARCHIVED
+      responses:
+        "200":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/response"
+components:
+  schemas:
+    response:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

As the LRO of importing an OpenAPI file, the polling URL requires the `asyncId` query string to retrieve the actual failure message. This PR adds a custom poller to override the default provisioningState poller.

Also setting the `Partial` to true is required to fix the issue https://github.com/hashicorp/terraform-provider-azurerm/issues/24379#issuecomment-1899251199.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccApiManagementApi_importOpenapiInvalide (180.43s)
PASS
```

![image](https://github.com/user-attachments/assets/f2230571-3671-480d-b3ec-90ecca512ad1)

The failing cases are not related to this PR. Some of them are fixed in #28194.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_api` - fix poller of importing OpenAPI content [GH-23322]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23322, fixes #22042, fixes #28201 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
