### PR TITLE
`linting` - new/updated linter violations

### DIFF
--- a/internal/provider/framework/helpers_test.go
+++ b/internal/provider/framework/helpers_test.go
@@ -23,9 +23,7 @@ func Test_getOidcToken(t *testing.T) {
 
 	if result == nil {
 		t.Fatalf("getOidcToken returned nil result without an error")
-	}
-
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getOidcToken did not return expected string (%s), got %+v", expectedString, *result)
 	}
 }
@@ -43,9 +41,7 @@ func Test_getOidcTokenFromFile(t *testing.T) {
 
 	if result == nil {
 		t.Fatalf("getOidcToken returned nil result without an error")
-	}
-
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getOidcToken did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -117,8 +113,7 @@ func Test_getClientSecret(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientSecret returned nil result without an error")
-	}
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getCLientSecret did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -152,8 +147,7 @@ func Test_getClientSecretFromFile(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientSecretFromFile returned nil result without an error")
-	}
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getClientSecret did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -185,8 +179,7 @@ func Test_getClientID(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	}
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -218,8 +211,7 @@ func Test_getClientIDFromFile(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	}
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -238,8 +230,7 @@ func Test_getClientIDAKSWorkload(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	}
-	if *result != expectedString {
+	} else if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -270,9 +261,7 @@ func Test_decodeCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decodeCertificate returned unexpected error %v", err)
 	}
-	if result == nil {
-		t.Fatalf("decodeCertificate returned nil result without an error")
-	}
+
 	if string(result) != expected {
 		t.Fatalf("decodeCertificate did not return expected result `%s`, got `%s`", expected, result)
 	}

--- a/internal/sdk/resource_helpers_test.go
+++ b/internal/sdk/resource_helpers_test.go
@@ -132,8 +132,7 @@ func TestParseStructTags_WithValue(t *testing.T) {
 
 		if actual == nil {
 			t.Fatalf("expected actual to have a value but got nil")
-		}
-		if !reflect.DeepEqual(*data.expected, *actual) {
+		} else if !reflect.DeepEqual(*data.expected, *actual) {
 			t.Fatalf("expected [%+v] and actual [%+v] didn't match", *data.expected, *actual)
 		}
 	}

--- a/internal/services/datafactory/data_factory_test.go
+++ b/internal/services/datafactory/data_factory_test.go
@@ -121,11 +121,11 @@ func TestDataFactoryDeserializePipelineActivities(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if items == nil && !tc.ExpectErr {
-			t.Fatal("Expected items got nil")
-		}
-
-		if len(*items) != tc.ExpectActivityCount {
+		if items == nil {
+			if !tc.ExpectErr {
+				t.Fatal("Expected items got nil")
+			}
+		} else if len(*items) != tc.ExpectActivityCount {
 			t.Fatal("Failed to deserialise pipeline")
 		}
 	}

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -665,7 +665,7 @@ func resourcePrivateEndpointRead(d *pluginsdk.ResourceData, meta interface{}) er
 			for _, dnsZoneId := range *privateDnsZoneIds {
 				flattened, err := retrieveAndFlattenPrivateDnsZone(ctx, dnsClient, dnsZoneId)
 				if err != nil {
-					return nil
+					return fmt.Errorf("reading %s for %s: %+v", dnsZoneId, id, err)
 				}
 
 				// an exceptional case but no harm in handling


### PR DESCRIPTION
also addresses several potential bugs:
* `azurerm_mssql_database` - fix bug where verifying TDE might fail to return an error on failure
* `azurerm_mssql_database` - fix several potential bugs where retry functions could return false negatives for actual errors
* `azurerm_private_endpoint` - fix a bug where reading Private DNS could error and exit the Read of the resource early without raising an error