### PR TITLE
azurerm_nginx_deployment - make network profile updateable

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -67,9 +67,7 @@ type DeploymentModel struct {
 	Tags                   map[string]string                          `tfschema:"tags"`
 }
 
-func expandNetworkProfile(
-	public []FrontendPublic, private []FrontendPrivate, networkInterface []NetworkInterface,
-) *nginxdeployment.NginxNetworkProfile {
+func expandNetworkProfile(public []FrontendPublic, private []FrontendPrivate, networkInterface []NetworkInterface,) *nginxdeployment.NginxNetworkProfile {
 	out := nginxdeployment.NginxNetworkProfile{
 		FrontEndIPConfiguration:       &nginxdeployment.NginxFrontendIPConfiguration{},
 		NetworkInterfaceConfiguration: &nginxdeployment.NginxNetworkInterfaceConfiguration{},

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -67,6 +67,44 @@ type DeploymentModel struct {
 	Tags                   map[string]string                          `tfschema:"tags"`
 }
 
+func expandNetworkProfile(
+	public []FrontendPublic, private []FrontendPrivate, networkInterface []NetworkInterface,
+) *nginxdeployment.NginxNetworkProfile {
+	out := nginxdeployment.NginxNetworkProfile{
+		FrontEndIPConfiguration:       &nginxdeployment.NginxFrontendIPConfiguration{},
+		NetworkInterfaceConfiguration: &nginxdeployment.NginxNetworkInterfaceConfiguration{},
+	}
+
+	if len(public) > 0 && len(public[0].IpAddress) > 0 {
+		var publicIPs []nginxdeployment.NginxPublicIPAddress
+		for _, ip := range public[0].IpAddress {
+			publicIPs = append(publicIPs, nginxdeployment.NginxPublicIPAddress{
+				Id: pointer.To(ip),
+			})
+		}
+		out.FrontEndIPConfiguration.PublicIPAddresses = &publicIPs
+	}
+
+	if len(private) > 0 {
+		var privateIPs []nginxdeployment.NginxPrivateIPAddress
+		for _, ip := range private {
+			alloc := nginxdeployment.NginxPrivateIPAllocationMethod(ip.AllocationMethod)
+			privateIPs = append(privateIPs, nginxdeployment.NginxPrivateIPAddress{
+				PrivateIPAddress:          pointer.To(ip.IpAddress),
+				PrivateIPAllocationMethod: &alloc,
+				SubnetId:                  pointer.To(ip.SubnetId),
+			})
+		}
+		out.FrontEndIPConfiguration.PrivateIPAddresses = &privateIPs
+	}
+
+	if len(networkInterface) > 0 {
+		out.NetworkInterfaceConfiguration.SubnetId = pointer.To(networkInterface[0].SubnetId)
+	}
+
+	return &out
+}
+
 type DeploymentResource struct{}
 
 var _ sdk.ResourceWithUpdate = (*DeploymentResource)(nil)
@@ -144,7 +182,6 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"frontend_public": {
 			Type:          pluginsdk.TypeList,
 			Optional:      true,
-			ForceNew:      true,
 			MaxItems:      1,
 			ConflictsWith: []string{"frontend_private"},
 			Elem: &pluginsdk.Resource{
@@ -152,7 +189,6 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"ip_address": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Schema{
 							Type:         pluginsdk.TypeString,
 							ValidateFunc: validation.StringIsNotEmpty,
@@ -165,27 +201,23 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"frontend_private": {
 			Type:          pluginsdk.TypeList,
 			Optional:      true,
-			ForceNew:      true,
 			ConflictsWith: []string{"frontend_public"},
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"ip_address": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 
 					"allocation_method": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
-						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice(nginxdeployment.PossibleValuesForNginxPrivateIPAllocationMethod(), false),
 					},
 
 					"subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 				},
 			},
@@ -194,13 +226,11 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"network_interface": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			ForceNew: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 				},
 			},
@@ -323,37 +353,7 @@ func (m DeploymentResource) Create() sdk.ResourceFunc {
 			}
 
 			prop.EnableDiagnosticsSupport = pointer.FromBool(model.DiagnoseSupportEnabled)
-			prop.NetworkProfile = &nginxdeployment.NginxNetworkProfile{
-				FrontEndIPConfiguration:       &nginxdeployment.NginxFrontendIPConfiguration{},
-				NetworkInterfaceConfiguration: &nginxdeployment.NginxNetworkInterfaceConfiguration{},
-			}
-
-			if public := model.FrontendPublic; len(public) > 0 && len(public[0].IpAddress) > 0 {
-				var publicIPs []nginxdeployment.NginxPublicIPAddress
-				for _, ip := range public[0].IpAddress {
-					publicIPs = append(publicIPs, nginxdeployment.NginxPublicIPAddress{
-						Id: pointer.To(ip),
-					})
-				}
-				prop.NetworkProfile.FrontEndIPConfiguration.PublicIPAddresses = &publicIPs
-			}
-
-			if private := model.FrontendPrivate; len(private) > 0 {
-				var privateIPs []nginxdeployment.NginxPrivateIPAddress
-				for _, ip := range private {
-					alloc := nginxdeployment.NginxPrivateIPAllocationMethod(ip.AllocationMethod)
-					privateIPs = append(privateIPs, nginxdeployment.NginxPrivateIPAddress{
-						PrivateIPAddress:          pointer.To(ip.IpAddress),
-						PrivateIPAllocationMethod: &alloc,
-						SubnetId:                  pointer.To(ip.SubnetId),
-					})
-				}
-				prop.NetworkProfile.FrontEndIPConfiguration.PrivateIPAddresses = &privateIPs
-			}
-
-			if len(model.NetworkInterface) > 0 {
-				prop.NetworkProfile.NetworkInterfaceConfiguration.SubnetId = pointer.To(model.NetworkInterface[0].SubnetId)
-			}
+			prop.NetworkProfile = expandNetworkProfile(model.FrontendPublic, model.FrontendPrivate, model.NetworkInterface)
 
 			isBasicSKU := strings.HasPrefix(model.Sku, "basic")
 			hasScaling := (model.Capacity > 0 || len(model.AutoScaleProfile) > 0)
@@ -614,6 +614,10 @@ func (m DeploymentResource) Update() sdk.ResourceFunc {
 				req.Properties.AutoUpgradeProfile = &nginxdeployment.AutoUpgradeProfile{
 					UpgradeChannel: model.UpgradeChannel,
 				}
+			}
+
+			if meta.ResourceData.HasChanges("frontend_public", "frontend_private", "network_interface") {
+				req.Properties.NetworkProfile = expandNetworkProfile(model.FrontendPublic, model.FrontendPrivate, model.NetworkInterface)
 			}
 
 			if strings.HasPrefix(model.Sku, "basic") && req.Properties.ScalingProperties != nil {

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -67,7 +67,7 @@ type DeploymentModel struct {
 	Tags                   map[string]string                          `tfschema:"tags"`
 }
 
-func expandNetworkProfile(public []FrontendPublic, private []FrontendPrivate, networkInterface []NetworkInterface,) *nginxdeployment.NginxNetworkProfile {
+func expandNetworkProfile(public []FrontendPublic, private []FrontendPrivate, networkInterface []NetworkInterface) *nginxdeployment.NginxNetworkProfile {
 	out := nginxdeployment.NginxNetworkProfile{
 		FrontEndIPConfiguration:       &nginxdeployment.NginxFrontendIPConfiguration{},
 		NetworkInterfaceConfiguration: &nginxdeployment.NginxNetworkInterfaceConfiguration{},

--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -6,6 +6,7 @@ package nginx_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2024-11-01-preview/nginxdeployment"
@@ -69,6 +70,72 @@ func TestAccNginxDeployment_update(t *testing.T) {
 	})
 }
 
+func TestAccNginxDeployment_updateNetworkInterface(t *testing.T) {
+	data := acceptance.BuildTestData(t, nginx.DeploymentResource{}.ResourceType(), "test")
+	r := DeploymentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateNetworkInterface(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_interface.0.subnet_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.Network/virtualNetworks/[\w-]+/subnets/subnet2-[\w-]+$`)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNginxDeployment_updateFrontendPrivate(t *testing.T) {
+	data := acceptance.BuildTestData(t, nginx.DeploymentResource{}.ResourceType(), "test")
+	r := DeploymentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateFrontendPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("frontend_private.0.ip_address").HasValue("10.0.2.11"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNginxDeployment_updateFrontendPublic(t *testing.T) {
+	data := acceptance.BuildTestData(t, nginx.DeploymentResource{}.ResourceType(), "test")
+	r := DeploymentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateFrontendPublic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("frontend_public.0.ip_address.0").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.Network/publicIPAddresses/acctest2-[\w-]+$`)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNginxDeployment_systemAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, nginx.DeploymentResource{}.ResourceType(), "test")
 	r := DeploymentResource{}
@@ -113,6 +180,41 @@ resource "azurerm_nginx_deployment" "test" {
 
   frontend_public {
     ip_address = [azurerm_public_ip.test.id]
+  }
+
+  network_interface {
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  capacity = 10
+
+  email = "test@test.com"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a DeploymentResource) basicPrivate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_nginx_deployment" "test" {
+  name                      = "acctest-%[2]d"
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "standardv2_Monthly"
+  location                  = azurerm_resource_group.test.location
+  diagnose_support_enabled  = false
+  automatic_upgrade_channel = "stable"
+
+  frontend_private {
+    allocation_method = "Static"
+    ip_address        = "10.0.2.10"
+    subnet_id         = azurerm_subnet.test.id
   }
 
   network_interface {
@@ -248,6 +350,109 @@ resource "azurerm_nginx_deployment" "test" {
 `, a.template(data), data.RandomInteger)
 }
 
+func (a DeploymentResource) updateNetworkInterface(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_nginx_deployment" "test" {
+  name                      = "acctest-%[2]d"
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "standardv2_Monthly"
+  location                  = azurerm_resource_group.test.location
+  diagnose_support_enabled  = false
+  automatic_upgrade_channel = "stable"
+
+  frontend_private {
+    allocation_method = "Static"
+    ip_address        = "10.0.2.10"
+    subnet_id         = azurerm_subnet.test.id
+  }
+
+  network_interface {
+    subnet_id = azurerm_subnet.test2.id
+  }
+
+  capacity = 10
+
+  email = "testing@test.com"
+
+  tags = {
+    foo = "bar2"
+  }
+}
+`, a.template(data), data.RandomInteger)
+}
+
+func (a DeploymentResource) updateFrontendPrivate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_nginx_deployment" "test" {
+  name                      = "acctest-%[2]d"
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "standardv2_Monthly"
+  location                  = azurerm_resource_group.test.location
+  diagnose_support_enabled  = false
+  automatic_upgrade_channel = "stable"
+
+  frontend_private {
+    allocation_method = "Static"
+    ip_address        = "10.0.2.11"
+    subnet_id         = azurerm_subnet.test.id
+  }
+
+  network_interface {
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  capacity = 10
+
+  email = "test@test.com"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, a.template(data), data.RandomInteger)
+}
+
+func (a DeploymentResource) updateFrontendPublic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_nginx_deployment" "test" {
+  name                      = "acctest-%[2]d"
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "standardv2_Monthly"
+  location                  = azurerm_resource_group.test.location
+  diagnose_support_enabled  = false
+  automatic_upgrade_channel = "stable"
+
+  frontend_public {
+    ip_address = [azurerm_public_ip.test2.id]
+  }
+
+  network_interface {
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  capacity = 10
+
+  email = "testing@test.com"
+
+  tags = {
+    foo = "bar2"
+  }
+}
+`, a.template(data), data.RandomInteger)
+}
+
 func (a DeploymentResource) systemAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
@@ -341,6 +546,18 @@ resource "azurerm_public_ip" "test" {
   }
 }
 
+resource "azurerm_public_ip" "test2" {
+  name                = "acctest2-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = {
+    environment = "Production"
+  }
+}
+
 resource "azurerm_virtual_network" "test" {
   name                = "acctestvirtnet%[1]d"
   address_space       = ["10.0.0.0/16"]
@@ -349,10 +566,27 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "subbet%[1]d"
+  name                 = "subnet-%[1]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name = "NGINX.NGINXPLUS/nginxDeployments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "subnet2-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.3.0/24"]
   delegation {
     name = "delegation"
 

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -103,11 +103,11 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `frontend_private` - (Optional) One or more `frontend_private` blocks as defined below. Changing this forces a new NGINX Deployment to be created.
+* `frontend_private` - (Optional) One or more `frontend_private` blocks as defined below.
 
-* `frontend_public` - (Optional) A `frontend_public` block as defined below. Changing this forces a new NGINX Deployment to be created.
+* `frontend_public` - (Optional) A `frontend_public` block as defined below.
 
-* `network_interface` - (Optional) One or more `network_interface` blocks as defined below. Changing this forces a new NGINX Deployment to be created.
+* `network_interface` - (Optional) One or more `network_interface` blocks as defined below.
 
 * `automatic_upgrade_channel` - (Optional) Specify the automatic upgrade channel for the NGINX deployment. Defaults to `stable`. The possible values are `stable` and `preview`.
 
@@ -127,23 +127,23 @@ A `identity` block supports the following:
 
 A `frontend_private` block supports the following:
 
-* `allocation_method` - (Required) Specify the method for allocating the private IP. Possible values are `Static` and `Dynamic`. Changing this forces a new NGINX Deployment to be created.
+* `allocation_method` - (Required) Specify the method for allocating the private IP. Possible values are `Static` and `Dynamic`.
 
-* `ip_address` - (Required) Specify the private IP Address. Changing this forces a new NGINX Deployment to be created.
+* `ip_address` - (Required) Specify the private IP Address.
 
-* `subnet_id` - (Required) Specify the Subnet Resource ID for this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
+* `subnet_id` - (Required) Specify the Subnet Resource ID for this NGINX Deployment.
 
 ---
 
 A `frontend_public` block supports the following:
 
-* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
+* `ip_address` - (Optional) Specifies a list of Public IP Resource ID to this NGINX Deployment.
 
 ---
 
 A `network_interface` block supports the following:
 
-* `subnet_id` - (Required) Specify The Subnet Resource ID for this NGINX Deployment. Changing this forces a new NGINX Deployment to be created.
+* `subnet_id` - (Required) Specify The Subnet Resource ID for this NGINX Deployment.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The NGINXaaS API was updated to include the network profile of a deployment in its update properties. This allows blocks that encompass the network profile, `frontend_public`, `frontend_private`, and `network_configuration`, to be updated without the deployment having to be recreated. All fields within the network profile must be specified when making the update.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
$ make acctests SERVICE='nginx' TESTARGS='-run=TestAccNginxDeployment' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/nginx -run=TestAccNginxDeployment -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNginxDeploymentDataSource_basic
=== PAUSE TestAccNginxDeploymentDataSource_basic
=== RUN   TestAccNginxDeploymentDataSource_autoscaling
=== PAUSE TestAccNginxDeploymentDataSource_autoscaling
=== RUN   TestAccNginxDeployment_basic
=== PAUSE TestAccNginxDeployment_basic
=== RUN   TestAccNginxDeployment_update
=== PAUSE TestAccNginxDeployment_update
=== RUN   TestAccNginxDeployment_systemAssignedIdentity
=== PAUSE TestAccNginxDeployment_systemAssignedIdentity
=== RUN   TestAccNginxDeployment_userAssignedIdentity
=== PAUSE TestAccNginxDeployment_userAssignedIdentity
=== RUN   TestAccNginxDeployment_autoscaling
=== PAUSE TestAccNginxDeployment_autoscaling
=== CONT  TestAccNginxDeploymentDataSource_basic
=== CONT  TestAccNginxDeployment_systemAssignedIdentity
=== CONT  TestAccNginxDeployment_autoscaling
=== CONT  TestAccNginxDeployment_userAssignedIdentity
=== CONT  TestAccNginxDeployment_basic
=== CONT  TestAccNginxDeployment_update
=== CONT  TestAccNginxDeploymentDataSource_autoscaling
--- PASS: TestAccNginxDeploymentDataSource_basic (463.82s)
--- PASS: TestAccNginxDeploymentDataSource_autoscaling (470.53s)
--- PASS: TestAccNginxDeployment_basic (499.47s)
--- PASS: TestAccNginxDeployment_userAssignedIdentity (515.80s)
--- PASS: TestAccNginxDeployment_systemAssignedIdentity (521.45s)
--- PASS: TestAccNginxDeployment_update (725.60s)
--- PASS: TestAccNginxDeployment_autoscaling (853.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx 859.784s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nginx_deployment` - make network profile updateable


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
