### PR TITLE
Replace hardcoded MaxInt32 value with constant

### DIFF
--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -5,6 +5,7 @@ package helpers
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -89,7 +90,7 @@ func IpRestrictionSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      65000,
-					ValidateFunc: validation.IntBetween(1, 2147483647),
+					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 					Description:  "The priority value of this `ip_restriction`.",
 				},
 

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -548,7 +549,7 @@ func VirtualMachineGalleryApplicationSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      0,
-					ValidateFunc: validation.IntBetween(0, 2147483647),
+					ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 				},
 
 				// NOTE: Per the service team, "this is a pass through value that we just add to the model but don't depend on. It can be any string."

--- a/internal/services/compute/virtual_machine_gallery_application_assignment_resource.go
+++ b/internal/services/compute/virtual_machine_gallery_application_assignment_resource.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -60,7 +61,7 @@ func (r VirtualMachineGalleryApplicationAssignmentResource) Arguments() map[stri
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
 			Default:      0,
-			ValidateFunc: validation.IntBetween(0, 2147483647),
+			ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 		},
 
 		"tag": {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -149,7 +150,7 @@ func VirtualMachineScaleSetGalleryApplicationSchema() *pluginsdk.Schema {
 					Optional:     true,
 					Default:      0,
 					ForceNew:     true,
-					ValidateFunc: validation.IntBetween(0, 2147483647),
+					ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 				},
 
 				// NOTE: Per the service team, "this is a pass through value that we just add to the model but don't depend on. It can be any string."

--- a/internal/services/cosmos/common/cors_rule.go
+++ b/internal/services/cosmos/common/cors_rule.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"math"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -74,7 +75,7 @@ func SchemaCorsRule() *pluginsdk.Schema {
 				"max_age_in_seconds": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
-					ValidateFunc: validation.IntBetween(1, 2147483647),
+					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 				},
 			},
 		},

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"regexp"
 	"strings"
@@ -386,7 +387,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 							Optional:         true,
 							Default:          100,
 							DiffSuppressFunc: suppressConsistencyPolicyStalenessConfiguration,
-							ValidateFunc:     validation.IntBetween(10, 2147483647), // single region values
+							ValidateFunc:     validation.IntBetween(10, math.MaxInt32), // single region values
 						},
 					},
 				},

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -6,6 +6,7 @@ package cosmos
 import (
 	"fmt"
 	"log"
+	"math"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
@@ -66,7 +67,7 @@ func resourceCosmosDbCassandraTable() *pluginsdk.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.IntBetween(-1, 2147483647),
+					validation.IntBetween(-1, math.MaxInt32),
 					validation.IntNotInSlice([]int{0}),
 				),
 			},

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -77,7 +78,7 @@ func resourceCosmosDbGremlinGraph() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
 				ValidateFunc: validation.All(
-					validation.IntBetween(-1, 2147483647),
+					validation.IntBetween(-1, math.MaxInt32),
 					validation.IntNotInSlice([]int{0}),
 				),
 			},
@@ -188,7 +189,7 @@ func resourceCosmosDbGremlinGraph() *pluginsdk.Resource {
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			// `analytical_storage_ttl` can't be disabled once it's enabled
 			pluginsdk.ForceNewIfChange("analytical_storage_ttl", func(ctx context.Context, old, new, _ interface{}) bool {
-				return (old.(int) == -1 || (old.(int) >= 1 && old.(int) <= 2147483647)) && new.(int) == 0
+				return (old.(int) == -1 || (old.(int) >= 1 && old.(int) <= math.MaxInt32)) && new.(int) == 0
 			}),
 		),
 	}

--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -113,7 +114,7 @@ func (DnsZoneResource) Arguments() map[string]*pluginsdk.Schema {
 						Type:         pluginsdk.TypeInt,
 						Optional:     true,
 						Default:      3600,
-						ValidateFunc: validation.IntBetween(0, 2147483647),
+						ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 					},
 
 					"tags": commonschema.Tags(),

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -6,6 +6,7 @@ package logic
 import (
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -1003,7 +1004,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      65000,
-					ValidateFunc: validation.IntBetween(1, 2147483647),
+					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 				},
 
 				"action": {

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -382,15 +383,15 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 						"max_server_memory_mb": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
-							Default:      2147483647,
-							ValidateFunc: validation.IntBetween(128, 2147483647),
+							Default:      math.MaxInt32,
+							ValidateFunc: validation.IntBetween(128, math.MaxInt32),
 						},
 
 						"min_server_memory_mb": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Default:      0,
-							ValidateFunc: validation.IntBetween(0, 2147483647),
+							ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 						},
 					},
 				},
@@ -1420,7 +1421,7 @@ func flattenSqlVirtualMachineSQLInstance(input *sqlvirtualmachines.SQLInstanceSe
 		maxDop = *input.MaxDop
 	}
 
-	var maxServerMemoryMB int64 = 2147483647
+	var maxServerMemoryMB int64 = math.MaxInt32
 	if input.MaxServerMemoryMB != nil {
 		maxServerMemoryMB = *input.MaxServerMemoryMB
 	}

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -335,7 +336,7 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.IntBetween(0, 2147483647),
+							ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 						},
 
 						"sa_lifetime": {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -405,7 +406,7 @@ func resourceVirtualNetworkGatewaySchema() map[string]*pluginsdk.Schema {
 								"sa_data_size_in_kilobytes": {
 									Type:         pluginsdk.TypeInt,
 									Required:     true,
-									ValidateFunc: validation.IntBetween(1024, 2147483647),
+									ValidateFunc: validation.IntBetween(1024, math.MaxInt32),
 								},
 							},
 						},

--- a/internal/services/network/vpn_gateway_connection_resource.go
+++ b/internal/services/network/vpn_gateway_connection_resource.go
@@ -6,6 +6,7 @@ package network
 import (
 	"fmt"
 	"log"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -218,7 +219,7 @@ func resourceVPNGatewayConnection() *pluginsdk.Resource {
 									"sa_data_size_kb": {
 										Type:         pluginsdk.TypeInt,
 										Required:     true,
-										ValidateFunc: validation.IntBetween(0, 2147483647),
+										ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 									},
 									"encryption_algorithm": {
 										Type:         pluginsdk.TypeString,

--- a/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -5,6 +5,7 @@ package privatedns
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -75,7 +76,7 @@ func resourcePrivateDnsCNameRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(0, 2147483647),
+				ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -6,6 +6,7 @@ package privatedns
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -92,7 +93,7 @@ func resourcePrivateDnsMxRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -5,6 +5,7 @@ package privatedns
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -76,7 +77,7 @@ func resourcePrivateDnsPtrRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -6,6 +6,7 @@ package privatedns
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -102,7 +103,7 @@ func resourcePrivateDnsSrvRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -5,6 +5,7 @@ package privatedns
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -83,7 +84,7 @@ func resourcePrivateDnsTxtRecord() *pluginsdk.Resource {
 			"ttl": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 2147483647),
+				ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 			},
 
 			"fqdn": {

--- a/internal/services/privatedns/private_dns_zone_resource.go
+++ b/internal/services/privatedns/private_dns_zone_resource.go
@@ -5,6 +5,7 @@ package privatedns
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -117,7 +118,7 @@ func resourcePrivateDnsZone() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Default:      3600,
-							ValidateFunc: validation.IntBetween(0, 2147483647),
+							ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 						},
 
 						"tags": commonschema.Tags(),

--- a/internal/services/storage/storage_sync_server_endpoint_resource.go
+++ b/internal/services/storage/storage_sync_server_endpoint_resource.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -91,7 +92,7 @@ func (r SyncServerEndpointResource) Arguments() map[string]*pluginsdk.Schema {
 		"tier_files_older_than_days": {
 			Optional:     true,
 			Type:         pluginsdk.TypeInt,
-			ValidateFunc: validation.IntBetween(1, 2147483647),
+			ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 		},
 
 		"initial_download_policy": {

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -81,7 +82,7 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 						"ttl": {
 							Type:         pluginsdk.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(0, 2147483647),
+							ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 						},
 					},
 				},

--- a/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
@@ -6,6 +6,7 @@ package trafficmanager_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"testing"
 
@@ -234,7 +235,7 @@ func TestAccTrafficManagerProfile_updateTTL(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.withTTL(data, "Geographic", 2147483647),
+			Config: r.withTTL(data, "Geographic", math.MaxInt32),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -6,6 +6,7 @@ package web
 import (
 	"fmt"
 	"log"
+	"math"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
@@ -844,7 +845,7 @@ func schemaAppServiceIpRestriction() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      65000,
-					ValidateFunc: validation.IntBetween(1, 2147483647),
+					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 				},
 
 				"action": {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
