### PR TITLE
Storage: Eliminating listing storage account when its resource ID is available to use GET

### DIFF
--- a/internal/services/storage/storage_account_queue_properties_data_plane_resource.go
+++ b/internal/services/storage/storage_account_queue_properties_data_plane_resource.go
@@ -297,7 +297,7 @@ func (s AccountQueuePropertiesResource) Create() sdk.ResourceFunc {
 			}
 			accountReplicationType := accountReplicationTypeParts[1]
 
-			accountDetails, err := storageClient.FindAccount(ctx, accountID.SubscriptionId, accountID.StorageAccountName)
+			accountDetails, err := storageClient.GetAccount(ctx, *accountID)
 			if err != nil {
 				return err
 			}
@@ -398,7 +398,7 @@ func (s AccountQueuePropertiesResource) Read() sdk.ResourceFunc {
 
 			state.StorageAccountId = id.ID()
 
-			account, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			account, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return metadata.MarkAsGone(id)
 			}
@@ -481,7 +481,7 @@ func (s AccountQueuePropertiesResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			account, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			account, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
@@ -514,7 +514,7 @@ func (s AccountQueuePropertiesResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			account, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			account, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}

--- a/internal/services/storage/storage_account_queue_properties_data_plane_resource_test.go
+++ b/internal/services/storage/storage_account_queue_properties_data_plane_resource_test.go
@@ -158,7 +158,7 @@ func (r AccountQueuePropertiesResource) Exists(ctx context.Context, client *clie
 		return nil, err
 	}
 
-	account, err := client.Storage.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+	account, err := client.Storage.GetAccount(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1492,7 +1492,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// Start of Data Plane access - this entire block can be removed for 5.0, as the data_plane_available flag becomes redundant at that time.
 	if !features.FivePointOhBeta() && dataPlaneAvailable {
 		dataPlaneClient := meta.(*clients.Client).Storage
-		dataPlaneAccount, err := storageUtils.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+		dataPlaneAccount, err := storageUtils.GetAccount(ctx, id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
@@ -1925,7 +1925,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 				return fmt.Errorf("`queue_properties` aren't supported for account kind %q in sku tier %q", accountKind, accountTier)
 			}
 
-			account, err := dataPlaneClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			account, err := dataPlaneClient.GetAccount(ctx, *id)
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
@@ -1953,7 +1953,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 				return fmt.Errorf("`static_website` aren't supported for account kind %q in sku tier %q", accountKind, accountTier)
 			}
 
-			account, err := dataPlaneClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			account, err := dataPlaneClient.GetAccount(ctx, *id)
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
@@ -2030,7 +2030,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	// we then need to find the storage account
-	account, err := storageUtils.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+	account, err := storageUtils.GetAccount(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}

--- a/internal/services/storage/storage_account_static_website_data_plane_resource.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource.go
@@ -103,7 +103,7 @@ func (a AccountStaticWebsiteResource) Create() sdk.ResourceFunc {
 			}
 			accountReplicationType := accountReplicationTypeParts[1]
 
-			accountDetails, err := storageClient.FindAccount(ctx, accountID.SubscriptionId, accountID.StorageAccountName)
+			accountDetails, err := storageClient.GetAccount(ctx, *accountID)
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func (a AccountStaticWebsiteResource) Read() sdk.ResourceFunc {
 
 			state.StorageAccountId = id.ID()
 
-			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			accountDetails, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return metadata.MarkAsGone(id)
 			}
@@ -193,7 +193,7 @@ func (a AccountStaticWebsiteResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			accountDetails, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return nil // lint:ignore nilerr If we don't find the account we can safely assume we don't need to remove the website since it must already be deleted
 			}
@@ -233,7 +233,7 @@ func (a AccountStaticWebsiteResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			accountDetails, err := storageClient.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+			accountDetails, err := storageClient.GetAccount(ctx, *id)
 			if err != nil {
 				return err
 			}

--- a/internal/services/storage/storage_account_static_website_data_plane_resource_test.go
+++ b/internal/services/storage/storage_account_static_website_data_plane_resource_test.go
@@ -105,7 +105,7 @@ func (r AccountStaticWebsiteResource) Exists(ctx context.Context, client *client
 		return nil, err
 	}
 
-	accountDetails, err := client.Storage.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
+	accountDetails, err := client.Storage.GetAccount(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}

--- a/internal/services/storage/storage_containers_data_source.go
+++ b/internal/services/storage/storage_containers_data_source.go
@@ -89,7 +89,6 @@ func (r storageContainersDataSource) Read() sdk.ResourceFunc {
 
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			blobContainersClient := metadata.Client.Storage.ResourceManager.BlobContainers
-			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			var plan storageContainersDataSourceModel
 			if err := metadata.Decode(&plan); err != nil {
@@ -101,7 +100,7 @@ func (r storageContainersDataSource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			account, err := metadata.Client.Storage.FindAccount(ctx, subscriptionId, id.StorageAccountName)
+			account, err := metadata.Client.Storage.GetAccount(ctx, *id)
 			if err != nil {
 				return fmt.Errorf("retrieving Storage Account %q: %v", id.StorageAccountName, err)
 			}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Listing storage accounts under the scope of a subscription causing a lot of data consistency issues as is reported in #15048. Almost, all the list calls come from the invocation of https://github.com/hashicorp/terraform-provider-azurerm/blob/509724aad4e78f1b8b41c1935219bc7e88b064f8/internal/services/storage/client/helpers.go#L149

The main reason to call the list is to **map a storage account name to a storage account ID, with its API model (contains the different storage service endpoints)**.

There are multiple call points, which can be catagorized into the following:

- Non-storage resources reference a storage account by name (e.g. `azurerm_machine_learning_datastore_blobstorage`): This is mostly because the API is designed to contain only the storage account name and a container name, while the provider tends to combine them into a storage container id (for UX).
- Storage data plane resources: The ID of these resources are their data plane URL, from which only the storage account name can be extracted. Calling the list API will return the storage details including the primary endpoints for each storage services (e.g. blob, table, etc.). This is then used to initialize the data plane client.

In the other case, that are covered by this PR is that the resource itself has the full storage account ID (instead of the name):

- `azurerm_storage_account`, `azurerm_storage_account_static_website`, `azurerm_storage_account_queue_properties`: The resource id is just the storage account resource id
- `azurerm_storage_containers` DS: It references the storage account id

For these cases, a simple storage account targeted `GET` is enough.

For the long run, I think the storage account detail is not necessary for those data plane resources to build their clients. Since those data plane resources have their service-specific endpoint as the their resource id, we can then statically build the endpoints for other services, with a little more care about the [Azure DNS zone endpoints](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#azure-dns-zone-endpoints-preview). I'll hold on implementing this part until we've reached an agreement on this direction.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
💤  TF_ACC=1 go test -v -parallel 6 -timeout=20h -run='TestAccStorageAccount_DNSEndpointTypeAzure|TestAccStorageAccount_basic|TestAccDataSourceStorageContainers_basic|TestAccountStaticWebsiteResource_update' ./internal/services/storage
=== RUN   TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== RUN   TestAccStorageAccount_DNSEndpointTypeAzure
=== PAUSE TestAccStorageAccount_DNSEndpointTypeAzure
=== RUN   TestAccountStaticWebsiteResource_update
=== PAUSE TestAccountStaticWebsiteResource_update
=== RUN   TestAccDataSourceStorageContainers_basic
=== PAUSE TestAccDataSourceStorageContainers_basic
=== CONT  TestAccStorageAccount_basic
=== CONT  TestAccountStaticWebsiteResource_update
=== CONT  TestAccDataSourceStorageContainers_basic
=== CONT  TestAccStorageAccount_DNSEndpointTypeAzure
--- PASS: TestAccStorageAccount_DNSEndpointTypeAzure (119.34s)
--- PASS: TestAccDataSourceStorageContainers_basic (130.44s)
--- PASS: TestAccStorageAccount_basic (198.03s)
--- PASS: TestAccountStaticWebsiteResource_update (250.28s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       250.305s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Relating to #15048


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
