### PR TITLE
New Data Source: `azurerm_stack_hci_storage_path`

### DIFF
--- a/internal/services/azurestackhci/registration.go
+++ b/internal/services/azurestackhci/registration.go
@@ -46,6 +46,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		StackHCIClusterDataSource{},
+		StackHCIStoragePathDataSource{},
 	}
 }
 

--- a/internal/services/azurestackhci/stack_hci_storage_path_data_source.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_data_source.go
@@ -49,7 +49,7 @@ func (r StackHCIStoragePathDataSource) Arguments() map[string]*pluginsdk.Schema 
 			),
 		},
 
-		"resource_group_name": commonschema.ResourceGroupName(),
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 	}
 }
 
@@ -88,7 +88,7 @@ func (r StackHCIStoragePathDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("%s does not exist", id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/internal/services/azurestackhci/stack_hci_storage_path_data_source.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_data_source.go
@@ -1,0 +1,120 @@
+package azurestackhci
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2024-01-01/storagecontainers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type StackHCIStoragePathDataSource struct{}
+
+var _ sdk.DataSource = StackHCIStoragePathDataSource{}
+
+type StackHCIStoragePathDataSourceModel struct {
+	Name              string                 `tfschema:"name"`
+	ResourceGroupName string                 `tfschema:"resource_group_name"`
+	Location          string                 `tfschema:"location"`
+	CustomLocationId  string                 `tfschema:"custom_location_id"`
+	Path              string                 `tfschema:"path"`
+	Tags              map[string]interface{} `tfschema:"tags"`
+}
+
+func (r StackHCIStoragePathDataSource) ResourceType() string {
+	return "azurerm_stack_hci_storage_path"
+}
+
+func (r StackHCIStoragePathDataSource) ModelObject() interface{} {
+	return &StackHCIStoragePathDataSourceModel{}
+}
+
+func (r StackHCIStoragePathDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[a-zA-Z0-9][\-\.\_a-zA-Z0-9]{1,78}[a-zA-Z0-9]$`),
+				"name must begin and end with an alphanumeric character, be between 3 and 80 characters in length and can only contain alphanumeric characters, hyphens, periods or underscores.",
+			),
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (r StackHCIStoragePathDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"custom_location_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"path": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (r StackHCIStoragePathDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AzureStackHCI.StorageContainers
+
+			var state StackHCIStoragePathDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := storagecontainers.NewStorageContainerID(subscriptionId, state.ResourceGroupName, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s does not exist", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Tags = tags.Flatten(model.Tags)
+
+				if model.ExtendedLocation != nil && model.ExtendedLocation.Name != nil {
+					customLocationId, err := customlocations.ParseCustomLocationIDInsensitively(*model.ExtendedLocation.Name)
+					if err != nil {
+						return err
+					}
+
+					state.CustomLocationId = customLocationId.ID()
+				}
+
+				if props := model.Properties; props != nil {
+					state.Path = props.Path
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
@@ -1,0 +1,38 @@
+package azurestackhci_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type StackHCIStoragePathDataSource struct{}
+
+func TestAccStackHCIStoragePathDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_storage_path", "test")
+	d := StackHCIStoragePathDataSource{}
+
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_location_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("path").IsNotEmpty(),
+			),
+		},
+	})
+}
+
+func (d StackHCIStoragePathDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_stack_hci_storage_path" "test" {
+  name                = azurerm_stack_hci_storage_path.test.name
+  resource_group_name = azurerm_stack_hci_storage_path.test.resource_group_name
+}
+`, StackHCIStoragePathResource{}.complete(data))
+}

--- a/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
@@ -2,6 +2,7 @@ package azurestackhci_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -11,6 +12,10 @@ import (
 type StackHCIStoragePathDataSource struct{}
 
 func TestAccStackHCIStoragePathDataSource_basic(t *testing.T) {
+	if os.Getenv(customLocationIdEnv) == "" {
+		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)
+	}
+
 	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_storage_path", "test")
 	d := StackHCIStoragePathDataSource{}
 

--- a/website/docs/d/stack_hci_storage_path.html.markdown
+++ b/website/docs/d/stack_hci_storage_path.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Azure Stack HCI"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_stack_hci_storage_path"
+description: |-
+  Gets information about an existing Stack HCI Storage Path.
+---
+
+# Data Source: azurerm_stack_hci_storage_path
+
+Use this data source to access information about an existing Stack HCI Storage Path.
+
+## Example Usage
+
+```hcl
+data "azurerm_stack_hci_storage_path" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_stack_hci_storage_path.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Stack HCI Storage Path.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Stack HCI Storage Path exists. Changing this forces a new Stack HCI Storage Path to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Stack HCI Storage Path.
+
+* `custom_location_id` - The ID of the Custom Location where the Stack HCI Storage Path exists.
+
+* `location` - The Azure Region where the Stack HCI Storage Path exists.
+
+* `path` - The file path on the disk where the Stack HCI Storage Path was created.
+
+* `tags` - A mapping of tags assigned to the Stack HCI Storage Path.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Stack HCI Storage Path.
+

--- a/website/docs/d/stack_hci_storage_path.html.markdown
+++ b/website/docs/d/stack_hci_storage_path.html.markdown
@@ -14,8 +14,8 @@ Use this data source to access information about an existing Stack HCI Storage P
 
 ```hcl
 data "azurerm_stack_hci_storage_path" "example" {
-  name                = "existing"
-  resource_group_name = "existing"
+  name                = "example-hci-storage-path-name"
+  resource_group_name = "example-rg"
 }
 
 output "id" {
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of this Stack HCI Storage Path.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Stack HCI Storage Path exists. Changing this forces a new Stack HCI Storage Path to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Stack HCI Storage Path exists.
 
 ## Attributes Reference
 
@@ -50,4 +50,3 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Stack HCI Storage Path.
-


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
New Data Source: azurerm_stack_hci_storage_path
reference:

[Azure doc](https://learn.microsoft.com/en-us/azure/azure-local/manage/create-storage-path?tabs=azurecli)
[REST API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2024-01-01/storageContainers.json)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![image](https://github.com/user-attachments/assets/93dfd626-d8bf-44c0-8e28-4ac5f4e7bed4)
[log](https://gist.github.com/teowa/deacbec4f59aeb3271143cbe916fdbab)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Data Source: `azurerm_stack_hci_storage_path`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
