### PR TITLE
Replace FivePointOhBeta flag with FivePointOh

### DIFF
--- a/contributing/topics/guide-breaking-changes.md
+++ b/contributing/topics/guide-breaking-changes.md
@@ -4,7 +4,7 @@ To keep up with and accommodate the changing pace of Azure, the provider needs t
 
 The `azurerm` provider attempts to be as "surface stable" as possible during minor and patch releases meaning breaking changes are typically only made during major releases, however exceptions are sometimes made for minor releases when the breaking change is deemed necessary or is unavoidable. Terraform users rely on the stability of Terraform providers as not only can configuration changes be costly to make, test, and deploy they can also affect downstream tooling such as modules. Even as part of a major release, breaking changes that are overly large or have little benefit can delay users upgrading to the next major version.
 
-Generally we can safely introduce breaking changes into the provider for the major release using a feature flag. For the next major release that would be the `features.FivePointOhBeta()` flag which is available in the provider today. This guide includes several topics on how to do common deprecations and breaking changes in the provider using this feature flag, as well as additional guidance on how to deal with changing default values in the Azure API. 
+Generally we can safely introduce breaking changes into the provider for the major release using a feature flag. For the next major release that would be the `features.FivePointOh()` flag which is available in the provider today. This guide includes several topics on how to do common deprecations and breaking changes in the provider using this feature flag, as well as additional guidance on how to deal with changing default values in the Azure API. 
 
 Types of breaking changes covered are:
 
@@ -75,7 +75,7 @@ The steps outlined below uses an example resource that is deprecated, but the sa
             MySqlFlexibleServerResource{},
         }
         
-        if !features.FivePointOhBeta() {
+        if !features.FivePointOh() {
             resources = append(resources, ExampleResource{})
         }
         
@@ -91,7 +91,7 @@ The steps outlined below uses an example resource that is deprecated, but the sa
     
         }
     
-        if !features.FivePointOhBeta() {
+        if !features.FivePointOh() {
             resources["azurerm_example"] = resourceExample()
         }
     
@@ -103,7 +103,7 @@ The steps outlined below uses an example resource that is deprecated, but the sa
 
     ```go
     func TestAccExample_basic(t *testing.T) {
-        if features.FivePointOhBeta() {
+        if features.FivePointOh() {
             t.Skipf("Skipping since `azurerm_example` is deprecated and will be removed in 5.0")
         }
         data := acceptance.BuildTestData(t, "azurerm_example", "test")
@@ -170,7 +170,7 @@ The following example follows a fictional resource that will have the following 
          },
       }
    
-      if !features.FivePointOhBeta() {
+      if !features.FivePointOh() {
          args["enable_scaling"] = &pluginsdk.Schema{
             Type:     pluginsdk.TypeBool,
             Optional: true,
@@ -201,7 +201,7 @@ The following example follows a fictional resource that will have the following 
 
    ```go
    func (ExampleResource) complete(data acceptance.TestData) string {
-   if !features.FivePointOhBeta() {
+   if !features.FivePointOh() {
         return fmt.Sprintf(`
    provider "azurerm" {
      features {}
@@ -359,7 +359,7 @@ func (r SparkResource) Arguments() map[string]*pluginsdk.Schema{
             },
         }
 
-    if !features.FivePointOhBeta() {
+    if !features.FivePointOh() {
         args["spark_version"].Default = "2.4"
     }
 	

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -98,9 +98,6 @@ func userAgent(userAgent, tfVersion, partnerID string, disableTerraformPartnerID
 	tfUserAgent := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io)", tfVersion)
 
 	providerUserAgent := fmt.Sprintf("%s terraform-provider-azurerm/%s", tfUserAgent, version.ProviderVersion)
-	if features.FivePointOhBeta() {
-		providerUserAgent = fmt.Sprintf("%s terraform-provider-azurerm/%s+5.0-beta", tfUserAgent, version.ProviderVersion)
-	}
 	userAgent = strings.TrimSpace(fmt.Sprintf("%s %s", userAgent, providerUserAgent))
 
 	// append the CloudShell version to the user agent if it exists

--- a/internal/features/five_point_oh.go
+++ b/internal/features/five_point_oh.go
@@ -3,11 +3,6 @@
 
 package features
 
-import (
-	"os"
-	"strings"
-)
-
 // nolint gocritic
 // DeprecatedInFivePointOh returns the deprecation message if the provider
 // is running in 5.0 mode - otherwise returns an empty string (such that
@@ -16,7 +11,7 @@ import (
 //   - Signify resources which will be Deprecated in 5.0, but not Removed (which will happen in a later release).
 //   - For properties undergoing a rename, where the renamed property will only be introduced in the next release
 func DeprecatedInFivePointOh(deprecationMessage string) string {
-	if !FivePointOhBeta() {
+	if !FivePointOh() {
 		return ""
 	}
 
@@ -30,20 +25,4 @@ func DeprecatedInFivePointOh(deprecationMessage string) string {
 // during the development of 4.x until 5.0 is ready.
 func FivePointOh() bool {
 	return false
-}
-
-// FivePointOhBeta returns whether this provider is running in 5.0 mode
-// which is an opt-in Beta of the changes coming in 5.0.
-//
-// This exists to allow breaking changes to be piped through the provider
-// during the development of 4.x until 5.0 is ready.
-//
-// The environment variable `ARM_FIVEPOINTZERO_BETA` has been added
-// to facilitate testing. But it should be noted that
-// `ARM_FIVEPOINTZERO_BETA` is ** NOT READY FOR PUBLIC USE ** and
-// ** SHOULD NOT BE SET IN PRODUCTION ENVIRONMENTS **
-// Setting `ARM_FIVEPOINTZERO_BETA` will cause irreversible changes
-// to your state.
-func FivePointOhBeta() bool {
-	return FivePointOh() || strings.EqualFold(os.Getenv("ARM_FIVEPOINTZERO_BETA"), "true")
 }

--- a/internal/features/five_point_oh.go
+++ b/internal/features/five_point_oh.go
@@ -3,6 +3,11 @@
 
 package features
 
+import (
+	"os"
+	"strings"
+)
+
 // nolint gocritic
 // DeprecatedInFivePointOh returns the deprecation message if the provider
 // is running in 5.0 mode - otherwise returns an empty string (such that
@@ -23,6 +28,12 @@ func DeprecatedInFivePointOh(deprecationMessage string) string {
 //
 // This exists to allow breaking changes to be piped through the provider
 // during the development of 4.x until 5.0 is ready.
+// The environment variable `ARM_FIVEPOINTZERO_BETA` has been added
+// to facilitate testing. But it should be noted that
+// `ARM_FIVEPOINTZERO_BETA` is ** NOT READY FOR PUBLIC USE ** and
+// ** SHOULD NOT BE SET IN PRODUCTION ENVIRONMENTS **
+// Setting `ARM_FIVEPOINTZERO_BETA` will cause irreversible changes
+// to your state.
 func FivePointOh() bool {
-	return false
+	return strings.EqualFold(os.Getenv("ARM_FIVEPOINTZERO_BETA"), "true")
 }

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -528,7 +528,7 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 	client.StopContext = ctx
 
 	resourceProviderRegistrationSet := getEnvStringOrDefault(data.ResourceProviderRegistrations, "ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsCore)
-	if !providerfeatures.FivePointOhBeta() {
+	if !providerfeatures.FivePointOh() {
 		resourceProviderRegistrationSet = getEnvStringOrDefault(data.ResourceProviderRegistrations, "ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsLegacy)
 	}
 

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -111,7 +111,7 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 		ValidateFunc: keyvaultValidate.NestedItemIdWithOptionalVersion,
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema["cdn_managed_https"].Elem.(*pluginsdk.Resource).Schema["tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -119,7 +119,7 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["tls"].Elem.(*pluginsdk.Resource).Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeString,
 			Optional:   true,

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -50,7 +50,7 @@ func TestAccCdnFrontDoorCustomDomain_requiresImport(t *testing.T) {
 }
 
 func TestAccCdnFrontDoorCustomDomain_update(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("There is no available `tls_version` to test update, to test CMK, it requires an official certificate from approved provider list instead of testing cert.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -771,7 +771,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimal_tls_version"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -247,7 +247,7 @@ func TestAccCosmosDBAccount_updateTagsWithUserAssignedDefaultIdentity(t *testing
 }
 
 func TestAccCosmosDBAccount_minimalTlsVersion(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("There is no more available values for `minimal_tls_version` to test.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")

--- a/internal/services/databricks/databricks_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_customer_managed_key_resource_test.go
@@ -20,7 +20,7 @@ import (
 type DatabricksWorkspaceCustomerManagedKeyResource struct{}
 
 func TestAccDatabricksWorkspaceCustomerManagedKey_basic(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Resource no longer exists in 5.0")
 	}
 
@@ -43,7 +43,7 @@ func TestAccDatabricksWorkspaceCustomerManagedKey_basic(t *testing.T) {
 }
 
 func TestAccDatabricksWorkspaceCustomerManagedKey_remove(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Resource no longer exists in 5.0")
 	}
 
@@ -73,7 +73,7 @@ func TestAccDatabricksWorkspaceCustomerManagedKey_remove(t *testing.T) {
 }
 
 func TestAccDatabricksWorkspaceCustomerManagedKey_requiresImport(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Resource no longer exists in 5.0")
 	}
 
@@ -94,7 +94,7 @@ func TestAccDatabricksWorkspaceCustomerManagedKey_requiresImport(t *testing.T) {
 }
 
 func TestAccDatabricksWorkspaceCustomerManagedKey_noIp(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Resource no longer exists in 5.0")
 	}
 

--- a/internal/services/databricks/registration.go
+++ b/internal/services/databricks/registration.go
@@ -48,7 +48,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_databricks_virtual_network_peering":                  resourceDatabricksVirtualNetworkPeering(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resources["azurerm_databricks_workspace_customer_managed_key"] = resourceDatabricksWorkspaceCustomerManagedKey()
 	}
 

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -269,7 +269,7 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 		),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -476,7 +476,7 @@ func TestAccEventHubNamespace_publicNetworkAccessUpdate(t *testing.T) {
 }
 
 func TestAccEventHubNamespace_minimumTLSUpdate(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("The `minimum_tls_version` has only one possible value `1.2`, we can not update it.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")

--- a/internal/services/eventhub/eventhub_resource.go
+++ b/internal/services/eventhub/eventhub_resource.go
@@ -163,7 +163,7 @@ func resourceEventHub() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		r.Schema["namespace_id"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -213,7 +213,7 @@ func resourceEventHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		resourceGroupName = namespaceId.ResourceGroupName
 	}
 
-	if !features.FivePointOhBeta() && namespaceName == "" {
+	if !features.FivePointOh() && namespaceName == "" {
 		namespaceName = d.Get("namespace_name").(string)
 		resourceGroupName = d.Get("resource_group_name").(string)
 	}
@@ -331,7 +331,7 @@ func resourceEventHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	d.Set("name", id.EventhubName)
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		d.Set("namespace_name", id.NamespaceName)
 		d.Set("resource_group_name", id.ResourceGroupName)
 	}

--- a/internal/services/eventhub/eventhub_resource_test.go
+++ b/internal/services/eventhub/eventhub_resource_test.go
@@ -361,7 +361,7 @@ func (EventHubResource) Exists(ctx context.Context, clients *clients.Client, sta
 }
 
 func (EventHubResource) basic(data acceptance.TestData, partitionCount int) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -246,7 +246,7 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		// Due to the way the `site_config.public_network_access_enabled` property and the `public_network_access` property
 		// influence each other, the default needs to be handled in the Create for now until `site_config.public_network_access_enabled`
 		// is removed in v5.0
@@ -341,7 +341,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	publicNetworkAccess := d.Get("public_network_access").(string)
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		// if a user is still using `site_config.public_network_access_enabled` we should be setting `public_network_access` for them
 		publicNetworkAccess = reconcilePNA(d)
 		if v := siteEnvelope.Properties.SiteConfig.PublicNetworkAccess; v != nil && *v == helpers.PublicNetworkAccessDisabled {
@@ -456,7 +456,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	if !features.FivePointOhBeta() { // Until 5.0 the site_config value of this must be reflected back into the top-level property if not set there
+	if !features.FivePointOh() { // Until 5.0 the site_config value of this must be reflected back into the top-level property if not set there
 		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(d))
 	}
 
@@ -489,7 +489,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
-	if d.HasChange("site_config") || (d.HasChange("public_network_access") && !features.FivePointOhBeta()) { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
+	if d.HasChange("site_config") || (d.HasChange("public_network_access") && !features.FivePointOh()) { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
 		siteConfigResource := webapps.SiteConfigResource{
 			Properties: &siteConfig,
 		}
@@ -911,7 +911,7 @@ func schemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["public_network_access_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,
@@ -1144,7 +1144,7 @@ func flattenLogicAppStandardSiteConfig(input *webapps.SiteConfig) []interface{} 
 		publicNetworkAccessEnabled = !strings.EqualFold(pointer.From(input.PublicNetworkAccess), helpers.PublicNetworkAccessDisabled)
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		result["public_network_access_enabled"] = publicNetworkAccessEnabled
 	}
 
@@ -1371,7 +1371,7 @@ func expandLogicAppStandardSiteConfig(d *pluginsdk.ResourceData) (webapps.SiteCo
 		siteConfig.VnetRouteAllEnabled = pointer.To(v.(bool))
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(d))
 	}
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -959,7 +959,7 @@ func TestAccLogicAppStandard_vNetIntegrationUpdate(t *testing.T) {
 }
 
 func TestAccLogicAppStandard_publicNetworkAccessEnabled(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping since `site_config.public_network_access_enabled` is removed in v5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")

--- a/internal/services/maps/maps_creator_resource_test.go
+++ b/internal/services/maps/maps_creator_resource_test.go
@@ -21,7 +21,7 @@ import (
 type MapsCreatorResource struct{}
 
 func TestAccMapsCreator_basic(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_maps_creator` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_maps_creator", "test")
@@ -38,7 +38,7 @@ func TestAccMapsCreator_basic(t *testing.T) {
 }
 
 func TestAccMapsCreator_requiresImport(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_maps_creator` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_maps_creator", "test")
@@ -55,7 +55,7 @@ func TestAccMapsCreator_requiresImport(t *testing.T) {
 }
 
 func TestAccMapsCreator_complete(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_maps_creator` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_maps_creator", "test")
@@ -72,7 +72,7 @@ func TestAccMapsCreator_complete(t *testing.T) {
 }
 
 func TestAccMapsCreator_update(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_maps_creator` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_maps_creator", "test")

--- a/internal/services/maps/registration.go
+++ b/internal/services/maps/registration.go
@@ -42,7 +42,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_maps_account": resourceMapsAccount(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resources["azurerm_maps_creator"] = resourceMapsCreator()
 	}
 

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -102,7 +102,7 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["enabled_log"].Elem.(*pluginsdk.Resource).Schema["retention_policy"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeList,
 			Optional:   true,
@@ -374,7 +374,7 @@ func expandMonitorAADDiagnosticsSettingsEnabledLogs(input []interface{}) []diagn
 			Enabled:  true,
 		}
 
-		if !features.FivePointOhBeta() {
+		if !features.FivePointOh() {
 			if len(v["retention_policy"].([]interface{})) != 0 && v["retention_policy"].([]interface{})[0] != nil {
 				policyRaw := v["retention_policy"].([]interface{})[0].(map[string]interface{})
 				retentionDays := policyRaw["days"].(int)
@@ -412,7 +412,7 @@ func flattenMonitorAADDiagnosticEnabledLogs(input *[]diagnosticsettings.LogSetti
 			"category": category,
 		}
 
-		if !features.FivePointOhBeta() {
+		if !features.FivePointOh() {
 			policies := make([]interface{}, 0)
 			if inputPolicy := v.RetentionPolicy; inputPolicy != nil {
 				if inputPolicy.Days != 0 || inputPolicy.Enabled {

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -500,7 +500,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
 }
 
 func (MonitorAADDiagnosticSettingResource) retentionDisabled(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -1824,7 +1824,7 @@ func resourceMsSqlDatabaseSchema() map[string]*pluginsdk.Schema {
 		"tags": commonschema.Tags(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		atLeastOneOf := []string{
 			"long_term_retention_policy.0.weekly_retention", "long_term_retention_policy.0.monthly_retention",
 			"long_term_retention_policy.0.yearly_retention", "long_term_retention_policy.0.week_of_year",

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -200,7 +200,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 		),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -53,7 +53,7 @@ func TestAccMsSqlServer_complete(t *testing.T) {
 }
 
 func TestAccMsSqlServer_minimumTLSVersionDisabled(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("The service require minimum TLS version to be 1.2+, skip the `disabled` testing.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")

--- a/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
@@ -120,7 +120,7 @@ func (r MsSqlManagedDatabaseResource) Arguments() map[string]*pluginsdk.Schema {
 		"tags": tags.Schema(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		atLeastOneOf := []string{
 			"long_term_retention_policy.0.weekly_retention", "long_term_retention_policy.0.monthly_retention",
 			"long_term_retention_policy.0.yearly_retention", "long_term_retention_policy.0.week_of_year",

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -313,7 +313,7 @@ func (r MsSqlManagedInstanceResource) Arguments() map[string]*pluginsdk.Schema {
 		"tags": tags.Schema(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		args["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     schema.TypeString,
 			Optional: true,

--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -154,7 +154,7 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["private_link_fast_path_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,

--- a/internal/services/network/network_packet_capture_resource_test.go
+++ b/internal/services/network/network_packet_capture_resource_test.go
@@ -20,7 +20,7 @@ import (
 type NetworkPacketCaptureResource struct{}
 
 func testAccNetworkPacketCapture_localDisk(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Skipping since `azure_network_packet_capture` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_network_packet_capture", "test")
@@ -38,7 +38,7 @@ func testAccNetworkPacketCapture_localDisk(t *testing.T) {
 }
 
 func testAccNetworkPacketCapture_requiresImport(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Skipping since `azure_network_packet_capture` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_network_packet_capture", "test")
@@ -59,7 +59,7 @@ func testAccNetworkPacketCapture_requiresImport(t *testing.T) {
 }
 
 func testAccNetworkPacketCapture_storageAccount(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Skipping since `azure_network_packet_capture` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_network_packet_capture", "test")
@@ -77,7 +77,7 @@ func testAccNetworkPacketCapture_storageAccount(t *testing.T) {
 }
 
 func testAccNetworkPacketCapture_storageAccountAndLocalDisk(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Skipping since `azure_network_packet_capture` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_network_packet_capture", "test")
@@ -95,7 +95,7 @@ func testAccNetworkPacketCapture_storageAccountAndLocalDisk(t *testing.T) {
 }
 
 func testAccNetworkPacketCapture_withFilters(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("Skipping since `azure_network_packet_capture` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_network_packet_capture", "test")

--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -177,7 +177,7 @@ func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["network_security_group_id"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -218,7 +218,7 @@ func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interfa
 
 	targetResourceId := ""
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		if v, ok := d.GetOk("network_security_group_id"); ok && v.(string) != "" {
 			targetResourceId = v.(string)
 		}
@@ -319,7 +319,7 @@ func resourceNetworkWatcherFlowLogUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	targetResourceId := ""
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		if v, ok := d.GetOk("network_security_group_id"); ok && v.(string) != "" {
 			targetResourceId = v.(string)
 		}
@@ -430,7 +430,7 @@ func resourceNetworkWatcherFlowLogRead(d *pluginsdk.ResourceData, meta interface
 				targetResourceId = nicId.ID()
 			}
 
-			if !features.FivePointOhBeta() && targetIsNSG {
+			if !features.FivePointOh() && targetIsNSG {
 				d.Set("network_security_group_id", targetResourceId)
 			}
 

--- a/internal/services/network/network_watcher_flow_log_resource_test.go
+++ b/internal/services/network/network_watcher_flow_log_resource_test.go
@@ -331,7 +331,7 @@ resource "azurerm_storage_account" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) basicConfig(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -372,7 +372,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) basicConfigWithVirtualNetwork(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -509,7 +509,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) requiresImport(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -550,7 +550,7 @@ resource "azurerm_network_watcher_flow_log" "import" {
 }
 
 func (r NetworkWatcherFlowLogResource) retentionPolicyConfig(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -591,7 +591,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) retentionPolicyConfigUpdateStorageAccount(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -654,7 +654,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) disabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -697,7 +697,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsEnabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -768,7 +768,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsUpdateInterval(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -841,7 +841,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsDisabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -913,7 +913,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) versionConfig(data acceptance.TestData, version int) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -986,7 +986,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) location(data acceptance.TestData) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 
@@ -1029,7 +1029,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
 }
 
 func (r NetworkWatcherFlowLogResource) tags(data acceptance.TestData, v string) string {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
 

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -175,7 +175,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_web_application_firewall_policy":           resourceWebApplicationFirewallPolicy(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resources["azurerm_network_packet_capture"] = resourceNetworkPacketCapture()
 	}
 

--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -395,7 +395,7 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 							*/
 							Optional: true,
 							// We'll remove computed in 5.0 so we don't break existing configurations
-							Computed: !features.FivePointOhBeta(),
+							Computed: !features.FivePointOh(),
 						},
 
 						"max_request_body_size_in_kb": {

--- a/internal/services/nginx/nginx_configuration_data_source.go
+++ b/internal/services/nginx/nginx_configuration_data_source.go
@@ -88,7 +88,7 @@ func (m ConfigurationDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		dataSource["protected_file"].Elem.(*pluginsdk.Resource).Schema["content"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeString,
 			Computed:   true,

--- a/internal/services/nginx/nginx_deployment_data_source.go
+++ b/internal/services/nginx/nginx_deployment_data_source.go
@@ -181,7 +181,7 @@ func (m DeploymentDataSource) Attributes() map[string]*pluginsdk.Schema {
 		"tags": commonschema.TagsDataSource(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		dataSource["managed_resource_group"] = &pluginsdk.Schema{
 			Deprecated: "The `managed_resource_group` field isn't supported by the API anymore and has been deprecated and will be removed in v5.0 of the AzureRM Provider.",
 			Type:       pluginsdk.TypeString,
@@ -261,7 +261,7 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 					output.DataplaneAPIEndpoint = pointer.ToString(props.DataplaneApiEndpoint)
 					output.DiagnoseSupportEnabled = pointer.ToBool(props.EnableDiagnosticsSupport)
 
-					if !features.FivePointOhBeta() {
+					if !features.FivePointOh() {
 						if props.Logging != nil && props.Logging.StorageAccount != nil {
 							output.LoggingStorageAccount = []LoggingStorageAccount{
 								{

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -236,7 +236,7 @@ func (m DeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"tags": commonschema.Tags(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource["managed_resource_group"] = &pluginsdk.Schema{
 			Deprecated:   "The `managed_resource_group` field isn't supported by the API anymore and has been deprecated and will be removed in v5.0 of the AzureRM Provider.",
 			Type:         pluginsdk.TypeString,
@@ -327,7 +327,7 @@ func (m DeploymentResource) Create() sdk.ResourceFunc {
 
 			prop := &nginxdeployment.NginxDeploymentProperties{}
 
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				if len(model.LoggingStorageAccount) > 0 {
 					prop.Logging = &nginxdeployment.NginxLogging{
 						StorageAccount: &nginxdeployment.NginxStorageAccount{
@@ -470,7 +470,7 @@ func (m DeploymentResource) Read() sdk.ResourceFunc {
 					output.DataplaneAPIEndpoint = pointer.ToString(props.DataplaneApiEndpoint)
 					output.DiagnoseSupportEnabled = pointer.ToBool(props.EnableDiagnosticsSupport)
 
-					if !features.FivePointOhBeta() {
+					if !features.FivePointOh() {
 						if props.Logging != nil && props.Logging.StorageAccount != nil {
 							output.LoggingStorageAccount = []LoggingStorageAccount{
 								{
@@ -581,7 +581,7 @@ func (m DeploymentResource) Update() sdk.ResourceFunc {
 			}
 
 			req.Properties = &nginxdeployment.NginxDeploymentUpdateProperties{}
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				if meta.ResourceData.HasChange("logging_storage_account") && len(model.LoggingStorageAccount) > 0 {
 					req.Properties.Logging = &nginxdeployment.NginxLogging{
 						StorageAccount: &nginxdeployment.NginxStorageAccount{

--- a/internal/services/orbital/contact_profile_resource_test.go
+++ b/internal/services/orbital/contact_profile_resource_test.go
@@ -21,7 +21,7 @@ import (
 type ContactProfileResource struct{}
 
 func TestAccContactProfile_basic(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
@@ -39,7 +39,7 @@ func TestAccContactProfile_basic(t *testing.T) {
 }
 
 func TestAccContactProfile_multipleChannels(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
@@ -57,7 +57,7 @@ func TestAccContactProfile_multipleChannels(t *testing.T) {
 }
 
 func TestAccContactProfile_addChannel(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
@@ -82,7 +82,7 @@ func TestAccContactProfile_addChannel(t *testing.T) {
 }
 
 func TestAccContactProfile_update(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")
@@ -106,7 +106,7 @@ func TestAccContactProfile_update(t *testing.T) {
 }
 
 func TestAccContactProfile_complete(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact_profile` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact_profile", "test")

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -22,7 +22,7 @@ import (
 type ContactResource struct{}
 
 func TestAccContact_basic(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_contact` is deprecated and will be removed in 5.0")
 	}
 	skipContact(t)

--- a/internal/services/orbital/registration.go
+++ b/internal/services/orbital/registration.go
@@ -29,7 +29,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		return []sdk.Resource{
 			SpacecraftResource{},
 			ContactProfileResource{},

--- a/internal/services/orbital/spacecraft_resource_test.go
+++ b/internal/services/orbital/spacecraft_resource_test.go
@@ -21,7 +21,7 @@ import (
 type SpacecraftResource struct{}
 
 func TestAccSpacecraft_basic(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")
@@ -39,7 +39,7 @@ func TestAccSpacecraft_basic(t *testing.T) {
 }
 
 func TestAccSpacecraft_update(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")
@@ -63,7 +63,7 @@ func TestAccSpacecraft_update(t *testing.T) {
 }
 
 func TestAccSpacecraft_complete(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since `azurerm_orbital_spacecraft` is deprecated and will be removed in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_orbital_spacecraft", "test")

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -397,7 +397,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 		),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -86,7 +86,7 @@ func resourceRedisEnterpriseCluster() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/securitycenter/registration.go
+++ b/internal/services/securitycenter/registration.go
@@ -54,7 +54,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_security_center_server_vulnerability_assessment_virtual_machine": resourceServerVulnerabilityAssessmentVirtualMachine(),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resources["azurerm_security_center_auto_provisioning"] = resourceSecurityCenterAutoProvisioning()
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
@@ -119,7 +119,7 @@ func resourceSentinelAlertRuleFusion() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["name"] = &pluginsdk.Schema{
 			Deprecated:   "the `name` is deprecated and will be removed in v5.0 version of the provider.",
 			Type:         pluginsdk.TypeString,
@@ -138,7 +138,7 @@ func resourceSentinelAlertRuleFusionCreate(d *pluginsdk.ResourceData, meta inter
 	defer cancel()
 
 	name := SentinelAlertRuleFusionName
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		name = d.Get("name").(string)
 	}
 
@@ -244,7 +244,7 @@ func resourceSentinelAlertRuleFusionRead(d *pluginsdk.ResourceData, meta interfa
 
 	workspaceId := alertrules.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		d.Set("name", id.RuleId)
 	}
 	d.Set("log_analytics_workspace_id", workspaceId.ID())

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -268,7 +268,7 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 		),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["minimum_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -229,7 +229,7 @@ func TestAccAzureRMServiceBusNamespace_publicNetworkAccessUpdate(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusNamespace_minimumTLSUpdate(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping since the only possible value in 5.0 for `minimum_tls_version` is `1.2`, we can not test updating it.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace", "test")

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1119,7 +1119,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 					}
 				}
 
-				if !features.FivePointOhBeta() && !v.(*clients.Client).Features.Storage.DataPlaneAvailable {
+				if !features.FivePointOh() && !v.(*clients.Client).Features.Storage.DataPlaneAvailable {
 					if _, ok := d.GetOk("queue_properties"); ok {
 						return errors.New("cannot configure 'queue_properties' when the Provider Feature 'data_plane_available' is set to 'false'")
 					}
@@ -1148,7 +1148,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 		),
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		// lintignore:XS003
 		resource.Schema["static_website"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeList,
@@ -1275,7 +1275,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 		Deprecated: "this block has been deprecated and superseded by the `azurerm_storage_account_queue_properties` resource and will be removed in v5.0 of the AzureRM provider",
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		resource.Schema["min_tls_version"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -1490,7 +1490,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	supportLevel := availableFunctionalityForAccount(accountKind, accountTier, replicationType)
 	// Start of Data Plane access - this entire block can be removed for 5.0, as the data_plane_available flag becomes redundant at that time.
-	if !features.FivePointOhBeta() && dataPlaneAvailable {
+	if !features.FivePointOh() && dataPlaneAvailable {
 		dataPlaneClient := meta.(*clients.Client).Storage
 		dataPlaneAccount, err := storageUtils.FindAccount(ctx, id.SubscriptionId, id.StorageAccountName)
 		if err != nil {
@@ -1918,7 +1918,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		dataPlaneClient := meta.(*clients.Client).Storage
 		if d.HasChange("queue_properties") {
 			if !supportLevel.supportQueue {
@@ -2244,7 +2244,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("setting `share_properties` for %s: %+v", *id, err)
 	}
 
-	if !features.FivePointOhBeta() && dataPlaneAvailable {
+	if !features.FivePointOh() && dataPlaneAvailable {
 		dataPlaneClient := meta.(*clients.Client).Storage
 		queueProperties := make([]interface{}, 0)
 		if supportLevel.supportQueue {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -241,7 +241,7 @@ func TestAccStorageAccount_enableHttpsTrafficOnly(t *testing.T) {
 }
 
 func TestAccStorageAccount_minTLSVersion(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skipf("Skipping as the only possible value for `minimum_tls_version` is `1.2`")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
@@ -758,7 +758,7 @@ func TestAccStorageAccount_blobProperties_kindStorageNotSupportLastAccessTimeEna
 }
 
 func TestAccStorageAccount_queueProperties(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -798,7 +798,7 @@ func TestAccStorageAccount_queueProperties(t *testing.T) {
 }
 
 func TestAccStorageAccount_staticWebsiteEnabled(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -832,7 +832,7 @@ func TestAccStorageAccount_staticWebsiteEnabled(t *testing.T) {
 }
 
 func TestAccStorageAccount_staticWebsitePropertiesForStorageV2(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -858,7 +858,7 @@ func TestAccStorageAccount_staticWebsitePropertiesForStorageV2(t *testing.T) {
 }
 
 func TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -1715,7 +1715,7 @@ func TestAccStorageAccount_StorageV1_blobProperties(t *testing.T) {
 }
 
 func TestAccStorageAccount_StorageV1_queuePropertiesLRS(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -1734,7 +1734,7 @@ func TestAccStorageAccount_StorageV1_queuePropertiesLRS(t *testing.T) {
 }
 
 func TestAccStorageAccount_StorageV1_queuePropertiesGRS(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -1753,7 +1753,7 @@ func TestAccStorageAccount_StorageV1_queuePropertiesGRS(t *testing.T) {
 }
 
 func TestAccStorageAccount_StorageV1_queuePropertiesRAGRS(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 
@@ -1832,7 +1832,7 @@ func TestAccStorageAccount_noDataPlane(t *testing.T) {
 }
 
 func TestAccStorageAccount_noDataPlaneQueueShouldError(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
@@ -1847,7 +1847,7 @@ func TestAccStorageAccount_noDataPlaneQueueShouldError(t *testing.T) {
 }
 
 func TestAccStorageAccount_noDataPlaneWebsiteShouldError(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("test not valid in 5.0")
 	}
 

--- a/internal/services/storage/storage_container_data_source.go
+++ b/internal/services/storage/storage_container_data_source.go
@@ -68,7 +68,7 @@ func dataSourceStorageContainer() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		r.Schema["resource_manager_id"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeString,
 			Computed:   true,
@@ -107,7 +107,7 @@ func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{})
 
 	containerName := d.Get("name").(string)
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		storageClient := meta.(*clients.Client).Storage
 		accountName := d.Get("storage_account_name").(string)
 		if accountName != "" {
@@ -196,7 +196,7 @@ func dataSourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{})
 			d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 			d.Set("has_legal_hold", props.HasLegalHold)
 
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				d.Set("resource_manager_id", id.ID())
 			}
 		}

--- a/internal/services/storage/storage_container_data_source_test.go
+++ b/internal/services/storage/storage_container_data_source_test.go
@@ -46,7 +46,7 @@ data "azurerm_storage_container" "test" {
 }
 
 func TestAccStorageContainerDataSource_basicDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -45,7 +45,7 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		Update: resourceStorageContainerUpdate,
 
 		Importer: helpers.ImporterValidatingStorageResourceId(func(id, storageDomainSuffix string) error {
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				if strings.HasPrefix(id, "/subscriptions/") {
 					_, err := commonids.ParseStorageContainerID(id)
 					return err
@@ -126,7 +126,7 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -166,7 +166,7 @@ func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{})
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		storageClient := meta.(*clients.Client).Storage
 		if accountName := d.Get("storage_account_name").(string); accountName != "" {
 			account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
@@ -276,7 +276,7 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := containers.ParseContainerID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
@@ -362,7 +362,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := containers.ParseContainerID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
@@ -441,7 +441,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 			d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 			d.Set("has_legal_hold", props.HasLegalHold)
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				d.Set("resource_manager_id", id.ID())
 			}
 		}
@@ -456,7 +456,7 @@ func resourceStorageContainerDelete(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		storageClient := meta.(*clients.Client).Storage
 
 		id, err := containers.ParseContainerID(d.Id(), storageClient.StorageDomainSuffix)

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -23,7 +23,7 @@ import (
 type StorageContainerResource struct{}
 
 func TestAccStorageContainer_basicDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -72,7 +72,7 @@ func TestAccStorageContainer_complete(t *testing.T) {
 }
 
 func TestAccStorageContainer_deleteAndRecreateDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -127,7 +127,7 @@ func TestAccStorageContainer_deleteAndRecreate(t *testing.T) {
 }
 
 func TestAccStorageContainer_basicAzureADAuthDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -161,7 +161,7 @@ func TestAccStorageContainer_basicAzureADAuth(t *testing.T) {
 }
 
 func TestAccStorageContainer_requiresImportDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -195,7 +195,7 @@ func TestAccStorageContainer_requiresImport(t *testing.T) {
 }
 
 func TestAccStorageContainer_updateDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -245,7 +245,7 @@ func TestAccStorageContainer_update(t *testing.T) {
 }
 
 func TestAccStorageContainer_encryptionScopeDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -279,7 +279,7 @@ func TestAccStorageContainer_encryptionScope(t *testing.T) {
 }
 
 func TestAccStorageContainer_metaDataDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -341,7 +341,7 @@ func TestAccStorageContainer_metaData(t *testing.T) {
 }
 
 func TestAccStorageContainer_rootDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -361,7 +361,7 @@ func TestAccStorageContainer_rootDeprecated(t *testing.T) {
 }
 
 func TestAccStorageContainer_webDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as test is not valid in 5.0")
 	}
 
@@ -397,7 +397,7 @@ func TestAccStorageContainer_web(t *testing.T) {
 }
 
 func (r StorageContainerResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	if !features.FivePointOhBeta() && !strings.HasPrefix(state.ID, "/subscriptions") {
+	if !features.FivePointOh() && !strings.HasPrefix(state.ID, "/subscriptions") {
 		id, err := containers.ParseContainerID(state.ID, client.Storage.StorageDomainSuffix)
 		if err != nil {
 			return nil, err

--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -82,7 +82,7 @@ func dataSourceStorageShare() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,
@@ -120,7 +120,7 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 	shareName := d.Get("name").(string)
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		storageClient := meta.(*clients.Client).Storage
 		if accountName := d.Get("storage_account_name").(string); accountName != "" {
 			account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
@@ -201,7 +201,7 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		d.Set("resource_manager_id", id.ID())
 	}
 

--- a/internal/services/storage/storage_share_data_source_test.go
+++ b/internal/services/storage/storage_share_data_source_test.go
@@ -15,7 +15,7 @@ import (
 type dataSourceStorageShare struct{}
 
 func TestAccDataSourceStorageShare_basicDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -39,7 +39,7 @@ func resourceStorageShare() *pluginsdk.Resource {
 		Delete: resourceStorageShareDelete,
 
 		Importer: helpers.ImporterValidatingStorageResourceId(func(id, storageDomainSuffix string) error {
-			if !features.FivePointOhBeta() {
+			if !features.FivePointOh() {
 				if strings.HasPrefix(id, "/subscriptions") {
 					_, err := fileshares.ParseShareID(id)
 					return err
@@ -156,7 +156,7 @@ func resourceStorageShare() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,
@@ -194,7 +194,7 @@ func resourceStorageShareCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		storageClient := meta.(*clients.Client).Storage
 		if accountName := d.Get("storage_account_name").(string); accountName != "" {
 			shareName := d.Get("name").(string)
@@ -323,7 +323,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := shares.ParseShareID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
@@ -415,7 +415,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 		}
 	}
 
-	if !features.FivePointOhBeta() {
+	if !features.FivePointOh() {
 		d.Set("resource_manager_id", id.ID())
 	}
 
@@ -452,7 +452,7 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		id, err := shares.ParseShareID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
 			return err
@@ -575,7 +575,7 @@ func resourceStorageShareDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOhBeta() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := shares.ParseShareID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -22,7 +22,7 @@ import (
 type StorageShareResource struct{}
 
 func TestAccStorageShare_basicDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
@@ -71,7 +71,7 @@ func TestAccStorageShare_complete(t *testing.T) {
 }
 
 func TestAccStorageShare_requiresImportDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -105,7 +105,7 @@ func TestAccStorageShare_requiresImport(t *testing.T) {
 }
 
 func TestAccStorageShare_disappearsDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
@@ -120,7 +120,7 @@ func TestAccStorageShare_disappearsDeprecated(t *testing.T) {
 }
 
 func TestAccStorageShare_deleteAndRecreateDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -149,7 +149,7 @@ func TestAccStorageShare_deleteAndRecreateDeprecated(t *testing.T) {
 }
 
 func TestAccStorageShare_metaDataDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -197,7 +197,7 @@ func TestAccStorageShare_metaData(t *testing.T) {
 }
 
 func TestAccStorageShare_aclDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -259,7 +259,7 @@ func TestAccStorageShare_acl(t *testing.T) {
 }
 
 func TestAccStorageShare_aclGhostedRecallDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -293,7 +293,7 @@ func TestAccStorageShare_aclGhostedRecall(t *testing.T) {
 }
 
 func TestAccStorageShare_updateQuotaDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -339,7 +339,7 @@ func TestAccStorageShare_updateQuota(t *testing.T) {
 }
 
 func TestAccStorageShare_largeQuotaDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -387,7 +387,7 @@ func TestAccStorageShare_largeQuota(t *testing.T) {
 }
 
 func TestAccStorageShare_accessTierStandardDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -435,7 +435,7 @@ func TestAccStorageShare_accessTierStandard(t *testing.T) {
 }
 
 func TestAccStorageShare_accessTierPremiumDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -469,7 +469,7 @@ func TestAccStorageShare_accessTierPremium(t *testing.T) {
 }
 
 func TestAccStorageShare_nfsProtocolDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -504,7 +504,7 @@ func TestAccStorageShare_nfsProtocol(t *testing.T) {
 
 // TestAccStorageShare_protocolUpdate is to ensure destroy-then-create of the storage share can tolerant the "ShareBeingDeleted" issue.
 func TestAccStorageShare_protocolUpdateDeprecated(t *testing.T) {
-	if features.FivePointOhBeta() {
+	if features.FivePointOh() {
 		t.Skip("skipping as not valid in 5.0")
 	}
 
@@ -552,7 +552,7 @@ func TestAccStorageShare_protocolUpdate(t *testing.T) {
 }
 
 func (r StorageShareResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	if !features.FivePointOhBeta() && !strings.HasPrefix(state.ID, "/subscriptions") {
+	if !features.FivePointOh() && !strings.HasPrefix(state.ID, "/subscriptions") {
 		id, err := shares.ParseShareID(state.ID, client.Storage.StorageDomainSuffix)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Replaced all references to `FivePointOhBeta` with `FivePointOh` and removed `FivePointOhBeta` feature flag

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
