### PR TITLE
[Enhancement:] `azurerm_cdn_frontdoor_firewall_policy` - `js_challenge_cookie_expiration_in_minutes` causing `BadRequest` error with `Standard_AzureFrontDoor` SKU

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_data_source_test.go
@@ -28,13 +28,13 @@ func TestAccCdnFrontDoorFirewallPolicyDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicyDataSourceJsChallenge_basic(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicyDataSource_jsChallengeBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_firewall_policy", "test")
 	d := CdnFrontDoorFirewallPolicyDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: d.basicJsChallenge(data),
+			Config: d.jsChallengePolicyBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("redirect_url").MatchesOtherKey(check.That("azurerm_cdn_frontdoor_firewall_policy.test").Key("redirect_url")),
 				check.That(data.ResourceName).Key("js_challenge_cookie_expiration_in_minutes").HasValue("45"),
@@ -54,7 +54,7 @@ data "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, CdnFrontDoorFirewallPolicyResource{}.basic(data))
 }
 
-func (CdnFrontDoorFirewallPolicyDataSource) basicJsChallenge(data acceptance.TestData) string {
+func (CdnFrontDoorFirewallPolicyDataSource) jsChallengePolicyBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -62,5 +62,5 @@ data "azurerm_cdn_frontdoor_firewall_policy" "test" {
   name                = azurerm_cdn_frontdoor_firewall_policy.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, CdnFrontDoorFirewallPolicyResource{}.basicJsChallenge(data))
+`, CdnFrontDoorFirewallPolicyResource{}.jSChallengePolicyBasic(data))
 }

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -466,7 +466,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 				sku := diff.Get("sku_name").(string)
 				policyInMinutes := diff.Get("js_challenge_cookie_expiration_in_minutes").(int)
 
-				if sku == string(waf.SkuNameStandardAzureFrontDoor) && int(policyInMinutes) > 0 {
+				if sku == string(waf.SkuNameStandardAzureFrontDoor) && policyInMinutes > 0 {
 					return fmt.Errorf("the 'js_challenge_cookie_expiration_in_minutes' field is only supported with the 'Premium_AzureFrontDoor' sku, got %q", sku)
 				}
 

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -6,6 +6,7 @@ package cdn
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -81,7 +82,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 
 			// NOTE: Through local testing, the new API js challenge expiration is always
 			// enabled no matter what and cannot be disabled for Premium_AzureFrontDoor
-			// not supported in Standard_AzureFrontDoor...
+			// and is not supported in Standard_AzureFrontDoor...
 			"js_challenge_cookie_expiration_in_minutes": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
@@ -640,7 +641,12 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 	props := *model.Properties
 
 	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url", "request_body_check_enabled", "js_challenge_cookie_expiration_in_minutes") {
+
+		log.Printf("\n\n\n\n\n\n\n\n\n\n\n\n0000/00/00 00:00:00 [DEBUG] *************************************************************************")
+
 		jsChallengeExpirationInMinutes := int64(d.Get("js_challenge_cookie_expiration_in_minutes").(int))
+
+		log.Printf("  jsChallengeExpirationInMinutes: %d", jsChallengeExpirationInMinutes)
 
 		enabled := waf.PolicyEnabledStateDisabled
 		if d.Get("enabled").(bool) {
@@ -658,7 +664,10 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 			RequestBodyCheck: pointer.To(requestBodyCheck),
 		}
 
-		if model.Sku.Name == pointer.To(waf.SkuNamePremiumAzureFrontDoor) {
+		log.Printf("  model.Sku.Name                  : %s", *model.Sku.Name)
+		log.Printf("  waf.SkuNamePremiumAzureFrontDoor: %s", waf.SkuNamePremiumAzureFrontDoor)
+
+		if *model.Sku.Name == waf.SkuNamePremiumAzureFrontDoor {
 			if jsChallengeExpirationInMinutes == 0 {
 				// if they removed it from the configuration file, set it back to the default value...
 				props.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.To(int64(30))
@@ -668,8 +677,12 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 					return err
 				}
 
+				log.Printf("  policyMinutes                                              : %d", *policyMinutes)
 				props.PolicySettings.JavascriptChallengeExpirationInMinutes = policyMinutes
 			}
+
+			log.Printf("  jsChallengeExpirationInMinutes                             : %d", jsChallengeExpirationInMinutes)
+			log.Printf("  props.PolicySettings.JavascriptChallengeExpirationInMinutes: %d", *props.PolicySettings.JavascriptChallengeExpirationInMinutes)
 		}
 
 		if redirectUrl := d.Get("redirect_url").(string); redirectUrl != "" {
@@ -683,6 +696,8 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 		if statusCode := int64(d.Get("custom_block_response_status_code").(int)); statusCode > 0 {
 			props.PolicySettings.CustomBlockResponseStatusCode = pointer.To(statusCode)
 		}
+
+		log.Printf("[DEBUG] *************************************************************************\n\n\n\n\n\n\n\n\n\n\n\n")
 	}
 
 	if d.HasChange("custom_rule") {

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -641,7 +641,6 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 	props := *model.Properties
 
 	if d.HasChanges("custom_block_response_body", "custom_block_response_status_code", "enabled", "mode", "redirect_url", "request_body_check_enabled", "js_challenge_cookie_expiration_in_minutes") {
-
 		log.Printf("\n\n\n\n\n\n\n\n\n\n\n\n0000/00/00 00:00:00 [DEBUG] *************************************************************************")
 
 		jsChallengeExpirationInMinutes := int64(d.Get("js_challenge_cookie_expiration_in_minutes").(int))
@@ -668,10 +667,10 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 		log.Printf("  waf.SkuNamePremiumAzureFrontDoor: %s", waf.SkuNamePremiumAzureFrontDoor)
 
 		if *model.Sku.Name == waf.SkuNamePremiumAzureFrontDoor {
-			if jsChallengeExpirationInMinutes == 0 {
-				// if they removed it from the configuration file, set it back to the default value...
-				props.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.To(int64(30))
-			} else {
+			if jsChallengeExpirationInMinutes != 0 {
+				// 	// if they removed it from the configuration file, set it back to the default value...
+				// 	props.PolicySettings.JavascriptChallengeExpirationInMinutes = nil
+				// } else {
 				policyMinutes, err := validateJsChallengeExpirationInMinutes(jsChallengeExpirationInMinutes)
 				if err != nil {
 					return err
@@ -679,10 +678,13 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 
 				log.Printf("  policyMinutes                                              : %d", *policyMinutes)
 				props.PolicySettings.JavascriptChallengeExpirationInMinutes = policyMinutes
-			}
 
-			log.Printf("  jsChallengeExpirationInMinutes                             : %d", jsChallengeExpirationInMinutes)
-			log.Printf("  props.PolicySettings.JavascriptChallengeExpirationInMinutes: %d", *props.PolicySettings.JavascriptChallengeExpirationInMinutes)
+				log.Printf("  jsChallengeExpirationInMinutes                             : %d", jsChallengeExpirationInMinutes)
+				log.Printf("  props.PolicySettings.JavascriptChallengeExpirationInMinutes: %d", *props.PolicySettings.JavascriptChallengeExpirationInMinutes)
+			} else {
+				log.Printf("  props.PolicySettings.JavascriptChallengeExpirationInMinutes: Removed from config Set back to default")
+				props.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.To(int64(30))
+			}
 		}
 
 		if redirectUrl := d.Get("redirect_url").(string); redirectUrl != "" {

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -492,7 +492,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 				managedRules := diff.Get("managed_rule").([]interface{})
 
 				if sku == string(waf.SkuNameStandardAzureFrontDoor) && len(managedRules) > 0 {
-					return fmt.Errorf("the 'managed_rule' code block is only supported with the '%q' sku, got %q", waf.SkuNamePremiumAzureFrontDoor, sku)
+					return fmt.Errorf("the 'managed_rule' code block is only supported with the %q sku, got %q", waf.SkuNamePremiumAzureFrontDoor, sku)
 				}
 
 				return nil

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -489,7 +489,7 @@ func TestAccCdnFrontDoorFirewallPolicy_jsChallengePolicyInvalidTimeSpanError(t *
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.jsChallengePolicyInvalidTimeSpanError(data),
-			ExpectError: regexp.MustCompile(`expected "js_challenge_cookie_expiration_in_minutes" to be in the range \(5 - 1440\), got 4`),
+			ExpectError: regexp.MustCompile(`expected js_challenge_cookie_expiration_in_minutes to be in the range \(5 - 1440\), got 4`),
 		},
 	})
 }

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -512,48 +512,6 @@ func TestAccCdnFrontDoorFirewallPolicy_skuDowngradeError(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_jsChallengeCustomRuleUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.jsChallengeCustomRuleBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.jsChallengeCustomRuleUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.jsChallengeCustomRuleBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.jsChallengeCustomRuleRemove(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.jsChallengeCustomRuleBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (CdnFrontDoorFirewallPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := waf.ParseFrontDoorWebApplicationFirewallPolicyID(state.ID)
 	if err != nil {

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -341,12 +341,12 @@ func TestAccCdnFrontDoorFirewallPolicy_StandardSkuManagedRuleError(t *testing.T)
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_StandardSkuCustomRuleJSChallengeActionError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_JSChallengeStandardSkuCustomRuleActionError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.StandardSkuCustomRuleJSChallengeActionError(data),
+			Config:      r.JSChallengeStandardSkuCustomRuleActionError(data),
 			ExpectError: regexp.MustCompile(`'custom_rule' blocks with the 'action' type of 'JSChallenge' are only supported for the 'Premium_AzureFrontDoor' sku, got action: "JSChallenge" (custom_rule.name: "RateLimitExcessiveRequests", sku_name: "Standard_AzureFrontDoor")`),
 		},
 	})
@@ -1087,7 +1087,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) StandardSkuCustomRuleJSChallengeActionError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) JSChallengeStandardSkuCustomRuleActionError(data acceptance.TestData) string {
 	tmp := r.templateStandard(data)
 	return fmt.Sprintf(`
 %s

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -34,15 +34,43 @@ func TestAccCdnFrontDoorFirewallPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicyJsChallenge_basic(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengePolicyBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicJsChallenge(data),
+			Config: r.jSChallengePolicyBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("js_challenge_cookie_expiration_in_minutes").HasValue("45"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeManagedRuleBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.jsChallengeManagedRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeCustomRuleBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.jsChallengeCustomRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -91,7 +119,36 @@ func TestAccCdnFrontDoorFirewallPolicy_update(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicyJsChallenge_update(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsOnePointOhUpdate(t *testing.T) {
+	// NOTE: Regression test case for issue #19088
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.drsOnePointOh(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.drsTwoPointOh(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.drsOnePointOh(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengePolicyUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -104,7 +161,7 @@ func TestAccCdnFrontDoorFirewallPolicyJsChallenge_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basicJsChallenge(data),
+			Config: r.jSChallengePolicyBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("js_challenge_cookie_expiration_in_minutes").HasValue("45"),
@@ -112,7 +169,7 @@ func TestAccCdnFrontDoorFirewallPolicyJsChallenge_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basicJsChallengeUpdate(data),
+			Config: r.jSChallengePolicyBasicUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("js_challenge_cookie_expiration_in_minutes").HasValue("1440"),
@@ -124,6 +181,90 @@ func TestAccCdnFrontDoorFirewallPolicyJsChallenge_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("js_challenge_cookie_expiration_in_minutes").HasValue("30"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeManagedRuleUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.jsChallengeManagedRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeManagedRuleUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeManagedRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeManagedRuleRemove(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeManagedRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeCustomRuleUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.jsChallengeCustomRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeCustomRuleUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeCustomRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeCustomRuleRemove(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.jsChallengeCustomRuleBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -145,13 +286,13 @@ func TestAccCdnFrontDoorFirewallPolicy_complete(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSOnePointOh(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsOnePointOh(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.DRSOnePointOh(data),
+			Config: r.drsOnePointOh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -160,66 +301,37 @@ func TestAccCdnFrontDoorFirewallPolicy_DRSOnePointOh(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSOnePointOhUpdate(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsOnePointOhError(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.DRSOnePointOh(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.DRSTwoPointOh(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.DRSOnePointOh(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccCdnFrontDoorFirewallPolicy_DRSOnePointOhError(t *testing.T) {
-	// NOTE: Regression test case for issue #19088
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.DRSOnePointOhError(data),
+			Config:      r.drsOnePointOhError(data),
 			ExpectError: regexp.MustCompile(`"AnomalyScoring" is only valid in managed rules where 'type' is DRS`),
 		},
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSOnePointOhTypeError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsOnePointOhTypeError(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.DRSOnePointOhTypeError(data),
+			Config:      r.drsOnePointOhTypeError(data),
 			ExpectError: regexp.MustCompile("If you wish to use the 'Microsoft_DefaultRuleSet' type please update your 'version' field to be '1.1', '2.0' or '2.1'"),
 		},
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOh(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOh(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.DRSTwoPointOh(data),
+			Config: r.drsTwoPointOh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -228,27 +340,27 @@ func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOh(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOhUpdate(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOhUpdate(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.DRSTwoPointOh(data),
+			Config: r.drsTwoPointOh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.DRSOnePointOh(data),
+			Config: r.drsOnePointOh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.DRSTwoPointOh(data),
+			Config: r.drsTwoPointOh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -257,37 +369,37 @@ func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOhUpdate(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOhError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOhError(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.DRSTwoPointOhError(data),
+			Config:      r.drsTwoPointOhError(data),
 			ExpectError: regexp.MustCompile("the managed rules 'action' field must be set to 'AnomalyScoring' or 'Log' if the managed rule is DRS 2.0 or above"),
 		},
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOhTypeError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOhTypeError(t *testing.T) {
 	// NOTE: Regression test case for issue #19088
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.DRSTwoPointOhTypeError(data),
+			Config:      r.drsTwoPointOhTypeError(data),
 			ExpectError: regexp.MustCompile("If you wish to use the 'DefaultRuleSet' type please update your 'version' field to be '1.0' or 'preview-0.1'"),
 		},
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOneAction(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOneAction(t *testing.T) {
 	// NOTE: Regression test case for issue #19561
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.DRSTwoPointOneActionLog(data),
+			Config: r.drsTwoPointOneActionLog(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -296,68 +408,25 @@ func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOneAction(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_DRSTwoPointOneActionError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_drsTwoPointOneActionError(t *testing.T) {
 	// NOTE: Regression test case for issue #19561
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.DRSTwoPointOneActionError(data),
+			Config:      r.drsTwoPointOneActionError(data),
 			ExpectError: regexp.MustCompile("the managed rules 'action' field must be set to 'AnomalyScoring' or 'Log' if the managed rule is DRS 2.0 or above"),
 		},
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_JSChallengeDRSError(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengePolicyStandardSku(t *testing.T) {
+	// NOTE: Regression test case for issue #28716
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.JSChallengeDRSError(data),
-			ExpectError: regexp.MustCompile(`"JSChallenge" is only valid if the managed rules 'type' is 'Microsoft_BotManagerRuleSet', got "DefaultRuleSet"`),
-		},
-	})
-}
-
-func TestAccCdnFrontDoorFirewallPolicy_JSChallengeStandardSkuError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.JSChallengeStandardSkuError(data),
-			ExpectError: regexp.MustCompile(`the 'js_challenge_cookie_expiration_in_minutes' field is only supported with the 'Premium_AzureFrontDoor' sku, got "Standard_AzureFrontDoor"`),
-		},
-	})
-}
-
-func TestAccCdnFrontDoorFirewallPolicy_StandardSkuManagedRuleError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.StandardSkuManagedRuleError(data),
-			ExpectError: regexp.MustCompile(`the 'managed_rule' code block is only supported with the 'Premium_AzureFrontDoor' sku, got "Standard_AzureFrontDoor"`),
-		},
-	})
-}
-
-func TestAccCdnFrontDoorFirewallPolicy_JSChallengeStandardSkuCustomRuleActionError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.JSChallengeStandardSkuCustomRuleActionError(data),
-			ExpectError: regexp.MustCompile(`'custom_rule' blocks with the 'action' type of 'JSChallenge' are only supported for the 'Premium_AzureFrontDoor' sku, got action: "JSChallenge" (custom_rule.name: "RateLimitExcessiveRequests", sku_name: "Standard_AzureFrontDoor")`),
-		},
-	})
-}
-
-func TestAccCdnFrontDoorFirewallPolicy_JSChallengeBasic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-	r := CdnFrontDoorFirewallPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.JSChallengeBasic(data),
+			Config: r.jsChallengePolicyStandardSku(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -366,31 +435,47 @@ func TestAccCdnFrontDoorFirewallPolicy_JSChallengeBasic(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_JSChallengeUpdate(t *testing.T) {
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeDRSError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.JSChallengeBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
+			Config:      r.jsChallengeDRSError(data),
+			ExpectError: regexp.MustCompile(`"JSChallenge" is only valid if the managed rules 'type' is 'Microsoft_BotManagerRuleSet'`),
 		},
-		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengePolicyStandardSkuError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.JSChallengeRemove(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
+			Config:      r.jsChallengePolicyStandardSkuError(data),
+			ExpectError: regexp.MustCompile(`the 'js_challenge_cookie_expiration_in_minutes' field is only supported with the 'Premium_AzureFrontDoor' sku`),
 		},
-		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_standardSkuManagedRuleError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.JSChallengeBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
+			Config:      r.standardSkuManagedRuleError(data),
+			ExpectError: regexp.MustCompile(`the 'managed_rule' code block is only supported with the 'Premium_AzureFrontDoor' sku`),
 		},
-		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorFirewallPolicy_jsChallengeStandardSkuCustomRuleActionError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.jsChallengeStandardSkuCustomRuleActionError(data),
+			ExpectError: regexp.MustCompile(`'custom_rule' blocks with the 'action' type of 'JSChallenge' are only supported for the 'Premium_AzureFrontDoor' sku, got action: "JSChallenge"`),
+		},
 	})
 }
 
@@ -460,7 +545,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) basicJsChallenge(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jSChallengePolicyBasic(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -476,7 +561,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) basicJsChallengeUpdate(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jSChallengePolicyBasicUpdate(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -701,7 +786,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSOnePointOh(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsOnePointOh(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -735,7 +820,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSOnePointOhError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsOnePointOhError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -769,7 +854,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSOnePointOhTypeError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsOnePointOhTypeError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -803,7 +888,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSTwoPointOh(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsTwoPointOh(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -837,7 +922,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSTwoPointOhError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsTwoPointOhError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -871,7 +956,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSTwoPointOhTypeError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsTwoPointOhTypeError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -905,7 +990,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSTwoPointOneActionLog(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsTwoPointOneActionLog(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -945,7 +1030,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) DRSTwoPointOneActionError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) drsTwoPointOneActionError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -985,7 +1070,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) JSChallengeDRSError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeDRSError(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -1019,7 +1104,25 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) JSChallengeStandardSkuError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengePolicyStandardSku(data acceptance.TestData) string {
+	tmp := r.templateStandard(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  redirect_url                      = "https://www.contoso.com"
+  custom_block_response_status_code = 403
+  custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+}
+`, tmp, data.RandomInteger)
+}
+
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengePolicyStandardSkuError(data acceptance.TestData) string {
 	tmp := r.templateStandard(data)
 	return fmt.Sprintf(`
 %s
@@ -1034,26 +1137,12 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
   custom_block_response_status_code = 403
   custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
 
-  managed_rule {
-    type    = "DefaultRuleSet"
-    version = "preview-0.1"
-    action  = "Block"
-
-    override {
-      rule_group_name = "PHP"
-
-      rule {
-        rule_id = "933100"
-        enabled = false
-        action  = "JSChallenge"
-      }
-    }
-  }
+  js_challenge_cookie_expiration_in_minutes = 45
 }
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) StandardSkuManagedRuleError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) standardSkuManagedRuleError(data acceptance.TestData) string {
 	tmp := r.templateStandard(data)
 	return fmt.Sprintf(`
 %s
@@ -1087,7 +1176,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) JSChallengeStandardSkuCustomRuleActionError(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeStandardSkuCustomRuleActionError(data acceptance.TestData) string {
 	tmp := r.templateStandard(data)
 	return fmt.Sprintf(`
 %s
@@ -1122,7 +1211,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) JSChallengeBasic(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeManagedRuleBasic(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -1156,7 +1245,129 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 `, tmp, data.RandomInteger)
 }
 
-func (r CdnFrontDoorFirewallPolicyResource) JSChallengeRemove(data acceptance.TestData) string {
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeCustomRuleBasic(data acceptance.TestData) string {
+	tmp := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  redirect_url                      = "https://www.contoso.com"
+  custom_block_response_status_code = 403
+  custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+
+  custom_rule {
+    name                           = "CustomJSChallenge"
+    enabled                        = true
+    priority                       = 2
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 10
+    type                           = "MatchRule"
+    action                         = "JSChallenge"
+
+    match_condition {
+      match_variable     = "RemoteAddr"
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+
+    match_condition {
+      match_variable     = "RequestHeader"
+      selector           = "UserAgent"
+      operator           = "Contains"
+      negation_condition = false
+      match_values       = ["windows"]
+      transforms         = ["Lowercase", "Trim"]
+    }
+  }
+}
+`, tmp, data.RandomInteger)
+}
+
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeManagedRuleUpdate(data acceptance.TestData) string {
+	tmp := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  redirect_url                      = "https://www.contoso.com"
+  custom_block_response_status_code = 403
+  custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+
+  managed_rule {
+    type    = "Microsoft_BotManagerRuleSet"
+    version = "1.0"
+    action  = "Log"
+
+    override {
+      rule_group_name = "BadBots"
+
+      rule {
+        rule_id = "Bot100200"
+        enabled = true
+        action  = "Allow"
+      }
+    }
+  }
+}
+`, tmp, data.RandomInteger)
+}
+
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeCustomRuleUpdate(data acceptance.TestData) string {
+	tmp := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  redirect_url                      = "https://www.contoso.com"
+  custom_block_response_status_code = 403
+  custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+
+  custom_rule {
+    name                           = "CustomJSChallenge"
+    enabled                        = true
+    priority                       = 2
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 10
+    type                           = "MatchRule"
+    action                         = "Allow"
+
+    match_condition {
+      match_variable     = "RemoteAddr"
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+
+    match_condition {
+      match_variable     = "RequestHeader"
+      selector           = "UserAgent"
+      operator           = "Contains"
+      negation_condition = false
+      match_values       = ["windows"]
+      transforms         = ["Lowercase", "Trim"]
+    }
+  }
+}
+`, tmp, data.RandomInteger)
+}
+
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeManagedRuleRemove(data acceptance.TestData) string {
 	tmp := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -1176,6 +1387,24 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
     version = "1.0"
     action  = "Log"
   }
+}
+`, tmp, data.RandomInteger)
+}
+
+func (r CdnFrontDoorFirewallPolicyResource) jsChallengeCustomRuleRemove(data acceptance.TestData) string {
+	tmp := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  redirect_url                      = "https://www.contoso.com"
+  custom_block_response_status_code = 403
+  custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
 }
 `, tmp, data.RandomInteger)
 }

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -1154,6 +1154,23 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
   redirect_url                      = "https://www.contoso.com"
   custom_block_response_status_code = 403
   custom_block_response_body        = "PGh0bWw+CjxoZWFkZXI+PHRpdGxlPkhlbGxvPC90aXRsZT48L2hlYWRlcj4KPGJvZHk+CkhlbGxvIHdvcmxkCjwvYm9keT4KPC9odG1sPg=="
+
+  custom_rule {
+    name                           = "ShortUserAgents"
+    enabled                        = true
+    type                           = "MatchRule"
+    priority                       = 500
+    rate_limit_threshold           = 1
+    rate_limit_duration_in_minutes = 5
+    action                         = "Allow"
+
+    match_condition {
+      match_variable = "RequestHeader"
+      selector       = "User-Agent"
+      operator       = "LessThanOrEqual"
+      match_values   = ["15"]
+    }
+  }
 }
 `, tmp, data.RandomInteger)
 }

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -127,7 +127,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
 }
 ```
 
-## Example Usage: JSChallenge Override
+## Example Usage: JSChallenge Managed Rule Override
 
 ```hcl
 managed_rule {
@@ -147,6 +147,26 @@ managed_rule {
 }
 ```
 
+## Example Usage: JSChallenge Custom Rule
+
+```hcl
+custom_rule {
+  name                           = "CustomJSChallenge"
+  enabled                        = true
+  priority                       = 2
+  rate_limit_duration_in_minutes = 1
+  rate_limit_threshold           = 10
+  type                           = "MatchRule"
+  action                         = "JSChallenge"
+
+  match_condition {
+    match_variable     = "RemoteAddr"
+    operator           = "IPMatch"
+    negation_condition = false
+    match_values       = ["192.168.1.0/24"]
+  }
+}
+```
 ## Argument Reference
 
 The following arguments are supported:
@@ -163,7 +183,7 @@ The following arguments are supported:
 
 * `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie lifetime in minutes, after which the user will be revalidated. Possible values are between `5` to `1440` minutes. Defaults to `30` minutes.
 
-!> **Note:** Azure Web Application Firewall JavaScript challenge is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
+!> **Note:** Setting the`js_challenge_cookie_expiration_in_minutes` policy is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 * `mode` - (Required) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -230,9 +230,7 @@ A `custom_rule` block supports the following:
 
 * `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
 
-* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, `Redirect` or `JSChallenge`.
-
-!> **Note:** Setting the `action` field to `JSChallenge` is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
+* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, `Redirect`, or `JSChallenge`.
 
 !> **Note:** Setting the `action` field to `JSChallenge` is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
@@ -256,23 +254,23 @@ A `match_condition` block supports the following:
 
 * `match_values` - (Required) Up to `600` possible values to match. Limit is in total across all `match_condition` blocks and `match_values` arguments. String value itself can be up to `256` characters in length.
 
-* `operator` - (Required) Comparison type to use for matching with the variable value. Possible values are `Any`, `BeginsWith`, `Contains`, `EndsWith`, `Equal`, `GeoMatch`, `GreaterThan`, `GreaterThanOrEqual`, `IPMatch`, `LessThan`, `LessThanOrEqual` or `RegEx`.
+* `operator` - (Required) Comparison type to use for matching with the variable value. Possible values are `Any`, `BeginsWith`, `Contains`, `EndsWith`, `Equal`, `GeoMatch`, `GreaterThan`, `GreaterThanOrEqual`, `IPMatch`, `LessThan`, `LessThanOrEqual`, or `RegEx`.
 
-* `selector` - (Optional) Match against a specific key if the `match_variable` is `QueryString`, `PostArgs`, `RequestHeader` or `Cookies`.
+* `selector` - (Optional) Match against a specific key if the `match_variable` is `QueryString`, `PostArgs`, `RequestHeader`, or `Cookies`.
 
 * `negation_condition` - (Optional) Should the result of the condition be negated.
 
-* `transforms` - (Optional) Up to `5` transforms to apply. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `URLDecode` or `URLEncode`.
+* `transforms` - (Optional) Up to `5` transforms to apply. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `URLDecode`, or `URLEncode`.
 
 ---
 
 A `managed_rule` block supports the following:
 
-* `type` - (Required) The name of the managed rule to use with this resource. Possible values include `DefaultRuleSet`, `Microsoft_DefaultRuleSet`, `BotProtection` or `Microsoft_BotManagerRuleSet`.
+* `type` - (Required) The name of the managed rule to use with this resource. Possible values include `DefaultRuleSet`, `Microsoft_DefaultRuleSet`, `BotProtection`, or `Microsoft_BotManagerRuleSet`.
 
-* `version` - (Required) The version of the managed rule to use with this resource. Possible values depends on which default rule set type you are using, for the `DefaultRuleSet` type the possible values include `1.0` or `preview-0.1`. For `Microsoft_DefaultRuleSet` the possible values include `1.1`, `2.0` or `2.1`. For `BotProtection` the value must be `preview-0.1` and for `Microsoft_BotManagerRuleSet` the possible values include `1.0` and `1.1`.
+* `version` - (Required) The version of the managed rule to use with this resource. Possible values depends on which default rule set type you are using, for the `DefaultRuleSet` type the possible values include `1.0` or `preview-0.1`. For `Microsoft_DefaultRuleSet` the possible values include `1.1`, `2.0`, or `2.1`. For `BotProtection` the value must be `preview-0.1` and for `Microsoft_BotManagerRuleSet` the possible values include `1.0` and `1.1`.
 
-* `action` - (Required) The action to perform for all default rule set rules when the managed rule is matched or when the anomaly score is 5 or greater depending on which version of the default rule set you are using. Possible values include `Allow`, `Log`, `Block`, and `Redirect`.
+* `action` - (Required) The action to perform for all default rule set rules when the managed rule is matched or when the anomaly score is 5 or greater depending on which version of the default rule set you are using. Possible values include `Allow`, `Log`, `Block`, or `Redirect`.
 
 * `exclusion` - (Optional) One or more `exclusion` blocks as defined below.
 
@@ -294,7 +292,7 @@ A `rule` block supports the following:
 
 * `rule_id` - (Required) Identifier for the managed rule.
 
-* `action` - (Required) The action to be applied when the managed rule matches or when the anomaly score is 5 or greater. Possible values for `DefaultRuleSet 1.1` and below are `Allow`, `Log`, `Block`, or `Redirect`. Possible values for `DefaultRuleSet 2.0` and above are `Log` or `AnomalyScoring`. Possible values for `Microsoft_BotManagerRuleSet` are `Allow`, `Log`, `Block`, `Redirect` or `JSChallenge`.
+* `action` - (Required) The action to be applied when the managed rule matches or when the anomaly score is 5 or greater. Possible values for `DefaultRuleSet 1.1` and below are `Allow`, `Log`, `Block`, or `Redirect`. Possible values for `DefaultRuleSet 2.0` and above are `Log` or `AnomalyScoring`. Possible values for `Microsoft_BotManagerRuleSet` are `Allow`, `Log`, `Block`, `Redirect`, or `JSChallenge`.
 
 -> **Note:** Please see the `DefaultRuleSet` [product documentation](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-drs?tabs=drs20#anomaly-scoring-mode) or the `Microsoft_BotManagerRuleSet` [product documentation](https://learn.microsoft.com/azure/web-application-firewall/afds/afds-overview) for more information.
 
@@ -312,7 +310,7 @@ An `exclusion` block supports the following:
 
 -> **Note:** `RequestBodyJsonArgNames` is only available on Default Rule Set (DRS) 2.0 or later
 
-* `operator` - (Required) Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to. Possible values are: `Equals`, `Contains`, `StartsWith`, `EndsWith`, `EqualsAny`.
+* `operator` - (Required) Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to. Possible values are: `Equals`, `Contains`, `StartsWith`, `EndsWith`, or `EqualsAny`.
 
 * `selector` - (Required) Selector for the value in the `match_variable` attribute this exclusion applies to.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -146,25 +146,6 @@ managed_rule {
   }
 }
 ```
-## Example Usage: JSChallenge Custom Rule
-
-```hcl
-custom_rule {
-  name                           = "CustomJSChallenge"
-  enabled                        = true
-  priority                       = 2
-  rate_limit_duration_in_minutes = 1
-  rate_limit_threshold           = 10
-  type                           = "MatchRule"
-  action                         = "JSChallenge"
-  match_condition {
-    match_variable     = "RemoteAddr"
-    operator           = "IPMatch"
-    negation_condition = false
-    match_values       = ["192.168.1.0/24"]
-  }
-}
-```
 
 ## Example Usage: JSChallenge Custom Rule
 
@@ -186,6 +167,7 @@ custom_rule {
   }
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -177,11 +177,13 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The sku's pricing tier for this Front Door Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
--> **Note:** The `Standard_AzureFrontDoor` Front Door Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` Front Door Firewall Policy skus may contain both `custom` and `managed` rules.
+-> **Note:** The `Standard_AzureFrontDoor` Front Door Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` Front Door Firewall Policy sku's may contain both `custom` and `managed` rules.
 
 * `enabled` - (Optional) Is the Front Door Firewall Policy enabled? Defaults to `true`.
 
 * `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie lifetime in minutes, after which the user will be revalidated. Possible values are between `5` to `1440` minutes. Defaults to `30` minutes.
+
+-> **Note:** The `js_challenge_cookie_expiration_in_minutes` field can only be set on `Premium_AzureFrontDoor` sku's. Please see the [Product Documentation](https://learn.microsoft.com/azure/web-application-firewall/waf-javascript-challenge) for more information.
 
 !> **Note:** Setting the`js_challenge_cookie_expiration_in_minutes` policy is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -189,7 +189,9 @@ A `custom_rule` block supports the following:
 
 * `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
 
-* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, or `Redirect`.
+* `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, `Redirect` or `JSChallenge`.
+
+!> **Note:** Setting the `action` field to `JSChallenge` is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 * `enabled` - (Optional) Is the rule is enabled or disabled? Defaults to `true`.
 
@@ -253,7 +255,7 @@ A `rule` block supports the following:
 
 -> **Note:** Please see the `DefaultRuleSet` [product documentation](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-drs?tabs=drs20#anomaly-scoring-mode) or the `Microsoft_BotManagerRuleSet` [product documentation](https://learn.microsoft.com/azure/web-application-firewall/afds/afds-overview) for more information.
 
-!> **Note:** The `action` field value `JSChallenge` is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
+!> **Note:** Setting the `action` field to `JSChallenge` is currently in **PREVIEW**. Please see the [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 * `enabled` - (Optional) Is the managed rule override enabled or disabled. Defaults to `false`
 


### PR DESCRIPTION
<!--  All Submissions -->

* `azurerm_cdn_frontdoor_firewall_policy` - added `sku_name` downgrade validation
* `azurerm_cdn_frontdoor_profile` - added `sku_name` downgrade validation

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![image](https://github.com/user-attachments/assets/1da880d5-8e1c-4525-84cf-52a12a7eaf45)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

BUG FIXES:

* `azurerm_cdn_frontdoor_firewall_policy` - fixed an issue where the `js_challenge_cookie_expiration_in_minutes` policies `default` value was causing `Standard_AzureFrontDoor` skus to receive a `BadRequest` error  [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change

## Related PR(s)
[#28717](https://github.com/hashicorp/terraform-provider-azurerm/pull/28717)
[#28750](https://github.com/hashicorp/terraform-provider-azurerm/pull/28750)

## Related Issue(s)
Fixes #28716
Fixes #28713

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
