### PR TITLE
`azurerm_cognitive_account`: allows `bypass` property for `network_acls`

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -241,6 +241,16 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 								},
 							},
 						},
+
+						"bypass": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							Default:  cognitiveservicesaccounts.ByPassSelectionNone,
+							ValidateFunc: validation.StringInSlice(
+								cognitiveservicesaccounts.PossibleValuesForByPassSelection(),
+								false,
+							),
+						},
 					},
 				},
 			},
@@ -696,7 +706,10 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 		networkRules = append(networkRules, rule)
 	}
 
+	bypass := cognitiveservicesaccounts.ByPassSelection(v["bypass"].(string))
+
 	ruleSet := cognitiveservicesaccounts.NetworkRuleSet{
+		Bypass:              &bypass,
 		DefaultAction:       &defaultAction,
 		IPRules:             &ipRules,
 		VirtualNetworkRules: &networkRules,
@@ -803,6 +816,7 @@ func flattenCognitiveAccountNetworkAcls(input *cognitiveservicesaccounts.Network
 	}
 
 	return []interface{}{map[string]interface{}{
+		"bypass":                input.Bypass,
 		"default_action":        input.DefaultAction,
 		"ip_rules":              pluginsdk.NewSet(pluginsdk.HashString, ipRules),
 		"virtual_network_rules": virtualNetworkRules,

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -243,10 +243,8 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 						},
 
 						"bypass": {
-							Type:        pluginsdk.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "Only supported for the kind `OpenAI`",
+							Type:     pluginsdk.TypeString,
+							Optional: true,
 							ValidateFunc: validation.StringInSlice(
 								cognitiveservicesaccounts.PossibleValuesForByPassSelection(),
 								false,
@@ -719,18 +717,15 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 		VirtualNetworkRules: &networkRules,
 	}
 
-	kind := d.Get("kind").(string)
-	bypass := cognitiveservicesaccounts.ByPassSelectionAzureServices
-	if kind == "OpenAI" {
-		if b, ok := d.GetOk("network_acls.0.bypass"); ok && b != "" {
-			bypass = cognitiveservicesaccounts.ByPassSelection(v["bypass"].(string))
-		}
-		ruleSet.Bypass = &bypass
-	} else {
-		if b, ok := d.GetOk("network_acls.0.bypass"); ok && b != "" {
+	if b, ok := d.GetOk("network_acls.0.bypass"); ok && b != "" {
+		kind := d.Get("kind").(string)
+		if kind != "OpenAI" {
 			return nil, nil, fmt.Errorf("the `network_acls.bypass` does not support Trusted Services for the kind %q", kind)
 		}
+		bypasss := cognitiveservicesaccounts.ByPassSelection(v["bypass"].(string))
+		ruleSet.Bypass = &bypasss
 	}
+
 	return &ruleSet, subnetIds, nil
 }
 

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -245,7 +245,8 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 						"bypass": {
 							Type:        pluginsdk.TypeString,
 							Optional:    true,
-							Description: "Only support for the kind `OpenAI`",
+							Computed:    true,
+							Description: "Only supported for the kind `OpenAI`",
 							ValidateFunc: validation.StringInSlice(
 								cognitiveservicesaccounts.PossibleValuesForByPassSelection(),
 								false,
@@ -719,8 +720,11 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 	}
 
 	kind := d.Get("kind").(string)
+	bypass := cognitiveservicesaccounts.ByPassSelectionAzureServices
 	if kind == "OpenAI" {
-		bypass := cognitiveservicesaccounts.ByPassSelection(v["bypass"].(string))
+		if b, ok := d.GetOk("network_acls.0.bypass"); ok && b != "" {
+			bypass = cognitiveservicesaccounts.ByPassSelection(v["bypass"].(string))
+		}
 		ruleSet.Bypass = &bypass
 	} else {
 		if b, ok := d.GetOk("network_acls.0.bypass"); ok && b != "" {

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -288,6 +288,13 @@ func TestAccCognitiveAccount_networkAclsVirtualNetworkRules(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.networkAclsVirtualNetworkBypassUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -971,6 +978,30 @@ resource "azurerm_cognitive_account" "test" {
 
   network_acls {
     bypass         = "AzureServices"
+    default_action = "Allow"
+    ip_rules       = ["123.0.0.101"]
+    virtual_network_rules {
+      subnet_id                            = azurerm_subnet.test_a.id
+      ignore_missing_vnet_service_endpoint = true
+    }
+  }
+}
+`, r.networkAclsTemplate(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CognitiveAccountResource) networkAclsVirtualNetworkBypassUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_cognitive_account" "test" {
+  name                  = "acctestcogacc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  kind                  = "OpenAI"
+  sku_name              = "S0"
+  custom_subdomain_name = "acctestcogacc-%d"
+
+  network_acls {
+    bypass         = "None"
     default_action = "Allow"
     ip_rules       = ["123.0.0.101"]
     virtual_network_rules {

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -1027,7 +1027,7 @@ resource "azurerm_cognitive_account" "test" {
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
-    bypass = "AzureServices"
+    bypass         = "AzureServices"
     default_action = "Deny"
     virtual_network_rules {
       subnet_id = azurerm_subnet.test_a.id
@@ -1054,7 +1054,7 @@ resource "azurerm_cognitive_account" "test" {
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
-    bypass = "None"
+    bypass         = "None"
     default_action = "Deny"
     virtual_network_rules {
       subnet_id = azurerm_subnet.test_a.id
@@ -1081,7 +1081,7 @@ resource "azurerm_cognitive_account" "test" {
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
-    bypass = "AzureServices"
+    bypass         = "AzureServices"
     default_action = "Deny"
     virtual_network_rules {
       subnet_id = azurerm_subnet.test_a.id

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -896,7 +896,7 @@ resource "azurerm_cognitive_account" "test" {
   name                  = "acctestcogacc-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  kind                  = "Face"
+  kind                  = "OpenAI"
   sku_name              = "S0"
   custom_subdomain_name = "acctestcogacc-%d"
 
@@ -920,7 +920,7 @@ resource "azurerm_cognitive_account" "test" {
   name                  = "acctestcogacc-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  kind                  = "Face"
+  kind                  = "OpenAI"
   sku_name              = "S0"
   custom_subdomain_name = "acctestcogacc-%d"
 

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -939,11 +939,12 @@ resource "azurerm_cognitive_account" "test" {
   name                  = "acctestcogacc-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  kind                  = "Face"
+  kind                  = "OpenAI"
   sku_name              = "S0"
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
+    bypass         = "None"
     default_action = "Deny"
     virtual_network_rules {
       subnet_id = azurerm_subnet.test_a.id
@@ -952,7 +953,6 @@ resource "azurerm_cognitive_account" "test" {
       subnet_id                            = azurerm_subnet.test_b.id
       ignore_missing_vnet_service_endpoint = true
     }
-
   }
 }
 `, r.networkAclsTemplate(data), data.RandomInteger, data.RandomInteger)
@@ -965,11 +965,12 @@ resource "azurerm_cognitive_account" "test" {
   name                  = "acctestcogacc-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  kind                  = "Face"
+  kind                  = "OpenAI"
   sku_name              = "S0"
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
+    bypass         = "AzureServices"
     default_action = "Allow"
     ip_rules       = ["123.0.0.101"]
     virtual_network_rules {

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 A `network_acls` block supports the following:
 
-* `bypass` - (Optional) Wether to allow truested Azure Services to access the service. Possible values are `None` and `AzureServices`. Defaults to `None`.
+* `bypass` - (Optional) Wether to allow truested Azure Services to access the service. Possible values are `None` and `AzureServices`. Defaults to `None`. Only the `Kind` of `OpenAI` is supported.
 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -98,6 +98,8 @@ The following arguments are supported:
 
 A `network_acls` block supports the following:
 
+* `bypass` - (Optional) Wether to allow truested Azure Services to access the service. Possible values are `None` and `AzureServices`. Defaults to `None`.
+
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Cognitive Account.

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -98,7 +98,9 @@ The following arguments are supported:
 
 A `network_acls` block supports the following:
 
-* `bypass` - (Optional) Whether to allow trusted Azure Services to access the service. Possible values are `None` and `AzureServices`. Only the `Kind` of `OpenAI` is supported. Defaults to `AzureServices`.
+* `bypass` - (Optional) Whether to allow trusted Azure Services to access the service. Possible values are `None` and `AzureServices`.
+
+> **NOTE:** `bypass` can only be set when `kind` is set to `OpenAI` 
 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 A `network_acls` block supports the following:
 
-* `bypass` - (Optional) Wether to allow truested Azure Services to access the service. Possible values are `None` and `AzureServices`. Defaults to `None`. Only the `Kind` of `OpenAI` is supported.
+* `bypass` - (Optional) Whether to allow trusted Azure Services to access the service. Possible values are `None` and `AzureServices`. Only the `Kind` of `OpenAI` is supported. Defaults to `AzureServices`.
 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -100,7 +100,7 @@ A `network_acls` block supports the following:
 
 * `bypass` - (Optional) Whether to allow trusted Azure Services to access the service. Possible values are `None` and `AzureServices`.
 
-> **NOTE:** `bypass` can only be set when `kind` is set to `OpenAI` 
+-> **NOTE:** `bypass` can only be set when `kind` is set to `OpenAI` 
 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR implements the `network_acls.bypass` property for `azurerm_coginitive_account`. [Azure Services for Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-virtual-networks?tabs=portal#grant-access-to-trusted-azure-services-for-azure-openai)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/cognitive -run=TestAccCognitiveAccount_networkAcls -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccCognitiveAccount_networkAclsVirtualNetworkRules
=== PAUSE TestAccCognitiveAccount_networkAclsVirtualNetworkRules
=== RUN   TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypass
=== PAUSE TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypass
=== RUN   TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypassKindNotSupported
=== PAUSE TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypassKindNotSupported
=== RUN   TestAccCognitiveAccount_networkAcls
=== PAUSE TestAccCognitiveAccount_networkAcls
=== CONT  TestAccCognitiveAccount_networkAclsVirtualNetworkRules
=== CONT  TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypassKindNotSupported
=== CONT  TestAccCognitiveAccount_networkAcls
=== CONT  TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypass
--- PASS: TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypassKindNotSupported (137.85s)
--- PASS: TestAccCognitiveAccount_networkAcls (216.38s)
--- PASS: TestAccCognitiveAccount_networkAclsVirtualNetworkRules (226.20s)
--- PASS: TestAccCognitiveAccount_networkAclsVirtualNetworkRulesWithBypass (258.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive	259.848s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cognitive_account` - support for the `bypass` trusted Azure Services property [GH-[28221](https://github.com/hashicorp/terraform-provider-azurerm/pull/28221)]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28304


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
