### PR TITLE
`azurerm_mssql_server` - add support for `administrator_login_password_wo` and `administrator_login_password_wo_version`

### DIFF
--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/servers"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlServerResource struct{}
@@ -305,6 +305,47 @@ func TestAccMsSqlServer_CMKServerTagsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlServer_writeOnlyAdminLoginPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MsSqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.writeOnlyAdminLoginPassword(data, "7h1515K4711-secret", 1),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep("administrator_login_password_wo_version"),
+		{
+			Config: r.writeOnlyAdminLoginPassword(data, "7h1515K4711-updated", 2),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep("administrator_login_password_wo_version"),
+	})
+}
+
+func TestAccMsSqlServer_updateToWriteOnlyPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MsSqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep("administrator_login_password"),
+		{
+			Config: r.writeOnlyAdminLoginPassword(data, "7h1515K4711-secret", 1),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep("administrator_login_password", "administrator_login_password_wo_version"),
+		{
+			Config: r.basic(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep("administrator_login_password"),
+	})
+}
+
 func (MsSqlServerResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ServerID(state.ID)
 	if err != nil {
@@ -321,7 +362,7 @@ func (MsSqlServerResource) Exists(ctx context.Context, client *clients.Client, s
 		return nil, fmt.Errorf("reading SQL Server %q (Resource Group %q): %v", id.Name, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MsSqlServerResource) basic(data acceptance.TestData) string {
@@ -1058,4 +1099,31 @@ resource "azurerm_key_vault_key" "test" {
   key_opts = ["unwrapKey", "wrapKey"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (MsSqlServerResource) writeOnlyAdminLoginPassword(data acceptance.TestData, secret string, version int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+%s
+
+resource "azurerm_mssql_server" "test" {
+  name                                    = "acctestsqlserver%[1]d"
+  resource_group_name                     = azurerm_resource_group.test.name
+  location                                = azurerm_resource_group.test.location
+  version                                 = "12.0"
+  administrator_login                     = "missadministrator"
+  administrator_login_password_wo_version = %[4]d
+  administrator_login_password_wo         = ephemeral.azurerm_key_vault_secret.test.value
+
+  outbound_network_restriction_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), version)
 }

--- a/internal/tf/pluginsdk/write_only.go
+++ b/internal/tf/pluginsdk/write_only.go
@@ -22,3 +22,16 @@ func GetWriteOnly(d *ResourceData, name string, attributeType cty.Type) (*cty.Va
 	}
 	return pointer.To(value), nil
 }
+
+// GetWriteOnlyFromDiff gets a write only attribute from the diff, checking that it is of an expected type and subsequently returns it
+func GetWriteOnlyFromDiff(d *ResourceDiff, name string, attributeType cty.Type) (*cty.Value, error) {
+	value, diags := d.GetRawConfigAt(cty.GetAttrPath(name))
+	if diags.HasError() {
+		return nil, fmt.Errorf("retrieving write-only attribute `%s`: %+v", name, diags)
+	}
+
+	if !value.Type().Equals(attributeType) {
+		return nil, fmt.Errorf("retrieving write-only attribute `%s`: value is not of type %v", name, attributeType)
+	}
+	return pointer.To(value), nil
+}

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -137,10 +137,12 @@ The following arguments are supported:
 
 * `administrator_login` - (Optional) The administrator login name for the new server. Required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`. When omitted, Azure will generate a default username which cannot be subsequently changed. Changing this forces a new resource to be created.
 
-* `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Either `administrator_login_password` or `administrator_login_password_wo` is required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+* `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). 
 
-* `administrator_login_password_wo` - (Optional, Write-Only) The Password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Either `administrator_login_password` or `administrator_login_password_wo` is required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
-* 
+* `administrator_login_password_wo` - (Optional, Write-Only) The Password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). 
+
+~> **Note:** Either `administrator_login_password` or `administrator_login_password_wo` is required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+
 * `administrator_login_password_wo_version` - (Optional) An integer value used to trigger an update for `administrator_login_password_wo`. This property should be incremented when updating `administrator_login_password_wo`.
 
 * `azuread_administrator` - (Optional) An `azuread_administrator` block as defined below.

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -137,7 +137,11 @@ The following arguments are supported:
 
 * `administrator_login` - (Optional) The administrator login name for the new server. Required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`. When omitted, Azure will generate a default username which cannot be subsequently changed. Changing this forces a new resource to be created.
 
-* `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+* `administrator_login_password` - (Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Either `administrator_login_password` or `administrator_login_password_wo` is required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+
+* `administrator_login_password_wo` - (Optional, Write-Only) The Password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Either `administrator_login_password` or `administrator_login_password_wo` is required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+* 
+* `administrator_login_password_wo_version` - (Optional) An integer value used to trigger an update for `administrator_login_password_wo`. This property should be incremented when updating `administrator_login_password_wo`.
 
 * `azuread_administrator` - (Optional) An `azuread_administrator` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for the write only attribute `administrator_login_password_wo`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server` - add support for `administrator_login_password_wo` and `administrator_login_password_wo_version` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
