### PR TITLE
`azurerm_storage_account` - fix error handling for `static_website` and `queue_properties` availability checks

### DIFF
--- a/internal/services/storage/custompollers/data_plane_static_website_availability_poller.go
+++ b/internal/services/storage/custompollers/data_plane_static_website_availability_poller.go
@@ -38,12 +38,12 @@ func NewDataPlaneStaticWebsiteAvailabilityPoller(ctx context.Context, client *st
 func (d *DataPlaneStaticWebsiteAvailabilityPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
 	resp, err := d.client.GetServiceProperties(ctx, d.storageAccountId.StorageAccountName)
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
-			if resp.HttpResponse == nil {
-				return nil, pollers.PollingDroppedConnectionError{
-					Message: err.Error(),
-				}
+		if resp.HttpResponse == nil {
+			return nil, pollers.PollingDroppedConnectionError{
+				Message: err.Error(),
 			}
+		}
+		if !response.WasNotFound(resp.HttpResponse) {
 			return nil, pollers.PollingFailedError{
 				Message: err.Error(),
 				HttpResponse: &client.Response{

--- a/internal/services/storage/storage_account_data_plane_helpers.go
+++ b/internal/services/storage/storage_account_data_plane_helpers.go
@@ -124,5 +124,5 @@ func connectionError(e error) bool {
 		return true
 	}
 
-	return regexp.MustCompile(`dial tcp .*:`).MatchString(e.Error()) || regexp.MustCompile(`EOF$`).MatchString(e.Error())
+	return regexp.MustCompile(`dial tcp`).MatchString(e.Error()) || regexp.MustCompile(`EOF$`).MatchString(e.Error())
 }

--- a/internal/services/storage/storage_account_data_plane_helpers_test.go
+++ b/internal/services/storage/storage_account_data_plane_helpers_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestConnectionError(t *testing.T) {
+	testcases := []struct {
+		Name        string
+		Error       error
+		ShouldMatch bool
+	}{
+		{
+			Name:        "No Route TO Host",
+			Error:       errors.New("dial tcp: connecting to example.blob.core.windows.net no route to host"),
+			ShouldMatch: true,
+		},
+		{
+			Name:        "DNS No Such Host",
+			Error:       errors.New("dial tcp: lookup example.blob.core.windows.net on 10.0.0.1:53: no such host"),
+			ShouldMatch: true,
+		},
+		{
+			Name:        "Proxy Dropped",
+			Error:       errors.New("EOF"),
+			ShouldMatch: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		if connectionError(tc.Error) != tc.ShouldMatch {
+			t.Errorf("expected %s to match but it did not", tc.Name)
+		}
+	}
+}


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR fixes handling certain network failures relating to availability checking of Data Plane endpoints in this resource. This has manifest as intermittent failures in DNS resolution for `static_website` and / or `queue_properties` checks.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - fix error handling for `static_website` and `queue_properties` availability checks


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
