### PR TITLE
`azurerm_mongo_cluster` - move the validation to create func for `source_server_id`

### DIFF
--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -238,6 +238,10 @@ func (r MongoClusterResource) Create() sdk.ResourceFunc {
 			}
 
 			if state.CreateMode == string(mongoclusters.CreateModeGeoReplica) {
+				if state.SourceServerId == "" {
+					return fmt.Errorf("`source_server_id` is required when `create_mode` is `GeoReplica`")
+				}
+
 				parameter.Properties.ReplicaParameters = &mongoclusters.MongoClusterReplicaParameters{
 					SourceLocation:   state.SourceLocation,
 					SourceResourceId: state.SourceServerId,
@@ -512,9 +516,6 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 					return fmt.Errorf("`version` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
 				}
 			case string(mongoclusters.CreateModeGeoReplica):
-				if state.SourceServerId == "" {
-					return fmt.Errorf("`source_server_id` is required when `create_mode` is `GeoReplica`")
-				}
 				if state.SourceLocation == "" {
 					return fmt.Errorf("`source_location` is required when `create_mode` is `GeoReplica`")
 				}

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -21,9 +21,10 @@ type MongoClusterResource struct{}
 func TestAccMongoClusterFreeTier(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"freeTier": { // Run tests in sequence since each subscription is limited to one free tier cluster per region and free tier is currently only available in South India.
-			"basic":  testAccMongoCluster_basic,
-			"update": testAccMongoCluster_update,
-			"import": testAccMongoCluster_requiresImport,
+			"basic":      testAccMongoCluster_basic,
+			"geoReplica": testAccMongoCluster_geoReplica,
+			"update":     testAccMongoCluster_update,
+			"import":     testAccMongoCluster_requiresImport,
 		},
 	})
 }
@@ -34,6 +35,21 @@ func testAccMongoCluster_basic(t *testing.T) {
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode"),
+	})
+}
+
+func testAccMongoCluster_geoReplica(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.geoReplica(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -21,10 +21,9 @@ type MongoClusterResource struct{}
 func TestAccMongoClusterFreeTier(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"freeTier": { // Run tests in sequence since each subscription is limited to one free tier cluster per region and free tier is currently only available in South India.
-			"basic":      testAccMongoCluster_basic,
-			"geoReplica": testAccMongoCluster_geoReplica,
-			"update":     testAccMongoCluster_update,
-			"import":     testAccMongoCluster_requiresImport,
+			"basic":  testAccMongoCluster_basic,
+			"update": testAccMongoCluster_update,
+			"import": testAccMongoCluster_requiresImport,
 		},
 	})
 }
@@ -35,21 +34,6 @@ func testAccMongoCluster_basic(t *testing.T) {
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_password", "create_mode"),
-	})
-}
-
-func testAccMongoCluster_geoReplica(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
-	r := MongoClusterResource{}
-
-	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.geoReplica(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -107,6 +91,21 @@ func TestAccMongoCluster_previewFeature(t *testing.T) {
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode"),
+		{
+			Config: r.geoReplica(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode", "source_location"),
+	})
+}
+
+func TestAccMongoCluster_geoReplica(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.geoReplica(data),
 			Check: acceptance.ComposeTestCheckFunc(


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
When running tf apply, the logic in CustomizeDiff checks if the SourceServerId is empty, but at that point, azurerm_mongo_cluster.test.id has not yet generated the value, so the check fails. To fix this issue, the check for SourceServerId needs to be moved to create function.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Below failed test case is also failed with same error on Teamcity Daily Run. So it's not related with this PR.
![image](https://github.com/user-attachments/assets/1af6d0f2-efbf-4361-8311-c03e6086d92a)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mongo_cluster` - move the validation to create func for `source_server_id`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28255


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
