### PR TITLE
`azurerm_container_registry` - fix  principal_id of azurerm_role_assignment

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -122,7 +122,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 }
 
 resource "azurerm_role_assignment" "example" {
-  principal_id                     = azurerm_kubernetes_cluster.example.kubelet_identity[0].principal_id
+  principal_id                     = azurerm_kubernetes_cluster.example.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"
   scope                            = azurerm_container_registry.example.id
   skip_service_principal_aad_check = true


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The current version of ‘Example Usage (Attaching a Container Registry to a Kubernetes Cluster)’ is not working now due to a structural mismatch.
So I fixed 
`azurerm_kubernetes_cluster.aks.kubelet_identity[0].principal_id` ->
`azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id`

And I tested that `azurerm_role_assignment` is successfully created and cluster can pull image from registry.

### Error with current example (terraform plan)
```
╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 33, in resource "azurerm_role_assignment" "ra":
│   33:   principal_id                     = azurerm_kubernetes_cluster.aks.kubelet_identity[0].principal_id
│ 
│ This object has no argument, nested block, or exported attribute named "principal_id".
╵
```

### Working appropriately after fix (terraform plan)
```
  # azurerm_role_assignment.ra will be created
  + resource "azurerm_role_assignment" "ra" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "AcrPull"
      + scope                            = (known after apply)
      + skip_service_principal_aad_check = true
    }
```

### The structure of `azurerm_kubernetes_cluster` (terraform.tfstate)
```
{
    "mode": "managed",
    "type": "azurerm_kubernetes_cluster",
    "name": "aks",
    "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
    "instances": [
      {
        "schema_version": 2,
        "attributes": {
          // ...
          "kubelet_identity": [
            {
              "client_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
              "object_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
              "user_assigned_identity_id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/MC_xxxxxxx/providers/Microsoft.ManagedIdentity/userAssignedIdentities/xxxxxxxx-agentpool"
            }
          ],
          // ...
        },
        // ...
      }
    ]
  },
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
