### PR TITLE
azurerm_private_dns_zone_virtual_network_link - Add support for Resolution Policy

### DIFF
--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -48,6 +49,11 @@ func dataSourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resolution_policy": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -79,6 +85,7 @@ func dataSourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, m
 		if props := model.Properties; props != nil {
 			d.Set("registration_enabled", props.RegistrationEnabled)
 
+			d.Set("resolution_policy", pointer.From(props.ResolutionPolicy))
 			if network := props.VirtualNetwork; network != nil {
 				d.Set("virtual_network_id", network.Id)
 			}

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -75,6 +76,13 @@ func resourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"resolution_policy": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(virtualnetworklinks.ResolutionPolicyDefault),
+				ValidateFunc: validation.StringInSlice(virtualnetworklinks.PossibleValuesForResolutionPolicy(), false),
+			},
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -108,6 +116,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 				Id: utils.String(d.Get("virtual_network_id").(string)),
 			},
 			RegistrationEnabled: utils.Bool(d.Get("registration_enabled").(bool)),
+			ResolutionPolicy:    pointer.To(virtualnetworklinks.ResolutionPolicy(d.Get("resolution_policy").(string))),
 		},
 	}
 
@@ -151,6 +160,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, met
 		if props := model.Properties; props != nil {
 			d.Set("registration_enabled", props.RegistrationEnabled)
 
+			d.Set("resolution_policy", pointer.From(props.ResolutionPolicy))
 			if network := props.VirtualNetwork; network != nil {
 				d.Set("virtual_network_id", network.Id)
 			}

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
@@ -190,6 +190,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "test" {
   virtual_network_id    = azurerm_virtual_network.test.id
   resource_group_name   = azurerm_resource_group.test.name
   registration_enabled  = true
+  resolution_policy     = "NxDomainRedirect"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
@@ -40,6 +40,8 @@ output "private_dns_a_record_id" {
 
 * `registration_enabled` - Whether the auto-registration of virtual machine records in the virtual network in the Private DNS zone is enabled or not.
 
+* `resolution_policy` - Specifies the policy for handling DNS resolution. If set to `NxDomainRedirect`, the DNS resolution will fall back to internet recursion when an authoritative NXDOMAIN response is received for a Private Link zone.
+
 * `tags` - A mapping of tags to assign to the resource.
 
 ## Timeouts

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `registration_enabled` - (Optional) Is auto-registration of virtual machine records in the virtual network in the Private DNS zone enabled? Defaults to `false`.
 
+* `resolution_policy` - (Optional) Specifies the policy for handling DNS resolution. If set to `NxDomainRedirect`, the DNS resolution will fall back to internet recursion when an authoritative NXDOMAIN response is received for a Private Link zone. Defaults to `Default` (no recursion).
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add support for the new setting `resolution_policy`
Supported values are: `Default` or `NxDomainRedirect`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_dns_zone_virtual_network_link ` - support for the `resolution_policy` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28087


