### PR TITLE
`azurerm_api_management_api`: split create and update method

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -392,7 +392,6 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 	if importVs, ok := d.GetOk("import"); ok {
 		if apiParams := expandApiManagementApiImport(importVs.([]interface{}), apiType, soapApiType,
 			path, d.Get("service_url").(string), version, versionSetId); apiParams != nil {
-
 			if err := client.CreateOrUpdateThenPoll(ctx, id, *apiParams, api.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
@@ -497,7 +496,6 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		if vs, hasImport := d.GetOk("import"); hasImport {
 			if apiParams := expandApiManagementApiImport(vs.([]interface{}), apiType, soapApiType,
 				path, serviceUrl, version, versionSetId); apiParams != nil {
-
 				if err := client.CreateOrUpdateThenPoll(ctx, *id, *apiParams, api.CreateOrUpdateOperationOptions{}); err != nil {
 					return fmt.Errorf("creating/updating %s: %+v", *id, err)
 				}

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -517,12 +517,11 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return errors.New("`display_name`, `protocols` are required when `source_api_id` is not set")
 	}
 
-	idPtr, err := api.ParseApiID(d.Id())
+	id, err := api.ParseApiID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	id := *idPtr
 	apiType := api.ApiTypeHTTP
 	if v, ok := d.GetOk("api_type"); ok {
 		apiType = api.ApiType(v.(string))
@@ -536,8 +535,8 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 			apiParams := expandApiManagementApiImport(vs.([]interface{}), apiType, soapApiType,
 				path, serviceUrl, version, versionSetId)
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, apiParams, api.CreateOrUpdateOperationOptions{}); err != nil {
-				return fmt.Errorf("creating/updating %s: %+v", id, err)
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, apiParams, api.CreateOrUpdateOperationOptions{}); err != nil {
+				return fmt.Errorf("creating/updating %s: %+v", *id, err)
 			}
 		}
 	}
@@ -628,8 +627,8 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		Properties: prop,
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, params, api.CreateOrUpdateOperationOptions{IfMatch: pointer.To("*")}); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, params, api.CreateOrUpdateOperationOptions{IfMatch: pointer.To("*")}); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", *id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -497,13 +497,10 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 
 func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).ApiManagement.ApiClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	revision := d.Get("revision").(string)
 	path := d.Get("path").(string)
-	apiId := fmt.Sprintf("%s;rev=%s", d.Get("name").(string), revision)
 	version := d.Get("version").(string)
 	versionSetId := d.Get("version_set_id").(string)
 	displayName := d.Get("display_name").(string)
@@ -520,8 +517,12 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return errors.New("`display_name`, `protocols` are required when `source_api_id` is not set")
 	}
 
-	id := api.NewApiID(subscriptionId, d.Get("resource_group_name").(string), d.Get("api_management_name").(string), apiId)
+	idPtr, err := api.ParseApiID(d.Id())
+	if err != nil {
+		return err
+	}
 
+	id := *idPtr
 	apiType := api.ApiTypeHTTP
 	if v, ok := d.GetOk("api_type"); ok {
 		apiType = api.ApiType(v.(string))

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -213,15 +213,7 @@ func TestAccApiManagementApi_importSwagger(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -236,15 +228,7 @@ func TestAccApiManagementApi_importOpenapi(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -259,30 +243,14 @@ func TestAccApiManagementApi_importSwaggerWithServiceUrl(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 		{
 			Config: r.importSwaggerWithServiceUrlUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -297,15 +265,7 @@ func TestAccApiManagementApi_importWsdl(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -320,15 +280,7 @@ func TestAccApiManagementApi_importWsdlWithSelector(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			ResourceName:      data.ResourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-			ImportStateVerifyIgnore: []string{
-				// not returned from the API
-				"import",
-			},
-		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -377,6 +329,28 @@ func TestAccApiManagementApi_complete(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementApi_completeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -774,6 +748,42 @@ resource "azurerm_api_management_api" "test" {
   }
 
   terms_of_service_url = "https://example:8080/service"
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) completeUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "Butter Parser Update"
+  path                = "butter-parser-update"
+  protocols           = ["https"]
+  revision            = "3"
+  description         = "What is my purpose? You parse butter update."
+  service_url         = "https://example.com/foo/bar/update"
+
+  subscription_key_parameter_names {
+    header = "X-Butter-Robot-API-Key"
+    query  = "location-update"
+  }
+
+  contact {
+    email = "test-update@test.com"
+    name  = "test-update"
+    url   = "https://example-update:8080"
+  }
+
+  license {
+    name = "test-license-update"
+    url  = "https://example:8080/license-update"
+  }
+
+  terms_of_service_url = "https://example:8080/service-update"
 }
 `, r.template(data, SkuNameConsumption), data.RandomInteger)
 }

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `import` - (Optional) A `import` block as documented below.
 
+-> **NOTE:** The `display_name`, `description`, `contact`, and `license` fields can be imported by the `import` block, which might cause a drift if these fields are set along with the `import` block.
+
 * `license` - (Optional) A `license` block as documented below.
 
 * `oauth2_authorization` - (Optional) An `oauth2_authorization` block as documented below.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


Split Update method from CreateUpdate method, and an update test for it.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccApiManagementApi_completeUpdate (252.61s)
PASS
```

![image](https://github.com/user-attachments/assets/f57439fd-f040-4d22-b1e6-266d0360f4da)


