### PR TITLE
`azurerm_ai_services`: allows `bypass` property for `network_acls`

### DIFF
--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -67,11 +67,11 @@ type VirtualNetworkRules struct {
 	IgnoreMissingVnetServiceEndpoint bool   `tfschema:"ignore_missing_vnet_service_endpoint"`
 }
 
-type AzureAIServicesNetworkACLs struct {
-	Bypass              string                               `tfschema:"bypass"`
-	DefaultAction       string                               `tfschema:"default_action"`
-	IpRules             []string                             `tfschema:"ip_rules"`
-	VirtualNetworkRules []AzureAIServicesVirtualNetworkRules `tfschema:"virtual_network_rules"`
+type NetworkACLs struct {
+	Bypass              string                `tfschema:"bypass"`
+	DefaultAction       string                `tfschema:"default_action"`
+	IpRules             []string              `tfschema:"ip_rules"`
+	VirtualNetworkRules []VirtualNetworkRules `tfschema:"virtual_network_rules"`
 }
 
 type CustomerManagedKey struct {
@@ -786,7 +786,7 @@ func flattenNetworkACLs(input *cognitiveservicesaccounts.NetworkRuleSet) []Netwo
 		}
 	}
 
-	return []AzureAIServicesNetworkACLs{{
+	return []NetworkACLs{{
 		Bypass:              string(*input.Bypass),
 		DefaultAction:       string(*input.DefaultAction),
 		IpRules:             ipRules,

--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -787,8 +787,8 @@ func flattenNetworkACLs(input *cognitiveservicesaccounts.NetworkRuleSet) []Netwo
 	}
 
 	return []NetworkACLs{{
-		Bypass:              string(*input.Bypass),
-		DefaultAction:       string(*input.DefaultAction),
+		Bypass:              string(pointer.From(input.Bypass)),
+		DefaultAction:       string(pointer.From(input.DefaultAction)),
 		IpRules:             ipRules,
 		VirtualNetworkRules: virtualNetworkRules,
 	}}

--- a/internal/services/cognitive/ai_services_resource_test.go
+++ b/internal/services/cognitive/ai_services_resource_test.go
@@ -108,6 +108,13 @@ func TestAccCognitiveAIServices_networkACLs(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.networkACLsBypassUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -618,6 +625,32 @@ resource "azurerm_ai_services" "test" {
   custom_subdomain_name = "acctestcogacc-%d"
 
   network_acls {
+    bypass         = "None"
+    default_action = "Allow"
+    ip_rules       = ["123.0.0.101"]
+    virtual_network_rules {
+      subnet_id = azurerm_subnet.test_a.id
+    }
+    virtual_network_rules {
+      subnet_id = azurerm_subnet.test_b.id
+    }
+  }
+}
+`, r.networkACLsTemplate(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r AzureAIServicesResource) networkACLsBypassUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_ai_services" "test" {
+  name                  = "acctestcogacc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctestcogacc-%d"
+
+  network_acls {
+    bypass         = "AzureServices"
     default_action = "Allow"
     ip_rules       = ["123.0.0.101"]
     virtual_network_rules {

--- a/internal/services/cognitive/ai_services_resource_test.go
+++ b/internal/services/cognitive/ai_services_resource_test.go
@@ -639,7 +639,7 @@ resource "azurerm_ai_services" "test" {
 `, r.networkACLsTemplate(data), data.RandomInteger, data.RandomInteger)
 }
 
-func (r AzureAIServicesResource) networkACLsBypassUpdated(data acceptance.TestData) string {
+func (r AIServices) networkACLsBypassUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 resource "azurerm_ai_services" "test" {

--- a/website/docs/r/ai_services.html.markdown
+++ b/website/docs/r/ai_services.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 A `network_acls` block supports the following:
 
+* `bypass` - (Optional) Whether to allow trusted Azure Services to access the service. Possible values are `None` and `AzureServices`. Defaults to `AzureServices`.
+* 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the AI Services Account.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR implements the `network_acls.bypass` property for `azurerm_ai_services`. [Azure Services for Azure AI Services](https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-virtual-networks?tabs=portal#grant-access-to-trusted-azure-services-for-azure-openai).

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/cognitive -run=TestAccCognitiveAIServices_networkACLs -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccCognitiveAIServices_networkACLs
=== PAUSE TestAccCognitiveAIServices_networkACLs
=== CONT  TestAccCognitiveAIServices_networkACLs
--- PASS: TestAccCognitiveAIServices_networkACLs (263.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive	265.555s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_ai_services` - support for the `bypass` trusted Azure Services property [[GH-28569](https://github.com/hashicorp/terraform-provider-azurerm/pull/28569)]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
