### PR TITLE
azurerm_cdn_frontdoor_firewall_policy - custom rules to accept JSChallenge

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -170,6 +170,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 								string(waf.ActionTypeBlock),
 								string(waf.ActionTypeLog),
 								string(waf.ActionTypeRedirect),
+								string(waf.ActionTypeJSChallenge),
 							}, false),
 						},
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -189,7 +189,7 @@ A `custom_rule` block supports the following:
 
 * `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
 
-* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, or `Redirect`.
+* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, `Redirect`, or `JSChallenge`.
 
 * `enabled` - (Optional) Is the rule is enabled or disabled? Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
`azurerm_cdn_frontdoor_firewall_policy ` Allow the creation of custom_rules with JSChallenge as the action.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).

## Testing 

I am unable to run tests that provision new resources due to organisation restrictions. However, I built the provider locally and ran terraform against a current workspace. Behaviour was as expected.
```
  # azurerm_cdn_frontdoor_firewall_policy.afd_waf_policy[0] will be updated in-place
  ~ resource "azurerm_cdn_frontdoor_firewall_policy" "afd_waf_policy" {
        id                                        = "/subscriptions/<SUBSCRIPTION>/resourceGroups/rg-rg-name/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/wafpolicy"
        name                                      = "wafpolicy"
        tags                                      = {  "excluded"      }
        # (8 unchanged attributes hidden)

      ~ custom_rule {
          ~ action                         = "Log" -> "JSChallenge"
            name                           = "jsChallenge"
            # (5 unchanged attributes hidden)

            # (6 unchanged blocks hidden)
        }

        # (14 unchanged blocks hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.

azurerm_cdn_frontdoor_firewall_policy.afd_waf_policy[0]: Modifications complete after 1m16s [id=/subscriptions/<SUBSCRIPTION>/resourceGroups/rg-rg-name/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/wafpolicy]
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_firewall_policy ` - added support for the `JSChallenge` action for custom_rule 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #[28713 ](https://github.com/hashicorp/terraform-provider-azurerm/issues/28713)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
