### PR TITLE
`azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` - only power off machines that are turned on

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1680,19 +1680,49 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 			if strings.EqualFold(*existing.Model.Properties.ProvisioningState, "failed") {
 				log.Printf("[DEBUG] Powering Off Linux Virtual Machine was skipped because the VM was in %q state %s", *model.Properties.ProvisioningState, id)
 			} else {
-				// ISSUE: 4920
-				// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
-				// thus this can be a large cost-saving when deleting larger instances
-				// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
-				log.Printf("[DEBUG] Powering Off Linux %s", id)
-				skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
-				options := virtualmachines.PowerOffOperationOptions{
-					SkipShutdown: pointer.To(skipShutdown),
+				// Issue 28218: Don't shutdown if already powered off
+				shouldShutDown := true
+				if model.Properties.InstanceView != nil && model.Properties.InstanceView.Statuses != nil {
+					for _, status := range *model.Properties.InstanceView.Statuses {
+						if status.Code == nil {
+							continue
+						}
+
+						// could also be the provisioning state which we're not bothered with here
+						state := strings.ToLower(*status.Code)
+						if !strings.HasPrefix(state, "powerstate/") {
+							continue
+						}
+
+						state = strings.TrimPrefix(state, "powerstate/")
+						switch state {
+						case "deallocated":
+							// VM already deallocated, no shutdown needed anymore
+							shouldShutDown = false
+						case "deallocating":
+							// VM is deallocating, no shutdown needed anymore
+							shouldShutDown = false
+						case "stopped":
+							// VM already stopped, no shutdown needed anymore
+							shouldShutDown = false
+						}
+					}
 				}
-				if err := client.PowerOffThenPoll(ctx, *id, options); err != nil {
-					return fmt.Errorf("powering off Linux %s: %+v", id, err)
+				if shouldShutDown {
+					// ISSUE: 4920
+					// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
+					// thus this can be a large cost-saving when deleting larger instances
+					// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
+					log.Printf("[DEBUG] Powering Off Linux %s", id)
+					skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
+					options := virtualmachines.PowerOffOperationOptions{
+						SkipShutdown: pointer.To(skipShutdown),
+					}
+					if err := client.PowerOffThenPoll(ctx, *id, options); err != nil {
+						return fmt.Errorf("powering off Linux %s: %+v", id, err)
+					}
+					log.Printf("[DEBUG] Powered Off Linux %s", id)
 				}
-				log.Printf("[DEBUG] Powered Off Linux %s", id)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Only power off machines that are turned on before deleting them.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

I did not find how to create a new test with a powered-off VM.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` -  Only power off running VMs [GH-28218]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28218


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
