### PR TITLE
`azurerm_postgresql_flexible_server_virtual_endpoint` - validate with `PostgresqlFlexibleServerVirtualEndpointIDInsensitively`

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/virtualendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -40,7 +41,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) ResourceType() string {
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
-	return virtualendpoints.ValidateVirtualEndpointID
+	return validate.PostgresqlFlexibleServerVirtualEndpointIDInsensitively
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Attributes() map[string]*pluginsdk.Schema {
@@ -134,7 +135,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 
 			state := PostgresqlFlexibleServerVirtualEndpointModel{}
 
-			id, err := virtualendpoints.ParseVirtualEndpointID(metadata.ResourceData.Id())
+			id, err := virtualendpoints.ParseVirtualEndpointIDInsensitively(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}

--- a/internal/services/postgres/validate/postgresql_flexible_server_virtual_endpoint_id.go
+++ b/internal/services/postgres/validate/postgresql_flexible_server_virtual_endpoint_id.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2023-06-01-preview/virtualendpoints"
+)
+
+func PostgresqlFlexibleServerVirtualEndpointIDInsensitively(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := virtualendpoints.ParseVirtualEndpointIDInsensitively(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/postgres/validate/postgresql_flexible_server_virtual_endpoint_id_test.go
+++ b/internal/services/postgres/validate/postgresql_flexible_server_virtual_endpoint_id_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestPostgresqlFlexibleServerVirtualEndpointID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DBforPostgreSQL/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DBforPostgreSQL/flexibleServers/",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DBforPostgreSQL/flexibleServers/server1",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DBforPostgreSQL/flexibleServers/server1/virtualEndpoints/endpoint1",
+			Valid: true,
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DBforPostgreSQL/flexibleServers/server1/virtualendpoints/endpoint1",
+			Valid: true,
+		},
+		{
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.DBFORPOSTGRESQL/FLEXIBLESERVERS/SERVER1/VIRTUALENDPOINTS/ENDPOINT1",
+			Valid: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := PostgresqlFlexibleServerVirtualEndpointIDInsensitively(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Though the [resource ID](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/VirtualEndpoints.json#L37) of Postgresql fs virtual endpoint is with the segment "virtualendpoints" on Swagger but the [resource ID](https://github.com/hashicorp/go-azure-sdk/blob/0dcdae31633ed2b0fe646d407d4fc210c600a67d/resource-manager/postgresql/2023-06-01-preview/virtualendpoints/id_virtualendpoint.go#L110) on the generated go azure sdk is with the segment "virtualEndpoints". So I will use the "xxxInsensitively" func to resolve this issue.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![image](https://github.com/user-attachments/assets/339646c5-ec0f-4a8a-a553-990e4087e184)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server_virtual_endpoint` - validate with `PostgresqlFlexibleServerVirtualEndpointIDInsensitively`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28410


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
