### PR TITLE
`azurerm_postgresql_flexible_server_virtual_endpoint` - allow `source_server_id` and `replica_server_id` to be identical

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -154,33 +154,35 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 				if props := model.Properties; props != nil {
 					state.Type = string(pointer.From(props.EndpointType))
 
-					if props.Members == nil || len(*props.Members) != 2 {
-						// if members list is nil, this is an endpoint that was previously deleted
+					if props.Members == nil || len(*props.Members) == 0 {
+						// if members list is nil or empty, this is an endpoint that was previously deleted
 						log.Printf("[INFO] Postgresql Flexible Server Endpoint %q was previously deleted - removing from state", id.ID())
 						return metadata.MarkAsGone(id)
 					}
 
-					// Model.Properties.Members is a tuple => [source_server_id, replication_server_name]
-					sourceServerName := (*props.Members)[0]
-					replicaServerName := (*props.Members)[1]
+					state.SourceServerId = servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, (*props.Members)[0]).ID()
 
-					sourceServerId := servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, sourceServerName).ID()
+					// Model.Properties.Members can contain 1 member which means source and replica are identical, or it can contain
+					// 2 members when source and replica are different => [source_server_id, replication_server_name]
+					replicaServerId := servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, (*props.Members)[0]).ID()
 
-					replicaServer, err := lookupFlexibleServerByName(ctx, flexibleServerClient, id, replicaServerName, sourceServerId)
-					if err != nil {
-						return err
-					}
-
-					state.SourceServerId = sourceServerId
-
-					if replicaServer != nil {
-						replicaId, err := servers.ParseFlexibleServerID(*replicaServer.Id)
+					if len(*props.Members) == 2 {
+						replicaServer, err := lookupFlexibleServerByName(ctx, flexibleServerClient, id, (*props.Members)[1], state.SourceServerId)
 						if err != nil {
 							return err
 						}
 
-						state.ReplicaServerId = replicaId.ID()
+						if replicaServer != nil {
+							replicaId, err := servers.ParseFlexibleServerID(*replicaServer.Id)
+							if err != nil {
+								return err
+							}
+
+							replicaServerId = replicaId.ID()
+						}
 					}
+
+					state.ReplicaServerId = replicaServerId
 				}
 			}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Briefly considered turning `replica_server_id` into an `Optional`+`Computed` property but decided against it since I think it's beneficial to be clear and explicit that they're identical.

## Testing 

![image](https://github.com/user-attachments/assets/eec4c052-d72e-4f6f-baad-d43b6becb828)
![image](https://github.com/user-attachments/assets/3e920277-35c0-47a9-8bc3-25ebd3383a82)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server_virtual_endpoint` - allow `source_server_id` and `replica_server_id` to be identical [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28502


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
