### PR TITLE
Update environment variable name for secondary test subscription 

### DIFF
--- a/internal/acceptance/data.go
+++ b/internal/acceptance/data.go
@@ -82,7 +82,7 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 
 	testData.Subscriptions = Subscriptions{
 		Primary:   os.Getenv("ARM_SUBSCRIPTION_ID"),
-		Secondary: os.Getenv("ARM_TEST_SUBSCRIPTION_ID_ALT"),
+		Secondary: os.Getenv("ARM_SUBSCRIPTION_ID_ALT"),
 	}
 
 	return testData


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Any tests referencing the secondary test subscription are being skipped because the environment variable is passed in as `ARM_SUBSCRIPTION_ID_ALT`
![image](https://github.com/user-attachments/assets/95675189-b495-43fa-bc36-c18c79b81f2f)

