### PR TITLE
`azurerm_policy_set_definition` - `parameters` is ForceNew if there are less or differing parameters between runs

### DIFF
--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -43,34 +43,7 @@ func resourceArmPolicyDefinition() *pluginsdk.Resource {
 
 		Schema: resourceArmPolicyDefinitionSchema(),
 
-		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
-			// `parameters` cannot have values removed so we'll ForceNew if there are less parameters between Terraform runs
-			if d.HasChange("parameters") {
-				oldParametersRaw, newParametersRaw := d.GetChange("parameters")
-				if oldParametersString := oldParametersRaw.(string); oldParametersString != "" {
-					newParametersString := newParametersRaw.(string)
-					if newParametersString == "" {
-						return d.ForceNew("parameters")
-					}
-
-					oldParameters, err := expandParameterDefinitionsValueFromString(oldParametersString)
-					if err != nil {
-						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
-					}
-
-					newParameters, err := expandParameterDefinitionsValueFromString(newParametersString)
-					if err != nil {
-						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
-					}
-
-					if len(newParameters) < len(oldParameters) {
-						return d.ForceNew("parameters")
-					}
-				}
-			}
-
-			return nil
-		}),
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(policyParamtersCustomizeDiff),
 	}
 }
 

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -47,6 +47,8 @@ func resourceArmPolicySetDefinition() *pluginsdk.Resource {
 		},
 
 		Schema: resourcePolicySetDefinitionSchema(),
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(policyParamtersCustomizeDiff),
 	}
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This brings the functionality of #26083 to `policy_set_definition` as well. 

Since `policy_set_definition` and `policy_definition` share the same parameter logic, I consolidated this diff logic into the `policy.go` and both resources now call the same `CustomizeDiffShim` function. I added additional functionality to the original `policy_definition` logic by also forcing new if the parameter lengths are the same but the parameters don't match (catching use cases of renames or +1/-1 parameters) since the Azure API will reject that in the current logic.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tested this manually and with acceptance testing (copying the tests from the `policy_definition`).

```
make acctests SERVICE=policy TESTARGS='-run=TestAccAzureRMPolicySetDefinition_removeParameter' TESTTIMEOUT=15m
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/policy -run=TestAccAzureRMPolicySetDefinition_removeParameter -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMPolicySetDefinition_removeParameter
=== PAUSE TestAccAzureRMPolicySetDefinition_removeParameter
=== CONT  TestAccAzureRMPolicySetDefinition_removeParameter
--- PASS: TestAccAzureRMPolicySetDefinition_removeParameter (176.64s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `policy_set_definition` - `parameters` is ForceNew if there are less or differing parameters between runs [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

No related issues found.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
