### PR TITLE
`azurerm_container_app(_job)` - Remove `termination_grace_period_seconds` attribute from probes

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/daprcomponents"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2024-03-01/containerapps"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2024-03-01/managedenvironments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -2033,11 +2034,11 @@ type ContainerAppLivenessProbe struct {
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
-	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
+	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds,removedInNextMajorVersion"`
 }
 
 func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MinItems: 1,
@@ -2126,19 +2127,23 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.IntBetween(1, 30),
 					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
-
-				"termination_grace_period_seconds": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
-				},
 			},
 		},
 	}
+
+	if !features.FivePointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
+			Type:        pluginsdk.TypeInt,
+			Computed:    true,
+			Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+		}
+	}
+
+	return schema
 }
 
 func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Computed: true,
 		Elem: &pluginsdk.Resource{
@@ -2210,15 +2215,19 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 					Computed:    true,
 					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
-
-				"termination_grace_period_seconds": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
-				},
 			},
 		},
 	}
+
+	if !features.FivePointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
+			Type:        pluginsdk.TypeInt,
+			Computed:    true,
+			Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+		}
+	}
+
+	return schema
 }
 
 func expandContainerAppLivenessProbe(input ContainerAppLivenessProbe) containerapps.ContainerAppProbe {
@@ -2312,11 +2321,11 @@ type ContainerAppStartupProbe struct {
 	Interval               int64        `tfschema:"interval_seconds"`
 	Timeout                int64        `tfschema:"timeout"`
 	FailureThreshold       int64        `tfschema:"failure_count_threshold"`
-	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds"`
+	TerminationGracePeriod int64        `tfschema:"termination_grace_period_seconds,removedInNextMajorVersion"`
 }
 
 func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MinItems: 1,
@@ -2405,19 +2414,23 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.IntBetween(1, 30),
 					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
-
-				"termination_grace_period_seconds": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
-				},
 			},
 		},
 	}
+
+	if !features.FivePointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
+			Type:        pluginsdk.TypeInt,
+			Computed:    true,
+			Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+		}
+	}
+
+	return schema
 }
 
 func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Computed: true,
 		Elem: &pluginsdk.Resource{
@@ -2485,15 +2498,19 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 					Computed:    true,
 					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `30`. Defaults to `3`.",
 				},
-
-				"termination_grace_period_seconds": {
-					Type:        pluginsdk.TypeInt,
-					Computed:    true,
-					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
-				},
 			},
 		},
 	}
+
+	if !features.FivePointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
+			Type:        pluginsdk.TypeInt,
+			Computed:    true,
+			Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+		}
+	}
+
+	return schema
 }
 
 func expandContainerAppStartupProbe(input ContainerAppStartupProbe) containerapps.ContainerAppProbe {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -2131,7 +2131,7 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
 			Type:        pluginsdk.TypeInt,
 			Computed:    true,
@@ -2219,7 +2219,7 @@ func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
 			Type:        pluginsdk.TypeInt,
 			Computed:    true,
@@ -2418,7 +2418,7 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
 			Type:        pluginsdk.TypeInt,
 			Computed:    true,
@@ -2502,7 +2502,7 @@ func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["termination_grace_period_seconds"] = &pluginsdk.Schema{
 			Type:        pluginsdk.TypeInt,
 			Computed:    true,

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -93,6 +93,16 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `tls.minimum_tls_version` property no longer accepts `TLS10` as a value.
 
+### `azurerm_container_app`
+
+* The deprecated `template.container.liveness_probe.termination_grace_period_seconds` property has been removed.
+* The deprecated `template.container.startup_probe.termination_grace_period_seconds` property has been removed.
+
+### `azurerm_container_app_job`
+
+* The deprecated `template.container.liveness_probe.termination_grace_period_seconds` property has been removed.
+* The deprecated `template.container.startup_probe.termination_grace_period_seconds` property has been removed.
+
 ### `azurerm_cosmosdb_account`
 
 * The `minimal_tls_version` property no longer accepts `Tls` or `Tls11` as a value.
@@ -187,6 +197,11 @@ Please follow the format in the example below for listing breaking changes in da
 * The deprecated `example_old_property` property has been removed in favour of the `example_new_property` property.
 * The deprecated `example_property_with_no_replacement` property has been removed.
 ```
+
+### `azurerm_container_app`
+
+* The deprecated `template.container.liveness_probe.termination_grace_period_seconds` property has been removed.
+* The deprecated `template.container.startup_probe.termination_grace_period_seconds` property has been removed.
 
 ### `azurerm_logic_app_standard`
 

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -161,8 +161,6 @@ A `liveness_probe` block supports the following:
 
 * `port` - The port number on which to connect. Possible values are between `1` and `65535`.
 
-* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
-
 * `timeout` - Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
 
 * `transport` - Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.
@@ -234,8 +232,6 @@ A `startup_probe` block supports the following:
 * `path` - The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
 
 * `port` - The port number on which to connect. Possible values are between `1` and `65535`.
-
-* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
 
 * `timeout` - Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -270,8 +270,6 @@ A `liveness_probe` block supports the following:
 
 * `port` - (Required) The port number on which to connect. Possible values are between `1` and `65535`.
 
-* `termination_grace_period_seconds` - The time in seconds after the container is sent the termination signal before the process if forcibly killed.
-
 * `timeout` - (Optional) Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
 
 * `transport` - (Required) Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.
@@ -345,8 +343,6 @@ A `startup_probe` block supports the following:
 * `path` - (Optional) The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
 
 * `port` - (Required) The port number on which to connect. Possible values are between `1` and `65535`.
-
-* `termination_grace_period_seconds` - The time in seconds after the container is sent the termination signal before the process if forcibly killed.
 
 * `timeout` - (Optional) Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
 

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -222,8 +222,6 @@ A `liveness_probe` block supports the following:
 
 * `timeout` - (Optional) Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
 
-* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
-
 ---
 
 A `header` block supports the following:
@@ -281,8 +279,6 @@ A `startup_probe` block supports the following:
 * `path` - (Optional) The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
 
 * `timeout` - (Optional) Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
-
-* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Remove `termination_grace_period_seconds` attribute from `liveness_probe` and `startup_probe` as the API does not currently return this property.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28470


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
