### PR TITLE
`azurerm_logic_app_standard` - `site_config.min_tls_version` and `site_config. scm_min_tls_version` no longer accept `1.0` or `1.1` as a value in 5.0.

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -793,8 +793,6 @@ func schemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
 					Optional: true,
 					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(webapps.SupportedTlsVersionsOnePointZero),
-						string(webapps.SupportedTlsVersionsOnePointOne),
 						string(webapps.SupportedTlsVersionsOnePointTwo),
 					}, false),
 				},
@@ -819,8 +817,6 @@ func schemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
 					Optional: true,
 					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						string(webapps.SupportedTlsVersionsOnePointZero),
-						string(webapps.SupportedTlsVersionsOnePointOne),
 						string(webapps.SupportedTlsVersionsOnePointTwo),
 					}, false),
 				},
@@ -916,6 +912,26 @@ func schemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
 			Optional:   true,
 			Computed:   true,
 			Deprecated: "the `site_config.public_network_access_enabled` property has been superseded by the `public_network_access` property and will be removed in v5.0 of the AzureRM Provider.",
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["scm_min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+			}, false),
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+			}, false),
 		}
 	}
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -101,6 +101,8 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
+* The `site_config.min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
+* The `site_config.scm_min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
 
 ### `azurerm_monitor_aad_diagnostic_setting`
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -211,11 +211,15 @@ The `site_config` block supports the following:
 
 * `scm_min_tls_version` - (Optional) Configures the minimum version of TLS required for SSL requests to the SCM site. Possible values are `1.0`, `1.1` and `1.2`.
 
+~> **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+
 * `scm_type` - (Optional) The type of Source Control used by the Logic App in use by the Windows Function App. Defaults to `None`. Possible values are: `BitbucketGit`, `BitbucketHg`, `CodePlexGit`, `CodePlexHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `None`, `OneDrive`, `Tfs`, `VSO`, and `VSTSRM`
 
 * `linux_fx_version` - (Optional) Linux App Framework and version for the App Service, e.g. `DOCKER|(golang:latest)`. Setting this value will also set the `kind` of application deployed to `functionapp,linux,container,workflowapp`
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the Logic App. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new Logic Apps.
+
+~> **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 
 * `pre_warmed_instance_count` - (Optional) The number of pre-warmed instances for this Logic App Only affects apps on the Premium plan.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

To deprecate TLS below 1.2 per the [announcement](https://azure.microsoft.com/en-us/updates?id=update-retirement-tls1-0-tls1-1-versions-azure-services)

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

5.0:
<img width="449" alt="image" src="https://github.com/user-attachments/assets/2fbece07-4afb-433c-a83b-5f46303835e7">

4.0:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/faf789f8-ffed-4886-81e1-a348978956ff">


Since these failures shall not be caused by this PR, can we continue?
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Testing in progress

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_standard` - `site_config.min_tls_version` and `site_config. scm_min_tls_version` no longer accept `1.0` or `1.1` as a value in 5.0. [GH-28229]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
