### PR TITLE
Test: Add `features {}` to the provider block

### DIFF
--- a/internal/services/authorization/role_management_policy_data_source_test.go
+++ b/internal/services/authorization/role_management_policy_data_source_test.go
@@ -71,7 +71,9 @@ func TestAccRoleManagementPolicyDataSource_resource(t *testing.T) {
 
 func (RoleManagementPolicyDataSource) managementGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 data "azurerm_client_config" "current" {
 }
@@ -94,7 +96,9 @@ data "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyDataSource) resourceGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]s"
@@ -115,7 +119,9 @@ data "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyDataSource) subscription(data acceptance.TestData) string {
 	return `
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 data "azurerm_subscription" "test" {}
 
@@ -133,7 +139,9 @@ data "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyDataSource) resource(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]s"

--- a/internal/services/authorization/role_management_policy_resource_test.go
+++ b/internal/services/authorization/role_management_policy_resource_test.go
@@ -181,7 +181,9 @@ func (RoleManagementPolicyResource) Exists(ctx context.Context, clients *clients
 
 func (RoleManagementPolicyResource) managementGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 provider "azuread" {}
 
@@ -245,7 +247,9 @@ resource "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyResource) resourceGroupTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]s"
@@ -345,7 +349,9 @@ resource "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyResource) subscriptionTemplate(data acceptance.TestData) string {
 	return `
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 data "azurerm_subscription" "test" {}
 
@@ -484,7 +490,9 @@ resource "azurerm_role_management_policy" "test" {
 
 func (RoleManagementPolicyResource) resourceTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]s"

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -657,7 +657,9 @@ func (r StorageBlobResource) blobMatchesContent(kind blobs.BlobType, expectedCon
 func (r StorageBlobResource) appendEmpty(data acceptance.TestData) string {
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 %s
 
@@ -673,7 +675,9 @@ resource "azurerm_storage_blob" "test" {
 func (r StorageBlobResource) appendEmptyMetaData(data acceptance.TestData) string {
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 %s
 
@@ -693,7 +697,9 @@ resource "azurerm_storage_blob" "test" {
 func (r StorageBlobResource) blockEmpty(data acceptance.TestData) string {
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 %s
 
@@ -710,6 +716,7 @@ func (r StorageBlobResource) blockEmptyAzureADAuth(data acceptance.TestData) str
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
 provider "azurerm" {
+  features {}
   storage_use_azuread = true
 }
 
@@ -1407,7 +1414,9 @@ resource "azurerm_storage_container" "test" {
 func (r StorageBlobResource) archive(data acceptance.TestData) string {
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
-provider "azurerm" {}
+provider "azurerm" {
+  features {}
+}
 
 %s
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

A follow up of #28052, where there are acctests have the `provider "azurerm" {}` block, but empty.

This PR uses the same way as #28052, finding out test configs that have no `features` defined, via

```
$ grep -rL "features" | sort
TestAccRoleManagementPolicyDataSource_managementGroup/0/terraform_plugin_test.tf
TestAccRoleManagementPolicyDataSource_resource/0/terraform_plugin_test.tf
TestAccRoleManagementPolicyDataSource_resourceGroup/0/terraform_plugin_test.tf
TestAccRoleManagementPolicyDataSource_subscription/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_managementGroup/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resource/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resource/2/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resourceGroup/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resourceGroup/2/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resourceGroup_activationRulesUpdate/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_resourceGroup_activationRulesUpdate/2/terraform_plugin_test.tf
TestAccRoleManagementPolicy_subscription/0/terraform_plugin_test.tf
TestAccRoleManagementPolicy_subscription/2/terraform_plugin_test.tf
TestAccStorageBlob_appendEmpty/0/terraform_plugin_test.tf
TestAccStorageBlob_appendEmptyMetaData/0/terraform_plugin_test.tf
TestAccStorageBlob_archive/0/terraform_plugin_test.tf
TestAccStorageBlob_blockEmpty/0/terraform_plugin_test.tf
TestAccStorageBlob_blockEmptyAzureADAuth/0/terraform_plugin_test.tf
TestAccStorageBlob_disappears/0/terraform_plugin_test.tf
```



> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
