### PR TITLE
doc: fix resource type name missing azurerm_ prefix of `azurerm_netapp_backup_vault` and `azurerm_netapp_backup_policy`

### DIFF
--- a/website/docs/r/netapp_backup_policy.html.markdown
+++ b/website/docs/r/netapp_backup_policy.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "NetApp"
 layout: "azurerm"
-page_title: "Azure Resource Manager: netapp_backup_policy"
+page_title: "Azure Resource Manager: azurerm_netapp_backup_policy"
 description: |-
   Manages a NetApp Backup Policy.
 ---
 
-# netapp_backup_policy
+# azurerm_netapp_backup_policy
 
 Manages a NetApp Backup Policy.
 

--- a/website/docs/r/netapp_backup_vault.html.markdown
+++ b/website/docs/r/netapp_backup_vault.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "NetApp"
 layout: "azurerm"
-page_title: "Azure Resource Manager: netapp_backup_vault"
+page_title: "Azure Resource Manager: azurerm_netapp_backup_vault"
 description: |-
   Manages a NetApp Backup Vault.
 ---
 
-# netapp_backup_vault
+# azurerm_netapp_backup_vault
 
 Manages a NetApp Backup Vault.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

missing prefix in the documents
https://registry.terraform.io/providers/hashicorp/azurerm/4.16.0/docs/resources/netapp_backup_vault
https://registry.terraform.io/providers/hashicorp/azurerm/4.16.0/docs/resources/netapp_backup_policy

![image](https://github.com/user-attachments/assets/3ca07438-ad1e-4f9d-b185-3632ee93b5fa)
![image](https://github.com/user-attachments/assets/c438074d-9857-40d9-a346-482259943f66)

which should be like below with correct full resource name in the title, or it may breaks some tools

![image](https://github.com/user-attachments/assets/158bd3f2-bc80-4897-a557-f6604df93f67)
