### PR TITLE
azurerm_windows_function_app - support for node 22

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1375,7 +1375,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
-					Description: "The version of Node to use. Possible values include `12`, `14`, `16`, `18`, `20` and `22`",
+					Description: "The version of Node to use. Possible values include `~12`, `~14`, `~16`, `~18`, `~20` and `~22`",
 				},
 
 				"java_version": {

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1366,6 +1366,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"~16",
 						"~18",
 						"~20",
+						"~22",
 					}, false),
 					ExactlyOneOf: []string{
 						"site_config.0.application_stack.0.dotnet_version",
@@ -1374,7 +1375,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
-					Description: "The version of Node to use. Possible values include `12`, `14`, `16` and `18`",
+					Description: "The version of Node to use. Possible values include `12`, `14`, `16`, `18`, `20` and `22`",
 				},
 
 				"java_version": {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -3543,12 +3543,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                            = "acctestsa%s"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  account_tier                    = "Standard"
-  account_replication_type        = "LRS"
-  allow_nested_items_to_be_public = false
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_service_plan" "test" {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -3543,11 +3543,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                            = "acctestsa%s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  account_tier                    = "Standard"
+  account_replication_type 		  = "LRS"
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_service_plan" "test" {
@@ -3648,6 +3649,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  allow_nested_items_to_be_public = true
 }
 
 resource "azurerm_storage_account" "update" {
@@ -3911,6 +3913,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  allow_nested_items_to_be_public = true
 }
 
 resource "azurerm_windows_function_app" "test" {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -3547,7 +3547,7 @@ resource "azurerm_storage_account" "test" {
   resource_group_name             = azurerm_resource_group.test.name
   location                        = azurerm_resource_group.test.location
   account_tier                    = "Standard"
-  account_replication_type 		  = "LRS"
+  account_replication_type        = "LRS"
   allow_nested_items_to_be_public = false
 }
 
@@ -3649,7 +3649,6 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  allow_nested_items_to_be_public = true
 }
 
 resource "azurerm_storage_account" "update" {
@@ -3913,7 +3912,6 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  allow_nested_items_to_be_public = true
 }
 
 resource "azurerm_windows_function_app" "test" {

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -850,6 +850,14 @@ func TestAccWindowsFunctionAppSlot_appStackNodeUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
 			),
 		},
+		data.ImportStep("site_credential.0.password"),
+		{
+			Config: r.appStackNode(data, SkuStandardPlan, "~22"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+			),
+		},
 		data.ImportStep(),
 	})
 }

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -635,7 +635,7 @@ An `application_stack` block supports the following:
 
 * `java_version` - (Optional) The version of Java to use. Possible values are `1.8`, `11` and `17` (In-Preview).
 
-* `node_version` - (Optional) The version of Node to use. Possible values are `~12`, `~14`, `~16`, `~18` and `~20`.
+* `node_version` - (Optional) The version of Node to use. Possible values are `~12`, `~14`, `~16`, `~18`, `~20`, and `~22`.
 
 * `powershell_core_version` - (Optional) The PowerShell Core version to use. Possible values are `7`, `7.2`, and `7.4`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This change set simply updates the Windows Function App schema to include Node ~22 to the list of supported versions.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

I ran the test and got past the previous errors, but could not get a passed test due to some intermittent networking issues

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

This was covered by an existing test that failed for me locally:

```shell
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccWindowsFunctionApp_appStackNodeUpdate -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWindowsFunctionApp_appStackNodeUpdate
=== PAUSE TestAccWindowsFunctionApp_appStackNodeUpdate
=== CONT  TestAccWindowsFunctionApp_appStackNodeUpdate
    testcase.go:173: Step 16/18 error: Error running pre-apply plan: exit status 1
        
        Error: expected site_config.0.application_stack.0.node_version to be one of ["~12" "~14" "~16" "~18" "~20"], got ~22
        
          with azurerm_windows_function_app.test,
          on terraform_plugin_test.tf line 71, in resource "azurerm_windows_function_app" "test":
          71:       node_version = "~22"
        
    panic.go:626: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: expected site_config.0.application_stack.0.node_version to be one of ["~12" "~14" "~16" "~18" "~20"], got ~22
        
          with azurerm_windows_function_app.test,
          on terraform_plugin_test.tf line 71, in resource "azurerm_windows_function_app" "test":
          71:       node_version = "~22"
        
--- FAIL: TestAccWindowsFunctionApp_appStackNodeUpdate (789.88s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice	791.997s
FAIL
```

After multiple attempts, I couldn't get it to complete successfully, but it did get past that step:

```shell
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccWindowsFunctionApp_appStackNodeUpdate -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWindowsFunctionApp_appStackNodeUpdate
=== PAUSE TestAccWindowsFunctionApp_appStackNodeUpdate
=== CONT  TestAccWindowsFunctionApp_appStackNodeUpdate
    testcase.go:173: Step 18/18 error running import: exit status 1
        
        Error: reading App Settings for Windows App Service (Subscription: "***"
        Resource Group Name: "acctestRG-WFA-250219074519342516"
        Site Name: "acctest-WFA-250219074519342516"): Post "https://management.azure.com/subscriptions/***/resourceGroups/acctestRG-WFA-250219074519342516/providers/Microsoft.Web/sites/acctest-WFA-250219074519342516/config/appSettings/list?api-version=2023-12-01": HTTP response was nil; connection may have been reset
        
        reading App Settings for Windows App Service (Subscription:
        "89f16fbc-ffc6-4c0a-b880-fe4be6063977"
        Resource Group Name: "acctestRG-WFA-250219074519342516"
        Site Name: "acctest-WFA-250219074519342516"): Post
        "https://management.azure.com/subscriptions/***/resourceGroups/acctestRG-WFA-250219074519342516/providers/Microsoft.Web/sites/acctest-WFA-250219074519342516/config/appSettings/list?api-version=2023-12-01":
        HTTP response was nil; connection may have been reset
        
--- FAIL: TestAccWindowsFunctionApp_appStackNodeUpdate (1064.98s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice	1067.161s
FAIL

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_function_app` - support for node 22 [GH-28782]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28782 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
