### PR TITLE
`azurerm_container_app` - fix validation for container app name and container names

### DIFF
--- a/internal/services/containerapps/validate/validate.go
+++ b/internal/services/containerapps/validate/validate.go
@@ -74,7 +74,7 @@ func ContainerAppName(i interface{}, k string) (warnings []string, errors []erro
 		return
 	}
 
-	if matched := regexp.MustCompile(`^([a-z])[a-z0-9-]{0,58}[a-z0-9]?$`).Match([]byte(v)); !matched || strings.HasSuffix(v, "-") || strings.Contains(v, "--") {
+	if matched := regexp.MustCompile(`^([a-z])[a-z0-9-]{0,30}[a-z0-9]?$`).Match([]byte(v)); !matched || strings.HasSuffix(v, "-") || strings.Contains(v, "--") {
 		errors = append(errors, fmt.Errorf("%q must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'. The length must not be more than 32 characters", k))
 		return
 	}
@@ -118,7 +118,7 @@ func ContainerAppContainerName(i interface{}, k string) (warnings []string, erro
 		return
 	}
 
-	if matched := regexp.MustCompile(`^([a-zA-Z0-9])[a-zA-Z0-9-.]{0,254}[a-z]?$`).Match([]byte(v)); !matched || strings.HasSuffix(v, "-") {
+	if matched := regexp.MustCompile(`^([a-z])[a-z0-9-.]{0,58}[a-z]$`).Match([]byte(v)); !matched || strings.HasSuffix(v, "-") {
 		errors = append(errors, fmt.Errorf("%q must consist of lower case alphanumeric characters, '-', or '.', start with an alphabetic character, and end with an alphanumeric character. The length must not be more than 60 characters", k))
 	}
 

--- a/internal/services/containerapps/validate/validate_test.go
+++ b/internal/services/containerapps/validate/validate_test.go
@@ -324,3 +324,105 @@ func TestContainerAppScaleRuleConcurrentRequests(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateContainerAppName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+		},
+		{
+			Input: "-",
+		},
+		{
+			Input: "9",
+		},
+		{
+			Input: "a-",
+		},
+		{
+			Input: "a.",
+		},
+		{
+			Input: "a--a",
+		},
+		{
+			Input: "Cannothavecapitals",
+		},
+		{
+			Input: "a-a",
+			Valid: true,
+		},
+		{
+			Input: "val-1-id",
+			Valid: true,
+		},
+		{
+			Input: "invalid12345678901234567890123456",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ContainerAppName(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t for %s: %+v", tc.Valid, valid, tc.Input, errors)
+		}
+	}
+}
+
+func TestValidateContainerAppContainerName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+		},
+		{
+			Input: "-",
+		},
+		{
+			Input: "9",
+		},
+		{
+			Input: "a-",
+		},
+		{
+			Input: "a.",
+
+		},
+		{
+			Input: "a--a",
+			Valid: true,
+		},
+		{
+			Input: "Cannothavecapitals",
+		},
+		{
+			Input: "a-a",
+			Valid: true,
+		},
+		{
+			Input: "val-1-id",
+			Valid: true,
+		},
+		{
+			Input: "invalid12345678901234567890123456",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ContainerAppContainerName(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t for %s: %+v", tc.Valid, valid, tc.Input, errors)
+		}
+	}
+}

--- a/internal/services/containerapps/validate/validate_test.go
+++ b/internal/services/containerapps/validate/validate_test.go
@@ -394,7 +394,6 @@ func TestValidateContainerAppContainerName(t *testing.T) {
 		},
 		{
 			Input: "a.",
-
 		},
 		{
 			Input: "a--a",


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes validation regex for container app names and container names.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24591


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
