### PR TITLE
`azurerm_logic_app_standard` - support disabling default basic auth policies

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -81,12 +81,22 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"ftp_publish_basic_authentication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"https_only": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
+			"scm_publish_basic_authentication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
 
 			"site_config": schemaLogicAppStandardSiteConfig(),
 
@@ -312,6 +322,28 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 
 	if model := connectionStringsResp.Model; model != nil {
 		if err = d.Set("connection_string", flattenLogicAppStandardDataSourceConnectionStrings(model.Properties)); err != nil {
+			return err
+		}
+	}
+
+	ftpBasicAuth, err := client.GetFtpAllowed(ctx, id)
+	if err != nil || ftpBasicAuth.Model == nil {
+		return fmt.Errorf("retrieving FTP publish basic authentication policy for %s: %+v", id, err)
+	}
+
+	if props := ftpBasicAuth.Model.Properties; props != nil {
+		if err := d.Set("ftp_publish_basic_authentication_enabled", props.Allow); err != nil {
+			return err
+		}
+	}
+
+	scmBasicAuth, err := client.GetScmAllowed(ctx, id)
+	if err != nil || scmBasicAuth.Model == nil {
+		return fmt.Errorf("retrieving SCM publish basic authentication policy for %s: %+v", id, err)
+	}
+
+	if props := scmBasicAuth.Model.Properties; props != nil {
+		if err := d.Set("scm_publish_basic_authentication_enabled", props.Allow); err != nil {
 			return err
 		}
 	}

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -332,9 +332,7 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if props := ftpBasicAuth.Model.Properties; props != nil {
-		if err := d.Set("ftp_publish_basic_authentication_enabled", props.Allow); err != nil {
-			return err
-		}
+		d.Set("ftp_publish_basic_authentication_enabled", props.Allow)
 	}
 
 	scmBasicAuth, err := client.GetScmAllowed(ctx, id)
@@ -343,9 +341,7 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if props := scmBasicAuth.Model.Properties; props != nil {
-		if err := d.Set("scm_publish_basic_authentication_enabled", props.Allow); err != nil {
-			return err
-		}
+		d.Set("scm_publish_basic_authentication_enabled", props.Allow)
 	}
 
 	configResp, err := client.GetConfiguration(ctx, id)

--- a/internal/services/logic/logic_app_standard_data_source_test.go
+++ b/internal/services/logic/logic_app_standard_data_source_test.go
@@ -21,11 +21,13 @@ func TestAccLogicAppStandardDataSource_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("custom_domain_verification_id").Exists(),
+				check.That(data.ResourceName).Key("ftp_publish_basic_authentication_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,workflowapp"),
-				check.That(data.ResourceName).Key("version").HasValue("~4"),
 				check.That(data.ResourceName).Key("outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("possible_outbound_ip_addresses").Exists(),
-				check.That(data.ResourceName).Key("custom_domain_verification_id").Exists(),
+				check.That(data.ResourceName).Key("scm_publish_basic_authentication_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("version").HasValue("~4"),
 			),
 		},
 	})

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -393,6 +393,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	d.SetId(id.ID())
 
+	// This setting is enabled by default on creation of a logic app, we only need to update if config sets this as `false`
 	if ftpAuth := d.Get("ftp_publish_basic_authentication_enabled").(bool); !ftpAuth {
 		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
 			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
@@ -405,6 +406,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
+	// This setting is enabled by default on creation of a logic app, we only need to update if config sets this as `false`
 	if scmAuth := d.Get("scm_publish_basic_authentication_enabled").(bool); !scmAuth {
 		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
 			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
@@ -555,6 +557,8 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
+	// HasChange will return `true` when config specifies this argument as `true` during initial creation.
+	// To avoid unnecessary updates, check if the resource is new.
 	if d.HasChange("ftp_publish_basic_authentication_enabled") && !d.IsNewResource() {
 		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
 			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
@@ -567,6 +571,8 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
+	// HasChange will return `true` when config specifies this argument as `true` during initial creation.
+	// To avoid unnecessary updates, check if the resource is new.
 	if d.HasChange("scm_publish_basic_authentication_enabled") && !d.IsNewResource() {
 		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
 			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
@@ -719,9 +725,7 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if props := ftpBasicAuth.Model.Properties; props != nil {
-		if err := d.Set("ftp_publish_basic_authentication_enabled", props.Allow); err != nil {
-			return err
-		}
+		d.Set("ftp_publish_basic_authentication_enabled", props.Allow)
 	}
 
 	scmBasicAuth, err := client.GetScmAllowed(ctx, *id)
@@ -730,9 +734,7 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if props := scmBasicAuth.Model.Properties; props != nil {
-		if err := d.Set("scm_publish_basic_authentication_enabled", props.Allow); err != nil {
-			return err
-		}
+		d.Set("scm_publish_basic_authentication_enabled", props.Allow)
 	}
 
 	siteCredentials, err := helpers.ListPublishingCredentials(ctx, client, *id)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1947,6 +1947,9 @@ resource "azurerm_app_service_plan" "test" {
 
 func (LogicAppStandardResource) templateLinux(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
@@ -2233,10 +2236,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) siteConfigPublicNetworkAccessEnabled(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -41,6 +41,34 @@ func TestAccLogicAppStandard_basic(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_publishBasicAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAuth(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicAuth(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(), {
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppStandard_publicNetworkAccessDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
@@ -1028,10 +1056,6 @@ func (r LogicAppStandardResource) hasExtensionBundleAppSetting(shouldExist bool)
 
 func (r LogicAppStandardResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1045,12 +1069,26 @@ resource "azurerm_logic_app_standard" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LogicAppStandardResource) publicNetworkAccess(data acceptance.TestData, status string) string {
+func (r LogicAppStandardResource) basicAuth(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  ftp_publish_basic_authentication_enabled = %[3]t
+  scm_publish_basic_authentication_enabled = %[3]t
+}
+`, r.template(data), data.RandomInteger, enabled)
 }
 
+func (r LogicAppStandardResource) publicNetworkAccess(data acceptance.TestData, status string) string {
+	return fmt.Sprintf(`
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1067,10 +1105,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) containerized(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1090,10 +1124,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) extensionBundle(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1111,10 +1141,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) siteConfigVnetRouteAllEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1133,9 +1159,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) appSettingsVnetRouteAllEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1153,7 +1176,6 @@ resource "azurerm_logic_app_standard" "test" {
 }
 
 func (r LogicAppStandardResource) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -1165,15 +1187,11 @@ resource "azurerm_logic_app_standard" "import" {
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 }
-`, template)
+`, r.basic(data))
 }
 
 func (r LogicAppStandardResource) tags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1194,11 +1212,8 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) tagsUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
+
 resource "azurerm_logic_app_standard" "test" {
   name                       = "acctest-%d-func"
   location                   = azurerm_resource_group.test.location
@@ -1217,10 +1232,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) version(data acceptance.TestData, version string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1241,10 +1252,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) appSettings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1266,10 +1273,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) customShare(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_storage_share" "custom" {
@@ -1297,11 +1300,8 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) siteConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
+
 resource "azurerm_logic_app_standard" "test" {
   name                       = "acctest-%d-func"
   location                   = azurerm_resource_group.test.location
@@ -1331,10 +1331,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) healthCheck(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1354,10 +1350,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) connectionStrings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1379,10 +1371,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) app64bit(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1402,10 +1390,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) httpsOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1422,10 +1406,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) basicIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1445,10 +1425,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) userAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_user_assigned_identity" "test" {
@@ -1478,10 +1454,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) corsSettings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1510,10 +1482,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) enableHttp2(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1533,10 +1501,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) minTlsVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1556,10 +1520,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) ftpsState(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1579,10 +1539,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) preWarmedInstanceCount(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1602,10 +1558,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) computedPreWarmedInstanceCount(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1621,10 +1573,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) oneIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1646,10 +1594,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) oneServiceTagIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1671,10 +1615,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) oneVNetSubnetIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_virtual_network" "test" {
@@ -1710,10 +1650,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) manyIpRestrictions(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1747,10 +1683,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) ipRestrictionRemoved(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1770,10 +1702,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) scmType(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1793,10 +1721,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) scmUseMainIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1819,10 +1743,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) scmIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1844,10 +1764,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) unsetScmIpRestriction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1867,10 +1783,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) scmMinTlsVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1890,10 +1802,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) updateStorageAccountKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1909,10 +1817,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) clientCertMode(data acceptance.TestData, modeValue string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1929,10 +1833,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) elasticInstanceMinimum(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1952,10 +1852,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) appScaleLimit(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -1975,10 +1871,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) runtimeScaleMonitoringEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -2000,10 +1892,6 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (r LogicAppStandardResource) dotnetVersion(data acceptance.TestData, functionVersion string, version string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_logic_app_standard" "test" {
@@ -2025,6 +1913,9 @@ resource "azurerm_logic_app_standard" "test" {
 
 func (LogicAppStandardResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -59,7 +59,8 @@ func TestAccLogicAppStandard_publishBasicAuth(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(), {
+		data.ImportStep(),
+		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/website/docs/d/logic_app_standard.html.markdown
+++ b/website/docs/d/logic_app_standard.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Logic App Standard 
 
 ```hcl
 data "azurerm_logic_app_standard" "example" {
-  name                = "logicappstd"
+  name                = "example-logic-app"
   resource_group_name = "example-rg"
 }
 
@@ -27,9 +27,9 @@ output "id" {
 
 The following arguments are supported:
 
-* `name` - The name of this Logic App.
+* `name` - (Required) The name of the Logic App.
 
-* `resource_group_name` - The name of the Resource Group where the Logic App exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the Logic App exists.
 
 ## Attributes Reference
 
@@ -61,6 +61,8 @@ The following attributes are exported:
 
 * `enabled` - Whether the Logic App is enabled.
 
+* `ftp_publish_basic_authentication_enabled` - Whether the default FTP basic authentication publishing profile is enabled.
+
 * `https_only` - Whether the Logic App can only be accessed via HTTPS.
 
 * `kind` - The kind of the Logic App.
@@ -70,6 +72,8 @@ The following attributes are exported:
 * `possible_outbound_ip_addresses` - The possible outbound IP addresses of the Logic App.
 
 * `public_network_access` - Whether Public Network Access should be enabled or not.
+
+* `scm_publish_basic_authentication_enabled` - Whether the default SCM basic authentication publishing profile is enabled.
 
 * `site_config` - A `site_config` object as defined below.
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -15,33 +15,29 @@ Manages a Logic App (Standard / Single Tenant)
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "azure-functions-test-rg"
+  name     = "example"
   location = "West Europe"
 }
 
 resource "azurerm_storage_account" "example" {
-  name                     = "functionsapptestsa"
+  name                     = "examplestorageaccount"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
-resource "azurerm_app_service_plan" "example" {
-  name                = "azure-functions-test-service-plan"
+resource "azurerm_service_plan" "example" {
+  name                = "example-service-plan"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  kind                = "elastic"
 
-
-  sku {
-    tier = "WorkflowStandard"
-    size = "WS1"
-  }
+  os_type = "Windows"
+  sku_name = "WS1"
 }
 
 resource "azurerm_logic_app_standard" "example" {
-  name                       = "test-azure-functions"
+  name                       = "example-logic-app"
   location                   = azurerm_resource_group.example.location
   resource_group_name        = azurerm_resource_group.example.name
   app_service_plan_id        = azurerm_app_service_plan.example.id
@@ -57,16 +53,14 @@ resource "azurerm_logic_app_standard" "example" {
 
 ## Example Usage (for container mode)
 
-~> **Note:** You must set `azurerm_app_service_plan` `kind` to `Linux` and `reserved` to `true` when used with `linux_fx_version`
-
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "azure-functions-test-rg"
+  name     = "example"
   location = "West Europe"
 }
 
 resource "azurerm_storage_account" "example" {
-  name                     = "functionsapptestsa"
+  name                     = "examplestorageaccount"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
@@ -74,7 +68,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_app_service_plan" "example" {
-  name                = "azure-functions-test-service-plan"
+  name                = "example-service-plan"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   kind                = "Linux"
@@ -87,7 +81,7 @@ resource "azurerm_app_service_plan" "example" {
 }
 
 resource "azurerm_logic_app_standard" "example" {
-  name                       = "test-azure-functions"
+  name                       = "example-logic-app"
   location                   = azurerm_resource_group.example.location
   resource_group_name        = azurerm_resource_group.example.name
   app_service_plan_id        = azurerm_app_service_plan.example.id
@@ -111,7 +105,7 @@ resource "azurerm_logic_app_standard" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Logic App Changing this forces a new resource to be created. 
+* `name` - (Required) Specifies the name of the Logic App. Changing this forces a new resource to be created. 
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Logic App. Changing this forces a new resource to be created.
 
@@ -123,13 +117,15 @@ The following arguments are supported:
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Logic App.
 
+---
+
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **NOTE:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
+~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
 
 * `use_extension_bundle` - (Optional) Should the logic app use the bundled extension package? If true, then application settings for `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` will be created. Defaults to `true`.
 
-* `bundle_version` - (Optional) If `use_extension_bundle` then controls the allowed range for bundle versions. Defaults to `[1.*, 2.0.0)`.
+* `bundle_version` - (Optional) If `use_extension_bundle` is set to `true` this controls the allowed range for bundle versions. Defaults to `[1.*, 2.0.0)`.
 
 * `connection_string` - (Optional) A `connection_string` block as defined below.
 
@@ -139,6 +135,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Logic App enabled? Defaults to `true`.
 
+* `ftp_publish_basic_authentication_enabled` - (Optional) Whether the FTP basic authentication publishing profile is enabled. Defaults to `true`. 
+
 * `https_only` - (Optional) Can the Logic App only be accessed via HTTPS? Defaults to `false`.
 
 * `identity` - (Optional) An `identity` block as defined below.
@@ -147,21 +145,21 @@ The following arguments are supported:
 
 ~> **Note:** Setting this property will also set it in the Site Config.
 
+* `scm_publish_basic_authentication_enabled` - (Optional) Whether the default SCM basic authentication publishing profile is enabled. Defaults to `true`.
+
 * `site_config` - (Optional) A `site_config` object as defined below.
 
-* `storage_account_share_name` - (Optional) The name of the share used by the logic app, if you want to use a custom name. This corresponds to the WEBSITE_CONTENTSHARE appsetting, which this resource will create for you. If you don't specify a name, then this resource will generate a dynamic name. This setting is useful if you want to provision a storage account and create a share using azurerm_storage_share
+* `storage_account_share_name` - (Optional) The name of the share used by the logic app, if you want to use a custom name. This corresponds to the WEBSITE_CONTENTSHARE appsetting, which this resource will create for you. If you don't specify a name, then this resource will generate a dynamic name. This setting is useful if you want to provision a storage account and create a share using `azurerm_storage_share`.
 
-~> **Note:** When integrating a `CI/CD pipeline` and expecting to run from a deployed package in `Azure` you must seed your `app settings` as part of terraform code for Logic App to be successfully deployed. `Important Default key pairs`: (`"WEBSITE_RUN_FROM_PACKAGE" = ""`, `"FUNCTIONS_WORKER_RUNTIME" = "node"` (or Python, etc), `"WEBSITE_NODE_DEFAULT_VERSION" = "10.14.1"`, `"APPINSIGHTS_INSTRUMENTATIONKEY" = ""`).
+~> **Note:** When integrating a `CI/CD pipeline` and expecting to run from a deployed package in `Azure` you must seed your `app settings` as part of terraform code for Logic App to be successfully deployed. `Important Default key pairs`: (`"WEBSITE_RUN_FROM_PACKAGE" = ""`, `"FUNCTIONS_WORKER_RUNTIME" = "node"` (or Python, etc.), `"WEBSITE_NODE_DEFAULT_VERSION" = "10.14.1"`, `"APPINSIGHTS_INSTRUMENTATIONKEY" = ""`).
 
 ~> **Note:**  When using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
 
 * `version` - (Optional) The runtime version associated with the Logic App. Defaults to `~4`.
 
-~> **Note:**  Logic App version `3.x` will be out of support from December 3 2022. For more details refer [Logic Apps Standard Support for Functions Runtime V4](https://azure.microsoft.com/en-us/updates/logic-apps-standard-support-for-functions-runtime-v4/)
-
 * `virtual_network_subnet_id` - (Optional) The subnet ID which will be used by this resource for [regional virtual network integration](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#regional-virtual-network-integration).
 
-~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simutaneously.
+~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
 
@@ -215,7 +213,9 @@ The `site_config` block supports the following:
 
 * `scm_type` - (Optional) The type of Source Control used by the Logic App in use by the Windows Function App. Defaults to `None`. Possible values are: `BitbucketGit`, `BitbucketHg`, `CodePlexGit`, `CodePlexHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `None`, `OneDrive`, `Tfs`, `VSO`, and `VSTSRM`
 
-* `linux_fx_version` - (Optional) Linux App Framework and version for the App Service, e.g. `DOCKER|(golang:latest)`. Setting this value will also set the `kind` of application deployed to `functionapp,linux,container,workflowapp`
+* `linux_fx_version` - (Optional) Linux App Framework and version for the App Service, e.g. `DOCKER|(golang:latest)`. Setting this value will also set the `kind` of application deployed to `functionapp,linux,container,workflowapp`.
+
+~> **Note:** You must set `os_type` in `azurerm_service_plan` to `Linux` when this property is set.
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the Logic App. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new Logic Apps.
 
@@ -249,9 +249,9 @@ An `identity` block supports the following:
 
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Logic App Standard.
 
-~> **NOTE:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Logic App has been created. More details are available below.
+~> **Note:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Logic App has been created. More details are available below.
 
-~> **NOTE:** The `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+~> **Note:** The `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 
 ---
 
@@ -263,7 +263,7 @@ A `ip_restriction` block supports the following:
 
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
+-> **Note:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 
@@ -283,7 +283,7 @@ A `scm_ip_restriction` block supports the following:
 
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
+-> **Note:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
 * `name` - (Optional) The name for this IP Restriction.
 
@@ -309,13 +309,13 @@ A `headers` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Logic App
+* `id` - The ID of the Logic App.
 
 * `custom_domain_verification_id` - An identifier used by App Service to perform domain ownership verification via DNS TXT record.
 
-* `default_hostname` - The default hostname associated with the Logic App - such as `mysite.azurewebsites.net`
+* `default_hostname` - The default hostname associated with the Logic App - such as `mysite.azurewebsites.net`.
 
-* `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
+* `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`.
 
 * `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.
 
@@ -323,7 +323,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
 
-* `kind` - The Logic App kind - will be `functionapp,workflowapp`
+* `kind` - The Logic App kind.
 
 ---
 
@@ -332,8 +332,6 @@ The `identity` block exports the following:
 * `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
-
--> You can access the Principal ID via `azurerm_app_service.example.identity[0].principal_id` and the Tenant ID via `azurerm_app_service.example.identity[0].tenant_id`
 
 ---
 
@@ -348,8 +346,8 @@ The `site_credential` block exports the following:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App
-* `update` - (Defaults to 30 minutes) Used when updating the Logic App
 * `read` - (Defaults to 5 minutes) Used when retrieving the Logic App
+* `update` - (Defaults to 30 minutes) Used when updating the Logic App
 * `delete` - (Defaults to 30 minutes) Used when deleting the Logic App
 
 ## Import

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_service_plan" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
-  os_type = "Windows"
+  os_type  = "Windows"
   sku_name = "WS1"
 }
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -159,7 +159,7 @@ The following arguments are supported:
 
 * `virtual_network_subnet_id` - (Optional) The subnet ID which will be used by this resource for [regional virtual network integration](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#regional-virtual-network-integration).
 
-~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously.
+~> **Note:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simultaneously.
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add support for disabling default basic auth policies


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Failure was due to conflict
<img width="379" alt="image" src="https://github.com/user-attachments/assets/697f93a9-7fe6-44d2-b4f2-dc77d62afa78" />

Ran again:
<img width="484" alt="image" src="https://github.com/user-attachments/assets/eca863f6-5e87-4696-923f-04302a5bf875" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28613 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
