### PR TITLE
`azurerm_mssql_job_credential` - add `password_wo`, `password_wo_version` and split create/update

### DIFF
--- a/internal/services/mssql/mssql_job_credential_resource.go
+++ b/internal/services/mssql/mssql_job_credential_resource.go
@@ -8,22 +8,25 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/jobcredentials"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlJobCredential() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMsSqlJobCredentialCreateUpdate,
+		Create: resourceMsSqlJobCredentialCreate,
 		Read:   resourceMsSqlJobCredentialRead,
-		Update: resourceMsSqlJobCredentialCreateUpdate,
+		Update: resourceMsSqlJobCredentialUpdate,
 		Delete: resourceMsSqlJobCredentialDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -36,6 +39,10 @@ func resourceMsSqlJobCredential() *pluginsdk.Resource {
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
+		},
+
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("password"), cty.GetAttrPath("password_wo")),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -58,17 +65,32 @@ func resourceMsSqlJobCredential() *pluginsdk.Resource {
 			},
 
 			"password": {
-				Type:      pluginsdk.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"password_wo"},
+				ExactlyOneOf:  []string{"password", "password_wo"},
+			},
+			"password_wo": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				RequiredWith:  []string{"password_wo_version"},
+				ConflictsWith: []string{"password"},
+				ExactlyOneOf:  []string{"password_wo", "password"},
+			},
+			"password_wo_version": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"password_wo"},
 			},
 		},
 	}
 }
 
-func resourceMsSqlJobCredentialCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMsSqlJobCredentialCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.JobCredentialsClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Job Credential creation.")
@@ -79,35 +101,91 @@ func resourceMsSqlJobCredentialCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	}
 	jobCredentialId := jobcredentials.NewCredentialID(jaId.SubscriptionId, jaId.ResourceGroupName, jaId.ServerName, jaId.JobAgentName, d.Get("name").(string))
 
-	username := d.Get("username").(string)
+	existing, err := client.Get(ctx, jobCredentialId)
+	if err != nil && !response.WasNotFound(existing.HttpResponse) {
+		return fmt.Errorf("checking for presence of existing %s: %+v", jobCredentialId, err)
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_mssql_job_credential", jobCredentialId.ID())
+	}
+
+	woPassword, err := pluginsdk.GetWriteOnly(d, "password_wo", cty.String)
+	if err != nil {
+		return err
+	}
+
 	password := d.Get("password").(string)
-
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, jobCredentialId)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing MsSql %s: %+v", jobCredentialId, err)
-			}
-		}
-
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_mssql_job_credential", jobCredentialId.ID())
-		}
+	if !woPassword.IsNull() {
+		password = woPassword.AsString()
 	}
 
 	jobCredential := jobcredentials.JobCredential{
-		Name: utils.String(jobCredentialId.CredentialName),
+		Name: pointer.To(jobCredentialId.CredentialName),
 		Properties: &jobcredentials.JobCredentialProperties{
-			Username: username,
+			Username: d.Get("username").(string),
 			Password: password,
 		},
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, jobCredentialId, jobCredential); err != nil {
-		return fmt.Errorf("creating MsSql %s: %+v", jobCredentialId, err)
+		return fmt.Errorf("creating %s: %+v", jobCredentialId, err)
 	}
 
 	d.SetId(jobCredentialId.ID())
+
+	return resourceMsSqlJobCredentialRead(d, meta)
+}
+
+func resourceMsSqlJobCredentialUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.JobCredentialsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for Job Credential update.")
+
+	jaId, err := jobcredentials.ParseJobAgentID(d.Get("job_agent_id").(string))
+	if err != nil {
+		return err
+	}
+	jobCredentialId := jobcredentials.NewCredentialID(jaId.SubscriptionId, jaId.ResourceGroupName, jaId.ServerName, jaId.JobAgentName, d.Get("name").(string))
+
+	existing, err := client.Get(ctx, jobCredentialId)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", jobCredentialId, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", jobCredentialId)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `model.Properties` was nil", jobCredentialId)
+	}
+	payload := existing.Model
+
+	if d.HasChange("username") {
+		payload.Properties.Username = d.Get("username").(string)
+	}
+
+	if d.HasChange("password") {
+		payload.Properties.Password = d.Get("password").(string)
+	}
+
+	if d.HasChange("password_wo_version") {
+		woPassword, err := pluginsdk.GetWriteOnly(d, "password_wo", cty.String)
+		if err != nil {
+			return err
+		}
+
+		if !woPassword.IsNull() {
+			payload.Properties.Password = woPassword.AsString()
+		}
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, jobCredentialId, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", jobCredentialId, err)
+	}
 
 	return resourceMsSqlJobCredentialRead(d, meta)
 }
@@ -140,6 +218,9 @@ func resourceMsSqlJobCredentialRead(d *pluginsdk.ResourceData, meta interface{})
 			d.Set("username", props.Username)
 		}
 	}
+
+	d.Set("password_wo_version", d.Get("password_wo_version").(int))
+
 	return nil
 }
 

--- a/internal/services/mssql/mssql_job_credential_resource_test.go
+++ b/internal/services/mssql/mssql_job_credential_resource_test.go
@@ -11,9 +11,13 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/jobcredentials"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -71,6 +75,59 @@ func TestAccMsSqlJobCredential_update(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlJobCredential_writeOnlyPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_job_credential", "test")
+	r := MsSqlJobCredentialResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.writeOnlyPassword(data, "secret", 1),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("password_wo_version"),
+			{
+				Config: r.writeOnlyPassword(data, "secretUpdate", 2),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("password_wo_version"),
+		},
+	})
+}
+
+func TestAccMsSqlJobCredential_updateToWriteOnlyPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_job_credential", "test")
+	r := MsSqlJobCredentialResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("password"),
+			{
+				Config: r.writeOnlyPassword(data, "secret", 1),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("password", "password_wo_version"),
+			{
+				Config: r.basic(data),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("password"),
+		},
+	})
+}
+
 func (MsSqlJobCredentialResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := jobcredentials.ParseCredentialID(state.ID)
 	if err != nil {
@@ -88,46 +145,17 @@ func (MsSqlJobCredentialResource) Exists(ctx context.Context, client *clients.Cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (MsSqlJobCredentialResource) basic(data acceptance.TestData) string {
+func (r MsSqlJobCredentialResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-jobcredential-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_mssql_server" "test" {
-  name                         = "acctestmssqlserver%[1]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  location                     = azurerm_resource_group.test.location
-  version                      = "12.0"
-  administrator_login          = "4dministr4t0r"
-  administrator_login_password = "superSecur3!!!"
-}
-
-resource "azurerm_mssql_database" "test" {
-  name      = "acctestmssqldb%[1]d"
-  server_id = azurerm_mssql_server.test.id
-  collation = "SQL_Latin1_General_CP1_CI_AS"
-  sku_name  = "S1"
-}
-
-resource "azurerm_mssql_job_agent" "test" {
-  name        = "acctestmssqljobagent%[1]d"
-  location    = azurerm_resource_group.test.location
-  database_id = azurerm_mssql_database.test.id
-}
+%s
 
 resource "azurerm_mssql_job_credential" "test" {
-  name         = "acctestmssqljobcredential%[1]d"
+  name         = "acctestmssqljobcredential%[2]d"
   job_agent_id = azurerm_mssql_job_agent.test.id
   username     = "test"
   password     = "test"
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r MsSqlJobCredentialResource) requiresImport(data acceptance.TestData) string {
@@ -143,7 +171,36 @@ resource "azurerm_mssql_job_credential" "import" {
 `, r.basic(data))
 }
 
-func (MsSqlJobCredentialResource) update(data acceptance.TestData) string {
+func (r MsSqlJobCredentialResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_job_credential" "test" {
+  name         = "acctestmssqljobcredential%[2]d"
+  job_agent_id = azurerm_mssql_job_agent.test.id
+  username     = "test1"
+  password     = "test1"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MsSqlJobCredentialResource) writeOnlyPassword(data acceptance.TestData, secret string, version int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "azurerm_mssql_job_credential" "test" {
+  name                = "acctestmssqljobcredential%[3]d"
+  job_agent_id        = azurerm_mssql_job_agent.test.id
+  username            = "test"
+  password_wo         = ephemeral.azurerm_key_vault_secret.test.value
+  password_wo_version = %[4]d
+}
+`, r.template(data), acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), data.RandomInteger, version)
+}
+
+func (MsSqlJobCredentialResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -174,13 +231,6 @@ resource "azurerm_mssql_job_agent" "test" {
   name        = "acctestmssqljobagent%[1]d"
   location    = azurerm_resource_group.test.location
   database_id = azurerm_mssql_database.test.id
-}
-
-resource "azurerm_mssql_job_credential" "test" {
-  name         = "acctestmssqljobcredential%[1]d"
-  job_agent_id = azurerm_mssql_job_agent.test.id
-  username     = "test1"
-  password     = "test1"
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/r/mssql_job_credential.html.markdown
+++ b/website/docs/r/mssql_job_credential.html.markdown
@@ -56,9 +56,13 @@ The following arguments are supported:
 
 * `job_agent_id` - (Required) The ID of the Elastic Job Agent. Changing this forces a new Elastic Job Credential to be created.
 
-* `username` - (Required) The username part of the credential.
+* `username` - (Required) The username to use for this Elastic Job credential.
 
-* `password` - (Required) The password part of the credential.
+* `password` - (Optional) The password to use for this Elastic Job credential.
+
+* `password_wo` - (Optional, Write-Only) The password to use for this Elastic Job credential.
+
+* `password_wo_version` - (Optional) An integer value used to trigger an update for `password_wo`. This property should be incremented when updating `password_wo`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Add `password_wo` and `password_wo_version` properties
- Split create/update

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_job_credential` - support for the `password_wo` and `password_wo_version` properties [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)
https://github.com/hashicorp/tf-azure-stratosphere/issues/5

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
