### PR TITLE
`azurerm_orbital_spacecraft`, `azurerm_orbital_contact`, `azurerm_orbital_contact_profile`: Deprecate all orbital resources

### DIFF
--- a/internal/services/orbital/contact_profile_resource.go
+++ b/internal/services/orbital/contact_profile_resource.go
@@ -25,6 +25,12 @@ type ContactProfileResource struct{}
 
 var _ sdk.ResourceWithUpdate = ContactProfileResource{}
 
+var _ sdk.ResourceWithDeprecationAndNoReplacement = ContactProfileResource{}
+
+func (r ContactProfileResource) DeprecationMessage() string {
+	return "The `azurerm_orbital_contact_profile` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider."
+}
+
 type ContactProfileResourceModel struct {
 	Name                           string                    `tfschema:"name"`
 	ResourceGroup                  string                    `tfschema:"resource_group_name"`

--- a/internal/services/orbital/contact_profile_resource_test.go
+++ b/internal/services/orbital/contact_profile_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type ContactProfileResource struct{}
 
 func TestAccContactProfile_basic(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}
 
@@ -35,6 +39,9 @@ func TestAccContactProfile_basic(t *testing.T) {
 }
 
 func TestAccContactProfile_multipleChannels(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}
 
@@ -50,6 +57,9 @@ func TestAccContactProfile_multipleChannels(t *testing.T) {
 }
 
 func TestAccContactProfile_addChannel(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}
 
@@ -72,6 +82,9 @@ func TestAccContactProfile_addChannel(t *testing.T) {
 }
 
 func TestAccContactProfile_update(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}
 
@@ -93,6 +106,9 @@ func TestAccContactProfile_update(t *testing.T) {
 }
 
 func TestAccContactProfile_complete(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
 	r := ContactProfileResource{}
 

--- a/internal/services/orbital/contact_resource.go
+++ b/internal/services/orbital/contact_resource.go
@@ -19,6 +19,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var _ sdk.ResourceWithDeprecationAndNoReplacement = ContactResource{}
+
+func (r ContactResource) DeprecationMessage() string {
+	return "The `azurerm_orbital_contact` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider."
+}
+
 type ContactResource struct{}
 
 type ContactResourceModel struct {

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -21,6 +22,9 @@ import (
 type ContactResource struct{}
 
 func TestAccContact_basic(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_contact` is deprecated and will be removed in 5.0")
+	}
 	skipContact(t)
 
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact", "test")

--- a/internal/services/orbital/registration.go
+++ b/internal/services/orbital/registration.go
@@ -3,7 +3,10 @@
 
 package orbital
 
-import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+)
 
 type Registration struct{}
 
@@ -26,11 +29,15 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{
-		SpacecraftResource{},
-		ContactProfileResource{},
-		ContactResource{},
+	if !features.FivePointOhBeta() {
+		return []sdk.Resource{
+			SpacecraftResource{},
+			ContactProfileResource{},
+			ContactResource{},
+		}
 	}
+
+	return nil
 }
 
 var _ sdk.TypedServiceRegistration = Registration{}

--- a/internal/services/orbital/spacecraft_resource.go
+++ b/internal/services/orbital/spacecraft_resource.go
@@ -23,6 +23,12 @@ type SpacecraftResource struct{}
 
 var _ sdk.ResourceWithUpdate = SpacecraftResource{}
 
+var _ sdk.ResourceWithDeprecationAndNoReplacement = SpacecraftResource{}
+
+func (r SpacecraftResource) DeprecationMessage() string {
+	return "The `azurerm_orbital_spacecraft` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider."
+}
+
 type SpacecraftResourceModel struct {
 	Name            string                `tfschema:"name"`
 	ResourceGroup   string                `tfschema:"resource_group_name"`

--- a/internal/services/orbital/spacecraft_resource_test.go
+++ b/internal/services/orbital/spacecraft_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,9 @@ import (
 type SpacecraftResource struct{}
 
 func TestAccSpacecraft_basic(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")
 	r := SpacecraftResource{}
 
@@ -35,6 +39,9 @@ func TestAccSpacecraft_basic(t *testing.T) {
 }
 
 func TestAccSpacecraft_update(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")
 	r := SpacecraftResource{}
 
@@ -56,6 +63,9 @@ func TestAccSpacecraft_update(t *testing.T) {
 }
 
 func TestAccSpacecraft_complete(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")
 	r := SpacecraftResource{}
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -38,6 +38,18 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 * This deprecated resource has been removed from the Azure Provider. Please see the [documention for more details](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
 
+### `azurerm_orbital_spacecraft`
+
+* This deprecated resource has been retired and has been removed from the Azure Provider. 
+
+### `azurerm_orbital_contact`
+
+* This deprecated resource has been retired and has been removed from the Azure Provider.
+
+### `azurerm_orbital_contact_profile`
+
+* This deprecated resource has been retired and has been removed from the Azure Provider.
+
 ## Removed Data Sources
 
 Please follow the format in the example below for adding removed data sources:

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an orbital contact.
 
+~> **Note:** The `azurerm_orbital_contact` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/orbital_contact_profile.html.markdown
+++ b/website/docs/r/orbital_contact_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Contact profile.
 
+~> **Note:** The `azurerm_orbital_contact_profile` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/orbital_spacecraft.html.markdown
+++ b/website/docs/r/orbital_spacecraft.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Spacecraft.
 
+~> **Note:** The `azurerm_orbital_spacecraft` resource has been deprecated and will be removed in v5.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
