### PR TITLE
`azurerm_storage_table` - add attribute `resource_manager_id`

### DIFF
--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -103,7 +103,7 @@ func resourceStorageTable() *pluginsdk.Resource {
 			"resource_manager_id": {
 				Type:        pluginsdk.TypeString,
 				Computed:    true,
-				Description: "The ID of the Table in the Resource Manager format. Useful for cases like IAM that do not use the Data Plane ID.",
+				Description: "The Resource Manager ID of this Storage Table.",
 			},
 		},
 	}

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -221,7 +221,7 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 	d.Set("name", id.TableName)
 	d.Set("storage_account_name", id.AccountId.AccountName)
-	rmid := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tables/%s", subscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, id.TableName)
+	rmid := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default/tables/%s", subscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, id.TableName)
 	d.Set("resource_manager_id", rmid)
 
 	if err = d.Set("acl", flattenStorageTableACLs(acls)); err != nil {

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -98,6 +98,11 @@ func resourceStorageTable() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"resource_manager_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -216,6 +221,8 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 	d.Set("name", id.TableName)
 	d.Set("storage_account_name", id.AccountId.AccountName)
+	rmid := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tables/%s", subscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, id.TableName)
+	d.Set("resource_manager_id", rmid)
 
 	if err = d.Set("acl", flattenStorageTableACLs(acls)); err != nil {
 		return fmt.Errorf("setting `acl`: %v", err)

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -5,6 +5,7 @@ package storage
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"log"
 	"strings"
 	"time"
@@ -222,8 +223,7 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 	d.Set("name", id.TableName)
 	d.Set("storage_account_name", id.AccountId.AccountName)
-	rmid := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default/tables/%s", subscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, id.TableName)
-	d.Set("resource_manager_id", rmid)
+	d.Set("resource_manager_id", parse.NewStorageTableResourceManagerID(subscriptionId, account.StorageAccountId.ResourceGroupName, id.AccountId.AccountName, "default", id.TableName).ID())
 
 	if err = d.Set("acl", flattenStorageTableACLs(acls)); err != nil {
 		return fmt.Errorf("setting `acl`: %v", err)

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -5,7 +5,7 @@ package storage
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
 	"log"
 	"strings"
 	"time"
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -100,8 +100,9 @@ func resourceStorageTable() *pluginsdk.Resource {
 			},
 
 			"resource_manager_id": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+				Description: "The ID of the Table in the Resource Manager format. Useful for cases like IAM that do not use the Data Plane ID.",
 			},
 		},
 	}

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -5,7 +5,6 @@ package storage
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
 	"log"
 	"strings"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -82,21 +82,6 @@ func TestAccStorageTable_acl(t *testing.T) {
 	})
 }
 
-func TestAccStorageTable_resourceManagerId(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_storage_table", "test")
-	r := StorageTableResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.resourceManagerId(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (r StorageTableResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := tables.ParseTableID(state.ID, client.Storage.StorageDomainSuffix)
 	if err != nil {
@@ -275,18 +260,4 @@ resource "azurerm_storage_table" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
-}
-
-func (r StorageTableResource) resourceManagerId(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_storage_table.test.resource_manager_id
-  principal_id         = data.azurerm_client_config.current.object_id
-  role_definition_name = "Storage Table Data Contributor"
-}
-`, r.basic(data))
 }

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -305,7 +305,7 @@ resource "azurerm_storage_table" "test" {
   storage_account_name = azurerm_storage_account.test.name
 }
 
-data "azurerm_client_config" "current" { }
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_role_assignment" "access" {
   scope                = azurerm_storage_table.test.resource_manager_id

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -307,7 +307,7 @@ resource "azurerm_storage_table" "test" {
 
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_role_assignment" "access" {
+resource "azurerm_role_assignment" "test" {
   scope                = azurerm_storage_table.test.resource_manager_id
   principal_id         = data.azurerm_client_config.current.object_id
   role_definition_name = "Storage Table Data Contributor"

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -279,31 +279,7 @@ resource "azurerm_storage_table" "test" {
 
 func (r StorageTableResource) resourceManagerId(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-
-  tags = {
-    environment = "staging"
-  }
-}
-
-resource "azurerm_storage_table" "test" {
-  name                 = "acctestst%d"
-  storage_account_name = azurerm_storage_account.test.name
-}
+%s
 
 data "azurerm_client_config" "current" {}
 
@@ -312,5 +288,5 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = data.azurerm_client_config.current.object_id
   role_definition_name = "Storage Table Data Contributor"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+`, r.basic(data))
 }

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -68,7 +68,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Table within the Storage Account.
 
-* `resource_manager_id` - The ID of the Table in the Resource Manager format. Useful for cases like IAM that do not use the Data Plane ID.
+* `resource_manager_id` - The Resource Manager ID of this Storage Table.
 
 ## Timeouts
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -68,7 +68,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Table within the Storage Account.
 
-* `resource_manager_id` - The ID of the Table in the Resource Manager format, e.g. "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Storage/storageAccounts/myAccount/tableServices/default/tables/myTable/". Useful for cases like IAM that do not use the Data Plane ID.
+* `resource_manager_id` - The ID of the Table in the Resource Manager format, e.g. "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Storage/storageAccounts/myAccount/tableServices/default/tables/myTable". Useful for cases like IAM that do not use the Data Plane ID.
 
 ## Timeouts
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -68,7 +68,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Table within the Storage Account.
 
-* `resource_manager_id` - The ID of the Table in the Resource Manager format, e.g. "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Storage/storageAccounts/myAccount/tableServices/default/tables/myTable". Useful for cases like IAM that do not use the Data Plane ID.
+* `resource_manager_id` - The ID of the Table in the Resource Manager format. Useful for cases like IAM that do not use the Data Plane ID.
 
 ## Timeouts
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
-gst---
+---
 
 A `acl` block supports the following:
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
----
+gst---
 
 A `acl` block supports the following:
 
@@ -67,6 +67,8 @@ A `access_policy` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Table within the Storage Account.
+
+* `resource_manager_id` - The ID of the Table in the Resource Manager format, e.g. "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Storage/storageAccounts/myAccount/tableServices/default/tables/myTable/". Useful for cases like IAM that do not use the Data Plane ID.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds an attribute to the `azurerm_storage_table` resource, `resource_manager_id`, a computed value that looks like this:

```
/subscriptions/YOUR-SUB/
    resourceGroups/YOUR-RG
    /providers/Microsoft.Storage
    /storageAccounts/YOUR-ACCOUNT/tableService/default
    /tables/YOUR-TABLE
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="357" alt="image" src="https://github.com/user-attachments/assets/ec0d5530-9e3c-4869-83e5-4a8f027d3e08" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_table` - added `resource_manager_id` attribute [GH-28809]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #21525


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
