### PR TITLE
`azurerm_route_server` - Add support for `hub_routing_preference` property        

### DIFF
--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -293,7 +293,7 @@ func resourceRouteServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 				d.Set("branch_to_branch_traffic_enabled", props.AllowBranchToBranchTraffic)
 			}
 			if props.HubRoutingPreference != nil {
-				d.Set("hub_routing_preference", props.HubRoutingPreference)
+				d.Set("hub_routing_preference", string(*props.HubRoutingPreference))
 			}
 			if props.VirtualRouterAsn != nil {
 				d.Set("virtual_router_asn", props.VirtualRouterAsn)

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -143,7 +143,7 @@ func resourceRouteServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		Properties: &virtualwans.VirtualHubProperties{
 			Sku:                        pointer.To(d.Get("sku").(string)),
 			AllowBranchToBranchTraffic: pointer.To(d.Get("branch_to_branch_traffic_enabled").(bool)),
-			HubRoutingPreference:       (*virtualwans.HubRoutingPreference)(pointer.To(d.Get("hub_routing_preference").(string))),
+			HubRoutingPreference:       pointer.To(virtualwans.HubRoutingPreference(d.Get("hub_routing_preference").(string))),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -223,7 +223,7 @@ func resourceRouteServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if d.HasChange("hub_routing_preference") {
 		if v, ok := d.GetOk("hub_routing_preference"); ok {
-			payload.Properties.HubRoutingPreference = (*virtualwans.HubRoutingPreference)(pointer.To(v.(string)))
+			payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(v.(string))),
 		} else {
 			payload.Properties.HubRoutingPreference = nil
 		}

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -222,11 +222,7 @@ func resourceRouteServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("hub_routing_preference") {
-		if v, ok := d.GetOk("hub_routing_preference"); ok {
-			payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(v.(string)))
-		} else {
-			payload.Properties.HubRoutingPreference = nil
-		}
+		payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(d.Get("hub_routing_preference").(string)))
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -86,7 +86,7 @@ func resourceRouteServer() *pluginsdk.Resource {
 			"hub_routing_preference": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  string(virtualwans.HubRoutingPreferenceExpressRoute),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(virtualwans.HubRoutingPreferenceASPath),
 					string(virtualwans.HubRoutingPreferenceExpressRoute),

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -223,7 +223,7 @@ func resourceRouteServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if d.HasChange("hub_routing_preference") {
 		if v, ok := d.GetOk("hub_routing_preference"); ok {
-			payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(v.(string))),
+			payload.Properties.HubRoutingPreference = pointer.To(virtualwans.HubRoutingPreference(v.(string)))
 		} else {
 			payload.Properties.HubRoutingPreference = nil
 		}

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -292,9 +292,7 @@ func resourceRouteServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			if props.AllowBranchToBranchTraffic != nil {
 				d.Set("branch_to_branch_traffic_enabled", props.AllowBranchToBranchTraffic)
 			}
-			if props.HubRoutingPreference != nil {
-				d.Set("hub_routing_preference", string(*props.HubRoutingPreference))
-			}
+			d.Set("hub_routing_preference", pointer.From(props.HubRoutingPreference))
 			if props.VirtualRouterAsn != nil {
 				d.Set("virtual_router_asn", props.VirtualRouterAsn)
 			}

--- a/internal/services/network/route_server_resource_test.go
+++ b/internal/services/network/route_server_resource_test.go
@@ -26,7 +26,8 @@ func TestAccRouteServer_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r)),
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
 		data.ImportStep(),
 	})
@@ -71,13 +72,15 @@ func TestAccRouteServer_update(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r)),
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
 		data.ImportStep(),
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r)),
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
 		data.ImportStep(),
 	})
@@ -147,6 +150,7 @@ resource "azurerm_route_server" "test" {
   public_ip_address_id             = azurerm_public_ip.test.id
   subnet_id                        = azurerm_subnet.test.id
   branch_to_branch_traffic_enabled = true
+  hub_routing_preference           = "VpnGateway"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/network/route_server_resource_test.go
+++ b/internal/services/network/route_server_resource_test.go
@@ -83,6 +83,13 @@ func TestAccRouteServer_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 

--- a/website/docs/r/route_server.html.markdown
+++ b/website/docs/r/route_server.html.markdown
@@ -66,17 +66,17 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Route Server should exist. Changing this forces a new resource to be created.
 
-* `subnet_id` - (Required) The ID of the Subnet that the Route Server will reside. Changing this forces a new resource to be created.
-
--> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server.
-
-* `sku` - (Required) The SKU of the Route Server. The only possible value is `Standard`. Changing this forces a new resource to be created.
-
-* `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
-
 * `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s).
 
 * `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`.
+
+* `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
+
+* `sku` - (Required) The SKU of the Route Server. The only possible value is `Standard`. Changing this forces a new resource to be created.
+
+* `subnet_id` - (Required) The ID of the Subnet that the Route Server will reside. Changing this forces a new resource to be created.
+
+-> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/route_server.html.markdown
+++ b/website/docs/r/route_server.html.markdown
@@ -66,10 +66,6 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Route Server should exist. Changing this forces a new resource to be created.
 
-* `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s).
-
-* `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`.
-
 * `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
 
 * `sku` - (Required) The SKU of the Route Server. The only possible value is `Standard`. Changing this forces a new resource to be created.
@@ -77,6 +73,10 @@ The following arguments are supported:
 * `subnet_id` - (Required) The ID of the Subnet that the Route Server will reside. Changing this forces a new resource to be created.
 
 -> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server.
+
+* `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s).
+
+* `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/route_server.html.markdown
+++ b/website/docs/r/route_server.html.markdown
@@ -52,6 +52,7 @@ resource "azurerm_route_server" "example" {
   public_ip_address_id             = azurerm_public_ip.example.id
   subnet_id                        = azurerm_subnet.example.id
   branch_to_branch_traffic_enabled = true
+  hub_routing_preference           = "ASPath"
 }
 ```
 
@@ -67,13 +68,15 @@ The following arguments are supported:
 
 * `subnet_id` - (Required) The ID of the Subnet that the Route Server will reside. Changing this forces a new resource to be created.
 
--> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server
+-> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server.
 
 * `sku` - (Required) The SKU of the Route Server. The only possible value is `Standard`. Changing this forces a new resource to be created.
 
 * `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
 
-* `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s)
+* `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s).
+
+* `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -81,7 +84,7 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Route Server .
+* `id` - The ID of the Route Server.
 
 ## Timeouts
 

--- a/website/docs/r/route_server.html.markdown
+++ b/website/docs/r/route_server.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `branch_to_branch_traffic_enabled` - (Optional) Whether to enable route exchange between Azure Route Server and the gateway(s).
 
-* `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`.
+* `hub_routing_preference` - (Optional) The hub routing preference. Valid values are `ASPath`, `ExpressRoute` or `VpnGateway`. Defaults to `ExpressRoute`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- Add support for the `hub_routing_preference` property in `azurerm_route_server`.
- Updated docs to sort properties in alphabetical order, and added new docs for the `hub_routing_preference` property.

Here are the references for this feature 
- https://learn.microsoft.com/en-us/azure/virtual-wan/about-virtual-hub-routing-preference
- https://learn.microsoft.com/en-us/rest/api/virtualwan/virtual-hubs/create-or-update?view=rest-virtualwan-2024-05-01&tabs=HTTP#hubroutingpreference

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

All tests are passing - see [here](https://dev.azure.com/bubbletroubles/terraform/_build/results?buildId=152&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=33e5d3ec-87e7-5f80-0281-074c6962cb44).

```
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccRouteServer -parallel 6 -timeout 600m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccRouteServerBgpConnection_basic
=== PAUSE TestAccRouteServerBgpConnection_basic
=== RUN   TestAccRouteServerBgpConnection_requiresImport
=== PAUSE TestAccRouteServerBgpConnection_requiresImport
=== RUN   TestAccRouteServer_basic
=== PAUSE TestAccRouteServer_basic
=== RUN   TestAccRouteServer_requiresImport
=== PAUSE TestAccRouteServer_requiresImport
=== RUN   TestAccRouteServer_complete
=== PAUSE TestAccRouteServer_complete
=== RUN   TestAccRouteServer_update
=== PAUSE TestAccRouteServer_update
=== CONT  TestAccRouteServerBgpConnection_basic
=== CONT  TestAccRouteServer_requiresImport
=== CONT  TestAccRouteServer_update
=== CONT  TestAccRouteServer_complete
=== CONT  TestAccRouteServer_basic
=== CONT  TestAccRouteServerBgpConnection_requiresImport
--- PASS: TestAccRouteServer_requiresImport (1211.88s)
--- PASS: TestAccRouteServer_basic (1221.75s)
--- PASS: TestAccRouteServerBgpConnection_requiresImport (1385.48s)
--- PASS: TestAccRouteServer_complete (1405.40s)
--- PASS: TestAccRouteServerBgpConnection_basic (1482.51s)
--- PASS: TestAccRouteServer_update (1518.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/network	1518.659s

Finishing: make acctests
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_route_server` - support for the `hub_routing_preference` property [GH-28363]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
