### PR TITLE
azurerm_mssql_database - autopause_delay_update

### DIFF
--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -168,7 +168,7 @@ func TestAccMsSqlDatabase_gpServerless(t *testing.T) {
 			Config: r.gpServerless(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_pause_delay_in_minutes").HasValue("70"),
+				check.That(data.ResourceName).Key("auto_pause_delay_in_minutes").HasValue("42"),
 				check.That(data.ResourceName).Key("min_capacity").HasValue("0.75"),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_S_Gen5_2"),
 			),
@@ -1279,7 +1279,7 @@ func (r MsSqlDatabaseResource) gpServerless(data acceptance.TestData) string {
 resource "azurerm_mssql_database" "test" {
   name                        = "acctest-db-%[2]d"
   server_id                   = azurerm_mssql_server.test.id
-  auto_pause_delay_in_minutes = 70
+  auto_pause_delay_in_minutes = 42
   min_capacity                = 0.75
   sku_name                    = "GP_S_Gen5_2"
 }

--- a/internal/services/mssql/validate/database_auto_pause_delay.go
+++ b/internal/services/mssql/validate/database_auto_pause_delay.go
@@ -11,9 +11,9 @@ func DatabaseAutoPauseDelay(i interface{}, k string) (warnings []string, errors 
 		errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
 		return warnings, errors
 	}
-	min := 60
+	min := 15
 	max := 10080
-	if (v < min || v > max) && v%10 != 0 && v != -1 {
+	if (v < min || v > max) && v != -1 {
 		errors = append(errors, fmt.Errorf("expected %s to be in the range (%d - %d) and divisible by 10 or -1, got %d", k, min, max, v))
 		return warnings, errors
 	}

--- a/internal/services/mssql/validate/database_auto_pause_delay.go
+++ b/internal/services/mssql/validate/database_auto_pause_delay.go
@@ -14,7 +14,7 @@ func DatabaseAutoPauseDelay(i interface{}, k string) (warnings []string, errors 
 	min := 15
 	max := 10080
 	if (v < min || v > max) && v != -1 {
-		errors = append(errors, fmt.Errorf("expected %s to be in the range (%d - %d) and divisible by 10 or -1, got %d", k, min, max, v))
+		errors = append(errors, fmt.Errorf("expected %s to be in the range (%d - %d) or -1, got %d", k, min, max, v))
 		return warnings, errors
 	}
 

--- a/internal/services/mssql/validate/database_auto_pause_delay_test.go
+++ b/internal/services/mssql/validate/database_auto_pause_delay_test.go
@@ -13,6 +13,7 @@ func TestDatabaseAutoPauseDelay(t *testing.T) {
 		{"-1", false},
 		{"-2", true},
 		{"10", true},
+		{"42", false},
 		{"60", false},
 		{"65", false},
 		{"360", false},

--- a/internal/services/mssql/validate/database_auto_pause_delay_test.go
+++ b/internal/services/mssql/validate/database_auto_pause_delay_test.go
@@ -12,9 +12,9 @@ func TestDatabaseAutoPauseDelay(t *testing.T) {
 	}{
 		{"-1", false},
 		{"-2", true},
-		{"30", true},
+		{"10", true},
 		{"60", false},
-		{"65", true},
+		{"65", false},
 		{"360", false},
 		{"19900", true},
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR corrects the validation for the resource `azurerm_mssql_database`, its property `autopause_delay_in_minutes`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
Closes #27664 
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_database` - correct validation of `autopause_delay_in_minutes` [GH-28670]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27664


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
