### PR TITLE
[Enhancement:] `azurerm_cdn_frontdoor_profile` - add support for the `identity` property

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_profile_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/profiles"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -34,6 +35,8 @@ func dataSourceCdnFrontDoorProfile() *pluginsdk.Resource {
 			},
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"response_timeout_seconds": {
 				Type:     pluginsdk.TypeInt,
@@ -79,6 +82,10 @@ func dataSourceCdnFrontDoorProfileRead(d *pluginsdk.ResourceData, meta interface
 
 		if skuName := model.Sku.Name; skuName != nil {
 			d.Set("sku_name", string(pointer.From(skuName)))
+		}
+
+		if identity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity); err == nil {
+			d.Set("identity", identity)
 		}
 
 		if props := model.Properties; props != nil {

--- a/internal/services/cdn/cdn_frontdoor_profile_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_data_source_test.go
@@ -27,6 +27,51 @@ func TestAccCdnFrontDoorProfileDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorProfileDataSource_basicWithSystemIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	d := CdnFrontDoorProfileDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basicWithSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("sku_name").HasValue("Standard_AzureFrontDoor"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+			),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorProfileDataSource_basicWithUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	d := CdnFrontDoorProfileDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basicWithUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("sku_name").HasValue("Standard_AzureFrontDoor"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+			),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorProfileDataSource_basicWithSystemAndUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	d := CdnFrontDoorProfileDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basicWithSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("sku_name").HasValue("Standard_AzureFrontDoor"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned, UserAssigned"),
+			),
+		},
+	})
+}
+
 func (CdnFrontDoorProfileDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -36,4 +81,34 @@ data "azurerm_cdn_frontdoor_profile" "test" {
   resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
 }
 `, CdnFrontDoorProfileResource{}.complete(data))
+}
+
+func (CdnFrontDoorProfileDataSource) basicWithSystemIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+data "azurerm_cdn_frontdoor_profile" "test" {
+  name                = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontDoorProfileResource{}.basicWithSystemIdentity(data))
+}
+
+func (CdnFrontDoorProfileDataSource) basicWithUserIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+data "azurerm_cdn_frontdoor_profile" "test" {
+  name                = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontDoorProfileResource{}.basicWithUserIdentity(data))
+}
+
+func (CdnFrontDoorProfileDataSource) basicWithSystemAndUserIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+data "azurerm_cdn_frontdoor_profile" "test" {
+  name                = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontDoorProfileResource{}.basicWithSystemAndUserIdentity(data))
 }

--- a/internal/services/cdn/cdn_frontdoor_profile_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/profiles"
@@ -49,6 +50,8 @@ func resourceCdnFrontDoorProfile() *pluginsdk.Resource {
 			},
 
 			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"response_timeout_seconds": {
 				Type:         pluginsdk.TypeInt,
@@ -107,6 +110,15 @@ func resourceCdnFrontDoorProfileCreate(d *pluginsdk.ResourceData, meta interface
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
+	if v, ok := d.GetOk("identity"); ok {
+		i, err := identity.ExpandSystemAndUserAssignedMap(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		props.Identity = i
+	}
+
 	err = client.CreateThenPoll(ctx, id, props)
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
@@ -143,6 +155,15 @@ func resourceCdnFrontDoorProfileRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("sku_name", string(pointer.From(skuName)))
 		}
 
+		identity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+
+		if err := d.Set("identity", identity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
+
 		if props := model.Properties; props != nil {
 			d.Set("response_timeout_seconds", int(pointer.From(props.OriginResponseTimeoutSeconds)))
 
@@ -176,6 +197,15 @@ func resourceCdnFrontDoorProfileUpdate(d *pluginsdk.ResourceData, meta interface
 
 	if d.HasChange("response_timeout_seconds") {
 		props.Properties.OriginResponseTimeoutSeconds = pointer.To(int64(d.Get("response_timeout_seconds").(int)))
+	}
+
+	if d.HasChange("identity") {
+		i, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		props.Identity = i
 	}
 
 	err = client.UpdateThenPoll(ctx, pointer.From(id), props)

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -154,6 +154,7 @@ func TestAccCdnFrontDoorProfileWithSystemIdentity_update(t *testing.T) {
 				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -184,6 +185,7 @@ func TestAccCdnFrontDoorProfileWithUserIdentity_update(t *testing.T) {
 				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -374,9 +374,9 @@ provider "azurerm" {
 }
 %s
 resource "azurerm_cdn_frontdoor_profile" "test" {
-  name                = "acctestprofile-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Premium_AzureFrontDoor"
+  name                     = "acctestprofile-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  sku_name                 = "Premium_AzureFrontDoor"
   response_timeout_seconds = 120
   identity {
     type = "SystemAssigned"
@@ -396,9 +396,9 @@ provider "azurerm" {
 }
 %s
 resource "azurerm_cdn_frontdoor_profile" "test" {
-  name                = "acctestprofile-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Premium_AzureFrontDoor"
+  name                     = "acctestprofile-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  sku_name                 = "Premium_AzureFrontDoor"
   response_timeout_seconds = 120
   identity {
     type         = "UserAssigned"
@@ -419,9 +419,9 @@ provider "azurerm" {
 }
 %s
 resource "azurerm_cdn_frontdoor_profile" "test" {
-  name                = "acctestprofile-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Premium_AzureFrontDoor"
+  name                     = "acctestprofile-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  sku_name                 = "Premium_AzureFrontDoor"
   response_timeout_seconds = 120
   identity {
     type         = "SystemAssigned, UserAssigned"
@@ -444,7 +444,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  name = "acctestAFD-%d"
+  name                = "acctestAFD-%d"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -34,6 +34,48 @@ func TestAccCdnFrontDoorProfile_basic(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorProfileWithSystemIdentity_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorProfileWithUserIdentity_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorProfileWithSystemAndUserIdentity_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCdnFrontDoorProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
 	r := CdnFrontDoorProfileResource{}
@@ -85,6 +127,97 @@ func TestAccCdnFrontDoorProfile_update(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorProfileWithSystemIdentity_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateWithSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("120"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorProfileWithUserIdentity_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateWithUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("120"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorProfileWithSystemAndUserIdentity_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateWithSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("120"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("response_timeout_seconds").HasValue("240"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnFrontDoorProfileResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := profiles.ParseProfileID(state.ID)
 	if err != nil {
@@ -115,6 +248,62 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
   name                = "acctestprofile-%d"
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Standard_AzureFrontDoor"
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorProfileResource) basicWithSystemIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorProfileResource) basicWithUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorProfileResource) basicWithSystemAndUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -177,11 +366,85 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
 `, template, data.RandomInteger)
 }
 
+func (r CdnFrontDoorProfileResource) updateWithSystemIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Premium_AzureFrontDoor"
+  response_timeout_seconds = 120
+  identity {
+    type = "SystemAssigned"
+  }
+  tags = {
+    ENV = "Production"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorProfileResource) updateWithUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Premium_AzureFrontDoor"
+  response_timeout_seconds = 120
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+  tags = {
+    ENV = "Production"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorProfileResource) updateWithSystemAndUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+%s
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestprofile-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Premium_AzureFrontDoor"
+  response_timeout_seconds = 120
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+  tags = {
+    ENV = "Production"
+  }
+}
+`, template, data.RandomInteger)
+}
+
 func (CdnFrontDoorProfileResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-cdn-afdx-%d"
   location = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary)
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name = "acctestAFD-%d"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -27,6 +27,18 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where this Front Door Profile exists.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - The type of Managed Service Identity that is configured on this Front Door Profile.
+
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Front Door Profile.
+
+---
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -39,9 +39,22 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU for this Front Door Profile. Possible values include `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `response_timeout_seconds` - (Optional) Specifies the maximum response timeout in seconds. Possible values are between `16` and `240` seconds (inclusive). Defaults to `120` seconds.
 
 * `tags` - (Optional) Specifies a mapping of tags to assign to the resource.
+
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of managed identity to assign. Possible values are `SystemAssigned`, `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+* `identity_ids` - (Optional) - A list of one or more Resource IDs for User Assigned Managed identities to assign. Required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The purpose for this PR are as follows:

* add support for the `identity` field in the the AFD Profile resource


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![image](https://github.com/user-attachments/assets/0e3c8a95-b9c1-49b7-8b16-fb2ab4d4a1aa)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_profile` - add support for the `identity` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #20289

## Related PR(s)
Supersedes #28068

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
