### PR TITLE
`azurerm_managed_disk` - support expanding disk size without downtime for all types of `storage_account_type`

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -727,7 +727,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			if meta.(*clients.Client).Features.ManagedDisk.ExpandWithoutDowntime {
 				diskSupportsNoDowntimeResize := determineIfDataDiskSupportsNoDowntimeResize(disk.Model, oldSize.(int), newSize.(int))
 
-				vmSkuSupportsNoDowntimeResize, err := determineIfVirtualMachineSkuSupportsNoDowntimeResize(ctx, disk.Model.ManagedBy, virtualMachinesClient, skusClient)
+				vmSupportsNoDowntimeResize, err := determineIfVirtualMachineSupportsNoDowntimeResize(ctx, disk.Model, virtualMachinesClient, skusClient)
 				if err != nil {
 					return fmt.Errorf("determining if the Virtual Machine the Disk is attached to supports no-downtime-resize: %+v", err)
 				}
@@ -735,7 +735,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				// If a disk is 4 TiB or less, you can't expand it beyond 4 TiB without detaching it from the VM.
 				shouldDetach = oldSize.(int) < 4096 && newSize.(int) >= 4096
 
-				canBeResizedWithoutDowntime = *vmSkuSupportsNoDowntimeResize && *diskSupportsNoDowntimeResize
+				canBeResizedWithoutDowntime = *vmSupportsNoDowntimeResize && *diskSupportsNoDowntimeResize
 			}
 			if !canBeResizedWithoutDowntime {
 				log.Printf("[INFO] The %s, or the Virtual Machine that it's attached to, doesn't support no-downtime-resizing - requiring that the VM should be shutdown", *id)
@@ -828,8 +828,8 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 		// check instanceView State
 
-		locks.ByName(name, VirtualMachineResourceName)
-		defer locks.UnlockByName(name, VirtualMachineResourceName)
+		locks.ByName(virtualMachineId.VirtualMachineName, VirtualMachineResourceName)
+		defer locks.UnlockByName(virtualMachineId.VirtualMachineName, VirtualMachineResourceName)
 
 		vm, err := virtualMachinesClient.Get(ctx, *virtualMachineId, virtualmachines.DefaultGetOperationOptions())
 		if err != nil {

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -365,6 +365,29 @@ func TestAccManagedDisk_attachedDiskUpdate(t *testing.T) {
 	})
 }
 
+func TestAccManagedDisk_attachedDiskUpdateWithDowntime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskUpdateWithDowntime(data, 10),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.diskUpdateWithDowntime(data, 20),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("disk_size_gb").HasValue("20"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccManagedDisk_attachedPremiumV2DiskUpdateWithoutDowntime(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
@@ -402,6 +425,29 @@ func TestAccManagedDisk_attachedUltraDiskUpdateWithoutDowntime(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.ultraDiskUpdateWithoutDowntime(data, 20),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("disk_size_gb").HasValue("20"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccManagedDisk_attachedNvmeDiskUpdateWithDowntime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nvmeDiskUpdateWithDowntime(data, 10),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.nvmeDiskUpdateWithDowntime(data, 20),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("disk_size_gb").HasValue("20"),
@@ -1793,6 +1839,89 @@ resource "azurerm_virtual_machine_data_disk_attachment" "test" {
 `, r.templateAttached(data), data.RandomInteger, diskSize)
 }
 
+func (r ManagedDiskResource) diskUpdateWithDowntime(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestvm-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+  zone                            = "1"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%[1]d-disk1"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = %[3]d
+  zone                 = "1"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+`, data.RandomInteger, data.Locations.Primary, diskSize)
+}
+
 func (r ManagedDiskResource) premiumV2DiskUpdateWithoutDowntime(data acceptance.TestData, diskSize int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1936,6 +2065,94 @@ resource "azurerm_linux_virtual_machine" "test" {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  additional_capabilities {
+    ultra_ssd_enabled = true
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%[1]d-disk1"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "UltraSSD_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = %[3]d
+  zone                 = "1"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+`, data.RandomInteger, data.Locations.Primary, diskSize)
+}
+
+func (r ManagedDiskResource) nvmeDiskUpdateWithDowntime(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestvm-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_E2bds_v5"
+  admin_username                  = "adminuser"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+  disk_controller_type            = "NVMe"
+  zone                            = "1"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
 

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -365,6 +365,52 @@ func TestAccManagedDisk_attachedDiskUpdate(t *testing.T) {
 	})
 }
 
+func TestAccManagedDisk_attachedPremiumV2DiskUpdateWithoutDowntime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.premiumV2DiskUpdateWithoutDowntime(data, 10),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.premiumV2DiskUpdateWithoutDowntime(data, 20),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("disk_size_gb").HasValue("20"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccManagedDisk_attachedUltraDiskUpdateWithoutDowntime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ultraDiskUpdateWithoutDowntime(data, 10),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ultraDiskUpdateWithoutDowntime(data, 20),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("disk_size_gb").HasValue("20"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccManagedDisk_attachedStorageTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
@@ -1745,6 +1791,176 @@ resource "azurerm_virtual_machine_data_disk_attachment" "test" {
   caching            = "None"
 }
 `, r.templateAttached(data), data.RandomInteger, diskSize)
+}
+
+func (r ManagedDiskResource) premiumV2DiskUpdateWithoutDowntime(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestvm-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_D2s_v3"
+  admin_username                  = "adminuser"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+  zone                            = "1"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%[1]d-disk1"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "PremiumV2_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = %[3]d
+  zone                 = "1"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+`, data.RandomInteger, data.Locations.Primary, diskSize)
+}
+
+func (r ManagedDiskResource) ultraDiskUpdateWithoutDowntime(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestvm-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_D2s_v3"
+  admin_username                  = "adminuser"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+  zone                            = "1"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  additional_capabilities {
+    ultra_ssd_enabled = true
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%[1]d-disk1"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "UltraSSD_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = %[3]d
+  zone                 = "1"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+`, data.RandomInteger, data.Locations.Primary, diskSize)
 }
 
 func (r ManagedDiskResource) tierUpdateWhileAttached(data acceptance.TestData, tier string) string {

--- a/internal/services/compute/no_downtime_resize.go
+++ b/internal/services/compute/no_downtime_resize.go
@@ -61,7 +61,8 @@ func determineIfVirtualMachineSupportsNoDowntimeResize(ctx context.Context, disk
 	virtualMachineId, err := virtualmachines.ParseVirtualMachineIDInsensitively(*virtualMachineIdRaw)
 	if err != nil {
 		log.Printf("[DEBUG] unable to parse Virtual Machine ID %q that the Managed Disk is attached too - skipping no-downtime-resize since we can't guarantee that's available", *virtualMachineIdRaw)
-		return pointer.To(false), nil // lint:ignore nilerr this is not an error as we just want to skip the check in this situation since we can't guarantee it's available
+		//nolint:nilerr // this is not an error as we just want to skip the check in this situation since we can't guarantee it's available
+		return pointer.To(false), nil
 	}
 
 	log.Printf("[DEBUG] Retrieving %s..", *virtualMachineId)
@@ -83,7 +84,6 @@ func determineIfVirtualMachineSupportsNoDowntimeResize(ctx context.Context, disk
 			if model.Properties.StorageProfile != nil && model.Properties.StorageProfile.DiskControllerType != nil {
 				vmDiskControllerType = string(*model.Properties.StorageProfile.DiskControllerType)
 			}
-
 		}
 	}
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 ~> **NOTE:** If No Downtime Resizing is not available, be aware that changing this value is disruptive if the disk is attached to a Virtual Machine. The VM will be shut down and de-allocated as required by Azure to action the change. Terraform will attempt to start the machine again after the update if it was in a `running` state when the apply was started.
 
-~> **NOTE:** When upgrading `disk_size_gb` from value less than 4095 to a value greater than 4095, the disk will be detached from its associated Virtual Machine as required by Azure to action the change. Terraform will attempt to reattach the disk again after the update.
+~> **NOTE:** When upgrading `disk_size_gb` from a value less than 4095 to one greater than 4095, and if `storage_account_type` is not set to `PremiumV2_LRS` or `UltraSSD_LRS`, the disk will be detached from its associated Virtual Machine as required by Azure to action the change. Terraform will attempt to reattach the disk again after the update.
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Managed Disk should exist. Changing this forces a new Managed Disk to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

According to [MS-DOC](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime), `azurerm_managed_disk` should support expanding without downtime for all types of `storage_account_type`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccManagedDisk_attachedDiskUpdate (624.88s)
--- PASS: TestAccManagedDisk_attachedDiskUpdateWithDowntime (567.79s)
--- PASS: TestAccManagedDisk_attachedNvmeDiskUpdateWithDowntime (565.66s)
--- PASS: TestAccManagedDisk_attachedPremiumV2DiskUpdateWithoutDowntime (451.35s)
--- PASS: TestAccManagedDisk_attachedUltraDiskUpdateWithoutDowntime (469.52s)

--- PASS: TestAccManagedDisk_fromPlatformImage (187.13s)
--- PASS: TestAccManagedDisk_empty (197.46s)
--- PASS: TestAccManagedDisk_networkPolicy (200.78s)
--- PASS: TestAccManagedDisk_importEmpty_withZone (221.15s)
--- PASS: TestAccManagedDisk_premiumV2WithIOpsReadOnlyAndMBpsReadOnly (279.64s)
--- PASS: TestAccManagedDisk_copy (152.12s)
--- PASS: TestAccManagedDisk_optimizedFrequentAttach (156.60s)
--- PASS: TestAccManagedDisk_performancePlus (126.39s)
--- PASS: TestAccManagedDisk_import (319.17s)
--- PASS: TestAccManagedDisk_update (163.14s)
--- PASS: TestAccManagedDisk_diskEncryptionSet_update (618.17s)
--- PASS: TestAccManagedDisk_upload (169.91s)
--- PASS: TestAccManagedDisk_attachedStorageTypeUpdate (690.34s)
--- PASS: TestAccManagedDisk_attachedTierUpdate (702.50s)
--- PASS: TestAccManagedDisk_premiumV2WithIOpsReadWriteAndMBpsReadWrite (221.42s)
--- PASS: TestAccManagedDisk_storageAccountType (167.86s)
--- PASS: TestAccManagedDisk_create_withHyperVGeneration (171.28s)
--- PASS: TestAccManagedDisk_create_withOnDemandBurstingEnabled (178.29s)
--- PASS: TestAccManagedDisk_import_withUltraSSD (153.47s)
--- PASS: TestAccManagedDisk_encryption (621.32s)
--- PASS: TestAccManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly (211.46s)
--- PASS: TestAccManagedDisk_update_withOnDemandBurstingEnabled (243.16s)
--- PASS: TestAccManagedDisk_create_withSecureVMDiskEncryptionSetId (475.66s)
--- PASS: TestAccManagedDisk_update_withUltraSSD (159.25s)
--- PASS: TestAccManagedDisk_zeroGbFromPlatformImage (134.83s)
--- PASS: TestAccManagedDisk_create_withUltraSSD (169.41s)
--- PASS: TestAccManagedDisk_create_withTrustedLaunchEnabled (181.28s)
--- PASS: TestAccManagedDisk_create_withSecurityType (193.10s)
--- PASS: TestAccManagedDisk_detachFromVM (584.27s)
--- PASS: TestAccManagedDisk_create_withLogicalSectorSize (172.30s)
--- PASS: TestAccManagedDisk_publicNetworkAccessUpdated (238.62s)
--- PASS: TestAccManagedDisk_fromGalleryImage (1153.23s)
--- PASS: TestAccManagedDisk_update_withMaxShares (208.70s)
--- PASS: TestAccManagedDisk_publicNetworkAccessDisabled (173.43s)
--- PASS: TestAccManagedDisk_diskEncryptionSet (465.86s)
--- PASS: TestAccManagedDisk_requiresImport (159.53s)
--- PASS: TestAccManagedDisk_publicNetworkAccessDefault (176.43s)
--- PASS: TestAccManagedDisk_networkPolicy_update_withAllowPrivate (287.41s)
--- PASS: TestAccManagedDisk_networkPolicy_create_withAllowPrivate (211.65s)
--- PASS: TestAccManagedDisk_onlineLiveResize (728.97s)
--- PASS: TestAccManagedDisk_networkPolicy_update (232.47s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_managed_disk` - support expanding disk size without downtime for all types of `storage_account_type`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes [#28603](https://github.com/hashicorp/terraform-provider-azurerm/issues/28603)
Fixes [#26550](https://github.com/hashicorp/terraform-provider-azurerm/issues/26550)

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
