### PR TITLE
`azurerm_postgresql_flexible_server`: more support for in-place major version upgrade

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -352,31 +352,17 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 		},
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
-			createModeVal := d.Get("create_mode").(string)
-
-			if createModeVal == string(servers.CreateModeUpdate) {
+			if d.HasChange("version") {
 				oldVersionVal, newVersionVal := d.GetChange("version")
+				// `version` value has been validated already, ignore the parse errors is safe
+				oldVersion, _ := strconv.ParseInt(oldVersionVal.(string), 10, 32)
+				newVersion, _ := strconv.ParseInt(newVersionVal.(string), 10, 32)
 
-				if oldVersionVal != "" && newVersionVal != "" {
-					oldVersion, err := strconv.ParseInt(oldVersionVal.(string), 10, 32)
-					if err != nil {
-						return err
-					}
-
-					newVersion, err := strconv.ParseInt(newVersionVal.(string), 10, 32)
-					if err != nil {
-						return err
-					}
-
-					if oldVersion < newVersion {
-						return nil
-					}
+				if oldVersion > newVersion {
+					d.ForceNew("version")
 				}
+				return nil
 			}
-
-			d.ForceNew("create_mode")
-			d.ForceNew("version")
-
 			return nil
 		}, func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
 			oldLoginName, _ := diff.GetChange("administrator_login")

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -177,6 +177,12 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForServerVersion(), false),
 			},
 
+			"allow_major_version_update_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"zone": commonschema.ZoneSingleOptional(),
 
 			"create_mode": {
@@ -358,8 +364,19 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				oldVersion, _ := strconv.ParseInt(oldVersionVal.(string), 10, 32)
 				newVersion, _ := strconv.ParseInt(newVersionVal.(string), 10, 32)
 
+				if oldVersion == 0 {
+					return nil
+				}
+
 				if oldVersion > newVersion {
 					d.ForceNew("version")
+					return nil
+				}
+
+				// if create_mode is not Update and allow_major_version_update_enabled is not set to true, then major version update is not allowed
+				if d.Get("create_mode").(string) != string(servers.CreateModeUpdate) &&
+					!d.Get("allow_major_version_update_enabled").(bool) {
+					return fmt.Errorf("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_update_enabled` to true")
 				}
 				return nil
 			}
@@ -654,6 +671,7 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 	d.Set("name", id.FlexibleServerName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("administrator_password_wo_version", d.Get("administrator_password_wo_version").(int))
+	d.Set("allow_major_version_update_enabled", d.Get("allow_major_version_update_enabled").(bool))
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -177,7 +177,7 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForServerVersion(), false),
 			},
 
-			"allow_major_version_update_enabled": {
+			"allow_major_version_upgrade_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -373,10 +373,10 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 					return nil
 				}
 
-				// if create_mode is not Update and allow_major_version_update_enabled is not set to true, then major version update is not allowed
+				// if create_mode is not Update and allow_major_version_upgrade_enabled is not set to true, then major version upgrade is not allowed
 				if d.Get("create_mode").(string) != string(servers.CreateModeUpdate) &&
-					!d.Get("allow_major_version_update_enabled").(bool) {
-					return fmt.Errorf("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_update_enabled` to true")
+					!d.Get("allow_major_version_upgrade_enabled").(bool) {
+					return fmt.Errorf("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_upgrade_enabled` to true")
 				}
 				return nil
 			}
@@ -671,7 +671,7 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 	d.Set("name", id.FlexibleServerName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("administrator_password_wo_version", d.Get("administrator_password_wo_version").(int))
-	d.Set("allow_major_version_update_enabled", d.Get("allow_major_version_update_enabled").(bool))
+	d.Set("allow_major_version_upgrade_enabled", d.Get("allow_major_version_upgrade_enabled").(bool))
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -177,12 +177,6 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForServerVersion(), false),
 			},
 
-			"allow_major_version_upgrade_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
 			"zone": commonschema.ZoneSingleOptional(),
 
 			"create_mode": {
@@ -364,19 +358,8 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				oldVersion, _ := strconv.ParseInt(oldVersionVal.(string), 10, 32)
 				newVersion, _ := strconv.ParseInt(newVersionVal.(string), 10, 32)
 
-				if oldVersion == 0 {
-					return nil
-				}
-
 				if oldVersion > newVersion {
 					d.ForceNew("version")
-					return nil
-				}
-
-				// if create_mode is not Update and allow_major_version_upgrade_enabled is not set to true, then major version upgrade is not allowed
-				if d.Get("create_mode").(string) != string(servers.CreateModeUpdate) &&
-					!d.Get("allow_major_version_upgrade_enabled").(bool) {
-					return fmt.Errorf("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_upgrade_enabled` to true")
 				}
 				return nil
 			}
@@ -671,7 +654,6 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 	d.Set("name", id.FlexibleServerName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("administrator_password_wo_version", d.Get("administrator_password_wo_version").(int))
-	d.Set("allow_major_version_upgrade_enabled", d.Get("allow_major_version_upgrade_enabled").(bool))
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -191,7 +191,7 @@ func TestAccPostgresqlFlexibleServer_updateVersion(t *testing.T) {
 		data.ImportStep("administrator_password", "create_mode"),
 		{
 			Config:      r.withVersion(data, 13, "", false),
-			ExpectError: regexp.MustCompile("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_update_enabled` to true"),
+			ExpectError: regexp.MustCompile("major version update is not allowed, set `create_mode` to `Update` or set `allow_major_version_upgrade_enabled` to true"),
 		},
 		{
 			Config: r.withVersion(data, 13, "Update", false),
@@ -206,7 +206,7 @@ func TestAccPostgresqlFlexibleServer_updateVersion(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "allow_major_version_update_enabled"),
+		data.ImportStep("administrator_password", "create_mode", "allow_major_version_upgrade_enabled"),
 	})
 }
 
@@ -796,7 +796,7 @@ func (r PostgresqlFlexibleServerResource) withVersion(data acceptance.TestData, 
 	}
 
 	if allowMajorVersionUpdate {
-		allowMajorVersionUpdateProp = fmt.Sprintf("allow_major_version_update_enabled = %t", allowMajorVersionUpdate)
+		allowMajorVersionUpdateProp = fmt.Sprintf("allow_major_version_upgrade_enabled = %t", allowMajorVersionUpdate)
 	}
 
 	return fmt.Sprintf(`

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -115,8 +115,6 @@ The following arguments are supported:
 
 * `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `GeoRestore`, `PointInTimeRestore`, `Replica` and `Update`.
 
--> **Note:** `create_mode` cannot be changed to other values than `Update`, it's set since it's a parameter at creation. It's optional to change it to `Update` when do a major version upgrade.
-
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.
 
 * `private_dns_zone_id` - (Optional) The ID of the private DNS zone to create the PostgreSQL Flexible Server.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -161,6 +161,10 @@ The following arguments are supported:
 
 -> **Note:** Upgrading version wouldn't force a new resource to be created whilst it can still cause the server out of service for a while. Downgrading the version will force a new resource to be created.
 
+-> **Note:** An in-place version update requires that the `create_mode` is set to `Update` **OR** the `allow_major_version_update_enabled` is set to `true`.
+
+* `allow_major_version_update_enabled` - (Optional) Indicates whether major version updates are permitted for this server when `create_mode` is not set to `Update`. Defaults to `false`.
+
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 
 -> **Note:** Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the `zone` will be updated to reflect the current Primary Availability Zone. You can use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `zone` and `high_availability[0].standby_availability_zone` fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -113,11 +113,9 @@ The following arguments are supported:
 
 * `geo_redundant_backup_enabled` - (Optional) Is Geo-Redundant backup enabled on the PostgreSQL Flexible Server. Defaults to `false`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
-* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `GeoRestore`, `PointInTimeRestore`, `Replica` and `Update`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `GeoRestore`, `PointInTimeRestore`, `Replica` and `Update`.
 
--> **Note:** `create_mode` cannot be changed once it's set since it's a parameter at creation.
-
--> **Note:** While creating the resource, `create_mode` cannot be set to `Update`.
+-> **Note:** `create_mode` cannot be changed to other values than `Update`, it's set since it's a parameter at creation. It's optional to change it to `Update` when do a major version upgrade.
 
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.
 
@@ -161,7 +159,7 @@ The following arguments are supported:
 
 * `version` - (Optional) The version of PostgreSQL Flexible Server to use. Possible values are `11`,`12`, `13`, `14`, `15` and `16`. Required when `create_mode` is `Default`.
 
--> **Note:** When `create_mode` is `Update`, upgrading version wouldn't force a new resource to be created.
+-> **Note:** Upgrading version wouldn't force a new resource to be created whilst it can still cause the server out of service for a while. Downgrading the version will force a new resource to be created.
 
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -161,9 +161,9 @@ The following arguments are supported:
 
 -> **Note:** Upgrading version wouldn't force a new resource to be created whilst it can still cause the server out of service for a while. Downgrading the version will force a new resource to be created.
 
--> **Note:** An in-place version update requires that the `create_mode` is set to `Update` **OR** the `allow_major_version_update_enabled` is set to `true`.
+-> **Note:** An in-place version update requires that the `create_mode` is set to `Update` **OR** the `allow_major_version_upgrade_enabled` is set to `true`.
 
-* `allow_major_version_update_enabled` - (Optional) Indicates whether major version updates are permitted for this server when `create_mode` is not set to `Update`. Defaults to `false`.
+* `allow_major_version_upgrade_enabled` - (Optional) Indicates whether major version updates are permitted for this server when `create_mode` is not set to `Update`. Defaults to `false`.
 
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -159,11 +159,9 @@ The following arguments are supported:
 
 * `version` - (Optional) The version of PostgreSQL Flexible Server to use. Possible values are `11`,`12`, `13`, `14`, `15` and `16`. Required when `create_mode` is `Default`.
 
--> **Note:** Upgrading version wouldn't force a new resource to be created whilst it can still cause the server out of service for a while. Downgrading the version will force a new resource to be created.
+-> **Note:** Downgrading `version` isn't supported and will force a new PostgreSQL Flexible Server to be created.
 
--> **Note:** An in-place version update requires that the `create_mode` is set to `Update` **OR** the `allow_major_version_upgrade_enabled` is set to `true`.
-
-* `allow_major_version_upgrade_enabled` - (Optional) Indicates whether major version updates are permitted for this server when `create_mode` is not set to `Update`. Defaults to `false`.
+-> **Note:** In-place version updates are irreversible and may cause downtime for the PostgreSQL Flexible Server, determined by the size of the instance.
 
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Per API's behavior of `create_mode` only works when creating the instance, and upgrade the `version` of the server should not cause a force-recreate of the resource. I have tested locally, whether create_mode set or not, the version can be upgrade successfully. So this PR changes the force-new logic to only when downgrading the version.

This PR also move some related validation logic from `Create` to `CustomizeDiff`, so all the errors can be exposed in plan stage.

The new version update psudo logic:

```
// if version downgrade
if new_version < old_version:
  set force new and continue

// if version upgrade
if create_mode != "Update" and allow_major_version_upgrade_enabled is not True:
  raise an error of forbidding version update
else:
  in-place update
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccPostgresqlFlexibleServer_upgradeVersion (2564.89s)
--- PASS: TestAccPostgresqlFlexibleServer_updateVersion (1623.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres1623.389s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server` - support in-place major version upgrade [GH-25184]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25184


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
