### PR TITLE
azurerm_data_factory - customer-managed encryption key "cannot parse an empty string" bug fix

### DIFF
--- a/internal/services/datafactory/data_factory_resource.go
+++ b/internal/services/datafactory/data_factory_resource.go
@@ -209,7 +209,6 @@ func resourceDataFactory() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: commonids.ValidateUserAssignedIdentityID,
-				RequiredWith: []string{"customer_managed_key_id"},
 			},
 
 			"tags": commonschema.Tags(),
@@ -385,10 +384,10 @@ func resourceDataFactoryRead(d *pluginsdk.ResourceData, meta interface{}) error 
 					customerManagedKeyId = keyId.ID()
 				}
 
-				if encIdentity := enc.Identity; encIdentity != nil && encIdentity.UserAssignedIdentity != nil {
+				if encIdentity := enc.Identity; encIdentity != nil && encIdentity.UserAssignedIdentity != nil && *encIdentity.UserAssignedIdentity != "" {
 					parsed, err := commonids.ParseUserAssignedIdentityIDInsensitively(*encIdentity.UserAssignedIdentity)
 					if err != nil {
-						return fmt.Errorf("parsing %q: %+v", *encIdentity.UserAssignedIdentity, err)
+						return fmt.Errorf("parsing %q: %+v", "customer_managed_key_identity_id", err)
 					}
 					customerManagedKeyIdentityId = parsed.ID()
 				}

--- a/internal/services/datafactory/data_factory_resource_test.go
+++ b/internal/services/datafactory/data_factory_resource_test.go
@@ -240,6 +240,28 @@ func TestAccDataFactory_keyVaultKeyEncryption(t *testing.T) {
 	})
 }
 
+func TestAccDataFactory_keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
+	r := DataFactoryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity_basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity_cmkSet(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataFactory_globalParameter(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
 	r := DataFactoryResource{}
@@ -736,6 +758,116 @@ resource "azurerm_data_factory" "test" {
   customer_managed_key_identity_id = azurerm_user_assigned_identity.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (DataFactoryResource) keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestDF%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (DataFactoryResource) keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity_cmkSet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+data "azurerm_data_factory" "existing" {
+  name                = "acctestDF%d"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acckv%d"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Get",
+      "Delete",
+      "Purge",
+      "GetRotationPolicy",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_data_factory.existing.identity.0.principal_id
+
+    key_permissions = [
+      "Get",
+      "UnwrapKey",
+      "WrapKey"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "unwrapKey",
+    "wrapKey"
+  ]
+}
+
+resource "azurerm_data_factory" "test" {
+  name                    = "acctestDF%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+
+  customer_managed_key_id = azurerm_key_vault_key.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+	`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (DataFactoryResource) globalParameter(data acceptance.TestData) string {

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `customer_managed_key_id` - (Optional) Specifies the Azure Key Vault Key ID to be used as the Customer Managed Key (CMK) for double encryption. Required with user assigned identity.
 
-* `customer_managed_key_identity_id` - (Optional) Specifies the ID of the user assigned identity associated with the Customer Managed Key. Must be supplied if `customer_managed_key_id` is set.
+* `customer_managed_key_identity_id` - (Optional) Specifies the ID of the user assigned identity associated with the Customer Managed Key. Must be supplied at factory creation if `customer_managed_key_id` is set. Can be left empty once factory is created to use the system assigned identity. See the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/data-factory/enable-customer-managed-key) for more information.
 
 * `purview_id` - (Optional) Specifies the ID of the purview account resource associated with the Data Factory.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes a bug where if `customer_managed_key_id` is set on an existing data factory, `customer_managed_key_identity_id` is assumed to be present, but it could be an empty string when Managed Service Identity (MSI) is used. As a result user see a parsing error when the provider attempted to parse the json payload back into state.

To reproduce the bug:

1. In Terraform, deploy a data factory without `customer_managed_key_id` set and with `SystemAssigned` identity
1. In portal, setup a key vault and key for encryption (refer to detailed instruction [here](https://learn.microsoft.com/en-us/azure/data-factory/enable-customer-managed-key))
1. In Terraform, set the `customer_managed_key_id` to the URL of the key created in step 2 and deploy

Expected: Terraform deploy completed with no errors

Actual: Terraform deploy failed with error: `Error: parsing "": parsing "": cannot parse an empty string`

The reproduction step above reflects the `TestAccDataFactory_keyVaultKeyEncryptionWithExistingDataFactoryAndManagedServiceIdentity` I implemented in this PR.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Acceptance test invoked with following command: `make acctests SERVICE='datafactory' TESTARGS='-run="TestAccDataFactory_"' TESTTIMEOUT='120m'`

And all 17 tests passes. Please find the log via [this link](https://microsoftapc-my.sharepoint.com/:u:/g/personal/tangerry_microsoft_com/EW_7R0OQ7btJh2DgtT97J08BC87H5a5uv37PwAY75FWpxg?e=qoKokW) (access restricted, please DM me on Slack).

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory` - customer-managed encryption key "cannot parse an empty string" bug fix [GH-27717]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27717 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
