### PR TITLE
make Marketplace Details & Plan Data configurable for Palo Alto NGFW

### DIFF
--- a/internal/services/paloalto/schema/marketplace_details.go
+++ b/internal/services/paloalto/schema/marketplace_details.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/firewalls"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type MarketplaceDetails struct {
+	OfferId     string `json:"offer_id,omitempty"`
+	PublisherId string `json:"publisher_id,omitempty"`
+}
+
+func MarketplaceDetailsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"offer_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      "pan_swfw_cloud_ngfw",
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"publisher_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      "paloaltonetworks",
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func ExpandMarketplaceDetails(input []MarketplaceDetails) firewalls.MarketplaceDetails {
+	result := firewalls.MarketplaceDetails{
+		OfferId:     "pan_swfw_cloud_ngfw",
+		PublisherId: "paloaltonetworks",
+	}
+
+	if len(input) == 1 {
+		p := input[0]
+
+		if p.OfferId != "" {
+			result.OfferId = p.OfferId
+		}
+
+		if p.PublisherId != "" {
+			result.PublisherId = p.PublisherId
+		}
+	}
+
+	return result
+}
+
+func FlattenMarketplaceDetails(input firewalls.MarketplaceDetails) []MarketplaceDetails {
+	result := MarketplaceDetails{}
+
+	result.OfferId = input.OfferId
+	result.PublisherId = input.PublisherId
+
+	return []MarketplaceDetails{result}
+}

--- a/internal/services/paloalto/schema/plan_data.go
+++ b/internal/services/paloalto/schema/plan_data.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2023-09-01/firewalls"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PlanData struct {
+	BillingCycle string `json:"billing_cycle,omitempty"`
+	PlanId       string `json:"plan_id,omitempty"`
+	UsageType    string `json:"usage_type,omitempty"`
+}
+
+func PlanDataSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"plan_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      "panw-cloud-ngfw-payg",
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"billing_cycle": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      firewalls.BillingCycleMONTHLY,
+					ValidateFunc: validation.StringInSlice(firewalls.PossibleValuesForBillingCycle(), false),
+				},
+
+				"usage_type": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      firewalls.UsageTypePAYG,
+					ValidateFunc: validation.StringInSlice(firewalls.PossibleValuesForUsageType(), false),
+				},
+			},
+		},
+	}
+}
+
+func ExpandPlanData(input []PlanData) firewalls.PlanData {
+	result := firewalls.PlanData{
+		BillingCycle: firewalls.BillingCycleMONTHLY,
+		UsageType:    pointer.To(firewalls.UsageTypePAYG),
+		PlanId:       "panw-cloud-ngfw-payg",
+	}
+
+	if len(input) == 1 {
+		p := input[0]
+
+		if p.BillingCycle != "" {
+			result.BillingCycle = firewalls.BillingCycle(p.BillingCycle)
+		}
+
+		if p.PlanId != "" {
+			result.PlanId = p.PlanId
+		}
+
+		if p.UsageType != "" {
+			result.UsageType = (*firewalls.UsageType)(&p.UsageType)
+		}
+	}
+
+	return result
+}
+
+func FlattenPlanData(input firewalls.PlanData) []PlanData {
+	result := PlanData{}
+
+	result.BillingCycle = string(input.BillingCycle)
+	result.PlanId = input.PlanId
+	result.UsageType = string(*input.UsageType)
+
+	return []PlanData{result}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Closes #28267

Palo Alto changed the plan id and the one hard coded in the provider is no longer valid.  This keeps the old one for backwards compatibility.  Would like to backport this to v3.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests. - I'm unable to run this as my company doesn't let me.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_palo_alto_next_generation_firewall_virtual_network_panorama` - support for `marketplace_details` and `plan_data` properties [GH-28401]
* `azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack` - support for `marketplace_details` and `plan_data` properties [GH-28401]
* `azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama` - support for `marketplace_details` and `plan_data` properties [GH-28401]
* `azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack ` - support for `marketplace_details` and `plan_data` properties [GH-28401]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28267


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
