### PR TITLE
`azurerm_private_endpoint` - subnet_id comparison should be case insensitive

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -69,10 +70,11 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"subnet_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: commonids.ValidateSubnetID,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     commonids.ValidateSubnetID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"network_interface": {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

A few notes on testing.

1. I added _TestAccPrivateEndpoint_subnetCaseInsensitivity_ test. This test creates a PE with a subnet. Then, it re-runs the creation process, making the subnet name all capitalized, to make sure the PE does not get recreated. My changes follow the case insensitive implementation as the application_gateway resource. However, application_gateway does not include any case insensitivity tests. If you don't want me to add a case sensitivity test, I'm happy to remove it.

In running all the private endpoint resource tests, I noticed a few other things and took the following actions. I'm adding this info here in the event tests are run and there are issues as part of your testing as well.

1. _TestAccPrivateEndpoint_privateDnsZoneUpdate_'s update process was not using the same name for the resource when updating the resource was attemped and the test would fail. I fixed this. 
2. _TestAccPrivateEndpoint_updateNicName_ is an incorrect test and fails as part of the pre-apply check. The custom_network_interface_name cannot be updated and the test was failing. I fixed this by changing the test name to TestAccPrivateEndpoint_customNicName and testing only that a custom NIC name could be applied. The original test was added back in 2022 and I'm not sure why it was passing.
3. Two tests, _TestAccPrivateEndpoint_multipleInstances_ and _TestAccPrivateEndpoint_multipleInstancesWithLinkAlias_, currently fail with the following error:
4. 
=== NAME  TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
    testcase.go:173: Step 1/1 error: Pre-apply plan check(s) failed:
        azurerm_private_endpoint.test - Resource not found in plan ResourceChanges

I was able to identify that it's because the resource name is azurerm_private_endpoint.test, which is under test, but the Terraform generated creates multiple instances of the private endpoint, addressable as azurerm_private_endpoint.test.0, azurerm_private_endpoint.test.1, etc. I wasn't able to figure out why this was happening, but also noticed the same issue occurs on the Container Group resource's _TestAccContainerGroup_virtualNetworkParallel_ function. This leads me to believe the failure is either something specific to my environment or a change to the Terraform plugin testing SDK had a change that requires these tests be modified.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_endpoint` - subnet_id comparison is case-insensitive [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #19200 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
