### PR TITLE
`azurerm_hdinsight_spark_cluster`: add support for `availability_zones`

### DIFF
--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -351,6 +351,19 @@ func expandHDInsightsMetastore(input []interface{}) map[string]interface{} {
 	return config
 }
 
+func expandHDInsightAvailabilityZones(input []interface{}) *[]string {
+	if len(input) == 0 {
+		return nil
+	}
+
+	zones := make([]string, 0)
+	for _, v := range input {
+		zones = append(zones, v.(string))
+	}
+
+	return pointer.To(zones)
+}
+
 func flattenHDInsightsMetastores(d *pluginsdk.ResourceData, configurations map[string]map[string]string) {
 	result := map[string]interface{}{}
 

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -75,6 +75,14 @@ func resourceHDInsightSparkCluster() *pluginsdk.Resource {
 
 			"location": commonschema.Location(),
 
+			"availability_zones": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
 			"cluster_version": SchemaHDInsightClusterVersion(),
 
 			"tier": SchemaHDInsightTier(),
@@ -172,6 +180,9 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightSparkComponentVersion(componentVersionsRaw)
 
+	availabilityZonesRaw := d.Get("availability_zones").([]interface{})
+	availabilityZones := expandHDInsightAvailabilityZones(availabilityZonesRaw)
+
 	gatewayRaw := d.Get("gateway").([]interface{})
 	configurations := ExpandHDInsightsConfigurations(gatewayRaw)
 
@@ -246,6 +257,7 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 			},
 			ComputeIsolationProperties: computeIsolationProperties,
 		},
+		Zones:    availabilityZones,
 		Tags:     tags.Expand(t),
 		Identity: expandedIdentity,
 	}
@@ -349,6 +361,7 @@ func resourceHDInsightSparkClusterRead(d *pluginsdk.ResourceData, meta interface
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))
+		d.Set("availability_zones", pointer.From(model.Zones))
 
 		// storage_account isn't returned so I guess we just leave it ¯\_(ツ)_/¯
 		if props := model.Properties; props != nil {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1327,7 +1327,7 @@ resource "azurerm_storage_container" "test" {
   storage_account_name  = azurerm_storage_account.test.name
   container_access_type = "private"
 }
-`, data.RandomInteger, "east us", data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (HDInsightSparkClusterResource) gen2template(data acceptance.TestData) string {

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -89,7 +89,9 @@ The following arguments are supported:
 
 * `cluster_version` - (Required) Specifies the Version of HDInsights which should be used for this Cluster. Changing this forces a new resource to be created.
 
-* `component_version` - (Required) A `component_version` block as defined below.
+* `component_version` - (Required) A `component_version` block as defined below. Changing this forces a new resource to be created.
+
+* `availability_zones` - (Optional) Specifies the Availability Zones which this HDInsight Spark Cluster should exist.
 
 * `encryption_in_transit_enabled` - (Optional) Whether encryption in transit is enabled for this Cluster. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_hdinsight_spark_cluster`: add support for `availability_zones`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28130


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
