### PR TITLE
`azurerm_storage_container` and `azurerm_storage_share` - add support for migrating from deprecated `storage_account_name` to  `storage_account_id` 

### DIFF
--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -130,7 +131,6 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validate.StorageAccountName,
 			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
 			Deprecated:   "the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will be removed in version 5.0 of the Provider.",
@@ -139,7 +139,6 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		r.Schema["storage_account_id"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: commonids.ValidateStorageAccountID,
 			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
 		}
@@ -148,6 +147,33 @@ func resourceStorageContainer() *pluginsdk.Resource {
 			Type:       pluginsdk.TypeString,
 			Computed:   true,
 			Deprecated: "this property has been deprecated in favour of `id` and will be removed in version 5.0 of the Provider.",
+		}
+
+		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
+			// Resource Manager ID in use, but change to `storage_account_id` should recreate
+			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
+				return diff.ForceNew("storage_account_id")
+			}
+
+			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate
+			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
+				// converting from storage_account_id to the deprecated storage_account_name is not supported
+				oldAccountId, _ := diff.GetChange("storage_account_id")
+				oldName, newName := diff.GetChange("storage_account_name")
+
+				if oldAccountId.(string) != "" && newName.(string) != "" {
+					return diff.ForceNew("storage_account_name")
+				}
+
+				if oldName.(string) != "" && newName.(string) != "" {
+					return diff.ForceNew("storage_account_name")
+				}
+			}
+			if diff.GetRawConfig().AsValueMap()["storage_account_name"].IsNull() {
+				diff.SetNewComputed("storage_account_name")
+			}
+
+			return nil
 		}
 	}
 
@@ -362,7 +388,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") && d.Get("storage_account_id") == "" {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := containers.ParseContainerID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
@@ -415,6 +441,19 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return nil
 	}
 
+	if !features.FivePointOh() {
+		// Deal with the ID changing if the user changes from `storage_account_name` to `storage_account_id`
+		if !strings.HasPrefix(d.Id(), "/subscriptions/") {
+			accountId, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
+			if err != nil {
+				return err
+			}
+
+			id := commonids.NewStorageContainerID(subscriptionId, accountId.ResourceGroupName, accountId.StorageAccountName, d.Get("name").(string))
+			d.SetId(id.ID())
+		}
+	}
+
 	id, err := commonids.ParseStorageContainerID(d.Id())
 	if err != nil {
 		return err
@@ -442,6 +481,7 @@ func resourceStorageContainerRead(d *pluginsdk.ResourceData, meta interface{}) e
 			d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 			d.Set("has_legal_hold", props.HasLegalHold)
 			if !features.FivePointOh() {
+				d.Set("storage_account_name", "")
 				d.Set("resource_manager_id", id.ID())
 			}
 		}

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -169,9 +169,6 @@ func resourceStorageContainer() *pluginsdk.Resource {
 					return diff.ForceNew("storage_account_name")
 				}
 			}
-			if diff.GetRawConfig().AsValueMap()["storage_account_name"].IsNull() {
-				diff.SetNewComputed("storage_account_name")
-			}
 
 			return nil
 		}

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -150,12 +150,12 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		}
 
 		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
-			// Resource Manager ID in use, but change to `storage_account_id` should recreate
+			// Resource Manager ID in use, but change to `storage_account_id` should recreate - won't trigger on create as diff.Id() will be ""
 			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
 				return diff.ForceNew("storage_account_id")
 			}
 
-			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate
+			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate - won't trigger on create as diff.Id() will be ""
 			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
 				// converting from storage_account_id to the deprecated storage_account_name is not supported
 				oldAccountId, _ := diff.GetChange("storage_account_id")

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -506,7 +506,6 @@ resource "azurerm_storage_container" "test" {
 }
 
 func (r StorageContainerResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -515,11 +514,10 @@ resource "azurerm_storage_container" "test" {
   storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -541,7 +539,7 @@ resource "azurerm_storage_container" "test" {
     k2 = "v2"
   }
 }
-`, template, data.RandomString, data.RandomInteger)
+`, r.template(data), data.RandomString, data.RandomInteger)
 }
 
 func (r StorageContainerResource) basicAzureADAuthDeprecated(data acceptance.TestData) string {
@@ -621,7 +619,6 @@ resource "azurerm_storage_container" "import" {
 }
 
 func (r StorageContainerResource) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -630,11 +627,10 @@ resource "azurerm_storage_container" "import" {
   storage_account_id    = azurerm_storage_container.test.storage_account_id
   container_access_type = azurerm_storage_container.test.container_access_type
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) updateDeprecated(data acceptance.TestData, accessType, metadataVal string) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -647,11 +643,10 @@ resource "azurerm_storage_container" "test" {
     test = "%s"
   }
 }
-`, template, accessType, metadataVal)
+`, r.template(data), accessType, metadataVal)
 }
 
 func (r StorageContainerResource) update(data acceptance.TestData, accessType, metadataVal string) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -664,11 +659,10 @@ resource "azurerm_storage_container" "test" {
     test = "%s"
   }
 }
-`, template, accessType, metadataVal)
+`, r.template(data), accessType, metadataVal)
 }
 
 func (r StorageContainerResource) encryptionScopeDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -685,11 +679,10 @@ resource "azurerm_storage_container" "test" {
 
   default_encryption_scope = azurerm_storage_encryption_scope.test.name
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r StorageContainerResource) encryptionScope(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -706,11 +699,10 @@ resource "azurerm_storage_container" "test" {
 
   default_encryption_scope = azurerm_storage_encryption_scope.test.name
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r StorageContainerResource) metaDataDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -723,11 +715,10 @@ resource "azurerm_storage_container" "test" {
     hello = "world"
   }
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) metaData(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -740,11 +731,10 @@ resource "azurerm_storage_container" "test" {
     hello = "world"
   }
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) metaDataUpdatedDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -758,11 +748,10 @@ resource "azurerm_storage_container" "test" {
     panda = "pops"
   }
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) metaDataUpdated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -776,11 +765,10 @@ resource "azurerm_storage_container" "test" {
     panda = "pops"
   }
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) metaDataEmptyDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -791,11 +779,10 @@ resource "azurerm_storage_container" "test" {
 
   metadata = {}
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) metaDataEmpty(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -806,7 +793,7 @@ resource "azurerm_storage_container" "test" {
 
   metadata = {}
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) rootDeprecated(data acceptance.TestData) string {
@@ -822,7 +809,6 @@ resource "azurerm_storage_container" "test" {
 }
 
 func (r StorageContainerResource) webDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -831,11 +817,10 @@ resource "azurerm_storage_container" "test" {
   storage_account_name  = azurerm_storage_account.test.name
   container_access_type = "private"
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) web(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -844,7 +829,7 @@ resource "azurerm_storage_container" "test" {
   storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageContainerResource) template(data acceptance.TestData) string {
@@ -906,7 +891,6 @@ func TestValidateStorageContainerName(t *testing.T) {
 }
 
 func (r StorageContainerResource) withAccountName(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -915,5 +899,5 @@ resource "azurerm_storage_container" "test" {
   storage_account_name  = azurerm_storage_account.test.name
   container_access_type = "private"
 }
-`, template)
+`, r.template(data))
 }

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -446,7 +446,7 @@ func TestAccStorageContainer_migrateFromStorageIDShouldFail(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config:      r.basic(data),
+			Config:      r.withAccountName(data),
 			ExpectError: regexp.MustCompile("expected action to not be Replace"),
 		},
 	})

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -160,7 +161,6 @@ func resourceStorageShare() *pluginsdk.Resource {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 			ExactlyOneOf: []string{
 				"storage_account_name",
 				"storage_account_id",
@@ -171,7 +171,6 @@ func resourceStorageShare() *pluginsdk.Resource {
 		r.Schema["storage_account_id"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 			ExactlyOneOf: []string{
 				"storage_account_name",
 				"storage_account_id",
@@ -182,6 +181,33 @@ func resourceStorageShare() *pluginsdk.Resource {
 			Type:       pluginsdk.TypeString,
 			Computed:   true,
 			Deprecated: "this property is deprecated and will be removed 5.0 and replaced by the `id` property.",
+		}
+
+		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
+			// Resource Manager ID in use, but change to `storage_account_id` should recreate
+			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
+				return diff.ForceNew("storage_account_id")
+			}
+
+			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate
+			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
+				// converting from storage_account_id to the deprecated storage_account_name is not supported
+				oldAccountId, _ := diff.GetChange("storage_account_id")
+				oldName, newName := diff.GetChange("storage_account_name")
+
+				if oldAccountId.(string) != "" && newName.(string) != "" {
+					return diff.ForceNew("storage_account_name")
+				}
+
+				if oldName.(string) != "" && newName.(string) != "" {
+					return diff.ForceNew("storage_account_name")
+				}
+			}
+			if diff.GetRawConfig().AsValueMap()["storage_account_name"].IsNull() {
+				diff.SetNewComputed("storage_account_name")
+			}
+
+			return nil
 		}
 	}
 
@@ -323,7 +349,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") {
+	if !features.FivePointOh() && !strings.HasPrefix(d.Id(), "/subscriptions/") && d.Get("storage_account_id").(string) == "" {
 		storageClient := meta.(*clients.Client).Storage
 		id, err := shares.ParseShareID(d.Id(), storageClient.StorageDomainSuffix)
 		if err != nil {
@@ -382,6 +408,19 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return nil
 	}
 
+	if !features.FivePointOh() {
+		// Deal with the ID changing if the user changes from `storage_account_name` to `storage_account_id`
+		if !strings.HasPrefix(d.Id(), "/subscriptions/") {
+			accountId, err := commonids.ParseStorageAccountID(d.Get("storage_account_id").(string))
+			if err != nil {
+				return err
+			}
+
+			id := fileshares.NewShareID(subscriptionId, accountId.ResourceGroupName, accountId.StorageAccountName, d.Get("name").(string))
+			d.SetId(id.ID())
+		}
+	}
+
 	id, err := fileshares.ParseShareID(d.Id())
 	if err != nil {
 		return err
@@ -417,6 +456,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 	if !features.FivePointOh() {
 		d.Set("resource_manager_id", id.ID())
+		d.Set("storage_account_name", "")
 	}
 
 	// TODO - The following section for `url` will need to be updated to go-azure-sdk when the Giovanni Deprecation process has been completed

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -203,9 +203,6 @@ func resourceStorageShare() *pluginsdk.Resource {
 					return diff.ForceNew("storage_account_name")
 				}
 			}
-			if diff.GetRawConfig().AsValueMap()["storage_account_name"].IsNull() {
-				diff.SetNewComputed("storage_account_name")
-			}
 
 			return nil
 		}

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -6,6 +6,7 @@ package storage_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -548,6 +549,61 @@ func TestAccStorageShare_protocolUpdate(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShare_migrateToStorageID(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
+	r := StorageShareResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withAccountName(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsSet(),
+				check.That(data.ResourceName).Key("storage_account_id").DoesNotExist(),
+				check.That(data.ResourceName).Key("id").MatchesRegex(regexp.MustCompile("https:*")),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsEmpty(),
+				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
+				check.That(data.ResourceName).Key("id").MatchesRegex(regexp.MustCompile("/subscriptions/*")),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShare_migrateFromStorageIDShouldFail(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as test is not valid in 5.0")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
+	r := StorageShareResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
+				check.That(data.ResourceName).Key("storage_account_name").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:      r.withAccountName(data),
+			ExpectError: regexp.MustCompile("expected action to not be Replace"),
+		},
 	})
 }
 
@@ -1250,6 +1306,19 @@ resource "azurerm_storage_share" "test" {
   quota              = 100
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, protocol)
+}
+
+func (r StorageShareResource) withAccountName(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 5
+}
+`, template, data.RandomString)
 }
 
 func (r StorageShareResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -596,7 +596,7 @@ func TestAccStorageShare_migrateFromStorageIDShouldFail(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
-				check.That(data.ResourceName).Key("storage_account_name").DoesNotExist(),
+				check.That(data.ResourceName).Key("storage_account_name").IsEmpty(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -674,7 +674,6 @@ func (r StorageShareResource) Destroy(ctx context.Context, client *clients.Clien
 }
 
 func (r StorageShareResource) basicDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -683,11 +682,10 @@ resource "azurerm_storage_share" "test" {
   storage_account_name = azurerm_storage_account.test.name
   quota                = 5
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -696,11 +694,10 @@ resource "azurerm_storage_share" "test" {
   storage_account_id = azurerm_storage_account.test.id
   quota              = 5
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -726,11 +723,10 @@ resource "azurerm_storage_share" "test" {
     foo   = "bar"
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) metaDataDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -743,11 +739,10 @@ resource "azurerm_storage_share" "test" {
     hello = "world"
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) metaData(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -760,11 +755,10 @@ resource "azurerm_storage_share" "test" {
     hello = "world"
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) metaDataUpdatedDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -778,11 +772,10 @@ resource "azurerm_storage_share" "test" {
     happy = "birthday"
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) metaDataUpdated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -796,11 +789,10 @@ resource "azurerm_storage_share" "test" {
     happy = "birthday"
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) aclDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -819,11 +811,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) acl(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -842,11 +833,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) aclGhostedRecallDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -862,11 +852,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) aclGhostedRecall(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -882,11 +871,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) aclUpdatedDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -914,11 +902,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) aclUpdated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -946,11 +933,10 @@ resource "azurerm_storage_share" "test" {
     }
   }
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) requiresImportDeprecated(data acceptance.TestData) string {
-	template := r.basicDeprecated(data)
 	return fmt.Sprintf(`
 %s
 
@@ -959,7 +945,7 @@ resource "azurerm_storage_share" "import" {
   storage_account_name = azurerm_storage_share.test.storage_account_name
   quota                = azurerm_storage_share.test.quota
 }
-`, template)
+`, r.template(data))
 }
 
 func (r StorageShareResource) requiresImport(data acceptance.TestData) string {
@@ -975,7 +961,6 @@ resource "azurerm_storage_share" "import" {
 }
 
 func (r StorageShareResource) updateQuotaDeprecated(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -984,11 +969,10 @@ resource "azurerm_storage_share" "test" {
   storage_account_name = azurerm_storage_account.test.name
   quota                = 5
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) updateQuota(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -997,7 +981,7 @@ resource "azurerm_storage_share" "test" {
   storage_account_id = azurerm_storage_account.test.id
   quota              = 5
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) largeQuotaDeprecated(data acceptance.TestData) string {
@@ -1309,7 +1293,6 @@ resource "azurerm_storage_share" "test" {
 }
 
 func (r StorageShareResource) withAccountName(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -1318,7 +1301,7 @@ resource "azurerm_storage_share" "test" {
   storage_account_name = azurerm_storage_account.test.name
   quota                = 5
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
 func (r StorageShareResource) template(data acceptance.TestData) string {

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 * `storage_account_name` - (Optional) The name of the Storage Account where the Container should be created. Changing this forces a new resource to be created. This property is deprecated in favour of `storage_account_id`.
 
+~> **Note:** Migrating from the deprecated `storage_account_name` to `storage_account_id` is supported without recreation. Any other change to either property will result in the resource being recreated.
+
 * `storage_account_id` - (Optional) The name of the Storage Account where the Container should be created. Changing this forces a new resource to be created.
 
 ~> **NOTE:** One of `storage_account_name` or `storage_account_id` must be specified. When specifying `storage_account_id` the resource will use the Resource Manager API, rather than the Data Plane API.

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -54,7 +54,9 @@ The following arguments are supported:
 * `name` - (Required) The name of the share. Must be unique within the storage account where the share is located. Changing this forces a new resource to be created.
 
 * `storage_account_name` - (Optional) Specifies the storage account in which to create the share. Changing this forces a new resource to be created. This property is deprecated in favour of `storage_account_id`.
- 
+
+~> **Note:** Migrating from the deprecated `storage_account_name` to `storage_account_id` is supported without recreation. Any other change to either property will result in the resource being recreated.
+
 * `storage_account_id` - (Optional) Specifies the storage account in which to create the share. Changing this forces a new resource to be created.
 
 ~> **NOTE:** One of `storage_account_name` or `storage_account_id` must be specified. When specifying `storage_account_id` the resource will use the Resource Manager API, rather than the Data Plane API. 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR enables users of the `azurerm_storage_container` and `azurerm_storage_share` to migrate from the use of `storage_account_name` to `storage_account_id` without recreating the resource.

The supported migration path is one-way, changing from `storage_account_id` to `storage_account_name` will force the recreation of the resources, any other changes to either property will result in the recreation of the resource.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_container` - add support for migrating from deprecated `storage_account_name` to  `storage_account_id` 
* `azurerm_storage_share` - add support for migrating from deprecated `storage_account_name` to  `storage_account_id` 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
closes #27942


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
