### PR TITLE
`azurerm_storage_queue` - Support `storage_account_id`

### DIFF
--- a/internal/services/storage/storage_queue_data_source.go
+++ b/internal/services/storage/storage_queue_data_source.go
@@ -7,9 +7,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/queueservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/accounts"
@@ -17,7 +21,7 @@ import (
 )
 
 func dataSourceStorageQueue() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Read: dataSourceStorageQueueRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -30,75 +34,132 @@ func dataSourceStorageQueue() *pluginsdk.Resource {
 				Required: true,
 			},
 
-			"storage_account_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
+			"storage_account_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: commonids.ValidateStorageAccountID,
 			},
 
 			"metadata": MetaDataComputedSchema(),
-
-			"resource_manager_id": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["storage_account_name"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validate.StorageAccountName,
+			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
+			Deprecated:   "the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will be removed in version 5.0 of the Provider.",
+		}
+
+		r.Schema["storage_account_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateStorageAccountID,
+			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
+		}
+
+		r.Schema["resource_manager_id"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeString,
+			Computed:   true,
+			Deprecated: "this property has been deprecated in favour of `id` and will be removed in version 5.0 of the Provider.",
+		}
+	}
+
+	return r
 }
 
 func dataSourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	storageClient := meta.(*clients.Client).Storage
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	queueClient := meta.(*clients.Client).Storage.ResourceManager.QueueService
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	queueName := d.Get("name").(string)
-	accountName := d.Get("storage_account_name").(string)
 
-	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
-	if err != nil {
-		return fmt.Errorf("retrieving Storage Account %q for Queue %q: %v", accountName, queueName, err)
-	}
-	if account == nil {
-		return fmt.Errorf("locating Storage Account %q for Queue %q", accountName, queueName)
-	}
+	if !features.FivePointOh() {
+		if accountName := d.Get("storage_account_name").(string); accountName != "" {
+			storageClient := meta.(*clients.Client).Storage
+			account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
+			if err != nil {
+				return fmt.Errorf("retrieving Storage Account %q for Queue %q: %v", accountName, queueName, err)
+			}
+			if account == nil {
+				return fmt.Errorf("locating Storage Account %q for Queue %q", accountName, queueName)
+			}
 
-	queuesDataPlaneClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return fmt.Errorf("building Queues Client: %v", err)
-	}
+			queuesDataPlaneClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+			if err != nil {
+				return fmt.Errorf("building Queues Client: %v", err)
+			}
 
-	// Determine the queue endpoint, so we can build a data plane ID
-	endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeQueue)
-	if err != nil {
-		return fmt.Errorf("determining Queue endpoint: %v", err)
-	}
+			// Determine the queue endpoint, so we can build a data plane ID
+			endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeQueue)
+			if err != nil {
+				return fmt.Errorf("determining Queue endpoint: %v", err)
+			}
 
-	// Parse the queue endpoint as a data plane account ID
-	accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
-	if err != nil {
-		return fmt.Errorf("parsing Account ID: %v", err)
-	}
+			// Parse the queue endpoint as a data plane account ID
+			accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
+			if err != nil {
+				return fmt.Errorf("parsing Account ID: %v", err)
+			}
 
-	id := queues.NewQueueID(*accountId, queueName)
+			id := queues.NewQueueID(*accountId, queueName)
 
-	props, err := queuesDataPlaneClient.Get(ctx, queueName)
-	if err != nil {
-		return fmt.Errorf("retrieving %s: %v", id, err)
-	}
+			props, err := queuesDataPlaneClient.Get(ctx, queueName)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %v", id, err)
+			}
 
-	d.SetId(id.ID())
+			d.SetId(id.ID())
 
-	d.Set("name", queueName)
-	d.Set("storage_account_name", accountName)
+			d.Set("name", queueName)
+			d.Set("storage_account_name", accountName)
 
-	if props != nil {
-		if err = d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
-			return fmt.Errorf("setting `metadata`: %v", err)
+			if props != nil {
+				if err = d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
+					return fmt.Errorf("setting `metadata`: %v", err)
+				}
+			}
+
+			resourceManagerId := parse.NewStorageQueueResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", queueName)
+			d.Set("resource_manager_id", resourceManagerId.ID())
+
+			return nil
 		}
 	}
 
-	resourceManagerId := parse.NewStorageQueueResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", queueName)
-	d.Set("resource_manager_id", resourceManagerId.ID())
+	accountId, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := queueservice.NewQueueID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.StorageAccountName, queueName)
+
+	resp, err := queueClient.QueueGet(ctx, id)
+	if err != nil {
+		return fmt.Errorf("retrieving %q: %v", id, err)
+	}
+
+	d.Set("name", id.QueueName)
+	d.Set("storage_account_id", commonids.NewStorageAccountID(id.SubscriptionId, id.ResourceGroupName, id.StorageAccountName).ID())
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if metadata := props.Metadata; metadata != nil {
+				if err := d.Set("metadata", FlattenMetaData(*metadata)); err != nil {
+					return fmt.Errorf("setting `metadata`: %s", err)
+				}
+			}
+		}
+	}
+
+	if !features.FivePointOh() {
+		d.Set("resource_manager_id", id.ID())
+	}
+
+	d.SetId(id.ID())
 
 	return nil
 }

--- a/internal/services/storage/storage_queue_data_source_test.go
+++ b/internal/services/storage/storage_queue_data_source_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type StorageQueueDataSource struct{}
@@ -27,6 +28,24 @@ func TestAccDataSourceStorageQueue_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccDataSourceStorageQueue_basicDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as not valid in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_queue", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageQueueDataSource{}.basicDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("metadata.%").HasValue("2"),
+				check.That(data.ResourceName).Key("metadata.k1").HasValue("v1"),
+				check.That(data.ResourceName).Key("metadata.k2").HasValue("v2"),
+			),
+		},
+	})
+}
 
 func (d StorageQueueDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -35,7 +54,42 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "queuedstest-%[1]s"
+  name     = "acctestqueue-%[1]s"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "acctestsadsc%[1]s"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_queue" "test" {
+  name               = "queuedstest-%[1]s"
+  storage_account_id = azurerm_storage_account.test.id
+  metadata = {
+    k1 = "v1"
+    k2 = "v2"
+  }
+}
+
+data "azurerm_storage_queue" "test" {
+  name               = azurerm_storage_queue.test.name
+  storage_account_id = azurerm_storage_queue.test.storage_account_id
+}
+`, data.RandomString, data.Locations.Primary, data.RandomInteger)
+}
+func (d StorageQueueDataSource) basicDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestqueue-%[1]s"
   location = "%[2]s"
 }
 

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -6,10 +6,16 @@ package storage
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/queueservice"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
@@ -22,13 +28,22 @@ import (
 )
 
 func resourceStorageQueue() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceStorageQueueCreate,
 		Read:   resourceStorageQueueRead,
 		Update: resourceStorageQueueUpdate,
 		Delete: resourceStorageQueueDelete,
 
 		Importer: helpers.ImporterValidatingStorageResourceId(func(id, storageDomainSuffix string) error {
+			if !features.FivePointOh() {
+				if strings.HasPrefix(id, "/subscriptions/") {
+					_, err := queueservice.ParseQueueID(id)
+					return err
+				}
+				_, err := queues.ParseQueueID(id, storageDomainSuffix)
+				return err
+			}
+
 			_, err := queues.ParseQueueID(id, storageDomainSuffix)
 			return err
 		}),
@@ -53,190 +68,335 @@ func resourceStorageQueue() *pluginsdk.Resource {
 				ValidateFunc: validate.StorageQueueName,
 			},
 
-			"storage_account_name": {
+			"storage_account_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.StorageAccountName,
+				ValidateFunc: commonids.ValidateStorageAccountID,
 			},
 
 			"metadata": MetaDataSchema(),
-
-			"resource_manager_id": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["storage_account_name"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.StorageAccountName,
+			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
+			Deprecated:   "the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will be removed in version 5.0 of the Provider.",
+		}
+
+		r.Schema["storage_account_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateStorageAccountID,
+			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
+		}
+
+		r.Schema["resource_manager_id"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeString,
+			Computed:   true,
+			Deprecated: "this property has been deprecated in favour of `id` and will be removed in version 5.0 of the Provider.",
+		}
+	}
+
+	return r
 }
 
 func resourceStorageQueueCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	storageClient := meta.(*clients.Client).Storage
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	queueClient := meta.(*clients.Client).Storage.ResourceManager.QueueService
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	queueName := d.Get("name").(string)
-	accountName := d.Get("storage_account_name").(string)
 
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := ExpandMetaData(metaDataRaw)
 
-	account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
-	if err != nil {
-		return fmt.Errorf("retrieving Account %q for Queue %q: %v", accountName, queueName, err)
+	if !features.FivePointOh() {
+		if accountName := d.Get("storage_account_name").(string); accountName != "" {
+			storageClient := meta.(*clients.Client).Storage
+
+			account, err := storageClient.FindAccount(ctx, subscriptionId, accountName)
+			if err != nil {
+				return fmt.Errorf("retrieving Account %q for Queue %q: %v", accountName, queueName, err)
+			}
+			if account == nil {
+				return fmt.Errorf("locating Storage Account %q", accountName)
+			}
+
+			queuesDataPlaneClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+			if err != nil {
+				return fmt.Errorf("building Queues Client: %v", err)
+			}
+
+			// Determine the queue endpoint, so we can build a data plane ID
+			endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeQueue)
+			if err != nil {
+				return fmt.Errorf("determining Queue endpoint: %v", err)
+			}
+
+			// Parse the queue endpoint as a data plane account ID
+			accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
+			if err != nil {
+				return fmt.Errorf("parsing Account ID: %v", err)
+			}
+
+			id := queues.NewQueueID(*accountId, queueName).ID()
+
+			exists, err := queuesDataPlaneClient.Exists(ctx, queueName)
+			if err != nil {
+				return fmt.Errorf("checking for existing %s: %v", id, err)
+			}
+			if exists != nil && *exists {
+				return tf.ImportAsExistsError("azurerm_storage_queue", id)
+			}
+
+			if err = queuesDataPlaneClient.Create(ctx, queueName, metaData); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			d.SetId(id)
+
+			return resourceStorageQueueRead(d, meta)
+		}
 	}
-	if account == nil {
-		return fmt.Errorf("locating Storage Account %q", accountName)
-	}
 
-	queuesDataPlaneClient, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return fmt.Errorf("building Queues Client: %v", err)
-	}
-
-	// Determine the queue endpoint, so we can build a data plane ID
-	endpoint, err := account.DataPlaneEndpoint(client.EndpointTypeQueue)
-	if err != nil {
-		return fmt.Errorf("determining Queue endpoint: %v", err)
-	}
-
-	// Parse the queue endpoint as a data plane account ID
-	accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
-	if err != nil {
-		return fmt.Errorf("parsing Account ID: %v", err)
-	}
-
-	id := queues.NewQueueID(*accountId, queueName).ID()
-
-	exists, err := queuesDataPlaneClient.Exists(ctx, queueName)
-	if err != nil {
-		return fmt.Errorf("checking for existing %s: %v", id, err)
-	}
-	if exists != nil && *exists {
-		return tf.ImportAsExistsError("azurerm_storage_queue", id)
-	}
-
-	if err = queuesDataPlaneClient.Create(ctx, queueName, metaData); err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	d.SetId(id)
-
-	return resourceStorageQueueRead(d, meta)
-}
-
-func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	storageClient := meta.(*clients.Client).Storage
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+	accountId, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
 	if err != nil {
 		return err
 	}
 
-	metaDataRaw := d.Get("metadata").(map[string]interface{})
-	metaData := ExpandMetaData(metaDataRaw)
+	id := queueservice.NewQueueID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.StorageAccountName, queueName)
 
-	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
+	existing, err := queueClient.QueueGet(ctx, id)
 	if err != nil {
-		return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("checking for existing %q: %v", id, err)
+		}
 	}
-	if account == nil {
-		return fmt.Errorf("locating Storage Account %q", id.AccountId.AccountName)
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_storage_queue", id.ID())
 	}
 
-	client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+	payload := queueservice.StorageQueue{
+		Properties: &queueservice.QueueProperties{
+			Metadata: &metaData,
+		},
+	}
+
+	if _, err := queueClient.QueueCreate(ctx, id, payload); err != nil {
+		return fmt.Errorf("creating %s: %v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceStorageQueueRead(d, meta)
+
+}
+
+func resourceStorageQueueUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	queueClient := meta.(*clients.Client).Storage.ResourceManager.QueueService
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+		storageClient := meta.(*clients.Client).Storage
+
+		id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+		if err != nil {
+			return err
+		}
+
+		account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
+		if err != nil {
+			return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
+		}
+		if account == nil {
+			return fmt.Errorf("locating Storage Account %q", id.AccountId.AccountName)
+		}
+
+		client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		if err != nil {
+			return fmt.Errorf("building Queues Client: %v", err)
+		}
+
+		metaDataRaw := d.Get("metadata").(map[string]interface{})
+		metaData := ExpandMetaData(metaDataRaw)
+
+		if err = client.UpdateMetaData(ctx, id.QueueName, metaData); err != nil {
+			return fmt.Errorf("updating MetaData for %s: %v", id, err)
+		}
+
+		return resourceStorageQueueRead(d, meta)
+	}
+
+	id, err := queueservice.ParseQueueID(d.Id())
 	if err != nil {
-		return fmt.Errorf("building Queues Client: %v", err)
+		return err
 	}
 
-	if err = client.UpdateMetaData(ctx, id.QueueName, metaData); err != nil {
-		return fmt.Errorf("updating MetaData for %s: %v", id, err)
+	existing, err := queueClient.QueueGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %q: %v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("unexpected null model after retrieving %v", id)
+	}
+
+	payload := queueservice.StorageQueue{
+		Properties: existing.Model.Properties,
+	}
+
+	if d.HasChange("metadata") {
+		metaDataRaw := d.Get("metadata").(map[string]interface{})
+		payload.Properties.Metadata = pointer.To(ExpandMetaData(metaDataRaw))
+	}
+
+	if _, err := queueClient.QueueUpdate(ctx, *id, payload); err != nil {
+		return fmt.Errorf("updating %s: %v", id, err)
 	}
 
 	return resourceStorageQueueRead(d, meta)
 }
 
 func resourceStorageQueueRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	storageClient := meta.(*clients.Client).Storage
+	queueClient := meta.(*clients.Client).Storage.ResourceManager.QueueService
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+		storageClient := meta.(*clients.Client).Storage
+
+		id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+		if err != nil {
+			return err
+		}
+
+		account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
+		if err != nil {
+			return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
+		}
+		if account == nil {
+			log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountId.AccountName)
+			d.SetId("")
+			return nil
+		}
+
+		client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		if err != nil {
+			return fmt.Errorf("building Queues Client: %v", err)
+		}
+
+		queue, err := client.Get(ctx, id.QueueName)
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %v", id, err)
+		}
+		if queue == nil {
+			log.Printf("[INFO] Storage Queue %q no longer exists, removing from state...", id.QueueName)
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("name", id.QueueName)
+		d.Set("storage_account_name", id.AccountId.AccountName)
+
+		if err := d.Set("metadata", FlattenMetaData(queue.MetaData)); err != nil {
+			return fmt.Errorf("setting `metadata`: %s", err)
+		}
+
+		resourceManagerId := parse.NewStorageQueueResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, "default", id.QueueName)
+		d.Set("resource_manager_id", resourceManagerId.ID())
+
+		return nil
+	}
+
+	id, err := queueservice.ParseQueueID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
+	existing, err := queueClient.QueueGet(ctx, *id)
 	if err != nil {
-		return fmt.Errorf("retrieving Account %q for Queue %q: %v", id.AccountId.AccountName, id.QueueName, err)
-	}
-	if account == nil {
-		log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountId.AccountName)
-		d.SetId("")
-		return nil
-	}
-
-	client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return fmt.Errorf("building Queues Client: %v", err)
-	}
-
-	queue, err := client.Get(ctx, id.QueueName)
-	if err != nil {
-		return fmt.Errorf("retrieving %s: %v", id, err)
-	}
-	if queue == nil {
-		log.Printf("[INFO] Storage Queue %q no longer exists, removing from state...", id.QueueName)
-		d.SetId("")
-		return nil
+		if response.WasNotFound(existing.HttpResponse) {
+			log.Printf("[DEBUG] %q was not found, removing from state", *id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
 	d.Set("name", id.QueueName)
-	d.Set("storage_account_name", id.AccountId.AccountName)
+	d.Set("storage_account_id", commonids.NewStorageAccountID(id.SubscriptionId, id.ResourceGroupName, id.StorageAccountName).ID())
 
-	if err := d.Set("metadata", FlattenMetaData(queue.MetaData)); err != nil {
-		return fmt.Errorf("setting `metadata`: %s", err)
+	if model := existing.Model; model != nil {
+		if prop := model.Properties; prop != nil {
+			if metadata := prop.Metadata; metadata != nil {
+				if err := d.Set("metadata", FlattenMetaData(*metadata)); err != nil {
+					return fmt.Errorf("setting `metadata`: %s", err)
+				}
+			}
+		}
 	}
 
-	resourceManagerId := parse.NewStorageQueueResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, "default", id.QueueName)
-	d.Set("resource_manager_id", resourceManagerId.ID())
+	if !features.FivePointOh() {
+		d.Set("resource_manager_id", id.ID())
+	}
 
 	return nil
 }
 
 func resourceStorageQueueDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	storageClient := meta.(*clients.Client).Storage
+	queueClient := meta.(*clients.Client).Storage.ResourceManager.QueueService
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+		storageClient := meta.(*clients.Client).Storage
+		id, err := queues.ParseQueueID(d.Id(), storageClient.StorageDomainSuffix)
+		if err != nil {
+			return err
+		}
+
+		account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
+		if err != nil {
+			return fmt.Errorf("retrieving Account %q for Queue %q: %s", id.AccountId.AccountName, id.QueueName, err)
+		}
+		if account == nil {
+			log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountId.AccountName)
+			d.SetId("")
+			return nil
+		}
+
+		client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
+		if err != nil {
+			return fmt.Errorf("building Queues Client: %v", err)
+		}
+
+		if err = client.Delete(ctx, id.QueueName); err != nil {
+			return fmt.Errorf("deleting %s: %v", id, err)
+		}
+		return nil
+	}
+
+	id, err := queueservice.ParseQueueID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	account, err := storageClient.FindAccount(ctx, subscriptionId, id.AccountId.AccountName)
-	if err != nil {
-		return fmt.Errorf("retrieving Account %q for Queue %q: %s", id.AccountId.AccountName, id.QueueName, err)
-	}
-	if account == nil {
-		log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountId.AccountName)
-		d.SetId("")
-		return nil
-	}
-
-	client, err := storageClient.QueuesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return fmt.Errorf("building Queues Client: %v", err)
-	}
-
-	if err = client.Delete(ctx, id.QueueName); err != nil {
-		return fmt.Errorf("deleting %s: %v", id, err)
+	if resp, err := queueClient.QueueDelete(ctx, *id); err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("deleting %s: %v", id, err)
+		}
 	}
 
 	return nil

--- a/internal/services/storage/storage_queue_resource_test.go
+++ b/internal/services/storage/storage_queue_resource_test.go
@@ -6,11 +6,15 @@ package storage_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/queueservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/queue/queues"
@@ -25,6 +29,25 @@ func TestAccStorageQueue_basic(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageQueue_basicDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as not valid in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicDeprecated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -48,6 +71,25 @@ func TestAccStorageQueue_basicAzureADAuth(t *testing.T) {
 	})
 }
 
+func TestAccStorageQueue_basicAzureADAuthDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as not valid in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAzureADAuthDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageQueue_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
 	r := StorageQueueResource{}
@@ -60,6 +102,25 @@ func TestAccStorageQueue_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccStorageQueue_requiresImportDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as not valid in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImportDeprecated),
 	})
 }
 
@@ -85,30 +146,81 @@ func TestAccStorageQueue_metaData(t *testing.T) {
 	})
 }
 
+func TestAccStorageQueue_metaDataDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as not valid in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.metaDataDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.metaDataUpdatedDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageQueueResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := queues.ParseQueueID(state.ID, client.Storage.StorageDomainSuffix)
+	if !features.FivePointOh() && !strings.HasPrefix(state.ID, "/subscriptions") {
+		id, err := queues.ParseQueueID(state.ID, client.Storage.StorageDomainSuffix)
+		if err != nil {
+			return nil, err
+		}
+		account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId.AccountName, id.QueueName, err)
+		}
+		if account == nil {
+			return nil, fmt.Errorf("unable to determine Resource Group for Storage Queue %q (Account %q)", id.QueueName, id.AccountId.AccountName)
+		}
+		queuesClient, err := client.Storage.QueuesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
+		if err != nil {
+			return nil, fmt.Errorf("building Queues Client: %+v", err)
+		}
+		queue, err := queuesClient.Get(ctx, id.QueueName)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving Queue %q (Account %q): %+v", id.QueueName, id.AccountId.AccountName, err)
+		}
+		return utils.Bool(queue != nil), nil
+	}
+
+	id, err := queueservice.ParseQueueID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
+	existing, err := client.Storage.ResourceManager.QueueService.QueueGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Account %q for Queue %q: %+v", id.AccountId.AccountName, id.QueueName, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	if account == nil {
-		return nil, fmt.Errorf("unable to determine Resource Group for Storage Queue %q (Account %q)", id.QueueName, id.AccountId.AccountName)
-	}
-	queuesClient, err := client.Storage.QueuesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return nil, fmt.Errorf("building Queues Client: %+v", err)
-	}
-	queue, err := queuesClient.Get(ctx, id.QueueName)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving Queue %q (Account %q): %+v", id.QueueName, id.AccountId.AccountName, err)
-	}
-	return utils.Bool(queue != nil), nil
+
+	return pointer.To(existing.Model != nil), nil
 }
 
 func (r StorageQueueResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "test" {
+  name               = "mysamplequeue-%d"
+  storage_account_id = azurerm_storage_account.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func (r StorageQueueResource) basicDeprecated(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -145,6 +257,37 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
+  name               = "mysamplequeue-%d"
+  storage_account_id = azurerm_storage_account.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r StorageQueueResource) basicAzureADAuthDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  storage_use_azuread = true
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
   name                 = "mysamplequeue-%d"
   storage_account_name = azurerm_storage_account.test.name
 }
@@ -153,6 +296,18 @@ resource "azurerm_storage_queue" "test" {
 
 func (r StorageQueueResource) requiresImport(data acceptance.TestData) string {
 	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "import" {
+  name               = azurerm_storage_queue.test.name
+  storage_account_id = azurerm_storage_queue.test.storage_account_id
+}
+`, template)
+}
+
+func (r StorageQueueResource) requiresImportDeprecated(data acceptance.TestData) string {
+	template := r.basicDeprecated(data)
 	return fmt.Sprintf(`
 %s
 
@@ -169,6 +324,22 @@ func (r StorageQueueResource) metaData(data acceptance.TestData) string {
 %s
 
 resource "azurerm_storage_queue" "test" {
+  name               = "mysamplequeue-%d"
+  storage_account_id = azurerm_storage_account.test.id
+
+  metadata = {
+    hello = "world"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r StorageQueueResource) metaDataDeprecated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "test" {
   name                 = "mysamplequeue-%d"
   storage_account_name = azurerm_storage_account.test.name
 
@@ -180,6 +351,23 @@ resource "azurerm_storage_queue" "test" {
 }
 
 func (r StorageQueueResource) metaDataUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "test" {
+  name               = "mysamplequeue-%d"
+  storage_account_id = azurerm_storage_account.test.id
+
+  metadata = {
+    hello = "world"
+    rick  = "M0rty"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r StorageQueueResource) metaDataUpdatedDeprecated(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s

--- a/website/docs/d/storage_queue.html.markdown
+++ b/website/docs/d/storage_queue.html.markdown
@@ -25,7 +25,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Queue.
 
-* `storage_account_name` - (Required) The name of the Storage Account where the Queue exists.
+* `storage_account_name` - (Optional) The name of the Storage Account where the Queue exists. This property is deprecated in favour of `storage_account_id`.
+
+* `storage_account_id` - (Optional) The name of the Storage Account where the Queue exists. This property will become Required in version 5.0 of the Provider.
+
+~> **NOTE:** One of `storage_account_name` or `storage_account_id` must be specified. When specifying `storage_account_id` the resource will use the Resource Manager API, rather than the Data Plane API.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -38,7 +38,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Queue which should be created within the Storage Account. Must be unique within the storage account the queue is located. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) Specifies the Storage Account in which the Storage Queue should exist. Changing this forces a new resource to be created.
+* `storage_account_name` - (Optional) The name of the Storage Account where the Storage Queue should be created. Changing this forces a new resource to be created. This property is deprecated in favour of `storage_account_id`.
+
+* `storage_account_id` - (Optional) The name of the Storage Account where the Storage Queue should be created. Changing this forces a new resource to be created.
+
+~> **NOTE:** One of `storage_account_name` or `storage_account_id` must be specified. When specifying `storage_account_id` the resource will use the Resource Manager API, rather than the Data Plane API.
 
 * `metadata` - (Optional) A mapping of MetaData which should be assigned to this Storage Queue.
 
@@ -63,6 +67,14 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 Storage Queue's can be imported using the `resource id`, e.g.
 
+If `storage_account_name` is used:
+
 ```shell
 terraform import azurerm_storage_queue.queue1 https://example.queue.core.windows.net/queue1
+```
+
+If `storage_account_id` is used:
+
+```shell
+terraform import azurerm_storage_queue.queue1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount/queueServices/default/queues
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR introduces the `storage_account_id` to supersede the `storage_account_name` property into `azurerm_storage_queue`. This allows the provider to create and manage the resource via the Resource Manager API rather than the Data Plane.
Existing resources using the `storage_account_name` property cannot be migrated directly, but can be removed and re-imported using the Resource Manager ID type.

The `storage_account_name` property is now deprecated and will be removed in v5.0 of the provider.

The `resource_manager_id` property is now deprecated and will be removed in v5.0 of the provider, this value is available as id in resources using `storage_account_id`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
$ TF_ACC=1 go test -v -timeout=20h -parallel=20 -run='(TestAccStorageQueue_|TestAccDataSourceStorageQueue_)' ./internal/services/storage
=== RUN   TestAccDataSourceStorageQueue_basic
=== PAUSE TestAccDataSourceStorageQueue_basic
=== RUN   TestAccDataSourceStorageQueue_basicDeprecated
=== PAUSE TestAccDataSourceStorageQueue_basicDeprecated
=== RUN   TestAccStorageQueue_basic
=== PAUSE TestAccStorageQueue_basic
=== RUN   TestAccStorageQueue_basicDeprecated
=== PAUSE TestAccStorageQueue_basicDeprecated
=== RUN   TestAccStorageQueue_basicAzureADAuth
=== PAUSE TestAccStorageQueue_basicAzureADAuth
=== RUN   TestAccStorageQueue_basicAzureADAuthDeprecated
=== PAUSE TestAccStorageQueue_basicAzureADAuthDeprecated
=== RUN   TestAccStorageQueue_requiresImport
=== PAUSE TestAccStorageQueue_requiresImport
=== RUN   TestAccStorageQueue_requiresImportDeprecated
=== PAUSE TestAccStorageQueue_requiresImportDeprecated
=== RUN   TestAccStorageQueue_metaData
=== PAUSE TestAccStorageQueue_metaData
=== RUN   TestAccStorageQueue_metaDataDeprecated
=== PAUSE TestAccStorageQueue_metaDataDeprecated
=== CONT  TestAccDataSourceStorageQueue_basic
=== CONT  TestAccStorageQueue_basicAzureADAuthDeprecated
=== CONT  TestAccStorageQueue_metaData
=== CONT  TestAccStorageQueue_requiresImportDeprecated
=== CONT  TestAccStorageQueue_requiresImport
=== CONT  TestAccStorageQueue_basicAzureADAuth
=== CONT  TestAccStorageQueue_metaDataDeprecated
=== CONT  TestAccDataSourceStorageQueue_basicDeprecated
=== CONT  TestAccStorageQueue_basicDeprecated
=== CONT  TestAccStorageQueue_basic
--- PASS: TestAccDataSourceStorageQueue_basic (184.06s)
--- PASS: TestAccDataSourceStorageQueue_basicDeprecated (185.39s)
--- PASS: TestAccStorageQueue_requiresImportDeprecated (194.65s)
--- PASS: TestAccStorageQueue_requiresImport (198.92s)
--- PASS: TestAccStorageQueue_basic (208.35s)
--- PASS: TestAccStorageQueue_basicDeprecated (211.60s)
--- PASS: TestAccStorageQueue_basicAzureADAuthDeprecated (214.12s)
--- PASS: TestAccStorageQueue_basicAzureADAuth (214.41s)
--- PASS: TestAccStorageQueue_metaData (275.78s)
--- PASS: TestAccStorageQueue_metaDataDeprecated (290.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       290.867s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_queue` - Support `storage_account_id` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Relating to https://github.com/hashicorp/terraform-provider-azurerm/pull/27733

Fixes #28562


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
