### PR TITLE
`azurerm_role_assignment`: check role assignment exits for 409 error

### DIFF
--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -388,7 +388,7 @@ func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, id parse.ScopedRoleAs
 				if existing := lookupRoleAssignment(ctx, roleAssignmentsClient, id, param.Properties); existing != nil && existing.Properties != nil {
 					existsID := roleassignments.NewScopedRoleAssignmentID(pointer.From(existing.Properties.Scope), pointer.From(existing.Name))
 					if configName := d.Get("name").(string); configName != "" && configName != pointer.From(existing.Name) {
-						return pluginsdk.NonRetryableError(fmt.Errorf("role assignment `%s` already exists with a different name: %s", id.ID(), pointer.From(existing.Name)))
+						return pluginsdk.NonRetryableError(fmt.Errorf("role assignment of `%s` already exists with a different id, modify the role assignment name and import with the exists id: `%s`", id.ID(), existsID.ID()))
 					}
 					return pluginsdk.NonRetryableError(tf.ImportAsExistsError("azurerm_role_assignment", existsID.ID()))
 				}

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -427,7 +427,6 @@ func lookupRoleAssignment(ctx context.Context, client *roleassignments.RoleAssig
 	listAssignments, err := client.ListForScopeComplete(ctx, commonids.NewScopeID(id.ScopedId.Scope), roleassignments.ListForScopeOperationOptions{
 		TenantId: pointer.To(id.TenantId),
 	})
-
 	if err != nil {
 		return nil
 	}

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -387,6 +387,9 @@ func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, id parse.ScopedRoleAs
 				// we omit the err in lookupRoleAssignment and return the origin Create error
 				if existing := lookupRoleAssignment(ctx, roleAssignmentsClient, id, param.Properties); existing != nil && existing.Properties != nil {
 					existsID := roleassignments.NewScopedRoleAssignmentID(pointer.From(existing.Properties.Scope), pointer.From(existing.Name))
+					if configName := d.Get("name").(string); configName != "" && configName != pointer.From(existing.Name) {
+						return pluginsdk.NonRetryableError(fmt.Errorf("role assignment `%s` already exists with a different name: %s", id.ID(), pointer.From(existing.Name)))
+					}
 					return pluginsdk.NonRetryableError(tf.ImportAsExistsError("azurerm_role_assignment", existsID.ID()))
 				}
 				return pluginsdk.NonRetryableError(err)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Scope, role_name, and principal_id define the role assignment while `name` is actually optional. So API responds a `409` conflict error when create a new role assignment with the same trio but different `name`. This PR is to update this logic when Create API responds 409:

1. List the existing role assignments to find the conflict resource.
2. if `name` was not given in configuration, return an import error to suggest use to import the existing role assignment id.
3. if `name` was specified in the configuration, then return an error to the user that another role assignment with id xxx already exists.

result example for scenario name not given:


```
azurerm_role_assignment.test2: Creating...
╷
│ Error: A resource with the ID "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/626d93de-afd8-41bd-af46-2c195e7b320c" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_role_assignment" for more information.
│
│   with azurerm_role_assignment.test2,
│   on main.tf line 18, in resource "azurerm_role_assignment" "test2":
│   18: resource "azurerm_role_assignment" "test2" {

```
and while name `626d93de-afd8-41bd-af46-2c195e7b320c` if given:

```
azurerm_role_assignment.test2: Creating...
╷
│ Error: role Assignment with name: 626d93de-afd8-41bd-af46-2c195e7b320c already exists: /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/626d93de-afd8-41bd-af46-2c195e7b320c
│
│   with azurerm_role_assignment.test2,
│   on main.tf line 18, in resource "azurerm_role_assignment" "test2":
│   18: resource "azurerm_role_assignment" "test2" {

```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_assignment` - update logic for checking exists role assignment [GH-28557]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28557

