### PR TITLE
Docs : remove the description of the feature in preview

### DIFF
--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -106,7 +106,7 @@ func (r MongoClusterResource) Arguments() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.StringInSlice(mongoclusters.PossibleValuesForPreviewFeature(), false),
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -81,8 +81,6 @@ The following arguments are supported:
 
 * `create_mode` - (Optional) The creation mode for the MongoDB Cluster. Possibles values are `Default` and `GeoReplica`. Defaults to `Default`. Changing this forces a new resource to be created.
 
--> **Note** The creation mode `GeoReplica` is currently in preview. It is only available when `preview_features` is set.
-
 * `preview_features` - (Optional) The preview features that can be enabled on the MongoDB Cluster. Changing this forces a new resource to be created.
 
 * `shard_count` -  (Optional) The Number of shards to provision on the MongoDB Cluster. Changing this forces a new resource to be created.


### PR DESCRIPTION
Purpose of this PR:
- Remove the description of the cross-region replication feature in preview as the feature recently became [generally available](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdevblogs.microsoft.com%2Fcosmosdb%2Fachieving-production-readiness-with-cross-region-replication-in-azure-cosmos-db-for-mongodb-vcore%2F&data=05%7C02%7Cv-elenaxin%40microsoft.com%7C9f5683a294f649d09a6208dd197ba2c9%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638694741106702598%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=YA%2FnJ8nXG4X93qetNO4PPph5ckjtBojHKIiZip5uOss%3D&reserved=0).
- Update test cases to test the generally available feature.

Test result:
```
PASS: TestAccMongoCluster_geoReplica
PASS: TestAccMongoCluster_previewFeature (2480.43s)
PASS: TestAccMongoClusterFreeTier/freeTier/update (3077.22s)
```
