### PR TITLE
FourPointOh - remove from `service/apimanagement`

### DIFF
--- a/internal/services/apimanagement/api_management_api_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/tag"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -69,11 +68,6 @@ func resourceApiManagementApiTagCreate(d *pluginsdk.ResourceData, meta interface
 
 	id := apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiId.ApiId, d.Get("name").(string))
 
-	if !features.FourPointOh() {
-		apiName := getApiName(apiId.ApiId)
-		id = apitag.NewApiTagID(subscriptionId, apiId.ResourceGroupName, apiId.ServiceName, apiName, d.Get("name").(string))
-	}
-
 	tagExists, err := tagClient.Get(ctx, tagId)
 	if err != nil {
 		if !response.WasNotFound(tagExists.HttpResponse) {
@@ -115,12 +109,6 @@ func resourceApiManagementApiTagRead(d *pluginsdk.ResourceData, meta interface{}
 	apiId := api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId)
 	tagId := apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
 
-	if !features.FourPointOh() {
-		apiName := getApiName(id.ApiId)
-		apiId = api.NewApiID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName)
-		tagId = apitag.NewApiTagID(subscriptionId, id.ResourceGroupName, id.ServiceName, apiName, id.TagId)
-	}
-
 	resp, err := client.TagGetByApi(ctx, tagId)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -149,11 +137,6 @@ func resourceApiManagementApiTagDelete(d *pluginsdk.ResourceData, meta interface
 	}
 
 	newId := apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, id.ApiId, id.TagId)
-
-	if !features.FourPointOh() {
-		name := getApiName(id.ApiId)
-		newId = apitag.NewApiTagID(id.SubscriptionId, id.ResourceGroupName, id.ServiceName, name, id.TagId)
-	}
 
 	if _, err = client.TagDetachFromApi(ctx, newId); err != nil {
 		return fmt.Errorf("detaching api tag %q: %+v", newId, err)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removing FourPointOh flag from `service/apimanagement`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
