### PR TITLE
`azurerm_storage_account_[queue_properties|static_website]` - Fix potential panics if the storage account is removed out of the band

### DIFF
--- a/internal/services/storage/storage_account_queue_properties_data_plane_resource.go
+++ b/internal/services/storage/storage_account_queue_properties_data_plane_resource.go
@@ -301,6 +301,9 @@ func (s AccountQueuePropertiesResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
+			if accountDetails == nil {
+				return fmt.Errorf("unable to locate %s", *accountID)
+			}
 
 			supportLevel := availableFunctionalityForAccount(accountDetails.Kind, accountTier, accountReplicationType)
 

--- a/internal/services/storage/storage_account_static_website_data_plane_resource.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource.go
@@ -107,6 +107,9 @@ func (a AccountStaticWebsiteResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
+			if accountDetails == nil {
+				return fmt.Errorf("unable to locate %s", *accountID)
+			}
 
 			supportLevel := availableFunctionalityForAccount(accountDetails.Kind, accountTier, accountReplicationType)
 
@@ -158,7 +161,7 @@ func (a AccountStaticWebsiteResource) Read() sdk.ResourceFunc {
 			state.StorageAccountId = id.ID()
 
 			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
-			if err != nil {
+			if err != nil || accountDetails == nil {
 				return metadata.MarkAsGone(id)
 			}
 
@@ -194,7 +197,7 @@ func (a AccountStaticWebsiteResource) Delete() sdk.ResourceFunc {
 			}
 
 			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
-			if err != nil {
+			if err != nil || accountDetails == nil {
 				// If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
 				return nil
 			}
@@ -237,6 +240,9 @@ func (a AccountStaticWebsiteResource) Update() sdk.ResourceFunc {
 			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
 			if err != nil {
 				return err
+			}
+			if accountDetails == nil {
+				return fmt.Errorf("unable to locate %s", *id)
 			}
 
 			client, err := storageClient.AccountsDataPlaneClient(ctx, *accountDetails, storageClient.DataPlaneOperationSupportingAnyAuthMethod())

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -572,6 +572,9 @@ func (r StorageBlobResource) Destroy(ctx context.Context, client *clients.Client
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Account %q for Blob %q (Container %q): %+v", id.AccountId.AccountName, id.BlobName, id.ContainerName, err)
 	}
+	if account == nil {
+		return utils.Bool(true), nil
+	}
 	blobsClient, err := client.Storage.BlobsDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
 		return nil, fmt.Errorf("building Blobs Client: %+v", err)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes the potential panics for `azurerm_storage_account_[queue_properties|static_website]`, during RUD, when the storage account is removed out of the band.

Meanwhile, I've also checked all the other references for the function call `storageClient.FindAccount()`, and ensure they've all handled the case that the 1st return value is `nil`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account_[queue_properties|static_website]` - Fix potential panics if the storage account is removed out of the band [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28362


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
