### PR TITLE
GHA : update auto-assign for PRs from forked repos

### DIFF
--- a/.github/workflows/auto-assign-reviewers-to-pr.yaml
+++ b/.github/workflows/auto-assign-reviewers-to-pr.yaml
@@ -1,9 +1,11 @@
 name: Assign Reviewer as Assignee
 
 on:
-  pull_request_review:
+  workflow_run:
+    workflows:
+      - "Pull Request Reviewed"
     types:
-      - submitted
+      - completed
 
 permissions:
   issues: write
@@ -13,20 +15,38 @@ jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Artifact
+        id: get_artifact
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: pull-request-reviewed.yaml
+
+      - name: env_vars
+        id: env_vars
+        if: steps.get_artifact.outcome == 'success'
+        run: |
+          echo "reviewer=$(cat artifact/reviewer.txt)" >>${GITHUB_OUTPUT}
+          echo "reviewState=$(cat artifact/reviewstate.txt)" >>${GITHUB_OUTPUT}
+          echo "prNumber=$(cat artifact/prnumber.txt)" >>${GITHUB_OUTPUT}
+
       - name: Assign the reviewer as assignee when changes are requested
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const reviewer = context.payload.review.user.login;
-            const prNumber = context.payload.pull_request.number;
-            const reviewState = context.payload.review.state;
+            const reviewer = '${{ steps.env_vars.outputs.reviewer }}';
+            const prNumber = parseInt('${{ steps.env_vars.outputs.prNumber }}', 10);
+            const reviewState = '${{ steps.env_vars.outputs.reviewState }}';
+            const repo = '${{ github.event.repository.name }}';
+            const owner = '${{ github.event.repository.owner.login }}';
 
             if (reviewState === 'changes_requested') {
               console.log(`Assigning reviewer: ${reviewer} to PR #${prNumber} as changes were requested.`);
               await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner: owner,
+                repo: repo,
                 issue_number: prNumber,
                 assignees: [reviewer],
               });

--- a/.github/workflows/pull-request-reviewed.yaml
+++ b/.github/workflows/pull-request-reviewed.yaml
@@ -12,23 +12,26 @@ jobs:
   add-or-remove-waiting-response:
     runs-on: ubuntu-latest
     steps:
-      - name: "Set Artifacts for add-waiting-response"
-        if: github.event.review.state != 'approved' && github.actor != github.event.pull_request.user.login
+      - name: "Set Artifacts"
         shell: bash
         run: |
           mkdir -p wr_actions
           echo ${{ github.owner }} > wr_actions/ghowner.txt
           echo ${{ github.repository }} > wr_actions/ghrepo.txt
           echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
+          echo ${{ github.event.review.user.login }} > wr_actions/reviewer.txt
+          echo ${{ github.event.review.state }} > wr_actions/reviewstate.txt
+      - name: "Set Artifacts for add-waiting-response"
+        if: github.event.review.state != 'approved' && github.actor != github.event.pull_request.user.login
+        shell: bash
+        run: |
+          mkdir -p wr_actions
           echo "add-waiting-response" > wr_actions/action.txt
       - name: "Set Artifacts for remove-waiting-response"
         if: github.actor == github.event.pull_request.user.login
         shell: bash
         run: |
           mkdir -p wr_actions
-          echo ${{ github.owner }} > wr_actions/ghowner.txt
-          echo ${{ github.repository }} > wr_actions/ghrepo.txt
-          echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
           echo "remove-waiting-response" > wr_actions/action.txt                
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:


### PR DESCRIPTION
<!--  All Submissions -->

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

- Sets the vars required for assigning in pull-request-reviewed.yaml to an artifact
- updates auto-assign to run on completion of the pull-request-reviewed.yaml workflow
- grabs required vars from downloaded artifact to assign 