### PR TITLE
Resolve 4.0 TODOs for `provider.go`

### DIFF
--- a/internal/provider/framework/helpers_test.go
+++ b/internal/provider/framework/helpers_test.go
@@ -23,7 +23,9 @@ func Test_getOidcToken(t *testing.T) {
 
 	if result == nil {
 		t.Fatalf("getOidcToken returned nil result without an error")
-	} else if *result != expectedString {
+	}
+
+	if *result != expectedString {
 		t.Fatalf("getOidcToken did not return expected string (%s), got %+v", expectedString, *result)
 	}
 }
@@ -41,7 +43,9 @@ func Test_getOidcTokenFromFile(t *testing.T) {
 
 	if result == nil {
 		t.Fatalf("getOidcToken returned nil result without an error")
-	} else if *result != expectedString {
+	}
+
+	if *result != expectedString {
 		t.Fatalf("getOidcToken did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -113,7 +117,8 @@ func Test_getClientSecret(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientSecret returned nil result without an error")
-	} else if *result != expectedString {
+	}
+	if *result != expectedString {
 		t.Fatalf("getCLientSecret did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -147,7 +152,8 @@ func Test_getClientSecretFromFile(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientSecretFromFile returned nil result without an error")
-	} else if *result != expectedString {
+	}
+	if *result != expectedString {
 		t.Fatalf("getClientSecret did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -179,7 +185,8 @@ func Test_getClientID(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	} else if *result != expectedString {
+	}
+	if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -211,7 +218,8 @@ func Test_getClientIDFromFile(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	} else if *result != expectedString {
+	}
+	if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -230,7 +238,8 @@ func Test_getClientIDAKSWorkload(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("getClientID returned nil result without an error")
-	} else if *result != expectedString {
+	}
+	if *result != expectedString {
 		t.Fatalf("getClientID did not return expected string `%s`, got `%s`", expectedString, *result)
 	}
 }
@@ -261,7 +270,9 @@ func Test_decodeCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decodeCertificate returned unexpected error %v", err)
 	}
-
+	if result == nil {
+		t.Fatalf("decodeCertificate returned nil result without an error")
+	}
 	if string(result) != expected {
 		t.Fatalf("decodeCertificate did not return expected result `%s`, got `%s`", expected, result)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -489,11 +489,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 // buildClient is used to configure behavioral aspects of the provider. To configure the
 // cloud environment and authentication-related settings, use the providerConfigure function.
 func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData, authConfig *auth.Credentials) (*clients.Client, diag.Diagnostics) {
-	// TODO: This hardcoded default is for v3.x, where `resource_provider_registrations` is not defined. Remove this hardcoded default in v4.0
-	providerRegistrations := resourceproviders.ProviderRegistrationsLegacy
-	if features.FourPointOhBeta() {
-		providerRegistrations = d.Get("resource_provider_registrations").(string)
-	}
+	providerRegistrations := d.Get("resource_provider_registrations").(string)
 
 	// TODO: Remove in v5.0
 	if d.Get("skip_provider_registration").(bool) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -328,58 +328,8 @@ func TestAccProvider_resourceProviders_explicit(t *testing.T) {
 }
 
 func TestAccProvider_cliAuth(t *testing.T) {
-	// TODO: remove this test in v4.0
-	if features.FourPointOhBeta() {
-		t.Skip("skipping 3.x specific test")
-	}
-
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
-	}
-
-	logging.SetOutput(t)
-
-	provider := TestAzureProvider()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	// Support only Azure CLI authentication
-	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		envName := d.Get("environment").(string)
-		env, err := environments.FromName(envName)
-		if err != nil {
-			t.Fatalf("configuring environment %q: %v", envName, err)
-		}
-
-		authConfig := &auth.Credentials{
-			Environment:                       *env,
-			EnableAuthenticatingUsingAzureCLI: true,
-		}
-
-		return buildClient(ctx, provider, d, authConfig)
-	}
-
-	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
-	if d != nil && d.HasError() {
-		t.Fatalf("err: %+v", d)
-	}
-
-	if errs := testCheckProvider(provider); len(errs) > 0 {
-		for _, err := range errs {
-			t.Error(err)
-		}
-	}
-}
-
-// TODO: remove TestAccProvider_cliAuth and rename this test to TestAccProvider_cliAuth in v4.0
-func TestAccProvider_cliAuthWithSubscriptionIdHint(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("TF_ACC not set")
-	}
-
-	// TODO: remove this condition in v4.0
-	if os.Getenv("ARM_SUBSCRIPTION_ID") == "" {
-		t.Skip("ARM_SUBSCRIPTION_ID not set")
 	}
 
 	logging.SetOutput(t)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Implements 4.0 TODOs for `provider.go` and its tests
- refactors unnecessary `else`s


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
