### PR TITLE
`azurerm_mongo_cluster` - remove the check logic for `administrator_password`

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -186,6 +186,10 @@ func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 			VersionConstraint: "=2.47.0",
 			Source:            "registry.terraform.io/hashicorp/azuread",
 		},
+		"random": {
+			VersionConstraint: "=3.6.3",
+			Source:            "registry.terraform.io/hashicorp/random",
+		},
 		"time": {
 			VersionConstraint: "=0.9.1",
 			Source:            "registry.terraform.io/hashicorp/time",

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -488,10 +488,6 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 					return fmt.Errorf("`administrator_username` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
 				}
 
-				if state.AdministratorPassword == "" {
-					return fmt.Errorf("`administrator_password` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
-				}
-
 				if state.ComputeTier == "" {
 					return fmt.Errorf("`compute_tier` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
 				}

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -21,9 +21,9 @@ type MongoClusterResource struct{}
 func TestAccMongoClusterFreeTier(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"freeTier": { // Run tests in sequence since each subscription is limited to one free tier cluster per region and free tier is currently only available in South India.
-			"basic":  testAccMongoCluster_basic,
-			"update": testAccMongoCluster_update,
-			"import": testAccMongoCluster_requiresImport,
+			"basic": testAccMongoCluster_basic,
+			//"update": testAccMongoCluster_update,
+			//"import": testAccMongoCluster_requiresImport,
 		},
 	})
 }
@@ -119,7 +119,7 @@ func (r MongoClusterResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "random_string" "test" {
+resource "random_password" "test" {
   length  = 8
   numeric = true
   upper   = true
@@ -131,7 +131,7 @@ resource "azurerm_mongo_cluster" "test" {
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_username = "adminTerraform"
-  administrator_password = random_string.test.result
+  administrator_password = random_password.test.result
   shard_count            = "1"
   compute_tier           = "Free"
   high_availability_mode = "Disabled"

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -21,9 +21,9 @@ type MongoClusterResource struct{}
 func TestAccMongoClusterFreeTier(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"freeTier": { // Run tests in sequence since each subscription is limited to one free tier cluster per region and free tier is currently only available in South India.
-			"basic":  testAccMongoCluster_basic,
-			"update": testAccMongoCluster_update,
-			"import": testAccMongoCluster_requiresImport,
+			"basic": testAccMongoCluster_basic,
+			//"update": testAccMongoCluster_update,
+			//"import": testAccMongoCluster_requiresImport,
 		},
 	})
 }
@@ -119,12 +119,19 @@ func (r MongoClusterResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
+resource "random_string" "test" {
+  length  = 8
+  numeric = true
+  upper   = true
+  lower   = true
+}
+
 resource "azurerm_mongo_cluster" "test" {
   name                   = "acctest-mc%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_username = "adminTerraform"
-  administrator_password = "QAZwsx123"
+  administrator_password = random_string.test.result
   shard_count            = "1"
   compute_tier           = "Free"
   high_availability_mode = "Disabled"

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -21,9 +21,9 @@ type MongoClusterResource struct{}
 func TestAccMongoClusterFreeTier(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"freeTier": { // Run tests in sequence since each subscription is limited to one free tier cluster per region and free tier is currently only available in South India.
-			"basic": testAccMongoCluster_basic,
-			//"update": testAccMongoCluster_update,
-			//"import": testAccMongoCluster_requiresImport,
+			"basic":  testAccMongoCluster_basic,
+			"update": testAccMongoCluster_update,
+			"import": testAccMongoCluster_requiresImport,
 		},
 	})
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
When running tf apply, the logic in CustomizeDiff checks if the AdministratorPassword is empty, but at that point, random_password has not yet generated the value, so the check fails. To fix this issue, the check for AdministratorPassword can be removed, as the logic for checking AdministratorUsername already exists in CustomizeDiff, and this field has the `RequiredWith: []string{"administrator_password"}` validation. Therefore, redundant checks in CustomizeDiff are not necessary.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/10ffe744-ce70-4e1b-b441-d9f32f088f66)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mongo_cluster` - remove the check logic for `administrator_password`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28204


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
