### PR TITLE
Provider function `parse_resource_id`: Populate the `resource_name` for resource group and subscription

### DIFF
--- a/internal/provider/function/parse_resource_id.go
+++ b/internal/provider/function/parse_resource_id.go
@@ -109,14 +109,18 @@ func (p ParseResourceIDFunction) Run(ctx context.Context, request function.RunRe
 	for k, v := range s {
 		switch v.Type {
 		case resourceids.ResourceGroupSegmentType:
-			output["resource_group_name"] = types.StringValue(parsed.Parsed[v.Name])
+			resourceGroupName := types.StringValue(parsed.Parsed[v.Name])
+			output["resource_group_name"] = resourceGroupName
+			output["resource_name"] = resourceGroupName
 
 		case resourceids.ResourceProviderSegmentType:
 			output["resource_provider"] = types.StringPointerValue(v.FixedValue)
 			fullResourceType = pointer.From(v.FixedValue)
 
 		case resourceids.SubscriptionIdSegmentType:
-			output["subscription_id"] = types.StringValue(parsed.Parsed["subscriptionId"])
+			subscriptionId := types.StringValue(parsed.Parsed["subscriptionId"])
+			output["subscription_id"] = subscriptionId
+			output["resource_name"] = subscriptionId
 
 		case resourceids.StaticSegmentType:
 			switch {

--- a/internal/provider/function/parse_resource_id_test.go
+++ b/internal/provider/function/parse_resource_id_test.go
@@ -42,6 +42,54 @@ func TestProviderFunctionParseResourceID_basic(t *testing.T) {
 	})
 }
 
+func TestProviderFunctionParseResourceID_subscription(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: testParseSubscriptionResourceIdOutput("/subscriptions/12345678-1234-9876-4563-123456789012"),
+				Check: acceptance.ComposeTestCheckFunc(
+					acceptance.TestCheckOutput("subscription_id", "12345678-1234-9876-4563-123456789012"),
+					acceptance.TestCheckOutput("resource_group_name", ""),
+					acceptance.TestCheckOutput("resource_type", "subscriptions"),
+					acceptance.TestCheckOutput("resource_name", "12345678-1234-9876-4563-123456789012"),
+					acceptance.TestCheckOutput("resource_scope", ""),
+					acceptance.TestCheckOutput("full_resource_type", "/subscriptions"),
+				),
+			},
+		},
+	})
+}
+
+func TestProviderFunctionParseResourceID_resourceGroup(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: testParseResourceGroupResourceIdOutput("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1"),
+				Check: acceptance.ComposeTestCheckFunc(
+					acceptance.TestCheckOutput("subscription_id", "12345678-1234-9876-4563-123456789012"),
+					acceptance.TestCheckOutput("resource_group_name", "resGroup1"),
+					acceptance.TestCheckOutput("resource_type", "resourceGroups"),
+					acceptance.TestCheckOutput("resource_name", "resGroup1"),
+					acceptance.TestCheckOutput("resource_scope", ""),
+					acceptance.TestCheckOutput("full_resource_type", "/resourceGroups"),
+				),
+			},
+		},
+	})
+}
+
 func TestProviderFunctionParseResourceID_scopedAtSubscription(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +184,78 @@ output "full_resource_type" {
 }
 
 
+`, id)
+}
+
+func testParseSubscriptionResourceIdOutput(id string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  parsed_id = provider::azurerm::parse_resource_id("%s")
+}
+
+output "resource_name" {
+  value = local.parsed_id["resource_name"]
+}
+
+output "resource_scope" {
+  value = local.parsed_id["resource_scope"]
+}
+
+output "resource_group_name" {
+  value = local.parsed_id["resource_group_name"]
+}
+
+output "resource_type" {
+  value = local.parsed_id["resource_type"]
+}
+
+output "subscription_id" {
+  value = local.parsed_id["subscription_id"]
+}
+
+output "full_resource_type" {
+  value = local.parsed_id["full_resource_type"]
+}
+`, id)
+}
+
+func testParseResourceGroupResourceIdOutput(id string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  parsed_id = provider::azurerm::parse_resource_id("%s")
+}
+
+output "resource_name" {
+  value = local.parsed_id["resource_name"]
+}
+
+output "resource_scope" {
+  value = local.parsed_id["resource_scope"]
+}
+
+output "resource_group_name" {
+  value = local.parsed_id["resource_group_name"]
+}
+
+output "resource_type" {
+  value = local.parsed_id["resource_type"]
+}
+
+output "subscription_id" {
+  value = local.parsed_id["subscription_id"]
+}
+
+output "full_resource_type" {
+  value = local.parsed_id["full_resource_type"]
+}
 `, id)
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR populates the `resource_name` returned by the provider function `parse_resource_id`, for resource group and subscription. The sanity here is that both of them returns the correct `(full_)resource_type`, the `resource_name` shall also be there to be consistent.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28295


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
