### PR TITLE
`azurerm_site_recovery_replicated_vm` - add `churn_option_selected`

### DIFF
--- a/examples/recovery-services/site-recovery-zone-zone/main.tf
+++ b/examples/recovery-services/site-recovery-zone-zone/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_resource_group" "secondary" {
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-vnet"
   resource_group_name = azurerm_resource_group.primary.name
-  address_space = ["192.168.1.0/24"]
+  address_space       = ["192.168.1.0/24"]
   location            = azurerm_resource_group.primary.location
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "${var.prefix}subnet"
   resource_group_name  = azurerm_resource_group.primary.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes = ["192.168.1.0/24"]
+  address_prefixes     = ["192.168.1.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
@@ -46,7 +46,7 @@ resource "azurerm_network_interface" "example" {
 }
 
 resource "azurerm_windows_virtual_machine" "example" {
-  name = substr("${var.prefix}-rep-vm", 0, 15)
+  name                = substr("${var.prefix}-rep-vm", 0, 15)
   resource_group_name = azurerm_resource_group.primary.name
   location            = azurerm_resource_group.primary.location
   size                = "Standard_D2s_v3"
@@ -134,7 +134,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_site_recovery_replicated_vm" "example" {
-  name = substr("${var.prefix}-rep-vm", 0, 15)
+  name                                      = substr("${var.prefix}-rep-vm", 0, 15)
   resource_group_name                       = azurerm_resource_group.secondary.name
   recovery_vault_name                       = azurerm_recovery_services_vault.example.name
   source_vm_id                              = azurerm_windows_virtual_machine.example.id

--- a/examples/recovery-services/site-recovery-zone-zone/main.tf
+++ b/examples/recovery-services/site-recovery-zone-zone/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_resource_group" "secondary" {
 resource "azurerm_virtual_network" "example" {
   name                = "${var.prefix}-vnet"
   resource_group_name = azurerm_resource_group.primary.name
-  address_space       = ["192.168.1.0/24"]
+  address_space = ["192.168.1.0/24"]
   location            = azurerm_resource_group.primary.location
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "${var.prefix}subnet"
   resource_group_name  = azurerm_resource_group.primary.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["192.168.1.0/24"]
+  address_prefixes = ["192.168.1.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {
@@ -46,7 +46,7 @@ resource "azurerm_network_interface" "example" {
 }
 
 resource "azurerm_windows_virtual_machine" "example" {
-  name                = "${var.prefix}-src-vm"
+  name = substr("${var.prefix}-rep-vm", 0, 15)
   resource_group_name = azurerm_resource_group.primary.name
   location            = azurerm_resource_group.primary.location
   size                = "Standard_D2s_v3"
@@ -134,7 +134,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_site_recovery_replicated_vm" "example" {
-  name                                      = "${var.prefix}-rep-vm"
+  name = substr("${var.prefix}-rep-vm", 0, 15)
   resource_group_name                       = azurerm_resource_group.secondary.name
   recovery_vault_name                       = azurerm_recovery_services_vault.example.name
   source_vm_id                              = azurerm_windows_virtual_machine.example.id
@@ -146,6 +146,8 @@ resource "azurerm_site_recovery_replicated_vm" "example" {
   target_recovery_protection_container_id   = azurerm_site_recovery_protection_container.secondary.id
   target_network_id                         = azurerm_virtual_network.example.id
   target_zone                               = "2"
+  # churn_option                              = "High"
+  # churn_option                              = "Normal"
 
   managed_disk {
     disk_id                    = data.azurerm_managed_disk.os_disk.id

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -303,6 +303,7 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 				Elem:       networkInterfaceResource(),
 			},
 
+			// ONLY available in API version 2023-06-01
 			"churn_option_selected": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -495,7 +495,7 @@ func resourceSiteRecoveryReplicatedItemCreate(d *pluginsdk.ResourceData, meta in
 	parameters := replicationprotecteditems.EnableProtectionInput{
 		Properties: &replicationprotecteditems.EnableProtectionInputProperties{
 			PolicyId: &policyId,
-			ProviderSpecificDetails: replicationprotecteditems.ReplicationProviderSpecificSettings{
+			ProviderSpecificDetails: replicationprotecteditems.A2AEnableProtectionInput{
 				FabricObjectId:                     sourceVmId,
 				RecoveryContainerId:                &targetProtectionContainerId,
 				RecoveryResourceGroupId:            &targetResourceGroupId,
@@ -648,6 +648,7 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 			},
 		},
 	}
+
 	err = client.UpdateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("updating replicated vm %s (vault %s): %+v", name, vaultName, err)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
