### PR TITLE
`azurerm_automation_software_update_configuration` remove deprecated misspelled attribute `error_meesage`

### DIFF
--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -805,7 +805,7 @@ func (m SoftwareUpdateConfigurationResource) Read() sdk.ResourceFunc {
 				}
 
 				if errorMessage := props.Error; errorMessage != nil {
-					state.ErrorMeesage = pointer.From(errorMessage.Message)
+					state.ErrorMessage = pointer.From(errorMessage.Message)
 				}
 			}
 

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -117,7 +117,6 @@ type SoftwareUpdateConfigurationModel struct {
 	AutomationAccountID   string       `tfschema:"automation_account_id"`
 	Name                  string       `tfschema:"name"`
 	ErrorCode             string       `tfschema:"error_code"`
-	ErrorMeesage          string       `tfschema:"error_meesage,removedInNextMajorVersion"`
 	ErrorMessage          string       `tfschema:"error_message"`
 	OperatingSystem       string       `tfschema:"operating_system,removedInNextMajorVersion"`
 	Linux                 []Linux      `tfschema:"linux"`

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -23,7 +23,6 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_automation_account" "example" {
-resource "azurerm_automation_account" "example" {
   name                = "example"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -23,6 +23,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_automation_account" "example" {
+resource "azurerm_automation_account" "example" {
   name                = "example"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The `error_meesage` attribute was already deprecated, so nothing should be depending on it. This PR removes the unused attribute and corrects the setting of the message to use the right source.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

No user-impacting changes


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

`azurerm_automation_software_update_configuration`: removes deprecated attribute `error_meesage` and corrects setting the message to use the current correctly spelled attribute


## Related Issue(s)
Fixes #20931 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
