### PR TITLE
`azurerm_api_management_api_tag_description`: update the swagger link in the acctest and example

### DIFF
--- a/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
@@ -191,7 +191,7 @@ resource "azurerm_api_management_api" "test" {
 
   import {
     content_format = "swagger-link-json"
-    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+    content_value  = "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/internal/services/apimanagement/testdata/api_management_api_swagger.json"
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_api_management_api" "example" {
 
   import {
     content_format = "swagger-link-json"
-    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+    content_value  = "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/internal/services/apimanagement/testdata/api_management_api_swagger.json"
   }
 }
 

--- a/website/docs/r/api_management_api_release.html.markdown
+++ b/website/docs/r/api_management_api_release.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_api_management_api" "example" {
 
   import {
     content_format = "swagger-link-json"
-    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+    content_value  = "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/internal/services/apimanagement/testdata/api_management_api_swagger.json"
   }
 }
 

--- a/website/docs/r/api_management_api_tag_description.html.markdown
+++ b/website/docs/r/api_management_api_tag_description.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_api_management_api" "example" {
 
   import {
     content_format = "swagger-link-json"
-    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+    content_value  = "https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/internal/services/apimanagement/testdata/api_management_api_swagger.json"
   }
 }
 


### PR DESCRIPTION
## Fix these acceptance failures:

![image](https://github.com/user-attachments/assets/d22dd7c1-dcfc-4063-8215-db32e9feb314)


## Test Result:
```
--- PASS: TestAccApiManagementApiDiagnostic_basic (312.80s)
PASS
```

![image](https://github.com/user-attachments/assets/a7e99978-6cd2-4dd2-a76c-abb793076acd)
