### PR TITLE
`azurerm_storage_container_immutability_policy` - fix immutability_period_in_days validation

### DIFF
--- a/internal/services/storage/storage_container_immutability_policy_resource.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource.go
@@ -104,7 +104,7 @@ func (r StorageContainerImmutabilityPolicyResource) CustomizeDiff() sdk.Resource
 
 			if lockedOld.(bool) {
 				if diff.HasChange("immutability_period_in_days") {
-					if periodOld, periodNew := diff.GetChange("immutability_period_in_days"); periodOld.(int) < periodNew.(int) {
+					if periodOld, periodNew := diff.GetChange("immutability_period_in_days"); periodOld.(int) > periodNew.(int) {
 						return fmt.Errorf("`immutability_period_in_days` cannot be decreased once an immutability policy has been locked")
 					}
 				}
@@ -230,28 +230,38 @@ func (r StorageContainerImmutabilityPolicyResource) Update() sdk.ResourceFunc {
 				},
 			}
 
-			options := immutabilitypolicies.BlobContainersCreateOrUpdateImmutabilityPolicyOperationOptions{
-				IfMatch: resp.Model.Etag,
-			}
-
-			updateResp, err := client.BlobContainersCreateOrUpdateImmutabilityPolicy(ctx, *containerId, input, options)
-			if err != nil {
-				return fmt.Errorf("updating %s: %+v", id, err)
-			}
-
-			// Lock the policy if requested - note that this is a one-way operation that prevents subsequent changes or
-			// deletion to the policy, the container it applies to, and the storage account where it resides.
-			if model.Locked {
-				if updateResp.Model == nil {
-					return fmt.Errorf("preparing to lock %s: model was nil", id)
+			if *resp.Model.Properties.State == immutabilitypolicies.ImmutabilityPolicyStateLocked {
+				// Only extending the immutability policy is allowed when the policy is locked
+				options := immutabilitypolicies.BlobContainersExtendImmutabilityPolicyOperationOptions{
+					IfMatch: resp.Model.Etag,
+				}
+				if _, err := client.BlobContainersExtendImmutabilityPolicy(ctx, *containerId, input, options); err != nil {
+					return fmt.Errorf("extending %s: %+v", id, err)
+				}
+			} else {
+				options := immutabilitypolicies.BlobContainersCreateOrUpdateImmutabilityPolicyOperationOptions{
+					IfMatch: resp.Model.Etag,
 				}
 
-				lockOptions := immutabilitypolicies.BlobContainersLockImmutabilityPolicyOperationOptions{
-					IfMatch: updateResp.Model.Etag,
+				updateResp, err := client.BlobContainersCreateOrUpdateImmutabilityPolicy(ctx, *containerId, input, options)
+				if err != nil {
+					return fmt.Errorf("updating %s: %+v", id, err)
 				}
 
-				if _, err = client.BlobContainersLockImmutabilityPolicy(ctx, *containerId, lockOptions); err != nil {
-					return fmt.Errorf("locking %s: %+v", id, err)
+				// Lock the policy if requested - note that this is a one-way operation that prevents subsequent changes or
+				// deletion to the policy, the container it applies to, and the storage account where it resides.
+				if model.Locked {
+					if updateResp.Model == nil {
+						return fmt.Errorf("preparing to lock %s: model was nil", id)
+					}
+
+					lockOptions := immutabilitypolicies.BlobContainersLockImmutabilityPolicyOperationOptions{
+						IfMatch: updateResp.Model.Etag,
+					}
+
+					if _, err = client.BlobContainersLockImmutabilityPolicy(ctx, *containerId, lockOptions); err != nil {
+						return fmt.Errorf("locking %s: %+v", id, err)
+					}
 				}
 			}
 

--- a/internal/services/storage/storage_container_immutability_policy_resource_test.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource_test.go
@@ -82,11 +82,6 @@ func TestAccStorageContainerImmutabilityPolicy_update(t *testing.T) {
 }
 
 func TestAccStorageContainerImmutabilityPolicy_completeLocked(t *testing.T) {
-	// This test has been written for manual testing of the `locked` property. Ordinarily we do not want to test this in automation,
-	// since locking an immutability policy renders the container and its storage account **immutable**. This test will always
-	// fail during cleanup for this reason. Uncomment the t.Skip() call to continue...
-	t.Skip("this test for manual execution only")
-
 	data := acceptance.BuildTestData(t, "azurerm_storage_container_immutability_policy", "test")
 	r := StorageContainerImmutabilityPolicyResource{}
 
@@ -120,6 +115,12 @@ func TestAccStorageContainerImmutabilityPolicy_completeLocked(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		// A locked policy cannot be deleted directly, but deleting its empty container
+		// also deletes the policy. Remove it from state so test cleanup can delete the
+		// container and its parent resources.
+		{
+			Config: r.immutabilityPolicyUnmanaged(data),
+		},
 	})
 }
 
@@ -179,6 +180,21 @@ resource "azurerm_storage_container_immutability_policy" "test" {
   locked = true
 }
 `, template, period)
+}
+
+func (r StorageContainerImmutabilityPolicyResource) immutabilityPolicyUnmanaged(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+removed {
+  from = azurerm_storage_container_immutability_policy.test
+
+  lifecycle {
+    destroy = false
+  }
+}
+`, template)
 }
 
 func (r StorageContainerImmutabilityPolicyResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_container_immutability_policy_resource_test.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource_test.go
@@ -99,7 +99,7 @@ func TestAccStorageContainerImmutabilityPolicy_completeLocked(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.completeLocked(data),
+			Config: r.completeLocked(data, 2),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -109,6 +109,17 @@ func TestAccStorageContainerImmutabilityPolicy_completeLocked(t *testing.T) {
 			Config:      r.basic(data),
 			ExpectError: regexp.MustCompile("unable to set `locked = false` - once an immutability policy locked it cannot be unlocked"),
 		},
+		{
+			Config:      r.completeLocked(data, 1),
+			ExpectError: regexp.MustCompile("`immutability_period_in_days` cannot be decreased once an immutability policy has been locked"),
+		},
+		{
+			Config: r.completeLocked(data, 3),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -154,20 +165,20 @@ resource "azurerm_storage_container_immutability_policy" "test" {
 `, template)
 }
 
-func (r StorageContainerImmutabilityPolicyResource) completeLocked(data acceptance.TestData) string {
+func (r StorageContainerImmutabilityPolicyResource) completeLocked(data acceptance.TestData, period uint) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_storage_container_immutability_policy" "test" {
   storage_container_resource_manager_id = azurerm_storage_container.test.id
-  immutability_period_in_days           = 2
+  immutability_period_in_days           = %d
   protected_append_writes_all_enabled   = true
   protected_append_writes_enabled       = false
 
   locked = true
 }
-`, template)
+`, template, period)
 }
 
 func (r StorageContainerImmutabilityPolicyResource) template(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28660 and supports the feature to extend a locked immutable policy.
As described on https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview#locked-versus-unlocked-policies, we can increase `immutability_period_in_days` five times.

> A maximum of five increases to the effective retention period is allowed over the lifetime of a locked policy that is defined at the container level.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Here is the output of running tests:

```console
$ make acctests SERVICE="storage" TESTARGS='-run=TestAccStorageContainerImmutabilityPolicy'
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageContainerImmutabilityPolicy -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageContainerImmutabilityPolicy_basic
=== PAUSE TestAccStorageContainerImmutabilityPolicy_basic
=== RUN   TestAccStorageContainerImmutabilityPolicy_completeUnlocked
=== PAUSE TestAccStorageContainerImmutabilityPolicy_completeUnlocked
=== RUN   TestAccStorageContainerImmutabilityPolicy_update
=== PAUSE TestAccStorageContainerImmutabilityPolicy_update
=== RUN   TestAccStorageContainerImmutabilityPolicy_completeLocked
=== PAUSE TestAccStorageContainerImmutabilityPolicy_completeLocked
=== CONT  TestAccStorageContainerImmutabilityPolicy_basic
=== CONT  TestAccStorageContainerImmutabilityPolicy_completeLocked
=== CONT  TestAccStorageContainerImmutabilityPolicy_completeUnlocked
=== CONT  TestAccStorageContainerImmutabilityPolicy_update
--- PASS: TestAccStorageContainerImmutabilityPolicy_basic (114.17s)
--- PASS: TestAccStorageContainerImmutabilityPolicy_completeUnlocked (116.86s)
--- PASS: TestAccStorageContainerImmutabilityPolicy_update (166.79s)
--- PASS: TestAccStorageContainerImmutabilityPolicy_completeLocked (179.46s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       181.290s
 ```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_container_immutability_policy` - fix immutability_period_in_days validation


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28660


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
