### PR TITLE
`azurerm_search_shared_private_link_service`: add lock for creating and updating

### DIFF
--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+var searchServiceResourceType = "azurerm_search_service"
+
 func resourceSearchService() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceSearchServiceCreate,

--- a/internal/services/search/search_shared_private_link_service_resource.go
+++ b/internal/services/search/search_shared_private_link_service_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/search/2024-06-01-preview/services"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/search/2024-06-01-preview/sharedprivatelinkresources"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -131,6 +132,9 @@ func (r SharedPrivateLinkServiceResource) Create() sdk.ResourceFunc {
 				parameters.Properties.RequestMessage = utils.String(model.RequestMessage)
 			}
 
+			locks.ByName(id.SearchServiceName, searchServiceResourceType)
+			defer locks.UnlockByName(id.SearchServiceName, searchServiceResourceType)
+
 			if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, sharedprivatelinkresources.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("creating/ updating %s: %+v", id, err)
 			}
@@ -213,6 +217,8 @@ func (r SharedPrivateLinkServiceResource) Update() sdk.ResourceFunc {
 						RequestMessage: utils.String(state.RequestMessage),
 					},
 				}
+				locks.ByName(id.SearchServiceName, searchServiceResourceType)
+				defer locks.UnlockByName(id.SearchServiceName, searchServiceResourceType)
 				if err := client.CreateOrUpdateThenPoll(ctx, *id, props, sharedprivatelinkresources.CreateOrUpdateOperationOptions{}); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

It's restricted to creating SPLs in sequence or the service will raise an error as described in #28601. This PR is to add a locker the search service resource to avoid parallel create/update.

Confirmation from Service Team:

> Yes, currently due to the provisioning logic we have we don’t support concurrent creation of SPLs. We’re trying to look at how we can facilitate this, but until then please do use any client side mechanisms to ensure they are created serially!
> 
> We don’t have an ETA of when that support will be added, will give you a heads up if we circle around to that. Right now we only have a best effort design in the works, not anything fool proof, so the client side option might be your best bet for a while


The example conflict error request/response:

```
PUT https://management.azure.com/subscriptions/xxx/resourceGroups/xxx/Microsoft.Search/searchServices/xxx/sharedPrivateLinkResources/xuwu-spl0?api-version=2024-06-01-preview HTTP/2.0

{"properties":{"groupId":"blob","privateLinkResourceId":"/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Storage/storageAccounts/xuwu1sa0","requestMessage":"please approve"}}

HTTP/2.0 409 
cache-control: no-store, no-cache

{"error":{"code":"","message":"There was a conflicting update. No change was made to the resource from this request."}}
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Added a new acc test for creating multiple SPLs:

```
--- PASS: TestAccSearchSharedPrivateLinkServiceResource_multiple (650.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/servic
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_search_shared_private_link_service` - fix error when create multiple SPL in one search service property [GH-28601]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28601


