### PR TITLE
acceptance tests - update plan check logic to not error if the resource isn't found in the plan

### DIFF
--- a/internal/acceptance/helpers/is_not_resource_action.go
+++ b/internal/acceptance/helpers/is_not_resource_action.go
@@ -19,67 +19,58 @@ type isNotResourceAction struct {
 
 // CheckPlan implements the plan check logic.
 func (e isNotResourceAction) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
-	foundResource := false
-
 	for _, rc := range req.Plan.ResourceChanges {
-		if e.resourceAddress != rc.Address {
-			continue
+		if e.resourceAddress == rc.Address {
+			switch e.actionType {
+			case plancheck.ResourceActionNoop:
+				if rc.Change.Actions.NoOp() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionCreate:
+				if rc.Change.Actions.Create() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionRead:
+				if rc.Change.Actions.Read() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionUpdate:
+				if rc.Change.Actions.Update() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionDestroy:
+				if rc.Change.Actions.Delete() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionDestroyBeforeCreate:
+				if rc.Change.Actions.DestroyBeforeCreate() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionCreateBeforeDestroy:
+				if rc.Change.Actions.CreateBeforeDestroy() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
+					return
+				}
+			case plancheck.ResourceActionReplace:
+				if rc.Change.Actions.Replace() {
+					resp.Error = fmt.Errorf("'%s' - expected action to not be %s, path: %v tried to update a value that is ForceNew", rc.Address, e.actionType, rc.Change.ReplacePaths)
+					return
+				}
+			default:
+				resp.Error = fmt.Errorf("%s - unexpected ResourceActionType: %s", rc.Address, e.actionType)
+				return
+			}
 		}
-
-		switch e.actionType {
-		case plancheck.ResourceActionNoop:
-			if rc.Change.Actions.NoOp() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionCreate:
-			if rc.Change.Actions.Create() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionRead:
-			if rc.Change.Actions.Read() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionUpdate:
-			if rc.Change.Actions.Update() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionDestroy:
-			if rc.Change.Actions.Delete() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionDestroyBeforeCreate:
-			if rc.Change.Actions.DestroyBeforeCreate() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionCreateBeforeDestroy:
-			if rc.Change.Actions.CreateBeforeDestroy() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s", rc.Address, e.actionType)
-				return
-			}
-		case plancheck.ResourceActionReplace:
-			if rc.Change.Actions.Replace() {
-				resp.Error = fmt.Errorf("'%s' - expected action to not be %s, path: %v tried to update a value that is ForceNew", rc.Address, e.actionType, rc.Change.ReplacePaths)
-				return
-			}
-		default:
-			resp.Error = fmt.Errorf("%s - unexpected ResourceActionType: %s", rc.Address, e.actionType)
-			return
-		}
-
-		foundResource = true
-		break
 	}
 
-	if !foundResource {
-		resp.Error = fmt.Errorf("%s - Resource not found in plan ResourceChanges", e.resourceAddress)
-		return
-	}
+	// If the resource we're looking for in the plan doesn't exist we don't return an error since we have tests in the provider
+	// that rely on a setup configuration before the pertinent test step is applied
 }
 
 // IsNotResourceAction returns a plan check that asserts that a given resource will not have a specific resource change type in the plan.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The plan check `CheckPlan` was introduced by #27319 to enable the acceptance testing shim to catch and error out from update tests that triggered a `ForceNew`. The current logic in `CheckPlan`causes a number of acceptance tests in the provider to fail with an error similar to the one below:
```
------- Stdout: -------
=== RUN   TestAccImage_standaloneImage
=== PAUSE TestAccImage_standaloneImage
=== CONT  TestAccImage_standaloneImage
    testcase.go:173: Step 1/4 error: Pre-apply plan check(s) failed:
        azurerm_image.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccImage_standaloneImage (18.69s)
FAIL
```
Tests failing with this error rely on a setup configuration as the first test step before applying the test configuration that's pertinent for testing the actual resource.

This PR inverts the logic in `CheckPlan` to only check for a `Replace` action and error if the resource exists in the plan as opposed to error'ing if it's missing.

## Testing 

Ideally the entire testing suite is run to catch any edge cases, given the size and scope of that it's not a feasible undertaking.

I ran three tests to validate the behaviour is as expected:

`TestAccImage_standaloneImage` - previously failed, now passes
`TestAccAppConfigurationKey_basicNoValue` - failed because it triggers a `ForceNew`, still fails meaning the original intent of the check is still intact
`TestAccAppConfigurationKey_KVToVault` - passed, still passes