### PR TITLE
Contributor Docs: Fix minor errors and add additional information

### DIFF
--- a/contributing/topics/guide-new-data-source.md
+++ b/contributing/topics/guide-new-data-source.md
@@ -148,7 +148,7 @@ func (ResourceGroupExampleDataSource) Attributes() map[string]*pluginsdk.Schema 
 }
 
 func (ResourceGroupExampleDataSource) ModelObject() interface{} {
-	return &ResourceGroupExampleDataSourceModel
+	return &ResourceGroupExampleDataSourceModel{}
 }
 
 func (ResourceGroupExampleDataSource) ResourceType() string {
@@ -159,6 +159,14 @@ func (ResourceGroupExampleDataSource) ResourceType() string {
 > In this case we're using the resource type `azurerm_resource_group_example` as [an existing Data Source for `azurerm_resource_group` exists](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) and the names need to be unique.
 
 These functions define a Data Source called `azurerm_resource_group_example`, which has one Required argument called `name` and two Computed arguments called `location` and `tags`.
+
+Schema fields should be ordered as follows:
+
+1. Any fields that make up the resource's ID, with the last user specified segment (usually the resource's name) first. (e.g. `name`, `resource_group_name`, or `name`, `parent_resource_id`)
+2. The `location` field.
+3. Required fields, sorted alphabetically.
+4. Optional fields, sorted alphabetically.
+5. Computed fields, sorted alphabetically. (Although in a typed data source these are always added within the `Attributes` method)
 
 ---
 
@@ -192,7 +200,7 @@ func (ResourceGroupExampleDataSource) Read() sdk.ResourceFunc {
 			
 			id := resources.NewResourceGroupExampleID(subscriptionId, state.Name)
 			
-			// then retrieve the Resource Group by it's ID 
+			// then retrieve the Resource Group by its ID 
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				// if the Resource Group doesn't exist (e.g. we get a 404 Not Found)

--- a/contributing/topics/guide-new-fields-to-data-source.md
+++ b/contributing/topics/guide-new-fields-to-data-source.md
@@ -16,7 +16,7 @@ The process is similar to [extending an existing Resource](guide-new-fields-to-r
 
 Building on the example from [adding a new data source](guide-new-data-source.md) the new property will need to be added into the `Attributes` list which contains a list of schema fields that are Computed only.
 
-The location of the new property within this list is determined alphabetically. Taking the hypothetical property `public_network_access_enabled` as an example this would then end up looking like this in `Attributes`.
+The location of the new property within this list is determined based on the order found in [adding a new data source](guide-new-data-source.md#step-3-scaffold-an-emptynew-data-source). Taking the hypothetical property `public_network_access_enabled` as an example this would then end up looking like this in `Attributes`.
 
 ```go
 func (ResourceGroupExampleDataSource) Attributes() map[string]*pluginsdk.Schema {

--- a/contributing/topics/guide-new-fields-to-resource.md
+++ b/contributing/topics/guide-new-fields-to-resource.md
@@ -14,7 +14,7 @@ Building on the example found in [adding a new resource](guide-new-resource.md) 
 
 Our hypothetical property `public_network_access_enabled` will be user configurable and thus will need to be added to the `Arguments` list.
 
-The position of the new property is determined alphabetically and will end up looking like the code block below.
+The position of the new property is determined based on the order found in [adding a new resource](guide-new-resource.md#step-3-scaffold-an-emptynew-resource) and will end up looking like the code block below.
 
 ```go
 func (ResourceGroupExampleResource) Arguments() map[string]*pluginsdk.Schema {

--- a/contributing/topics/reference-acceptance-testing.md
+++ b/contributing/topics/reference-acceptance-testing.md
@@ -18,7 +18,7 @@ See [Running the Tests](running-the-tests.md).
 
 ### Test Package
 
-While tests reside in the same folder as resource and data source .go files, they need to be in a separate test package to prevent circuler references. ie for the file `./internal/services/aab2c/aadb2c_directory_data_source_test.go` the package should be:
+While tests reside in the same folder as resource and data source .go files, they need to be in a separate test package to prevent circular references. i.e. for the file `./internal/services/aab2c/aadb2c_directory_data_source_test.go` the package should be:
 
 ```go
 package aadb2c_test
@@ -134,11 +134,12 @@ func TestAccExampleDataSource_complete(t *testing.T) {
                 {
                         Config: r.complete(data),
                         Check: acceptance.ComposeTestCheckFunc(
-                            check.That(data.ResourceName).Key("example_property").HasValue("bar")
-                            check.That(data.ResourceName).Key("example_optional_bool").HasValue("false")
-                            check.That(data.ResourceName).Key("example_optional_string").HasValue("foo")
+                            check.That(data.ResourceName).Key("example_property").HasValue("bar"),
+                            check.That(data.ResourceName).Key("example_optional_bool").HasValue("false"),
+                            check.That(data.ResourceName).Key("example_optional_string").HasValue("foo"),
                         ),
                 },
+                data.ImportStep(),
         })
 }
 

--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -36,7 +36,7 @@ In the cases where `Enabled` is the only field within the object we opt to flatt
 },
 ```
 
-However when there are multiple fields in addtion to the `Enabled` one and they are all required for the object/feature like in Example B, a terraform block is created with all the fields including `Enabled`. The corresponding Terraform schema would be as follows:
+However when there are multiple fields in addition to the `Enabled` field and they are all required for the object/feature like in Example B, a terraform block is created with all the fields including `Enabled`. The corresponding Terraform schema would be as follows:
 
 ```go
 "vertical_pod_autoscaler": {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Fixed minor errors and updated code snippets to be inline with current process
- Added expected ordering of properties based on [PR 28456 comment](https://github.com/hashicorp/terraform-provider-azurerm/pull/28456#discussion_r1914322362)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
