### PR TITLE
FourPointOh - removal from 's' resources/datasources

### DIFF
--- a/internal/services/securitycenter/security_center_contact_resource.go
+++ b/internal/services/securitycenter/security_center_contact_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -21,7 +20,7 @@ import (
 )
 
 func resourceSecurityCenterContact() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceSecurityCenterContactCreateUpdate,
 		Read:   resourceSecurityCenterContactRead,
 		Update: resourceSecurityCenterContactCreateUpdate,
@@ -40,11 +39,10 @@ func resourceSecurityCenterContact() *pluginsdk.Resource {
 		},
 
 		Schema: map[string]*pluginsdk.Schema{
-			// This becomes Required and ForceNew in 4.0 - override happens further down
 			"name": {
 				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Default:      "default1",
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -71,17 +69,6 @@ func resourceSecurityCenterContact() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	if features.FourPointOh() {
-		resource.Schema["name"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-	}
-
-	return resource
 }
 
 func resourceSecurityCenterContactCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -171,19 +170,6 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	enableBatchedOperations := d.Get("batched_operations_enabled").(bool)
 	enableExpress := d.Get("express_enabled").(bool)
 	enablePartitioning := d.Get("partitioning_enabled").(bool)
-	if !features.FourPointOh() {
-		if v := d.GetRawConfig().AsValueMap()["enable_batched_operations"]; !v.IsNull() {
-			enableBatchedOperations = d.Get("enable_batched_operations").(bool)
-		}
-
-		if v := d.GetRawConfig().AsValueMap()["enable_express"]; !v.IsNull() {
-			enableExpress = d.Get("enable_express").(bool)
-		}
-
-		if v := d.GetRawConfig().AsValueMap()["enable_partitioning"]; !v.IsNull() {
-			enablePartitioning = d.Get("enable_partitioning").(bool)
-		}
-	}
 
 	status := topics.EntityStatus(d.Get("status").(string))
 	parameters := topics.SBTopic{

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/validate"
@@ -74,17 +73,9 @@ func resourceSpringCloudGatewayRouteConfig() *pluginsdk.Resource {
 				},
 			},
 
-			// lintignore:S013
 			"protocol": {
 				Type:     pluginsdk.TypeString,
-				Optional: !features.FourPointOh(),
-				Required: features.FourPointOh(),
-				Default: func() interface{} {
-					if !features.FourPointOh() {
-						return string(appplatform.GatewayRouteConfigProtocolHTTP)
-					}
-					return nil
-				}(),
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(appplatform.GatewayRouteConfigProtocolHTTP),
 					string(appplatform.GatewayRouteConfigProtocolHTTPS),

--- a/internal/services/storage/storage_account_sas_data_source.go
+++ b/internal/services/storage/storage_account_sas_data_source.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/storage"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -23,11 +22,7 @@ const (
 // This is an ACCOUNT SAS : https://docs.microsoft.com/en-us/rest/api/storageservices/Constructing-an-Account-SAS
 // not Service SAS
 func dataSourceStorageAccountSharedAccessSignature() *pluginsdk.Resource {
-	sasSignedVersion := "2017-07-29"
-	if features.FourPointOhBeta() {
-		// TODO: Update the document as well
-		sasSignedVersion = "2022-11-02"
-	}
+	sasSignedVersion := "2022-11-02"
 	return &pluginsdk.Resource{
 		Read: dataSourceStorageAccountSasRead,
 

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -22,7 +21,7 @@ import (
 )
 
 func resourceSynapseSparkPool() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceSynapseSparkPoolCreate,
 		Read:   resourceSynapseSparkPoolRead,
 		Update: resourceSynapseSparkPoolUpdate,
@@ -215,11 +214,8 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "2.4",
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"2.4",
-					"3.1",
 					"3.2",
 					"3.3",
 					"3.4",
@@ -229,20 +225,6 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"tags": tags.Schema(),
 		},
 	}
-
-	if features.FourPointOh() {
-		resource.Schema["spark_version"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				"3.2",
-				"3.3",
-				"3.4",
-			}, false),
-		}
-	}
-
-	return resource
 }
 
 func resourceSynapseSparkPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -39,7 +38,7 @@ const (
 )
 
 func resourceSynapseWorkspace() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceSynapseWorkspaceCreate,
 		Read:   resourceSynapseWorkspaceRead,
 		Update: resourceSynapseWorkspaceUpdate,
@@ -272,8 +271,6 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 			"tags": tags.Schema(),
 		},
 	}
-
-	return resource
 }
 
 func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -473,8 +470,6 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Synapse.WorkspaceClient
-	aadAdminClient := meta.(*clients.Client).Synapse.WorkspaceAadAdminsClient
-	sqlAdminClient := meta.(*clients.Client).Synapse.WorkspaceSQLAadAdminsClient
 	azureADOnlyAuthenticationsClient := meta.(*clients.Client).Synapse.WorkspaceAzureADOnlyAuthenticationsClient
 	identitySQLControlClient := meta.(*clients.Client).Synapse.WorkspaceManagedIdentitySQLControlSettingsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
@@ -543,66 +538,6 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for azuread_authentication_only to finish updating for %s: %+v", id, err)
-		}
-	}
-
-	if !features.FourPointOh() {
-		if d.HasChange("aad_admin") {
-			aadAdmin := expandArmWorkspaceAadAdminInfo(d.Get("aad_admin").([]interface{}))
-			if aadAdmin != nil {
-				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-				}
-				workspaceAadAdminsCreateOrUpdateFuture, err := aadAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *aadAdmin)
-				if err != nil {
-					return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-
-				if err = workspaceAadAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-			} else {
-				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-				}
-				workspaceAadAdminsDeleteFuture, err := aadAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
-				if err != nil {
-					return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-
-				if err = workspaceAadAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-			}
-		}
-
-		if d.HasChange("sql_aad_admin") {
-			sqlAdmin := expandArmWorkspaceAadAdminInfo(d.Get("sql_aad_admin").([]interface{}))
-			if sqlAdmin != nil {
-				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-				}
-				workspaceSqlAdminsCreateOrUpdateFuture, err := sqlAdminClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlAdmin)
-				if err != nil {
-					return fmt.Errorf("updating Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-
-				if err = workspaceSqlAdminsCreateOrUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("waiting on updating for Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-			} else {
-				if err := waitSynapseWorkspaceProvisioningState(ctx, client, id); err != nil {
-					return fmt.Errorf("failed waiting for updating %s: %+v", id, err)
-				}
-				workspaceSqlAdminsDeleteFuture, err := sqlAdminClient.Delete(ctx, id.ResourceGroup, id.Name)
-				if err != nil {
-					return fmt.Errorf("setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-
-				if err = workspaceSqlAdminsDeleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("waiting on setting empty Synapse Workspace %q Sql Admin (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-				}
-			}
 		}
 	}
 
@@ -731,21 +666,6 @@ func expandArmWorkspaceDataLakeStorageAccountDetails(storageDataLakeGen2Filesyst
 	return &synapse.DataLakeStorageAccountDetails{
 		AccountURL: utils.String(fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)), // https://storageaccountname.dfs.core.windows.net/filesystemname -> https://storageaccountname.dfs.core.windows.net
 		Filesystem: utils.String(strings.TrimPrefix(uri.Path, "/")),            // https://storageaccountname.dfs.core.windows.net/filesystemname -> filesystemname
-	}
-}
-
-func expandArmWorkspaceAadAdminInfo(input []interface{}) *synapse.WorkspaceAadAdminInfo {
-	if len(input) == 0 || input[0] == nil {
-		return nil
-	}
-	v := input[0].(map[string]interface{})
-	return &synapse.WorkspaceAadAdminInfo{
-		AadAdminProperties: &synapse.AadAdminProperties{
-			TenantID:          utils.String(v["tenant_id"].(string)),
-			Login:             utils.String(v["login"].(string)),
-			AdministratorType: utils.String("ActiveDirectory"),
-			Sid:               utils.String(v["object_id"].(string)),
-		},
 	}
 }
 

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -39,7 +39,7 @@ resource "azurerm_storage_account" "example" {
 data "azurerm_storage_account_sas" "example" {
   connection_string = azurerm_storage_account.example.primary_connection_string
   https_only        = true
-  signed_version    = "2017-07-29"
+  signed_version    = "2022-11-02"
 
   resource_types {
     service   = true
@@ -81,7 +81,7 @@ output "sas_url_query_string" {
 * `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
 * `ip_addresses` - (Optional) IP address, or a range of IP addresses, from which to accept requests. When specifying a range, note that the range is inclusive.  
-* `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2017-07-29`.
+* `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2022-11-02`.
 * `resource_types` - A `resource_types` block as defined below.
 * `services` - A `services` block as defined below.
 * `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.

--- a/website/docs/r/security_center_contact.html.markdown
+++ b/website/docs/r/security_center_contact.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Security Center"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_security_center_contact"
 description: |-
-    Manages the subscription's Security Center Contact.
+  Manages the subscription's Security Center Contact.
 ---
 
 # azurerm_security_center_contact
@@ -25,7 +25,7 @@ resource "azurerm_security_center_contact" "example" {
 }
 ```
 
-## Argument Reference
+## Arguments Reference
 
 The following arguments are supported:
 
@@ -35,28 +35,30 @@ The following arguments are supported:
 
 * `email` - (Required) The email of the Security Center Contact.
 
-* `name` - (Optional) The name of the Security Center Contact. Defaults to `default1`.
+* `name` - (Required) The name of the Security Center Contact. Changing this forces a new Security Center Contact to be created.
+
+---
 
 * `phone` - (Optional) The phone number of the Security Center Contact.
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported:
+In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The Security Center Contact ID.
+* `id` - The ID of the Security Center Contact.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the Security Center Contact.
-* `update` - (Defaults to 60 minutes) Used when updating the Security Center Contact.
+* `create` - (Defaults to 1 hour) Used when creating the Security Center Contact.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Security Center Contact.
-* `delete` - (Defaults to 60 minutes) Used when deleting the Security Center Contact.
+* `update` - (Defaults to 1 hour) Used when updating the Security Center Contact.
+* `delete` - (Defaults to 1 hour) Used when deleting the Security Center Contact.
 
 ## Import
 
-The contact can be imported using the `resource id`, e.g.
+Security Center Contacts can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_security_center_contact.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/securityContacts/default1

--- a/website/docs/r/spring_cloud_gateway_route_config.html.markdown
+++ b/website/docs/r/spring_cloud_gateway_route_config.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `spring_cloud_gateway_id` - (Required) The ID of the Spring Cloud Gateway. Changing this forces a new Spring Cloud Gateway Route Config to be created.
 
-* `protocol` - (Required) Specifies the protocol of routed Spring Cloud App. Allowed values are `HTTP` and `HTTPS`. Defaults to `HTTP`.
+* `protocol` - (Required) Specifies the protocol of routed Spring Cloud App. Allowed values are `HTTP` and `HTTPS`.
 
 ~> **Note:** You likely want to use `HTTPS` in a production environment, since `HTTP` offers no encryption.
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -77,6 +77,8 @@ EOF
     filename = "config.txt"
   }
 
+  spark_version = 3.2
+
   tags = {
     ENV = "Production"
   }
@@ -94,6 +96,8 @@ The following arguments are supported:
 * `node_size_family` - (Required) The kind of nodes that the Spark Pool provides. Possible values are `HardwareAcceleratedFPGA`, `HardwareAcceleratedGPU`, `MemoryOptimized`, and `None`.
 
 * `node_size` - (Required) The level of node in the Spark Pool. Possible values are `Small`, `Medium`, `Large`, `None`, `XLarge`, `XXLarge` and `XXXLarge`.
+
+* `spark_version` - (Required) The Apache Spark version. Possible values are `3.2`, `3.3`, and `3.4`.
 
 * `node_count` - (Optional) The number of nodes in the Spark Pool. Exactly one of `node_count` or `auto_scale` must be specified.
 
@@ -122,8 +126,6 @@ The following arguments are supported:
 * `spark_log_folder` - (Optional) The default folder where Spark logs will be written. Defaults to `/logs`.
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
-
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2`, `3.3`, and `3.4`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

FourPointOh removals ('s' resources/datasources)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

It looks like the failing tests have been failing prior to these changes, except for `TestAccSynapseWorkspace_complete` which failed due to exceeding a resource quota for `Account` in eastus2 location

<details>
<summary>Test Outputs</summary>

```
— service/securitycenter
--- PASS: TestAccSecurityCenterContact (135.03s)
    --- PASS: TestAccSecurityCenterContact/contact (135.03s)
        --- PASS: TestAccSecurityCenterContact/contact/basic (35.50s)
        --- PASS: TestAccSecurityCenterContact/contact/update (50.42s)
        --- PASS: TestAccSecurityCenterContact/contact/requiresImport (26.15s)
        --- PASS: TestAccSecurityCenterContact/contact/phoneOptional (22.96s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter        137.610s

— service/servicebus
--- PASS: TestAccServiceBusTopic_enableDuplicateDetection (191.84s)
--- PASS: TestAccServiceBusTopic_requiresImport (194.73s)
--- PASS: TestAccServiceBusTopic_complete (213.74s)
--- PASS: TestAccServiceBusTopic_basicDisabled (225.19s)
--- PASS: TestAccServiceBusTopic_enablePartitioningStandard (241.13s)
--- PASS: TestAccServiceBusTopic_update (251.38s)
--- PASS: TestAccServiceBusTopic_basic (254.79s)
--- PASS: TestAccServiceBusTopic_basicDisableEnable (277.79s)
--- PASS: TestAccServiceBusTopic_maxMessageSizePremium (364.39s)
--- PASS: TestAccServiceBusTopic_isoTimeSpanAttributes (177.48s)
--- PASS: TestAccServiceBusTopic_enablePartitioningPremium (401.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    403.745s

— service/springcloud
--- FAIL: TestAccSpringCloudGatewayRouteConfig_complete (386.68s)
--- FAIL: TestAccSpringCloudGatewayRouteConfig_multipleRoutes (387.00s)
--- PASS: TestAccSpringCloudGatewayRouteConfig_requiresImport (516.92s)
--- PASS: TestAccSpringCloudGatewayRouteConfig_basic (642.54s)
--- FAIL: TestAccSpringCloudGatewayRouteConfig_update (889.19s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud   891.885s

— service/storage
--- PASS: TestAccDataSourceStorageAccountSas_resourceTypesString (0.00s)
--- PASS: TestAccDataSourceStorageAccountSas_servicesString (0.00s)
--- PASS: TestAccDataSourceStorageAccountSas_permissionsString (0.00s)
--- PASS: TestAccDataSourceStorageAccountSas_basic (146.33s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       148.990s

— service/synapse
--- PASS: TestAccSynapseWorkspace_basic (545.96s)
--- PASS: TestAccSynapseWorkspace_requiresImport (578.49s)
--- PASS: TestAccSynapseSparkPool_basic (602.50s)
--- PASS: TestAccSynapseSparkPool_isolation (631.63s)
--- PASS: TestAccSynapseWorkspace_azdo (720.60s)
--- PASS: TestAccSynapseWorkspace_customerManagedKeyActivation (743.07s)
--- PASS: TestAccSynapseSparkPool_sparkVersion (814.67s)
--- PASS: TestAccSynapseWorkspace_azdoTenant (483.48s)
--- PASS: TestAccSynapseSparkPool_requiresImport (548.45s)
--- FAIL: TestAccSynapseWorkspace_complete (108.49s)
--- PASS: TestAccSynapseWorkspace_azureAdOnlyAuthentication (676.67s)
--- PASS: TestAccSynapseWorkspace_cmkWithAADAdmin (677.51s)
--- PASS: TestAccSynapseWorkspace_github (667.94s)
--- FAIL: TestAccSynapseWorkspace_update (881.18s)
--- PASS: TestAccSynapseSparkPool_update (1648.74s)
--- PASS: TestAccSynapseSpark3Pool_complete (1774.52s)
--- PASS: TestAccSynapseSpark3Pool_update (1781.99s)
--- PASS: TestAccSynapseSparkPool_complete (1480.13s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse       2028.782s
```

</details>

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
