### PR TITLE
`azurerm_logic_app_standard` - fix setting `public_network_access` for conflicting API properties

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -484,7 +484,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
-	if d.HasChange("site_config") { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
+	if d.HasChange("site_config") || (d.HasChange("public_network_access") && !features.FivePointOhBeta()) { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
 		siteConfigResource := webapps.SiteConfigResource{
 			Properties: &siteConfig,
 		}
@@ -1367,9 +1367,9 @@ func expandLogicAppStandardSiteConfig(d *pluginsdk.ResourceData) (webapps.SiteCo
 	}
 
 	if !features.FivePointOhBeta() {
-		if v, ok := config["public_network_access_enabled"]; ok {
+		if v, ok := config["public_network_access_enabled"]; ok || d.Get("public_network_access").(string) != "" {
 			pna := helpers.PublicNetworkAccessEnabled
-			if !v.(bool) {
+			if !v.(bool) || d.Get("public_network_access").(string) == helpers.PublicNetworkAccessDisabled {
 				pna = helpers.PublicNetworkAccessDisabled
 			}
 			siteConfig.PublicNetworkAccess = pointer.To(pna)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -344,7 +344,6 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	if !features.FivePointOhBeta() {
 		// if a user is still using `site_config.public_network_access_enabled` we should be setting `public_network_access` for them
 		publicNetworkAccess = reconcilePNA(d)
-		// publicNetworkAccess = helpers.PublicNetworkAccessEnabled
 		if v := siteEnvelope.Properties.SiteConfig.PublicNetworkAccess; v != nil && *v == helpers.PublicNetworkAccessDisabled {
 			publicNetworkAccess = helpers.PublicNetworkAccessDisabled
 		}

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -50,6 +50,8 @@ func TestAccLogicAppStandard_publicNetworkAccessDisabled(t *testing.T) {
 			Config: r.publicNetworkAccess(data, "Disabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Disabled"),
+				check.That(data.ResourceName).Key("site_config.0.public_network_access_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -57,6 +59,17 @@ func TestAccLogicAppStandard_publicNetworkAccessDisabled(t *testing.T) {
 			Config: r.publicNetworkAccess(data, "Enabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("site_config.0.public_network_access_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, "Disabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Disabled"),
+				check.That(data.ResourceName).Key("site_config.0.public_network_access_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes a bug in setting `publicNetworkAccess` due to this being set in two places currently which can conflict with each other and cause inconsistent behaviour.



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_standard` - fix setting `public_network_access` for conflicting API properties


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes #27398


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
