### PR TITLE
`azurerm_machine_learning_compute_cluster` - `subnet_resource_id` does not have to be specified when `node_public_ip_enabled` is `false`

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -155,8 +155,10 @@ func resourceComputeCluster() *pluginsdk.Resource {
 			},
 
 			"subnet_resource_id": {
-				Type:     pluginsdk.TypeString,
+				Type: pluginsdk.TypeString,
+				// O + C as you don't have to specify it for Azure to assign one to the cluster
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -211,27 +213,11 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_machine_learning_compute_cluster", id.ID())
 	}
-	nodePublicIPEnabled, ok := d.Get("node_public_ip_enabled").(bool)
-	if !ok {
-		return fmt.Errorf("unable to assert type for `node_public_ip_enabled`")
-	}
-
-	subnetResourceID, ok := d.Get("subnet_resource_id").(string)
-	if !ok {
-		return fmt.Errorf("unable to assert type for `subnet_resource_id`")
-	}
-
-	workspaceInManagedVnet := false
 
 	if workspaceModel.Properties != nil &&
 		workspaceModel.Properties.ManagedNetwork != nil &&
 		workspaceModel.Properties.ManagedNetwork.Status != nil &&
 		workspaceModel.Properties.ManagedNetwork.Status.Status != nil {
-		workspaceInManagedVnet = *workspaceModel.Properties.ManagedNetwork.Status.Status == workspaces.ManagedNetworkStatusActive
-	}
-
-	if !nodePublicIPEnabled && subnetResourceID == "" && !workspaceInManagedVnet {
-		return fmt.Errorf("`subnet_resource_id` must be set if `node_public_ip_enabled` is set to `false` or the workspace is not in a managed network")
 	}
 
 	vmPriority := machinelearningcomputes.VMPriority(d.Get("vm_priority").(string))

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -156,7 +156,7 @@ func resourceComputeCluster() *pluginsdk.Resource {
 
 			"subnet_resource_id": {
 				Type: pluginsdk.TypeString,
-				// O + C as you don't have to specify it for Azure to assign one to the cluster
+				// NOTE: O + C as you don't have to specify it for Azure to assign one to the cluster
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -212,12 +212,6 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_machine_learning_compute_cluster", id.ID())
-	}
-
-	if workspaceModel.Properties != nil &&
-		workspaceModel.Properties.ManagedNetwork != nil &&
-		workspaceModel.Properties.ManagedNetwork.Status != nil &&
-		workspaceModel.Properties.ManagedNetwork.Status.Status != nil {
 	}
 
 	vmPriority := machinelearningcomputes.VMPriority(d.Get("vm_priority").(string))

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -156,7 +156,7 @@ func resourceComputeCluster() *pluginsdk.Resource {
 
 			"subnet_resource_id": {
 				Type: pluginsdk.TypeString,
-				// NOTE: O + C as you don't have to specify it for Azure to assign one to the cluster
+				// NOTE: O+C as you don't have to specify it for Azure to assign one to the cluster
 				Optional: true,
 				Computed: true,
 				ForceNew: true,

--- a/website/docs/r/machine_learning_compute_cluster.html.markdown
+++ b/website/docs/r/machine_learning_compute_cluster.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `local_auth_enabled` - (Optional) Whether local authentication methods is enabled. Defaults to `true`. Changing this forces a new Machine Learning Compute Cluster to be created.
 
-* `node_public_ip_enabled` - (Optional) Whether the compute cluster will have a public ip. To set this to false a `subnet_resource_id` needs to be set. Defaults to `true`. Changing this forces a new Machine Learning Compute Cluster to be created.
+* `node_public_ip_enabled` - (Optional) Whether the compute cluster will have a public ip. Defaults to `true`. Changing this forces a new Machine Learning Compute Cluster to be created.
 
 * `ssh_public_access_enabled` - (Optional) A boolean value indicating whether enable the public SSH port. Defaults to `false`. Changing this forces a new Machine Learning Compute Cluster to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR makes it possible so that  `subnet_resource_id` does not have to be specified when `node_public_ip_enabled` is `false`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_machine_learning_compute_cluster` - `subnet_resource_id` does not have to be specified when `node_public_ip_enabled` is `false` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27506


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
