### PR TITLE
azurerm_nginx_configuration - add content hash attribute to protected files

### DIFF
--- a/internal/services/nginx/nginx_configuration_data_source.go
+++ b/internal/services/nginx/nginx_configuration_data_source.go
@@ -20,6 +20,7 @@ import (
 type ProtectedFileData struct {
 	Content     string `tfschema:"content,removedInNextMajorVersion"`
 	VirtualPath string `tfschema:"virtual_path"`
+	ContentHash string `tfschema:"content_hash"`
 }
 
 type ConfigurationDataSourceModel struct {
@@ -69,6 +70,11 @@ func (m ConfigurationDataSource) Attributes() map[string]*pluginsdk.Schema {
 			Computed: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
+					"content_hash": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
 					"virtual_path": {
 						Type:     pluginsdk.TypeString,
 						Computed: true,
@@ -159,6 +165,7 @@ func (m ConfigurationDataSource) Read() sdk.ResourceFunc {
 					for _, file := range *files {
 						output.ProtectedFile = append(output.ProtectedFile, ProtectedFileData{
 							VirtualPath: pointer.From(file.VirtualPath),
+							ContentHash: pointer.From(file.ContentHash),
 						})
 					}
 				}

--- a/internal/services/nginx/nginx_configuration_data_source_test.go
+++ b/internal/services/nginx/nginx_configuration_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccNginxConfigurationDataSource_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("root_file").Exists(),
 				check.That(data.ResourceName).Key("config_file.0.content").Exists(),
+				check.That(data.ResourceName).Key("protected_file.0.content_hash").Exists(),
 			),
 		},
 	})

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -34,6 +34,7 @@ func (c ConfigFile) toSDKModel() nginxconfiguration.NginxConfigurationFile {
 type ProtectedFile struct {
 	Content     string `tfschema:"content"`
 	VirtualPath string `tfschema:"virtual_path"`
+	ContentHash string `tfschema:"content_hash"`
 }
 
 func (c ProtectedFile) toSDKModel() nginxconfiguration.NginxConfigurationProtectedFileRequest {
@@ -142,6 +143,11 @@ func (m ConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"content_hash": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
@@ -267,13 +273,14 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 					}
 				}
 
-				// GET returns protected files with virtual_path only without content
 				if files := prop.ProtectedFiles; files != nil {
 					configs := []ProtectedFile{}
 					for _, file := range *files {
 						config := ProtectedFile{
 							VirtualPath: pointer.ToString(file.VirtualPath),
+							ContentHash: pointer.ToString(file.ContentHash),
 						}
+						// GET returns protected files without content, so fill in from state
 						for _, protectedFile := range output.ProtectedFile {
 							if protectedFile.VirtualPath == pointer.ToString(file.VirtualPath) {
 								config.Content = protectedFile.Content
@@ -317,12 +324,24 @@ func (m ConfigurationResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving as nil for %v", *id)
 			}
 
+			// full update - fill in the existing fields from the API and then patch it
 			upd := nginxconfiguration.NginxConfigurationRequest{
 				Name: pointer.To(defaultConfigurationName),
 				Properties: &nginxconfiguration.NginxConfigurationRequestProperties{
-					// root file is required in update
 					RootFile: existing.Model.Properties.RootFile,
+					Files:    existing.Model.Properties.Files,
+					Package:  existing.Model.Properties.Package,
 				},
+			}
+
+			if existing.Model.Properties.ProtectedFiles != nil {
+				var pfs []nginxconfiguration.NginxConfigurationProtectedFileRequest
+				for _, f := range *existing.Model.Properties.ProtectedFiles {
+					pfs = append(pfs, nginxconfiguration.NginxConfigurationProtectedFileRequest{
+						VirtualPath: f.VirtualPath,
+					})
+				}
+				upd.Properties.ProtectedFiles = pointer.To(pfs)
 			}
 
 			if meta.ResourceData.HasChange("root_file") {
@@ -333,8 +352,9 @@ func (m ConfigurationResource) Update() sdk.ResourceFunc {
 				upd.Properties.Files = model.toSDKFiles()
 			}
 
-			// API does not return protected file field, so always set this field
-			upd.Properties.ProtectedFiles = model.toSDKProtectedFiles()
+			if meta.ResourceData.HasChange("protected_file") {
+				upd.Properties.ProtectedFiles = model.toSDKProtectedFiles()
+			}
 
 			if meta.ResourceData.HasChange("package_data") {
 				upd.Properties.Package = &nginxconfiguration.NginxConfigurationPackage{

--- a/website/docs/d/nginx_configuration.html.markdown
+++ b/website/docs/d/nginx_configuration.html.markdown
@@ -54,6 +54,8 @@ A `config_file` block exports the following:
 
 A `protected_file` block exports the following:
 
+* `content_hash` - The hash of the contents of this configuration file prefixed by the algorithm used.
+
 * `virtual_path` - The path of this configuration file.
 
 ## Timeouts

--- a/website/docs/r/nginx_configuration.html.markdown
+++ b/website/docs/r/nginx_configuration.html.markdown
@@ -149,6 +149,14 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of this Nginx Configuration.
 
+* `protected_file` - Zero or more `protected_file` blocks with sensitive information as defined below.
+
+---
+
+A `protected_file` block exports the following:
+
+* `content_hash` - The hash of the contents of this configuration file prefixed by the algorithm used.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The NGINXaaS API was updated to return protected files' virtual path and content hashes. It still does not return the file contents.

This updates the configuration resource and datasource by adding the new computed content_hash field.

It also updates how configurations are updated. Our API does a full update (CreateOrUpdate) when updating the configuration resource. Because of this, the request payload should include all fields. (https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/best-practices.md#separate-create-and-update-methods)

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
$ make acctests SERVICE='nginx' TESTARGS='-run=TestAccConfiguration_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccConfiguration_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccConfiguration_basic
=== PAUSE TestAccConfiguration_basic
=== RUN   TestAccConfiguration_withCertificate
=== PAUSE TestAccConfiguration_withCertificate
=== RUN   TestAccConfiguration_update
=== PAUSE TestAccConfiguration_update
=== RUN   TestAccConfiguration_requiresImport
=== PAUSE TestAccConfiguration_requiresImport
=== CONT  TestAccConfiguration_basic
=== CONT  TestAccConfiguration_update
=== CONT  TestAccConfiguration_withCertificate
=== CONT  TestAccConfiguration_requiresImport
--- PASS: TestAccConfiguration_requiresImport (516.17s)
--- PASS: TestAccConfiguration_basic (568.46s)
--- PASS: TestAccConfiguration_update (672.52s)
--- PASS: TestAccConfiguration_withCertificate (1059.85s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx 1066.499s
```

```
$ make acctests SERVICE='nginx' TESTARGS='-run=TestAccNginxConfigurationDataSource_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxConfigurationDataSource_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxConfigurationDataSource_basic
=== PAUSE TestAccNginxConfigurationDataSource_basic
=== CONT  TestAccNginxConfigurationDataSource_basic
--- PASS: TestAccNginxConfigurationDataSource_basic (500.42s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx 508.354s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nginx_configuration` - add content hash attribute to protected files


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
