### PR TITLE
Data source: `azurerm_container_app_environment`: Support log analytics workspaces in different subscriptions for data source

### DIFF
--- a/internal/services/containerapps/container_app_environment_data_source.go
+++ b/internal/services/containerapps/container_app_environment_data_source.go
@@ -72,7 +72,7 @@ func (r ContainerAppEnvironmentDataSource) Attributes() map[string]*pluginsdk.Sc
 		"log_analytics_workspace_name": {
 			Type:        pluginsdk.TypeString,
 			Computed:    true,
-			Description: "The name of the Log Analytics Workspace this Container Apps Managed Environment is linked to. (Only available if workspace is in same subscription)",
+			Description: "The name of the Log Analytics Workspace this Container Apps Managed Environment is linked to.",
 		},
 
 		"infrastructure_subnet_id": {

--- a/internal/services/containerapps/container_app_environment_data_source.go
+++ b/internal/services/containerapps/container_app_environment_data_source.go
@@ -72,7 +72,7 @@ func (r ContainerAppEnvironmentDataSource) Attributes() map[string]*pluginsdk.Sc
 		"log_analytics_workspace_name": {
 			Type:        pluginsdk.TypeString,
 			Computed:    true,
-			Description: "The name of the Log Analytics Workspace this Container Apps Managed Environment is linked to.",
+			Description: "The name of the Log Analytics Workspace this Container Apps Managed Environment is linked to. (Only available if workspace is in same subscription)",
 		},
 
 		"infrastructure_subnet_id": {
@@ -208,5 +208,5 @@ func findLogAnalyticsWorkspaceName(ctx context.Context, client *workspaces.Works
 		}
 	}
 
-	return "", fmt.Errorf("no matching workspace found")
+	return "", nil
 }

--- a/website/docs/d/container_app_environment.html.markdown
+++ b/website/docs/d/container_app_environment.html.markdown
@@ -52,6 +52,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `log_analytics_workspace_name` - The name of the Log Analytics Workspace this Container Apps Managed Environment is linked to.
 
+~> **NOTE:** This will only be populated for Environments that have `logs_destination` set to `log-analytics` and the Log Analytics Workspace is in the same subscription as the Environment.
+
 * `platform_reserved_cidr` - The IP range, in CIDR notation, that is reserved for environment infrastructure IP addresses.
 
 ~> **NOTE:** This will only be populated for Environments that have `internal_load_balancer_enabled` set to true.
@@ -62,7 +64,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `static_ip_address` - The Static IP address of the Environment.
 
-~> **NOTE:** If `internal_load_balancer_enabled` is true, this will be a Private IP in the subnet, otherwise this will be allocated a Public IPv4 address. 
+~> **NOTE:** If `internal_load_balancer_enabled` is true, this will be a Private IP in the subnet, otherwise this will be allocated a Public IPv4 address.
 
 * `tags` - A mapping of tags assigned to the resource.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

No longer throw an error for a valid Log Analytics Workspace `customerId` not in the same subscription as the container app environment. Return an empty name.

I can't think of any use case for throwing an error in this data source if an existing resource exists that is configured correctly. If the workspace name cannot be found in the CAE subscription then never mind, just leave it blank.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

I have not written a unit test for this scenario - it might be useful. Would need someone to suggest a way of mocking the client in the function though please. I note the function's other code branches have not yet got any tests as far as I could find.

I have tested the updated provider locally and it works successfully with a container app environment configured with a log analytics workspace from another subscription:

```sh
terraform state show data.azurerm_container_app_environment.test
# data.azurerm_container_app_environment.test:
data "azurerm_container_app_environment" "test" {
    custom_domain_verification_id    = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
    default_domain                   = "test-a00a0aa0.uksouth.azurecontainerapps.io"
    docker_bridge_cidr               = null
    id                               = "/subscriptions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/resourceGroups/test/providers/Microsoft.App/managedEnvironments/test"
    infrastructure_subnet_id         = "/subscriptions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/test/subnets/test"
    internal_load_balancer_enabled   = false
    location                         = "uksouth"
    log_analytics_workspace_name     = null
    name                             = "test"
    platform_reserved_cidr           = null
    platform_reserved_dns_ip_address = null
    resource_group_name              = "test"
    static_ip_address                = "xxx.xxx.xxx.xxx"
    tags                             = {}
}
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Data source `azurerm_container_app_environment` - support log analytics workspaces in different subscriptions [GH-25514]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25514


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
