### PR TITLE
`azurerm_storage_share_[directory|file]` - Deprecate `storage_share_id` in favor of `storage_share_url`

### DIFF
--- a/internal/services/storage/storage_share_directory_resource.go
+++ b/internal/services/storage/storage_share_directory_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -25,6 +26,45 @@ import (
 )
 
 func resourceStorageShareDirectory() *pluginsdk.Resource {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.StorageShareDirectoryName,
+		},
+
+		"storage_share_url": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+		},
+
+		"metadata": MetaDataSchema(),
+	}
+
+	if !features.FivePointOhBeta() {
+		// Keep the storage_share_id for compatibility.
+		schema["storage_share_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+			ExactlyOneOf: []string{"storage_share_id", "storage_share_url"},
+			Deprecated:   "This property has been deprecated in favour of `storage_share_url` and will be removed in version 5.0 of the Provider.",
+		}
+		schema["storage_share_url"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+			ExactlyOneOf: []string{"storage_share_id", "storage_share_url"},
+		}
+	}
+
 	resource := &pluginsdk.Resource{
 		Create: resourceStorageShareDirectoryCreate,
 		Read:   resourceStorageShareDirectoryRead,
@@ -43,23 +83,7 @@ func resourceStorageShareDirectory() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.StorageShareDirectoryName,
-			},
-
-			"storage_share_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: storageValidate.StorageShareDataPlaneID,
-			},
-
-			"metadata": MetaDataSchema(),
-		},
+		Schema: schema,
 	}
 
 	return resource
@@ -75,13 +99,21 @@ func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interfa
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	var storageShareId *shares.ShareId
-	var err error
-	if v, ok := d.GetOk("storage_share_id"); ok && v.(string) != "" {
-		storageShareId, err = shares.ParseShareID(v.(string), storageClient.StorageDomainSuffix)
-		if err != nil {
-			return err
+	var (
+		storageShareId *shares.ShareId
+		err            error
+	)
+	if features.FivePointOhBeta() {
+		storageShareId, err = shares.ParseShareID(d.Get("storage_share_url").(string), storageClient.StorageDomainSuffix)
+	} else {
+		storageShareURL := d.Get("storage_share_url")
+		if storageShareURL == "" {
+			storageShareURL = d.Get("storage_share_id")
 		}
+		storageShareId, err = shares.ParseShareID(storageShareURL.(string), storageClient.StorageDomainSuffix)
+	}
+	if err != nil {
+		return err
 	}
 
 	if storageShareId == nil {
@@ -226,7 +258,10 @@ func resourceStorageShareDirectoryRead(d *pluginsdk.ResourceData, meta interface
 	}
 
 	d.Set("name", id.DirectoryPath)
-	d.Set("storage_share_id", storageShareId.ID())
+	d.Set("storage_share_url", storageShareId.ID())
+	if !features.FivePointOhBeta() {
+		d.Set("storage_share_id", d.Get("storage_share_url"))
+	}
 
 	if err = d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
 		return fmt.Errorf("setting `metadata`: %v", err)
@@ -270,7 +305,11 @@ func storageShareDirectoryRefreshFunc(ctx context.Context, client *directories.C
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id.ShareName, id.DirectoryPath)
 		if err != nil {
-			return nil, strconv.Itoa(res.HttpResponse.StatusCode), fmt.Errorf("retrieving %s: %v", id, err)
+			state := "unknown"
+			if res.HttpResponse != nil {
+				state = strconv.Itoa(res.HttpResponse.StatusCode)
+			}
+			return nil, state, fmt.Errorf("retrieving %s: %v", id, err)
 		}
 
 		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil

--- a/internal/services/storage/storage_share_directory_resource_deprecated_test.go
+++ b/internal/services/storage/storage_share_directory_resource_deprecated_test.go
@@ -12,16 +12,21 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2023-11-03/file/directories"
 )
 
-type StorageShareDirectoryResource struct{}
+type StorageShareDirectoryResourceDeprecated struct{}
 
-func TestAccStorageShareDirectory_basic(t *testing.T) {
+func TestAccStorageShareDirectory_basic_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -34,9 +39,13 @@ func TestAccStorageShareDirectory_basic(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_basicAzureADAuth(t *testing.T) {
+func TestAccStorageShareDirectory_basicAzureADAuth_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -49,9 +58,13 @@ func TestAccStorageShareDirectory_basicAzureADAuth(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_uppercase(t *testing.T) {
+func TestAccStorageShareDirectory_uppercase_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -64,9 +77,13 @@ func TestAccStorageShareDirectory_uppercase(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_requiresImport(t *testing.T) {
+func TestAccStorageShareDirectory_requiresImport_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -79,9 +96,13 @@ func TestAccStorageShareDirectory_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_complete(t *testing.T) {
+func TestAccStorageShareDirectory_complete_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -94,9 +115,13 @@ func TestAccStorageShareDirectory_complete(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_update(t *testing.T) {
+func TestAccStorageShareDirectory_update_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "test")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -116,9 +141,13 @@ func TestAccStorageShareDirectory_update(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_nested(t *testing.T) {
+func TestAccStorageShareDirectory_nested_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "parent")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -134,9 +163,13 @@ func TestAccStorageShareDirectory_nested(t *testing.T) {
 	})
 }
 
-func TestAccStorageShareDirectory_nestedWithBackslashes(t *testing.T) {
+func TestAccStorageShareDirectory_nestedWithBackslashes_deprecated(t *testing.T) {
+	if features.FivePointOhBeta() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_directory", "dos")
-	r := StorageShareDirectoryResource{}
+	r := StorageShareDirectoryResourceDeprecated{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -151,7 +184,7 @@ func TestAccStorageShareDirectory_nestedWithBackslashes(t *testing.T) {
 	})
 }
 
-func (r StorageShareDirectoryResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageShareDirectoryResourceDeprecated) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := directories.ParseDirectoryID(state.ID, client.Storage.StorageDomainSuffix)
 	if err != nil {
 		return nil, err
@@ -177,19 +210,19 @@ func (r StorageShareDirectoryResource) Exists(ctx context.Context, client *clien
 	return utils.Bool(true), nil
 }
 
-func (r StorageShareDirectoryResource) basic(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "test" {
   name             = "dir"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 `, template)
 }
 
-func (r StorageShareDirectoryResource) basicAzureADAuth(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) basicAzureADAuth(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   storage_use_azuread = true
@@ -211,49 +244,49 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_share" "test" {
   name                 = "fileshare"
-  storage_account_id   = azurerm_storage_account.test.id
+  storage_account_name = azurerm_storage_account.test.name
   quota                = 50
 }
 
 resource "azurerm_storage_share_directory" "test" {
   name             = "dir"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageShareDirectoryResource) uppercase(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) uppercase(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "test" {
   name             = "UpperCaseCharacterS"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 `, template)
 }
 
-func (r StorageShareDirectoryResource) requiresImport(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) requiresImport(data acceptance.TestData) string {
 	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "import" {
   name             = azurerm_storage_share_directory.test.name
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 `, template)
 }
 
-func (r StorageShareDirectoryResource) complete(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "test" {
   name             = "dir"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 
   metadata = {
     hello = "world"
@@ -262,14 +295,14 @@ resource "azurerm_storage_share_directory" "test" {
 `, template)
 }
 
-func (r StorageShareDirectoryResource) updated(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) updated(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "test" {
   name             = "dir"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 
   metadata = {
     hello    = "world"
@@ -279,52 +312,52 @@ resource "azurerm_storage_share_directory" "test" {
 `, template)
 }
 
-func (r StorageShareDirectoryResource) nested(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) nested(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "parent" {
   name             = "123--parent-dir"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 
 resource "azurerm_storage_share_directory" "child_one" {
   name             = "${azurerm_storage_share_directory.parent.name}/child1"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 
 resource "azurerm_storage_share_directory" "child_two" {
   name             = "${azurerm_storage_share_directory.child_one.name}/childtwo--123"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 
 resource "azurerm_storage_share_directory" "multiple_child_one" {
   name             = "${azurerm_storage_share_directory.parent.name}/c"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 `, template)
 }
 
-func (r StorageShareDirectoryResource) nestedWithBackslashes(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) nestedWithBackslashes(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_share_directory" "c" {
   name             = "c"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
 }
 
 resource "azurerm_storage_share_directory" "dos" {
   name             = "c\\dos"
-  storage_share_url = azurerm_storage_share.test.url
+  storage_share_id = azurerm_storage_share.test.id
   depends_on       = [azurerm_storage_share_directory.c]
 }
 `, template)
 }
 
-func (r StorageShareDirectoryResource) template(data acceptance.TestData) string {
+func (r StorageShareDirectoryResourceDeprecated) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -345,7 +378,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_share" "test" {
   name                 = "fileshare"
-  storage_account_id = azurerm_storage_account.test.id
+  storage_account_name = azurerm_storage_account.test.name
   quota                = 50
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -24,6 +25,89 @@ import (
 )
 
 func resourceStorageShareFile() *pluginsdk.Resource {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"storage_share_url": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+		},
+
+		"path": {
+			Type:         pluginsdk.TypeString,
+			ForceNew:     true,
+			Optional:     true,
+			Default:      "",
+			ValidateFunc: storageValidate.StorageShareDirectoryName,
+		},
+
+		"content_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "application/octet-stream",
+		},
+
+		"content_encoding": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"content_md5": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"content_disposition": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"source": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			ForceNew:     true,
+		},
+
+		"content_length": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"metadata": MetaDataSchema(),
+	}
+
+	if !features.FivePointOhBeta() {
+		// Keep the storage_share_id for compatibility.
+		schema["storage_share_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+			ExactlyOneOf: []string{"storage_share_id", "storage_share_url"},
+			Deprecated:   "This property has been deprecated in favour of `storage_share_url` and will be removed in version 5.0 of the Provider.",
+		}
+		schema["storage_share_url"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageShareDataPlaneID,
+			ExactlyOneOf: []string{"storage_share_id", "storage_share_url"},
+		}
+	}
+
 	return &pluginsdk.Resource{
 		Create: resourceStorageShareFileCreate,
 		Read:   resourceStorageShareFileRead,
@@ -42,67 +126,7 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"storage_share_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: storageValidate.StorageShareDataPlaneID,
-			},
-
-			"path": {
-				Type:         pluginsdk.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				Default:      "",
-				ValidateFunc: storageValidate.StorageShareDirectoryName,
-			},
-
-			"content_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "application/octet-stream",
-			},
-
-			"content_encoding": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"content_md5": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"content_disposition": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"source": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				ForceNew:     true,
-			},
-
-			"content_length": {
-				Type:     pluginsdk.TypeInt,
-				Computed: true,
-			},
-
-			"metadata": MetaDataSchema(),
-		},
+		Schema: schema,
 	}
 }
 
@@ -112,7 +136,19 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	storageShareId, err := shares.ParseShareID(d.Get("storage_share_id").(string), storageClient.StorageDomainSuffix)
+	var (
+		storageShareId *shares.ShareId
+		err            error
+	)
+	if features.FivePointOhBeta() {
+		storageShareId, err = shares.ParseShareID(d.Get("storage_share_url").(string), storageClient.StorageDomainSuffix)
+	} else {
+		storageShareURL := d.Get("storage_share_url")
+		if storageShareURL == "" {
+			storageShareURL = d.Get("storage_share_id")
+		}
+		storageShareId, err = shares.ParseShareID(storageShareURL.(string), storageClient.StorageDomainSuffix)
+	}
 	if err != nil {
 		return err
 	}
@@ -293,7 +329,10 @@ func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	d.Set("name", id.FileName)
 	d.Set("path", id.DirectoryPath)
-	d.Set("storage_share_id", shares.NewShareID(id.AccountId, id.ShareName).ID())
+	d.Set("storage_share_url", shares.NewShareID(id.AccountId, id.ShareName).ID())
+	if !features.FivePointOhBeta() {
+		d.Set("storage_share_id", d.Get("storage_share_url"))
+	}
 
 	if err = d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
 		return fmt.Errorf("setting `metadata`: %s", err)

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -164,6 +164,14 @@ Please follow the format in the example below for listing breaking changes in re
 * The deprecated `storage_account_name` property has been removed in favour of the `storage_account_id` property.
 * The deprecated `resource_manager_id` property has been removed in favour of the `id` property.
 
+### `azurerm_storage_share_directory`
+
+* The deprecated `storage_share_id` property has been removed in favor of the `storage_share_url` property.
+
+### `azurerm_storage_share_file`
+
+* The deprecated `storage_share_id` property has been removed in favor of the `storage_share_url` property.
+
 ## Breaking Changes in Data Sources
 
 Please follow the format in the example below for listing breaking changes in data sources:

--- a/website/docs/r/storage_share_directory.html.markdown
+++ b/website/docs/r/storage_share_directory.html.markdown
@@ -30,13 +30,13 @@ resource "azurerm_storage_account" "example" {
 
 resource "azurerm_storage_share" "example" {
   name                 = "sharename"
-  storage_account_name = azurerm_storage_account.example.name
+  storage_account_id = azurerm_storage_account.example.id
   quota                = 50
 }
 
 resource "azurerm_storage_share_directory" "example" {
   name             = "example"
-  storage_share_id = azurerm_storage_share.example.id
+  storage_share_url = azurerm_storage_share.example.url
 }
 ```
 
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name (or path) of the Directory that should be created within this File Share. Changing this forces a new resource to be created.
 
-* `storage_share_id` - (Required) The Storage Share ID in which this file will be placed into. Changing this forces a new resource to be created.
+* `storage_share_url` - (Required) The Storage Share URL in which this file will be placed into. Changing this forces a new resource to be created.
 
 * `metadata` - (Optional) A mapping of metadata to assign to this Directory.
 

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -30,14 +30,14 @@ resource "azurerm_storage_account" "example" {
 
 resource "azurerm_storage_share" "example" {
   name                 = "sharename"
-  storage_account_name = azurerm_storage_account.example.name
+  storage_account_id   = azurerm_storage_account.example.id
   quota                = 50
 }
 
 resource "azurerm_storage_share_file" "example" {
-  name             = "my-awesome-content.zip"
-  storage_share_id = azurerm_storage_share.example.id
-  source           = "some-local-file.zip"
+  name              = "my-awesome-content.zip"
+  storage_share_url = azurerm_storage_share.example.url
+  source            = "some-local-file.zip"
 }
 ```
 
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name (or path) of the File that should be created within this File Share. Changing this forces a new resource to be created.
 
-* `storage_share_id` - (Required) The Storage Share ID in which this file will be placed into. Changing this forces a new resource to be created.
+* `storage_share_url` - (Required) The Storage Share URL in which this file will be placed into. Changing this forces a new resource to be created.
 
 * `path` - (Optional) The storage share directory that you would like the file placed into. Changing this forces a new resource to be created. Defaults to `""`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_storage_share_[directory|file]` - Deprecate `storage_share_id` in favor of `storage_share_url`.

Both `storage_share_id` and `storage_share_url` are exact the same in terms of the schema definition and the expected value, that shall be the storage share data plane URL. The split derives from how usres create the upstream `azurerm_storage_share`:
- If created using the deprecated `storage_account_name`, the resource id of `azurerm_storage_share` remains to be the data plane URL, which is accepted to be assigned to `storage_share_id` of the downstream `azurerm_storage_share_[directory|file]`. This means for existing configurations that use the deprecated properties, no breaking change is introduced.
- If created using the [newly introduced](https://github.com/hashicorp/terraform-provider-azurerm/pull/27733) `storage_account_id`, the resource id of `azurerm_storage_share` remains to be the azure resource manager id, which will cause issues like https://github.com/hashicorp/terraform-provider-azurerm/issues/28032. In this case, users are expected to assign the `url` attribute of the `azurerm_storage_share` to the `storage_share_url` (or `storage_share_id`, though deprecated).

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share_[directory|file]` - Deprecate `storage_share_id` in favor of `storage_share_url` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28032 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
